### PR TITLE
Fix balances do not matching

### DIFF
--- a/webapp/components/balance.tsx
+++ b/webapp/components/balance.tsx
@@ -22,7 +22,7 @@ const RenderBalance = ({
     )}
     {(status === 'error' || status === 'idle') && '-'}
     {status === 'success' &&
-      formatNumber(parseFloat(formatUnits(balance, token.decimals)), 2)}
+      formatNumber(formatUnits(balance, token.decimals), 2)}
   </>
 )
 

--- a/webapp/utils/format.ts
+++ b/webapp/utils/format.ts
@@ -5,5 +5,7 @@ export const formatNumber = (
   new Intl.NumberFormat('en-us', {
     maximumFractionDigits: fractionDigits,
     minimumFractionDigits: fractionDigits,
+    // @ts-expect-error not defined in TS types yet - See https://github.com/microsoft/TypeScript/issues/56269
+    roundingMode: 'floor',
     // @ts-expect-error NumberFormat.format accept strings, typings are wrong. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#parameters
   }).format(value)


### PR DESCRIPTION
Rounding down, so it doesn't look there's more money than we actually have!

Balances now match

<img width="1291" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/fc54aa82-81df-499e-96eb-49e4d07f605d">

MM wallet

<img width="439" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/57bbb183-ed11-44b7-ae42-00c9fbe9b25a">


Closes #27