### PR TITLE
Update actions/cache action to v4

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Restore cache
       id: npm-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: '**/node_modules'
         key: ${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
As the title says, because there were some warnings when running Github Actions

<img width="1498" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/656814f8-7a66-46ca-a3c3-3727f9799794">
