### PR TITLE
Fix client side redirect with locale

### DIFF
--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -4,15 +4,10 @@ import 'react-loading-skeleton/dist/skeleton.css'
 import { locales, type Locale } from 'app/i18n'
 import { Header } from 'components/header'
 import { WalletContext } from 'components/wallet-integration/walletContext'
-import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { NextIntlClientProvider } from 'next-intl'
 
 import { bricolageGrotesque, inter } from '../fonts'
-
-export const metadata: Metadata = {
-  title: 'BVM',
-}
 
 async function getMessages(locale: Locale) {
   try {

--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -1,11 +1,26 @@
+import { locales } from 'app/i18n'
+import type { Metadata } from 'next'
 import { ReactNode } from 'react'
 
 type Props = {
   children: ReactNode
 }
 
+export const metadata: Metadata = {
+  title: 'BVM',
+}
+
+export const generateStaticParams = async () =>
+  locales.map(locale => ({ locale }))
+
 // Since we have a `not-found.tsx` page on the root, a layout file
 // is required, even if it's just passing children through.
 export default function RootLayout({ children }: Props) {
-  return children
+  // Define empty body because otherwise it will break client redirects
+  // See https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
 }


### PR DESCRIPTION
There was an error when working locally in which the client-side redirects would break. This PR fixes that. It worked correctly on the static build

This was caused by #34 