### PR TITLE
Add deployment steps for onboarding page

### DIFF
--- a/marketing/Readme.md
+++ b/marketing/Readme.md
@@ -15,3 +15,20 @@ The recaptcha v3 key can be generated [in this page](https://www.google.com/reca
 ```bash
 npm run dev
 ```
+
+## Deployment
+
+Create a `.env.production` with the following configuration
+
+```bash
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY="<recaptcha-v3-key>"
+NEXT_PUBLIC_TESTNET_MODE=true|false # Depending on the network being deployed
+```
+
+Run the following command
+
+```bash
+npm run build
+```
+
+Deploy the `.out` folder to the server


### PR DESCRIPTION
This adds the deployment steps for the marketing/onboarding page in the Readme, so it can be linked in the issue #68