### PR TITLE
Add social links for discord and twitter

### DIFF
--- a/hemi-metadata/socials.ts
+++ b/hemi-metadata/socials.ts
@@ -1,0 +1,3 @@
+export const discordUrl = 'https://discord.com/invite/2DnVTugBf2'
+
+export const twitterUrl = 'https://twitter.com/hemi_xyz/'

--- a/landing/index.html
+++ b/landing/index.html
@@ -218,7 +218,12 @@
               <a class="cursor-pointer">Contact</a>
             </li>
             <li class="ml-auto py-2 pl-5">
-              <a class="cursor-pointer">
+              <a
+                class="cursor-pointer"
+                href="https://discord.com/invite/2DnVTugBf2"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="33"
@@ -246,7 +251,12 @@
               </a>
             </li>
             <li class="py-2 pl-5">
-              <a class="cursor-pointer">
+              <a
+                class="cursor-pointer"
+                href="https://twitter.com/hemi_xyz/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="33"
@@ -385,7 +395,11 @@
             </li>
             <div class="mt-auto flex items-center gap-x-5 py-4">
               <li>
-                <a>
+                <a
+                  href="https://discord.com/invite/2DnVTugBf2"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="33"
@@ -413,7 +427,12 @@
                 </a>
               </li>
               <li>
-                <a class="cursor-pointer">
+                <a
+                  class="cursor-pointer"
+                  href="https://twitter.com/hemi_xyz/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="33"

--- a/marketing/app/[locale]/header.tsx
+++ b/marketing/app/[locale]/header.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { discordUrl, twitterUrl } from 'hemi-metadata/socials'
 import { useTranslations } from 'next-intl'
 import Link from 'next-intl/link'
 import { useState } from 'react'
@@ -72,13 +73,23 @@ export const Header = function () {
   )
 
   const discordLink = (
-    <a className="cursor-pointer">
+    <a
+      className="cursor-pointer"
+      href={discordUrl}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
       <DiscordLogo />
     </a>
   )
 
   const XLink = (
-    <a className="cursor-pointer">
+    <a
+      className="cursor-pointer"
+      href={twitterUrl}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
       <XLogo />
     </a>
   )


### PR DESCRIPTION
This adds the discord and twittwr/x links to both marketing pages. It is not added in the `webapp` because the header has changed so I may need to add them there (originally, they weren't there). So that's why I saved the URLs as part of `hemi-metadata` (Except for the temp HTML file which can read of that package )

Closes #73