### PR TITLE
Remove uppercased symbols

### DIFF
--- a/webapp/app/[locale]/tunnel/page.tsx
+++ b/webapp/app/[locale]/tunnel/page.tsx
@@ -162,7 +162,7 @@ const FormContent = function ({ bridgeState, isRunningOperation }: Props) {
         <div className="flex flex-col justify-between">
           <div className="flex items-center justify-end gap-x-2 text-xs">
             <TokenLogo token={toToken} />
-            <span className="text-sm font-medium uppercase text-slate-700">
+            <span className="text-sm font-medium text-slate-700">
               {toToken.symbol}
             </span>
           </div>

--- a/webapp/components/TokenSelector.tsx
+++ b/webapp/components/TokenSelector.tsx
@@ -70,7 +70,7 @@ const TokenList = function ({
                     <Balance token={token} />
                   </div>
                   <div className="flex items-center justify-between text-zinc-400">
-                    <span className="uppercase">{token.symbol}</span>
+                    <span>{token.symbol}</span>
                     {/*  Hiding as there are no usd rates so far*/}
                     {/* <span>$1,234.12</span> */}
                   </div>
@@ -110,7 +110,7 @@ export const TokenSelector = function ({
         type="button"
       >
         <TokenLogo token={selectedToken} />
-        <span className="text-xs font-medium uppercase text-slate-700 sm:text-sm">
+        <span className="text-xs font-medium text-slate-700 sm:text-sm">
           {selectedToken.symbol}
         </span>
         <svg

--- a/webapp/components/header.tsx
+++ b/webapp/components/header.tsx
@@ -2,13 +2,13 @@
 
 import dynamic from 'next/dynamic'
 import { usePathname } from 'next/navigation'
+import { useTranslations } from 'next-intl'
 import Link from 'next-intl/link'
 import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { HamburgerIcon } from 'ui-common/components/hamburgerIcon'
 import { HemiLogoFull, HemiSymbol } from 'ui-common/components/hemiLogo'
 import { useOnClickOutside } from 'ui-common/hooks/useOnClickOutside'
-import { useTranslations } from 'next-intl'
 
 const WalletConnectButton = dynamic(
   () =>

--- a/webapp/components/reviewBox.tsx
+++ b/webapp/components/reviewBox.tsx
@@ -13,9 +13,7 @@ const SubSection = function ({ symbol, text, value }: SubSectionProps) {
   return (
     <div className="flex items-center justify-between py-3 text-xs font-normal md:text-sm">
       <p className="text-zinc-400">{text}</p>
-      <span className="uppercase">
-        {value === '0' ? '-' : `${getValue()} ${symbol}`}
-      </span>
+      <span>{value === '0' ? '-' : `${getValue()} ${symbol}`}</span>
     </div>
   )
 }


### PR DESCRIPTION
It was requested by Max Sanchez that symbols should not be uppercased, so now they are shown as defined in the chain definition

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/e16291b3-5be3-46bc-91c0-9765d8462ab4)
