### PR TITLE
Add trailing slash option on static exports

### DIFF
--- a/marketing/next.config.js
+++ b/marketing/next.config.js
@@ -8,6 +8,7 @@ const nextConfig = {
     unoptimized: true,
   },
   output: 'export',
+  trailingSlash: true,
   reactStrictMode: true,
   transpilePackages: ['ui-common'],
   webpack(config) {

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   },
   output: 'export',
   reactStrictMode: true,
+  trailingSlash: true,
   transpilePackages: ['ui-common', 'wagmi-erc20-hooks'],
   webpack(config) {
     config.resolve.fallback = { fs: false, net: false, tls: false }


### PR DESCRIPTION
An option was missing in `next.config.js`, so users can access directly into the URL

Accessing `https://app.hemi.xyz/en/tunnel` directly now works