### PR TITLE
Minor improvements on webapp lighthouse score

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/deposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/deposit.tsx
@@ -3,39 +3,19 @@
 import { useBridgeState } from 'app/[locale]/tunnel/useBridgeState'
 import { useDeposit } from 'app/[locale]/tunnel/useDeposit'
 import { useTransactionsList } from 'app/[locale]/tunnel/useTransactionsList'
+import { ReviewDeposit } from 'components/reviewBox'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { FormEvent, ReactNode, useEffect } from 'react'
-import Skeleton from 'react-loading-skeleton'
 import { Button } from 'ui-common/components/button'
 import { formatNumber } from 'utils/format'
 import { isNativeToken } from 'utils/token'
 import { formatUnits } from 'viem'
 import { useConfig, useNetwork } from 'wagmi'
 
+import { Erc20Approval } from './Erc20Approval'
 import { BridgeForm, canSubmit, getTotal } from './form'
-
-const Erc20Approval = dynamic(
-  () =>
-    import('app/[locale]/tunnel/_components/Erc20Approval').then(
-      mod => mod.Erc20Approval,
-    ),
-  {
-    loading: () => (
-      <Skeleton className="h-10 py-2" containerClassName="basis-1/4" />
-    ),
-    ssr: false,
-  },
-)
-
-const ReviewDeposit = dynamic(
-  () => import('components/reviewBox').then(mod => mod.ReviewDeposit),
-  {
-    loading: () => <Skeleton className="h-48 w-full md:w-80" />,
-    ssr: false,
-  },
-)
 
 const TransactionStatus = dynamic(
   () =>

--- a/webapp/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/webapp/app/[locale]/tunnel/_components/withdraw.tsx
@@ -1,11 +1,11 @@
 import { useBridgeState } from 'app/[locale]/tunnel/useBridgeState'
 import { useTransactionsList } from 'app/[locale]/tunnel/useTransactionsList'
+import { ReviewWithdraw } from 'components/reviewBox'
 import { useWithdraw } from 'app/[locale]/tunnel/useWithdraw'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { FormEvent, useEffect } from 'react'
-import Skeleton from 'react-loading-skeleton'
 import { Token } from 'types/token'
 import { Button } from 'ui-common/components/button'
 import { formatNumber } from 'utils/format'
@@ -14,14 +14,6 @@ import { type Chain, formatUnits } from 'viem'
 import { useConfig, useNetwork } from 'wagmi'
 
 import { BridgeForm, canSubmit, getTotal } from './form'
-
-const ReviewWithdraw = dynamic(
-  () => import('components/reviewBox').then(mod => mod.ReviewWithdraw),
-  {
-    loading: () => <Skeleton className="h-48 w-full md:w-80" />,
-    ssr: false,
-  },
-)
 
 const TransactionStatus = dynamic(
   () =>


### PR DESCRIPTION
These 2 components are shown as soon as loaded, so it's better not to load them dynamically, so the skeleton is not shown for a few seconds. This improves a bit the lighthouse scoring