### PR TITLE
Update hemi dai symbol

### DIFF
--- a/webapp/tokenList.ts
+++ b/webapp/tokenList.ts
@@ -38,8 +38,8 @@ const tokens: Token[] = [
     },
     logoURI:
       'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png',
-    name: 'Tunneled DAI',
-    symbol: 'tDAI',
+    name: 'Testnet Hemi DAI',
+    symbol: 'thDAI',
   },
 ]
 


### PR DESCRIPTION
Closes #124
This updates the hemi version of Dai to have the proper name according to [the convention defined](https://github.com/hemilabs/infrastructure/blob/main/NETWORK_INFO.md#token-naming-standards)