### PR TITLE
Add ws rpc url for Hemi testnet

### DIFF
--- a/hemi-metadata/index.ts
+++ b/hemi-metadata/index.ts
@@ -18,6 +18,7 @@ export const hemiTestnet = {
   rpcUrls: {
     default: {
       http: ['https://testnet.rpc.hemi.network/rpc'],
+      webSocket: ['wss://testnet.rpc.hemi.network/wsrpc'],
     },
     public: {
       http: ['https://testnet.rpc.hemi.network/rpc'],


### PR DESCRIPTION
Adding the WebSocket RPC url for Hemi testnet, defined [here](https://github.com/hemilabs/infrastructure/blob/26163ab48a8e77238408f74d78048212eb6e7e47/NETWORK_INFO.md?plain=1#L27)

Closes #126