### PR TITLE
Add hooks to get tx history

### DIFF
--- a/webapp/app/[locale]/tunnel/_hooks/useClaimTransaction.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useClaimTransaction.ts
@@ -2,7 +2,7 @@ import { MessageStatus } from '@eth-optimism/sdk'
 import { useQueryClient } from '@tanstack/react-query'
 import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
 import {
-  useGetTransactionMessageStatus,
+  useL1GetTransactionMessageStatus,
   useFinalizeMessage,
 } from 'hooks/useL2Bridge'
 import { useCallback } from 'react'
@@ -22,7 +22,7 @@ export const useClaimTransaction = function ({
 
   const connectedToL1 = useIsConnectedToExpectedNetwork(l1ChainId)
 
-  const transactionMessageStatus = useGetTransactionMessageStatus({
+  const transactionMessageStatus = useL1GetTransactionMessageStatus({
     l1ChainId,
     refetchUntilStatus: MessageStatus.READY_FOR_RELAY,
     transactionHash: withdrawTxHash,

--- a/webapp/app/[locale]/tunnel/_hooks/useProveTransaction.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useProveTransaction.ts
@@ -2,7 +2,7 @@ import { MessageStatus } from '@eth-optimism/sdk'
 import { useQueryClient } from '@tanstack/react-query'
 import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
 import {
-  useGetTransactionMessageStatus,
+  useL1GetTransactionMessageStatus,
   useProveMessage,
 } from 'hooks/useL2Bridge'
 import { useCallback } from 'react'
@@ -22,7 +22,7 @@ export const useProveTransaction = function ({
 
   const connectedToL1 = useIsConnectedToExpectedNetwork(l1ChainId)
 
-  const transactionMessageStatus = useGetTransactionMessageStatus({
+  const transactionMessageStatus = useL1GetTransactionMessageStatus({
     l1ChainId,
     refetchUntilStatus: MessageStatus.READY_TO_PROVE,
     transactionHash: withdrawTxHash,


### PR DESCRIPTION
Related to #143

This PR adds some of the hooks related to getting the info for the TX history

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/a53cddfe-0e6b-422d-9293-55a350c0f576)

Example usages

```ts
// Note: We need to figure out the best way to get the L1 chainId. For now, that app is not multi-chain
// this works
const { deposits = [] } = useGetDepositsByAddress(bridgeableNetworks[0].id)
const { withdrawals = [] } = useGetWithdrawalsByAddress(bridgeableNetworks[0].id)
```

For the "Time" column, we can use [wagmi's useBlock](https://wagmi.sh/react/api/hooks/useBlock), and calculate time passed from the timestamp

```ts
const { data: block } = useBlock({
    blockNumber: BigInt(deposit.blockNumber),
    includeTransactions: false,
  })
// NOTE: types do not include timestamp, but they are part of the response once loaded
console.log(block?.timestamp)
```

For getting the "Status" column, I added another custom hook

```ts
const status = useAnyChainGetTransactionMessageStatus({
    l1ChainId: bridgeableNetworks[0].id,
    transactionHash: '0x123'
  })
```

(All scenarios are simplified, we will need to check in each hook the `status` and show the proper loading info)