### PR TITLE
Rename bridge to tunnel

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/SetMaxBalance.tsx
+++ b/webapp/app/[locale]/tunnel/_components/SetMaxBalance.tsx
@@ -15,7 +15,7 @@ export const SetMaxBalance = function ({
   isRunningOperation,
   onSetMaxBalance,
 }: Props) {
-  const t = useTranslations('bridge-page.form')
+  const t = useTranslations('tunnel-page.form')
 
   const { balance: walletNativeTokenBalance } = useNativeTokenBalance(
     fromToken.chainId,

--- a/webapp/app/[locale]/tunnel/_components/claim.tsx
+++ b/webapp/app/[locale]/tunnel/_components/claim.tsx
@@ -10,11 +10,11 @@ import { Chain, formatUnits } from 'viem'
 import { useConfig } from 'wagmi'
 
 import { SubmitWhenConnectedToChain } from '../_components/submitWhenConnectedToChain'
-import { useBridgeState } from '../_hooks/useBridgeState'
 import { useClaimTransaction } from '../_hooks/useClaimTransaction'
 import { useTransactionsList } from '../_hooks/useTransactionsList'
+import { useTunnelState } from '../_hooks/useTunnelState'
 
-import { BridgeForm } from './form'
+import { TunnelForm } from './form'
 
 const SubmitButton = function ({
   l1ChainId,
@@ -41,7 +41,7 @@ const SubmitButton = function ({
           type="submit"
         >
           {t(
-            `bridge-page.submit-button.${
+            `tunnel-page.submit-button.${
               isClaiming ? 'claiming-withdrawal' : 'claim-withdrawal'
             }`,
           )}
@@ -53,7 +53,7 @@ const SubmitButton = function ({
 
 type Props = {
   renderForm: (isRunningOperation: boolean) => ReactNode
-  state: ReturnType<typeof useBridgeState> & { operation: 'claim' }
+  state: ReturnType<typeof useTunnelState> & { operation: 'claim' }
 }
 
 export const Claim = function ({ renderForm, state }: Props) {
@@ -179,18 +179,18 @@ export const Claim = function ({ renderForm, state }: Props) {
   const isClaiming = withdrawProgress === WithdrawProgress.CLAIMING
 
   const transactionsList = useTransactionsList({
-    inProgressMessage: t('bridge-page.transaction-status.claiming-withdrawal'),
+    inProgressMessage: t('tunnel-page.transaction-status.claiming-withdrawal'),
     isOperating: isClaiming,
     operation: 'claim',
     receipt: claimWithdrawalReceipt,
     receiptError: claimWithdrawalReceiptError,
-    successMessage: t('bridge-page.transaction-status.withdrawal-claimed'),
+    successMessage: t('tunnel-page.transaction-status.withdrawal-claimed'),
     txHash: claimWithdrawalTxHash,
     userConfirmationError: claimWithdrawalError,
   })
 
   return (
-    <BridgeForm
+    <TunnelForm
       formContent={renderForm(isClaiming)}
       onSubmit={handleClaim}
       reviewOperation={
@@ -224,7 +224,7 @@ export const Claim = function ({ renderForm, state }: Props) {
               {
                 id: 'prove',
                 status: 'success',
-                text: t('bridge-page.transaction-status.withdrawal-proved'),
+                text: t('tunnel-page.transaction-status.withdrawal-proved'),
                 txHash: proveWithdrawalTxHash,
               },
             ]

--- a/webapp/app/[locale]/tunnel/_components/deposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/deposit.tsx
@@ -11,12 +11,12 @@ import { isNativeToken } from 'utils/token'
 import { formatUnits } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 
-import { useBridgeState } from '../_hooks/useBridgeState'
 import { useDeposit } from '../_hooks/useDeposit'
 import { useTransactionsList } from '../_hooks/useTransactionsList'
+import { useTunnelState } from '../_hooks/useTunnelState'
 
 import { Erc20Approval } from './Erc20Approval'
-import { BridgeForm, canSubmit, getTotal } from './form'
+import { TunnelForm, canSubmit, getTotal } from './form'
 
 type OperationRunning = 'idle' | 'approving' | 'depositing'
 
@@ -42,12 +42,12 @@ const SubmitButton = function ({
   const getOperationButtonText = function () {
     const texts = {
       approve: {
-        idle: t('bridge-page.submit-button.approve-and-deposit'),
-        loading: t('bridge-page.submit-button.approving'),
+        idle: t('tunnel-page.submit-button.approve-and-deposit'),
+        loading: t('tunnel-page.submit-button.approving'),
       },
       deposit: {
-        idle: t('bridge-page.submit-button.deposit'),
-        loading: t('bridge-page.submit-button.depositing'),
+        idle: t('tunnel-page.submit-button.deposit'),
+        loading: t('tunnel-page.submit-button.depositing'),
       },
     }
     if (!isRunningOperation) {
@@ -80,7 +80,7 @@ const SubmitButton = function ({
 
 type Props = {
   renderForm: (isRunningOperation: boolean) => ReactNode
-  state: ReturnType<typeof useBridgeState> & { operation: 'deposit' }
+  state: ReturnType<typeof useTunnelState> & { operation: 'deposit' }
 }
 
 export const Deposit = function ({ renderForm, state }: Props) {
@@ -249,14 +249,14 @@ export const Deposit = function ({ renderForm, state }: Props) {
       })
 
   const approvalTransactionList = useTransactionsList({
-    inProgressMessage: t('bridge-page.transaction-status.erc20-approving', {
+    inProgressMessage: t('tunnel-page.transaction-status.erc20-approving', {
       symbol: fromToken.symbol,
     }),
     isOperating: operationRunning === 'approving',
     operation: 'approve',
     receipt: approvalReceipt,
     receiptError: approvalReceiptError,
-    successMessage: t('bridge-page.transaction-status.erc20-approved', {
+    successMessage: t('tunnel-page.transaction-status.erc20-approved', {
       symbol: fromToken.symbol,
     }),
     txHash: approvalTxHash,
@@ -264,7 +264,7 @@ export const Deposit = function ({ renderForm, state }: Props) {
   })
 
   const depositTransactionList = useTransactionsList({
-    inProgressMessage: t('bridge-page.transaction-status.depositing', {
+    inProgressMessage: t('tunnel-page.transaction-status.depositing', {
       fromInput: depositAmount,
       network: toChain?.name,
       symbol: fromToken.symbol,
@@ -273,7 +273,7 @@ export const Deposit = function ({ renderForm, state }: Props) {
     operation: 'deposit',
     receipt: depositReceipt,
     receiptError: depositReceiptError,
-    successMessage: t('bridge-page.transaction-status.deposited', {
+    successMessage: t('tunnel-page.transaction-status.deposited', {
       fromInput: depositAmount,
       symbol: fromToken.symbol,
     }),
@@ -286,7 +286,7 @@ export const Deposit = function ({ renderForm, state }: Props) {
   )
 
   return (
-    <BridgeForm
+    <TunnelForm
       formContent={renderForm(isRunningOperation)}
       onSubmit={handleDeposit}
       reviewOperation={

--- a/webapp/app/[locale]/tunnel/_components/form.tsx
+++ b/webapp/app/[locale]/tunnel/_components/form.tsx
@@ -84,7 +84,7 @@ type Props = {
   }[]
 }
 
-export const BridgeForm = ({
+export const TunnelForm = ({
   formContent,
   onSubmit,
   reviewOperation,

--- a/webapp/app/[locale]/tunnel/_components/prove.tsx
+++ b/webapp/app/[locale]/tunnel/_components/prove.tsx
@@ -10,11 +10,11 @@ import { formatUnits, type Chain } from 'viem'
 import { useConfig } from 'wagmi'
 
 import { SubmitWhenConnectedToChain } from '../_components/submitWhenConnectedToChain'
-import { useBridgeState } from '../_hooks/useBridgeState'
 import { useProveTransaction } from '../_hooks/useProveTransaction'
 import { useTransactionsList } from '../_hooks/useTransactionsList'
+import { useTunnelState } from '../_hooks/useTunnelState'
 
-import { BridgeForm } from './form'
+import { TunnelForm } from './form'
 
 const SubmitButton = function ({
   isProving,
@@ -33,7 +33,7 @@ const SubmitButton = function ({
       submitButton={
         <Button disabled={!isReadyToProve || isProving} type="submit">
           {t(
-            `bridge-page.submit-button.${
+            `tunnel-page.submit-button.${
               isProving ? 'proving-withdrawal' : 'prove-withdrawal'
             }`,
           )}
@@ -44,7 +44,7 @@ const SubmitButton = function ({
 }
 type Props = {
   renderForm: (isRunningOperation: boolean) => React.ReactNode
-  state: ReturnType<typeof useBridgeState> & { operation: 'prove' }
+  state: ReturnType<typeof useTunnelState> & { operation: 'prove' }
 }
 
 export const Prove = function ({ renderForm, state }: Props) {
@@ -161,18 +161,18 @@ export const Prove = function ({ renderForm, state }: Props) {
   const isProving = withdrawProgress === WithdrawProgress.PROVING
 
   const transactionsList = useTransactionsList({
-    inProgressMessage: t('bridge-page.transaction-status.proving-withdrawal'),
+    inProgressMessage: t('tunnel-page.transaction-status.proving-withdrawal'),
     isOperating: isProving,
     operation: 'prove',
     receipt: withdrawalProofReceipt,
     receiptError: withdrawalProofReceiptError,
-    successMessage: t('bridge-page.transaction-status.withdrawal-proved'),
+    successMessage: t('tunnel-page.transaction-status.withdrawal-proved'),
     txHash: proveWithdrawalTxHash,
     userConfirmationError: proveWithdrawalError,
   })
 
   return (
-    <BridgeForm
+    <TunnelForm
       formContent={renderForm(isProving)}
       onSubmit={handleProve}
       reviewOperation={
@@ -204,7 +204,7 @@ export const Prove = function ({ renderForm, state }: Props) {
               {
                 id: 'withdraw',
                 status: 'success',
-                text: t('bridge-page.transaction-status.withdrawn', {
+                text: t('tunnel-page.transaction-status.withdrawn', {
                   fromInput: withdrawAmount,
                   symbol: withdrawSymbol,
                 }),

--- a/webapp/app/[locale]/tunnel/_components/submitWhenConnectedToChain.tsx
+++ b/webapp/app/[locale]/tunnel/_components/submitWhenConnectedToChain.tsx
@@ -31,7 +31,7 @@ export const SubmitWhenConnectedToChain = function ({
         <>
           <NotificationBox
             backgroundColor="bg-orange-100"
-            text={t('bridge-page.form.switch-to-prove', {
+            text={t('tunnel-page.form.switch-to-prove', {
               network: targetChain.name,
             })}
           />

--- a/webapp/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/webapp/app/[locale]/tunnel/_components/withdraw.tsx
@@ -12,11 +12,11 @@ import { isNativeToken } from 'utils/token'
 import { type Chain, formatUnits } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 
-import { useBridgeState } from '../_hooks/useBridgeState'
 import { useTransactionsList } from '../_hooks/useTransactionsList'
+import { useTunnelState } from '../_hooks/useTunnelState'
 import { useWithdraw } from '../_hooks/useWithdraw'
 
-import { BridgeForm, canSubmit } from './form'
+import { TunnelForm, canSubmit } from './form'
 
 const hasBridgeConfiguration = (token: Token, l1ChainId: Chain['id']) =>
   isNativeToken(token) ||
@@ -24,7 +24,7 @@ const hasBridgeConfiguration = (token: Token, l1ChainId: Chain['id']) =>
 
 type Props = {
   renderForm: (isRunningOperation: boolean) => React.ReactNode
-  state: ReturnType<typeof useBridgeState> & { operation: 'withdraw' }
+  state: ReturnType<typeof useTunnelState> & { operation: 'withdraw' }
 }
 
 export const Withdraw = function ({ renderForm, state }: Props) {
@@ -151,7 +151,7 @@ export const Withdraw = function ({ renderForm, state }: Props) {
   const isWithdrawing = withdrawProgress === WithdrawProgress.WITHDRAWING
 
   const transactionsList = useTransactionsList({
-    inProgressMessage: t('bridge-page.transaction-status.withdrawing', {
+    inProgressMessage: t('tunnel-page.transaction-status.withdrawing', {
       fromInput: withdrawn,
       network: fromChain?.name,
       symbol: fromToken.symbol,
@@ -160,7 +160,7 @@ export const Withdraw = function ({ renderForm, state }: Props) {
     operation: 'withdraw',
     receipt: withdrawReceipt,
     receiptError: withdrawReceiptError,
-    successMessage: t('bridge-page.transaction-status.withdrawn', {
+    successMessage: t('tunnel-page.transaction-status.withdrawn', {
       fromInput,
       symbol: fromToken.symbol,
     }),
@@ -169,7 +169,7 @@ export const Withdraw = function ({ renderForm, state }: Props) {
   })
 
   return (
-    <BridgeForm
+    <TunnelForm
       formContent={renderForm(isWithdrawing)}
       onSubmit={handleWithdraw}
       reviewOperation={
@@ -187,7 +187,7 @@ export const Withdraw = function ({ renderForm, state }: Props) {
       submitButton={
         <Button disabled={!canWithdraw || isWithdrawing} type="submit">
           {t(
-            `bridge-page.submit-button.${
+            `tunnel-page.submit-button.${
               isWithdrawing ? 'withdrawing' : 'withdraw'
             }`,
           )}

--- a/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
@@ -17,7 +17,7 @@ type ProveWithdrawalData = {
   withdrawTxHash: Hash
 }
 
-type BridgeState = {
+type TunnelState = {
   extendedErc20Approval: boolean
   fromNetworkId: Chain['id']
   fromInput: string
@@ -91,7 +91,7 @@ const compilationError = function (_: never): never {
   throw new Error('Missing implementation of action in reducer')
 }
 
-const reducer = function (state: BridgeState, action: Actions): BridgeState {
+const reducer = function (state: TunnelState, action: Actions): TunnelState {
   const { type } = action
   switch (type) {
     case 'resetStateAfterOperation': {
@@ -223,7 +223,7 @@ const reducer = function (state: BridgeState, action: Actions): BridgeState {
   }
 }
 
-export const useBridgeState = function (): BridgeState & {
+export const useTunnelState = function (): TunnelState & {
   // will throw compile error if a proper function event is missing!
   [K in Actions['type']]: (
     payload?: Extract<Actions, { type: K }>['payload'],

--- a/webapp/app/[locale]/tunnel/page.tsx
+++ b/webapp/app/[locale]/tunnel/page.tsx
@@ -14,7 +14,7 @@ import { Deposit } from './_components/deposit'
 import { Prove } from './_components/prove'
 import { ToggleButton } from './_components/ToggleButton'
 import { Withdraw } from './_components/withdraw'
-import { useBridgeState } from './_hooks/useBridgeState'
+import { useTunnelState } from './_hooks/useTunnelState'
 
 const Balance = dynamic(
   () => import('components/balance').then(mod => mod.Balance),
@@ -55,11 +55,11 @@ const SwitchToNetwork = dynamic(
   },
 )
 type Props = {
-  bridgeState: ReturnType<typeof useBridgeState>
+  tunnelState: ReturnType<typeof useTunnelState>
   isRunningOperation: boolean
 }
 
-const FormContent = function ({ bridgeState, isRunningOperation }: Props) {
+const FormContent = function ({ tunnelState, isRunningOperation }: Props) {
   const {
     fromNetworkId,
     fromInput,
@@ -72,9 +72,9 @@ const FormContent = function ({ bridgeState, isRunningOperation }: Props) {
     updateToNetwork,
     toggleInput,
     toToken,
-  } = bridgeState
+  } = tunnelState
 
-  const t = useTranslations('bridge-page')
+  const t = useTranslations('tunnel-page')
 
   return (
     <>
@@ -171,22 +171,22 @@ const OperationsComponent = {
   withdraw: Withdraw,
 }
 
-export default function Bridge() {
-  const bridgeState = useBridgeState()
+export default function Tunnel() {
+  const tunnelState = useTunnelState()
 
-  const OperationComponent = OperationsComponent[bridgeState.operation]
+  const OperationComponent = OperationsComponent[tunnelState.operation]
 
   return (
     <div className="h-fit-rest-screen mx-auto flex w-full flex-col gap-y-4 px-4 md:max-w-fit md:flex-row md:gap-x-4 md:pt-10">
       <OperationComponent
         renderForm={isRunningOperation => (
           <FormContent
-            bridgeState={bridgeState}
             isRunningOperation={isRunningOperation}
+            tunnelState={tunnelState}
           />
         )}
         // @ts-expect-error This works, but TS does not pick it up correctly.
-        state={bridgeState}
+        state={tunnelState}
       />
     </div>
   )

--- a/webapp/components/reviewBox/reviewDeposit.tsx
+++ b/webapp/components/reviewBox/reviewDeposit.tsx
@@ -19,7 +19,7 @@ export const ReviewDeposit = function ({
   gasSymbol,
   total,
 }: Props) {
-  const t = useTranslations('bridge-page.review-deposit')
+  const t = useTranslations('tunnel-page.review-deposit')
   const tCommon = useTranslations('common')
   return (
     <Card>

--- a/webapp/components/reviewBox/reviewWithdraw.tsx
+++ b/webapp/components/reviewBox/reviewWithdraw.tsx
@@ -115,7 +115,7 @@ const Step = function ({
   ...props
 }: StepProps) {
   const { chains } = useConfig()
-  const t = useTranslations('bridge-page.review-withdraw')
+  const t = useTranslations('tunnel-page.review-withdraw')
 
   const icons = {
     completed: <CheckIcon />,
@@ -212,7 +212,7 @@ export const ReviewWithdraw = function ({
   withdrawTxHash,
   ...props
 }: Props) {
-  const t = useTranslations('bridge-page.review-withdraw')
+  const t = useTranslations('tunnel-page.review-withdraw')
 
   const getProgressStatus = function (step: WithdrawProgress): ProgressStatus {
     if (progress > step) return 'completed'

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -1,5 +1,5 @@
 {
-  "bridge-page": {
+  "tunnel-page": {
     "form": {
       "balance": "Balance",
       "from-network": "From Network",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -1,5 +1,5 @@
 {
-  "bridge-page": {
+  "tunnel-page": {
     "form": {
       "balance": "Balance",
       "from-network": "Desde la Red",


### PR DESCRIPTION
As we are using `Tunnel` everywhere, while the UI already showed this, the code still used `bridge` instead of tunnel. This PR updates that to avoid confusing as we redesign the app and it continues to grow.

The PR is just replacing `bridge` with `tunnel`  in all Hemi-related code. The hook that wraps OP SDK still uses `bridge` internally because Optimism uses the `bridge` terminology.

Closes #23 