### PR TITLE
Add connect modal to transaction history

### DIFF
--- a/webapp/components/connectWallet.tsx
+++ b/webapp/components/connectWallet.tsx
@@ -1,0 +1,22 @@
+import { ConnectButton } from '@rainbow-me/rainbowkit'
+import { useTranslations } from 'next-intl'
+import { Card } from 'ui-common/components/card'
+
+export const ConnectWallet = function () {
+  const t = useTranslations()
+  return (
+    <Card borderColor="gray" radius="large">
+      <div className="flex h-[50dvh] w-full flex-col items-center justify-center gap-y-2">
+        <h3 className="text-2xl font-normal text-black">
+          {t('common.connect-your-wallet')}
+        </h3>
+        <p className="text-base font-normal text-slate-500">
+          {t('transaction-history.connect-wallet-to-review')}
+        </p>
+        <div className="mt-2">
+          <ConnectButton />
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -1,5 +1,6 @@
 {
   "transaction-history": {
+    "connect-wallet-to-review": "Connect your wallet to review transaction history.",
     "in-challenge-period": "In Challenge period",
     "ready-to-claim": "Ready to claim",
     "ready-to-prove": "Ready to prove"
@@ -83,6 +84,7 @@
     "bitcoinhkit": "Bitcoin hKit",
     "connect-to-network": "Connect to {network}",
     "connect-wallet": "Connect Wallet",
+    "connect-your-wallet": "Connect your Wallet",
     "demos": "Demos",
     "dex": "DEX",
     "erc20-approve-10x-deposits": "Approve 10x the amount of this deposit",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -1,5 +1,6 @@
 {
   "transaction-history": {
+    "connect-wallet-to-review": "Conecte su billetera para revisar su historial de transacciones.",
     "in-challenge-period": "En período de Desafío",
     "ready-to-claim": "Listo para Reclamar",
     "ready-to-prove": "Listo para Probar"
@@ -81,8 +82,9 @@
   "common": {
     "add-hemi-to-wallet": "Añadir la red Hemi a su billetera",
     "bitcoinhkit": "hKit de Bitcoin",
-    "connect-wallet": "Conectar Billetera",
     "connect-to-network": "Conectarse a {network}",
+    "connect-wallet": "Conectar Billetera",
+    "connect-your-wallet": "Conecte su Billetera",
     "erc20-approve-10x-deposits": "Aprobar 10x el monto de este depósito",
     "erc20-approve-10x-detailed-description": "Al activar la aprobación 10x, automáticamente agregamos 10 veces el monto de esta transacción como monto autorizado para otras futuras, lo que le permite ahorrar dinero en tarifas de gas y tiempo.",
     "erc20-extra-approval": "Aprobar 10x este depósito",


### PR DESCRIPTION
~~Depends on #167~~
Closes #159 

This PR adds the "Connect wallet" modal. The button still has pending styles as the custom styles need to be implemented across the whole app (See #169). This way it is consistent with the header (which needs to be updated as part of #169)


<img width="1423" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/00cedaae-7e44-4d34-8e53-c65d5b6fdc8b">

<img width="716" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/8460b1f9-809d-461f-9789-0b7de0c6aad2">

<img width="499" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/9c22f5df-2133-4d53-8eb7-89619baa9394">


