### PR TITLE
Improve ux on lack of cta in deposits in tx list

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -166,8 +166,8 @@ const columnsBuilder = (
   {
     cell: ({ row }) =>
       isDeposit(row.original) ? (
-        // Deposits do not render an action, let's add empty space
-        <div className="h-9 w-24" />
+        // Deposits do not render an action, let's add a "-"
+        <span className="opacity-40">-</span>
       ) : (
         <WithdrawAction l1ChainId={l1ChainId} withdraw={row.original} />
       ),


### PR DESCRIPTION
Addressing [this comment](https://github.com/BVM-priv/ui-monorepo/pull/167#pullrequestreview-2018071451) after talking about it with Leandro and Nahuel.


This PR adds a `-` with opacity when there are no CTA (for successful deposits)