### PR TITLE
Fix padding on card component

### DIFF
--- a/ui-common/components/card.tsx
+++ b/ui-common/components/card.tsx
@@ -6,7 +6,7 @@ const borderColors = {
 } as const
 
 const paddingVariants = {
-  default: 'p-6 md:p-9',
+  large: 'p-6 md:p-9',
   medium: 'p-6',
   small: 'px-4 py-3',
 }
@@ -27,7 +27,7 @@ type CardProps = React.DetailedHTMLProps<
   HTMLDivElement
 > & {
   borderColor?: keyof typeof borderColors
-  padding?: keyof typeof paddingVariants
+  padding: keyof typeof paddingVariants
   radius?: keyof typeof radiusVariants
   shadow?: keyof typeof shadows
 }
@@ -35,7 +35,7 @@ type CardProps = React.DetailedHTMLProps<
 export const Card = ({
   children,
   borderColor: variant = 'default',
-  padding = 'default',
+  padding,
   radius = 'default',
   shadow = 'none',
 }: CardProps) => (

--- a/webapp/app/[locale]/demos/_components/demoCard.tsx
+++ b/webapp/app/[locale]/demos/_components/demoCard.tsx
@@ -31,7 +31,7 @@ export const DemoCard = ({
   subHeading,
 }: Props) => (
   <a href={href} rel="noopener noreferrer" target="_blank">
-    <Card borderColor="gray" shadow="soft">
+    <Card borderColor="gray" padding="small" shadow="soft">
       <div className="h-60 max-w-64 cursor-pointer">
         <div className="overflow-hidden rounded-xl border border-solid border-slate-100">
           <Image

--- a/webapp/app/[locale]/get-started/page.tsx
+++ b/webapp/app/[locale]/get-started/page.tsx
@@ -29,14 +29,14 @@ const NetworkPage = function () {
       </p>
       <main className="flex flex-col gap-y-4 md:w-full md:flex-row md:justify-between md:gap-x-4">
         <div className="md:basis-2/3">
-          <Card borderColor="gray" radius="large">
+          <Card borderColor="gray" padding="medium" radius="large">
             <Suspense>
               <ConfigureNetwork />
             </Suspense>
           </Card>
         </div>
         <div className="md:basis-1/3">
-          <Card borderColor="gray" radius="large">
+          <Card borderColor="gray" padding="medium" radius="large">
             <WelcomePack />
           </Card>
         </div>

--- a/webapp/app/[locale]/get-started/welcomePack.tsx
+++ b/webapp/app/[locale]/get-started/welcomePack.tsx
@@ -128,7 +128,7 @@ const ResetIcon = () => (
 )
 
 const PostClaimContainer = ({ children }: { children: ReactNode }) => (
-  <Card borderColor="gray" shadow="soft">
+  <Card borderColor="gray" padding="medium" shadow="soft">
     <div className="flex flex-col items-center justify-center gap-y-3">
       {children}
     </div>

--- a/webapp/app/[locale]/tunnel/_components/form.tsx
+++ b/webapp/app/[locale]/tunnel/_components/form.tsx
@@ -131,7 +131,7 @@ export const TunnelForm = function ({
         {['deposit', 'withdraw'].includes(operation) && (
           <SwitchToNetwork selectedNetwork={expectedChainId} />
         )}
-        <Card borderColor="gray" radius="large">
+        <Card borderColor="gray" padding="large" radius="large">
           <form
             className="flex flex-col gap-y-3 text-zinc-800"
             onSubmit={function (e: FormEvent) {

--- a/webapp/app/[locale]/tunnel/_components/reviewWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewWithdrawal.tsx
@@ -399,7 +399,7 @@ export const ReviewWithdrawal = function ({
   return (
     <Modal onClose={closeModal}>
       <div className="flex w-96 flex-col gap-y-4">
-        <Card>
+        <Card padding="large">
           <div className="flex items-center justify-between pb-2">
             <h4 className="text-base font-medium text-slate-950 lg:text-xl">
               {t('heading')}

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -255,7 +255,7 @@ export const TransactionHistory = function () {
     <>
       {status === 'connected' && (
         <>
-          <Card borderColor="gray" radius="large">
+          <Card borderColor="gray" padding="medium" radius="large">
             <div className="overflow-x-auto">
               <table className="w-full whitespace-nowrap">
                 <thead>

--- a/webapp/components/connectWallet.tsx
+++ b/webapp/components/connectWallet.tsx
@@ -5,7 +5,7 @@ import { Card } from 'ui-common/components/card'
 export const ConnectWallet = function () {
   const t = useTranslations()
   return (
-    <Card borderColor="gray" radius="large">
+    <Card borderColor="gray" padding="large" radius="large">
       <div className="flex h-[50dvh] w-full flex-col items-center justify-center gap-y-2">
         <h3 className="text-2xl font-normal text-black">
           {t('common.connect-your-wallet')}

--- a/webapp/components/getStarted.tsx
+++ b/webapp/components/getStarted.tsx
@@ -30,7 +30,7 @@ export function GetStarted({
                     ${className ?? ''}`}
     >
       <div className="m-auto max-md:p-6">
-        <Card radius="large" shadow="regular">
+        <Card padding="small" radius="large" shadow="regular">
           <div className="px-4 py-8 text-center">
             <h1 className="text-4xl font-medium tracking-tighter">
               {t('heading')}
@@ -57,7 +57,7 @@ export function GetStarted({
                   label: t('options.individual'),
                 },
               ].map(({ icon, handler, label }) => (
-                <Card borderColor="gray" key={label}>
+                <Card borderColor="gray" key={label} padding="small">
                   <div className="flex flex-col items-center px-2 py-4">
                     <div className="mb-10 mt-16">{icon}</div>
                     <Button onClick={handler} variant="secondary">


### PR DESCRIPTION
This PR removes the default padding option from the card component. Now we must specify in every scenario we want to use it. It also fixes all cards we have already implemented with no padding defined. 

Closes #184 