### PR TITLE
Add responsive design to network config panel

### DIFF
--- a/webapp/app/[locale]/get-started/addChain.tsx
+++ b/webapp/app/[locale]/get-started/addChain.tsx
@@ -29,7 +29,11 @@ export const AddChain = function ({ chain }: Props) {
 
   return (
     <>
-      {!isConnected && <ConnectButton />}
+      {!isConnected && (
+        <div className="w-full [&>div>button]:w-full [&>div>button]:!text-center">
+          <ConnectButton />
+        </div>
+      )}
       {!isChainAdded && isConnected && !connectedToChain && (
         <Button
           disabled={status === 'pending'}
@@ -41,7 +45,7 @@ export const AddChain = function ({ chain }: Props) {
         </Button>
       )}
       {(isChainAdded || connectedToChain) && (
-        <div className="flex items-center gap-2 rounded-lg bg-green-100 px-3 py-2">
+        <div className="flex w-full items-center justify-center gap-2 rounded-lg bg-green-100 px-3 py-2">
           <svg
             fill="none"
             height="14"

--- a/webapp/app/[locale]/get-started/configureNetworks.tsx
+++ b/webapp/app/[locale]/get-started/configureNetworks.tsx
@@ -101,14 +101,16 @@ const ChainRow = function ({ chain, layer, logo }: ChainRowProps) {
   const t = useTranslations('get-started.network')
 
   return (
-    <div className="flex items-center gap-x-3 text-sm font-medium">
-      {logo}
-      <div className="flex flex-col lg:flex-row lg:gap-x-1">
-        <p>{chain.name}</p>
-        <span className="text-neutral-400">·</span>
-        <span className="text-neutral-400">{t('layer', { layer })}</span>
+    <div className="flex flex-col gap-y-6 lg:flex-row lg:justify-between">
+      <div className="flex items-center gap-x-3 text-sm font-medium">
+        {logo}
+        <div className="flex flex-row gap-x-2">
+          <p>{chain.name}</p>
+          <span className="text-neutral-400">·</span>
+          <span className="text-neutral-400">{t('layer', { layer })}</span>
+        </div>
       </div>
-      <div className="ml-auto flex w-40 items-center justify-end gap-x-4">
+      <div className="flex items-center gap-x-4 lg:w-44">
         <AddChain chain={chain} />
       </div>
     </div>
@@ -208,7 +210,7 @@ export const ConfigureNetwork = function () {
 
   return (
     <div className="flex flex-col gap-y-6 px-1 py-2 lg:gap-y-9">
-      <div className="text-center text-sm">
+      <div className="flex justify-center lg:justify-start">
         <Tabs>
           <Tab
             href={getHref('automatic')}


### PR DESCRIPTION
Closes https://github.com/BVM-priv/ui-monorepo/issues/141

This PR adds responsive design to network configuration tabs

<img width="423" alt="Captura de Tela 2024-04-30 às 09 15 06" src="https://github.com/BVM-priv/ui-monorepo/assets/6604965/67ab997c-d197-497b-8f9b-00940a7a94f9">

<img width="423" alt="Captura de Tela 2024-04-30 às 09 17 54" src="https://github.com/BVM-priv/ui-monorepo/assets/6604965/77caac0f-08ae-41a9-b926-dad8d500355a">

<img width="759" alt="Captura de Tela 2024-04-30 às 09 19 44" src="https://github.com/BVM-priv/ui-monorepo/assets/6604965/869ed3e5-7082-4aa3-8528-f7483e9c4648">
