### PR TITLE
Fix balance text overflow on tunnel page

### DIFF
--- a/webapp/app/[locale]/tunnel/page.tsx
+++ b/webapp/app/[locale]/tunnel/page.tsx
@@ -108,37 +108,39 @@ const FormContent = function ({ tunnelState, isRunningOperation }: Props) {
           readonly={fromNetworkId === hemi.id}
         />
       </div>
-      <div className="flex justify-between rounded-xl bg-zinc-50 p-4 text-zinc-400">
-        <div className="flex basis-1/3 flex-col gap-y-2">
-          <span className="text-xs font-normal">{t('form.you-send')}</span>
-          <div className="flex max-w-7 sm:max-w-none">
-            <input
-              className="ml-1 max-w-28 bg-transparent text-base font-medium text-neutral-400"
-              disabled={isRunningOperation}
-              onChange={e => updateFromInput(e.target.value)}
-              type="text"
-              value={fromInput}
+      <div className="flex flex-col justify-between rounded-xl bg-zinc-50 p-4 text-zinc-400">
+        <div className="flex flex-row">
+          <div className="flex basis-1/3 flex-col gap-y-2">
+            <span className="text-xs font-normal">{t('form.you-send')}</span>
+            <div className="flex max-w-7 sm:max-w-none">
+              <input
+                className="ml-1 max-w-28 bg-transparent text-base font-medium text-neutral-400"
+                disabled={isRunningOperation}
+                onChange={e => updateFromInput(e.target.value)}
+                type="text"
+                value={fromInput}
+              />
+            </div>
+          </div>
+          <div className="flex basis-2/3 flex-col justify-between gap-y-3">
+            <TokenSelector
+              onSelectToken={updateFromToken}
+              selectedToken={fromToken}
+              tokens={tokenList.tokens.filter(
+                token => token.chainId === fromNetworkId,
+              )}
             />
           </div>
         </div>
-        <div className="flex basis-2/3 flex-col justify-between gap-y-3">
-          <TokenSelector
-            onSelectToken={updateFromToken}
-            selectedToken={fromToken}
-            tokens={tokenList.tokens.filter(
-              token => token.chainId === fromNetworkId,
-            )}
+        <div className="flex items-center justify-end gap-x-2 text-xs font-normal sm:text-sm">
+          {t('form.balance')}: <Balance token={fromToken} />
+          <SetMaxBalance
+            fromToken={fromToken}
+            isRunningOperation={isRunningOperation}
+            onSetMaxBalance={maxBalance =>
+              updateFromInput(formatNumber(maxBalance, 2))
+            }
           />
-          <div className="flex items-center justify-end gap-x-2 text-xs font-normal sm:text-sm">
-            {t('form.balance')}: <Balance token={fromToken} />
-            <SetMaxBalance
-              fromToken={fromToken}
-              isRunningOperation={isRunningOperation}
-              onSetMaxBalance={maxBalance =>
-                updateFromInput(formatNumber(maxBalance, 2))
-              }
-            />
-          </div>
         </div>
       </div>
       <div className="mx-auto flex h-10">
@@ -153,26 +155,28 @@ const FormContent = function ({ tunnelState, isRunningOperation }: Props) {
           readonly={toNetworkId === hemi.id}
         />
       </div>
-      <div className="flex justify-between rounded-xl bg-zinc-50 p-4 text-zinc-400">
-        <div className="flex flex-col gap-y-2">
-          <span className="text-xs font-normal">{t('form.you-receive')}</span>
-          <div className="flex items-center gap-x-2">
-            <span className="text-base font-medium text-neutral-400">
-              {/* Bridging goes 1:1, so output equals input */}
-              <span className="ml-1">{fromInput}</span>
-            </span>
+      <div className="flex flex-col justify-between rounded-xl bg-zinc-50 p-4 text-zinc-400">
+        <div className="flex flex-row">
+          <div className="flex basis-1/3 flex-col gap-y-2">
+            <span className="text-xs font-normal">{t('form.you-receive')}</span>
+            <div className="flex items-center gap-x-2">
+              <span className="text-base font-medium text-neutral-400">
+                {/* Bridging goes 1:1, so output equals input */}
+                <span className="ml-1">{fromInput}</span>
+              </span>
+            </div>
+          </div>
+          <div className="flex basis-2/3 justify-end gap-y-3">
+            <div className="flex items-center justify-end gap-x-2 text-xs">
+              <TokenLogo token={toToken} />
+              <span className="text-sm font-medium text-slate-700">
+                {toToken.symbol}
+              </span>
+            </div>
           </div>
         </div>
-        <div className="flex flex-col justify-between gap-y-3">
-          <div className="flex items-center justify-end gap-x-2 text-xs">
-            <TokenLogo token={toToken} />
-            <span className="text-sm font-medium text-slate-700">
-              {toToken.symbol}
-            </span>
-          </div>
-          <div className="flex items-center justify-end gap-x-2 text-sm font-normal">
-            {t('form.balance')}: <Balance token={toToken} />
-          </div>
+        <div className="flex items-center justify-end gap-x-2 text-sm font-normal">
+          {t('form.balance')}: <Balance token={toToken} />
         </div>
       </div>
     </>


### PR DESCRIPTION
Closes https://github.com/BVM-priv/ui-monorepo/issues/39

This PR fix the balance text overflow described in the issue above.

I fix it by removing the balance text from the inside of token selector `<div>` giving freedom for the text to expand left as shown below:

<img width="397" alt="Captura de Tela 2024-04-30 às 13 48 32" src="https://github.com/BVM-priv/ui-monorepo/assets/6604965/a57eba01-1217-48a7-bec3-ebb71d02274a">
