### PR TITLE
Implement paginator component

### DIFF
--- a/ui-common/components/tabs.tsx
+++ b/ui-common/components/tabs.tsx
@@ -3,7 +3,7 @@
 import Link from 'next-intl/link'
 import { ReactNode } from 'react'
 
-type Button = { onClick: () => void }
+type Button = { onClick?: () => void }
 type Anchor = { href: string }
 
 type TabProps = {
@@ -12,10 +12,8 @@ type TabProps = {
   selected?: boolean
 } & (Anchor | Button)
 
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-function tabIsButton(value: Button | Anchor): value is Button {
-  return (value as Button).onClick !== undefined
-}
+const tabIsButton = (value: Button | Anchor): value is Button =>
+  (value as Button).onClick !== undefined
 
 export const Tab = function ({
   children,
@@ -24,22 +22,23 @@ export const Tab = function ({
   ...props
 }: TabProps) {
   const isButton = tabIsButton(props)
-  const className = `px-6 py-2 text-sm font-medium inline-block ${
+  const className = `px-5 md:px-6 py-2 text-sm font-medium inline-block ${
     selected ? 'text-orange-950' : 'text-slate-300'
-  }`
+  }
+  ${disabled ? 'opacity-40' : 'opacity-100'}`
   return (
     <li className="border-y border-l border-solid border-slate-100 bg-white shadow-sm first:rounded-l-xl last:rounded-r-xl last:border-r">
-      {isButton && (
+      {(isButton || disabled) && (
         <button
           className={className}
           disabled={disabled || selected}
-          onClick={props.onClick}
+          onClick={isButton && !disabled ? props.onClick : undefined}
           type="button"
         >
           {children}
         </button>
       )}
-      {!isButton && (
+      {!isButton && props.href && (
         <Link className={className} href={props.href}>
           {children}
         </Link>

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/paginator.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/paginator.tsx
@@ -1,0 +1,136 @@
+import { ChevronDoubleLeftIcon } from 'components/icons/chevronDoubleLeftIcon'
+import { ChevronDoubleRightIcon } from 'components/icons/chevronDoubleRightIcon'
+import { ChevronLeftIcon } from 'components/icons/chevronLeftIcon'
+import { ChevronRightIcon } from 'components/icons/chevronRightIcon'
+import { Tab, Tabs } from 'ui-common/components/tabs'
+
+type Props = {
+  onPageChange: (page: number) => void
+  pageCount: number
+  pageIndex: number
+  windowSize: number
+}
+
+export const Paginator = function ({
+  onPageChange,
+  pageCount,
+  pageIndex,
+  windowSize,
+}: Props) {
+  const isMobile = windowSize < 1024
+  const pagesToShow = isMobile ? 2 : 5
+
+  let pagesBeforeCurrent = Math.floor((pagesToShow - 1) / 2)
+  let pagesAfterCurrent = pagesToShow - 1 - pagesBeforeCurrent
+
+  if (pageIndex - pagesBeforeCurrent < 0) {
+    pagesAfterCurrent += pagesBeforeCurrent - pageIndex
+    pagesBeforeCurrent = pageIndex
+  }
+
+  if (pageIndex + pagesAfterCurrent >= pageCount) {
+    const extraPages = pagesAfterCurrent - (pageCount - pageIndex - 1)
+    pagesAfterCurrent -= extraPages
+    pagesBeforeCurrent = Math.min(pageIndex, pagesBeforeCurrent + extraPages)
+  }
+
+  const isAtStart = pageIndex === 0
+  const isAtEnd = pageIndex === pageCount - 1
+
+  return (
+    <div className="mt-2 flex items-center justify-center space-x-3">
+      <div
+        className={`flex text-slate-500 ${
+          isAtStart ? 'cursor-default opacity-40' : 'cursor-pointer opacity-100'
+        }`}
+      >
+        <div
+          className={`${
+            !isAtStart
+              ? 'transition-colors duration-300 hover:text-slate-950'
+              : ''
+          }`}
+          onClick={() => onPageChange(0)}
+        >
+          <ChevronDoubleLeftIcon />
+        </div>
+        <div
+          className={`${
+            !isAtStart
+              ? 'transition-colors duration-300 hover:text-slate-950'
+              : ''
+          }`}
+          onClick={() => onPageChange(Math.max(0, pageIndex - 1))}
+        >
+          <ChevronLeftIcon />
+        </div>
+      </div>
+      <Tabs>
+        {pageIndex > pagesBeforeCurrent && (
+          <>
+            <Tab onClick={() => onPageChange(0)} selected={pageIndex === 0}>
+              1
+            </Tab>
+            {pageIndex > pagesBeforeCurrent + 1 && !isMobile && (
+              <Tab disabled>...</Tab>
+            )}
+          </>
+        )}
+        {Array.from(
+          { length: pagesBeforeCurrent + 1 + pagesAfterCurrent },
+          function (_, index) {
+            const pageToShow = pageIndex - pagesBeforeCurrent + index
+            return (
+              <Tab
+                key={pageToShow}
+                onClick={() => onPageChange(pageToShow)}
+                selected={pageIndex === pageToShow}
+              >
+                {pageToShow + 1}
+              </Tab>
+            )
+          },
+        )}
+        {pageIndex < pageCount - pagesAfterCurrent - 1 && (
+          <>
+            {pageIndex < pageCount - pagesAfterCurrent - 2 && !isMobile && (
+              <Tab disabled>...</Tab>
+            )}
+            <Tab
+              onClick={() => onPageChange(pageCount - 1)}
+              selected={pageIndex === pageCount - 1}
+            >
+              {pageCount}
+            </Tab>
+          </>
+        )}
+      </Tabs>
+      <div
+        className={`flex text-slate-500 ${
+          isAtEnd ? 'cursor-default opacity-40' : 'cursor-pointer opacity-100'
+        }`}
+      >
+        <div
+          className={`${
+            !isAtEnd
+              ? 'transition-colors duration-300 hover:text-slate-950'
+              : ''
+          }`}
+          onClick={() => onPageChange(Math.min(pageCount - 1, pageIndex + 1))}
+        >
+          <ChevronRightIcon />
+        </div>
+        <div
+          className={`${
+            !isAtEnd
+              ? 'transition-colors duration-300 hover:text-slate-950'
+              : ''
+          }`}
+          onClick={() => onPageChange(pageCount - 1)}
+        >
+          <ChevronDoubleRightIcon />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -19,7 +19,6 @@ import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { Card } from 'ui-common/components/card'
-import { Tabs, Tab } from 'ui-common/components/tabs'
 import { useWindowSize } from 'ui-common/hooks/useWindowSize'
 import { isDeposit } from 'utils/tunnel'
 import { Chain } from 'viem'
@@ -27,6 +26,7 @@ import { useAccount } from 'wagmi'
 
 import { Amount } from './amount'
 import { Chain as ChainComponent } from './chain'
+import { Paginator } from './paginator'
 import { TxLink } from './txLink'
 import { TxStatus } from './txStatus'
 import { TxTime } from './txTime'
@@ -315,19 +315,12 @@ export const TransactionHistory = function () {
             </div>
           </Card>
           {!loading && pageCount > 1 && (
-            <div className="mt-2 flex justify-center">
-              <Tabs>
-                {Array.from(Array(pageCount).keys()).map(index => (
-                  <Tab
-                    key={index}
-                    onClick={() => table.setPageIndex(index)}
-                    selected={pageIndex === index}
-                  >
-                    {index + 1}
-                  </Tab>
-                ))}
-              </Tabs>
-            </div>
+            <Paginator
+              onPageChange={table.setPageIndex}
+              pageCount={pageCount}
+              pageIndex={pageIndex}
+              windowSize={width}
+            />
           )}
         </>
       )}

--- a/webapp/components/icons/chevronDoubleLeftIcon.tsx
+++ b/webapp/components/icons/chevronDoubleLeftIcon.tsx
@@ -1,0 +1,17 @@
+export const ChevronDoubleLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    fill="none"
+    height="20"
+    width="21"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="m8.417 15-5-5 5-5m8.75 10-5-5 5-5"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.2}
+    />
+  </svg>
+)

--- a/webapp/components/icons/chevronDoubleRightIcon.tsx
+++ b/webapp/components/icons/chevronDoubleRightIcon.tsx
@@ -1,0 +1,19 @@
+export const ChevronDoubleRightIcon = (
+  props: React.SVGProps<SVGSVGElement>,
+) => (
+  <svg
+    fill="none"
+    height="20"
+    width="21"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="m12.583 15 5-5-5-5m-8.75 10 5-5-5-5"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.2}
+    />
+  </svg>
+)

--- a/webapp/components/icons/chevronLeftIcon.tsx
+++ b/webapp/components/icons/chevronLeftIcon.tsx
@@ -1,0 +1,17 @@
+export const ChevronLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    fill="none"
+    height="20"
+    width="21"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="m13 15-5-5 5-5"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.2}
+    />
+  </svg>
+)

--- a/webapp/components/icons/chevronRightIcon.tsx
+++ b/webapp/components/icons/chevronRightIcon.tsx
@@ -1,0 +1,17 @@
+export const ChevronRightIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    fill="none"
+    height="20"
+    width="21"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="m8 15 5-5-5-5"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.2}
+    />
+  </svg>
+)


### PR DESCRIPTION
This PR brings a `paginator` component. It implements a "sliding window" logic that shows a set of pages close to the selected page, as well as always offering an option to jump to the first and last pages if they are outside this range. For desktop view, there are always five windows available and for mobile there are 2 windows.

Screenshoots below

**Desktop:**
![Captura de Tela 2024-05-03 às 10 14 53](https://github.com/BVM-priv/ui-monorepo/assets/36503078/fbd88e3e-c24b-4268-bf53-67b9b7dbb96f)

![Captura de Tela 2024-05-03 às 10 15 04](https://github.com/BVM-priv/ui-monorepo/assets/36503078/91d45a9c-5c40-4058-8355-8527e53f7b68)

![Captura de Tela 2024-05-03 às 10 15 13](https://github.com/BVM-priv/ui-monorepo/assets/36503078/a45f6566-5813-4208-b29a-7170d5b03652)

**Mobile:**
![Captura de Tela 2024-05-03 às 10 15 27](https://github.com/BVM-priv/ui-monorepo/assets/36503078/ebed5d39-44ef-4740-a750-801254d194b7)
![Captura de Tela 2024-05-03 às 10 15 39](https://github.com/BVM-priv/ui-monorepo/assets/36503078/b1e0c55f-d7d9-4014-a19a-2d79b84444b5)
![Captura de Tela 2024-05-03 às 10 15 46](https://github.com/BVM-priv/ui-monorepo/assets/36503078/89235922-14fb-422e-868b-059ab1114f58)

Closes #168 