### PR TITLE
Center CTA in deposits' transaction history

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -243,7 +243,12 @@ const Body = function ({
           {rows.map(row => (
             <tr key={row.id}>
               {row.getVisibleCells().map(cell => (
-                <td className="p-2 text-neutral-700" key={cell.id}>
+                <td
+                  className={`py-2 text-neutral-700 ${
+                    cell.column.columnDef.id === 'action' ? 'text-center' : ''
+                  }`}
+                  key={cell.id}
+                >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
               ))}


### PR DESCRIPTION
Depends on #235 
Closes #205

<img width="643" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/011265fd-c7f7-469a-b3b5-fae3ba341d42">

The `-` are now aligned to the center