### PR TITLE
Fix space when navbar has submenus

### DIFF
--- a/webapp/app/[locale]/navbar/_components/navItem.tsx
+++ b/webapp/app/[locale]/navbar/_components/navItem.tsx
@@ -57,7 +57,7 @@ export const NavItem = function ({
   return (
     <NavRouterItem href={href} isExternal={isExternalLink(href)}>
       <div
-        className={`w-45 flex h-10 cursor-pointer items-center justify-between gap-0 rounded-tl-lg 
+        className={`w-45 mb-3 flex h-10 cursor-pointer items-center justify-between rounded-tl-lg 
             bg-transparent px-2.5 py-2 ${
               isSelected ? 'rounded-lg border border-slate-200' : 'hover group'
             }`}

--- a/webapp/app/[locale]/navbar/_components/navItems.tsx
+++ b/webapp/app/[locale]/navbar/_components/navItems.tsx
@@ -32,7 +32,7 @@ export const NavItems = function ({
   const t = useTranslations('common') as unknown as (key: string) => string
 
   return (
-    <div className="flex flex-col justify-center gap-3">
+    <div className="flex flex-col justify-center">
       {navItems.map(({ id, icon: Icon, href, subMenus }) => (
         <NavItem
           IconLeft={Icon}


### PR DESCRIPTION
As the title says, this PR fix the sidebar menu space when it renders submenus


![Captura de Tela 2024-05-08 às 15 15 56](https://github.com/BVM-priv/ui-monorepo/assets/36503078/6d37e9e5-e160-4865-96ba-6305b84346e1)

Closes #206 