### PR TITLE
Fix navbar to use only first part of path

### DIFF
--- a/webapp/app/[locale]/navbar/index.tsx
+++ b/webapp/app/[locale]/navbar/index.tsx
@@ -20,7 +20,9 @@ export const Navbar = function () {
 
   function getCurrentPath() {
     const cleanedUrl = pathname.replace(/^\/[a-z]{2}/, '').replace(/\/$/, '')
-    return cleanedUrl
+    const firstPath = `/${cleanedUrl.split('/')[1]}`
+
+    return firstPath
   }
 
   const handleItemClick = value =>


### PR DESCRIPTION
Closes https://github.com/BVM-priv/ui-monorepo/issues/204

As discussed on PR https://github.com/BVM-priv/ui-monorepo/pull/239 the navbar will highlight based on first part of path.
So if the current path is `/tunnel/transaction-history`, navbar will highlight only `/tunnel` excluding the rest of the path for all pages.

<img width="972" alt="Captura de Tela 2024-05-09 às 12 35 46" src="https://github.com/BVM-priv/ui-monorepo/assets/6604965/36392b02-b545-4b6a-b834-68530e2b4dd6">
