### PR TITLE
Bring all commits for lerna

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,14 +13,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          # Can't only bring commits since ${{ github.event.before }} yet https://github.com/actions/checkout/issues/1444
+          fetch-depth: 0
 
-      - name: Install Dependencies
-        run: npm ci
+      - name: Setup env
+        uses: ./.github/actions/setup-env
 
       # Migrations must be manually run before deploying the portal
       - name: Run migrations


### PR DESCRIPTION
After merging #226, when trying to deploy with Lerna, it runes the following command

```sh
npx lerna run deploy --scope=migrations-pg --since=31acba9451ccc0bc6ac11f55c28a3bc8458fc80e # previous commit in main
```

However, the `actions/checkout` only has in `.git` the current merged commit, so the comparison causes Lerna to fail

```sh
lerna ERR! Error: Command failed with exit code 128: git diff --name-only 31acba9451ccc0bc6ac11f55c28a3bc8458fc80e -- migrations-pg
lerna ERR! fatal: bad object 31acba9451ccc0bc6ac11f55c28a3bc8458fc80e
```

This PR brings all the commits so this check doesn't fail. There's no way to be a bit more efficient than "bring everything", according to https://github.com/actions/checkout/issues/1444. 

In addition to that, I also used our custom `setup-env` action instead of manually re-doing the setup

Related to 

- [https://github.com/BVM-priv/ui-monorepo/issues/219](https://github.com/BVM-priv/ui-monorepo/issues/219)
- https://github.com/BVM-priv/ui-monorepo/issues/131
- https://github.com/BVM-priv/ui-monorepo/issues/92