### PR TITLE
Fix total in form breaking for large numbers

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/deposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/deposit.tsx
@@ -312,7 +312,7 @@ export const Deposit = function ({ renderForm, state }: Props) {
           updateExtendedErc20Approval={updateExtendedErc20Approval}
         />
       }
-      total={formatNumber(totalDeposit, 3)}
+      total={totalDeposit}
       transactionsList={transactionsList}
     />
   )

--- a/webapp/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/webapp/app/[locale]/tunnel/_components/withdraw.tsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from 'react'
 import { NativeTokenSpecialAddressOnL2 } from 'tokenList'
 import { Token } from 'types/token'
 import { Button } from 'ui-common/components/button'
-import { formatNumber } from 'utils/format'
 import { isNativeToken, ZeroAddress } from 'utils/token'
 import { type Chain, formatUnits, parseUnits } from 'viem'
 import { useAccount } from 'wagmi'
@@ -205,7 +204,7 @@ export const Withdraw = function ({ renderForm, state }: Props) {
             )}
           </Button>
         }
-        total={formatNumber(fromInput, 3)}
+        total={fromInput}
         transactionsList={transactionsList}
       />
       {!!txHash && (


### PR DESCRIPTION
Closes #245

The tunnel form already applied formatting, so when the `Deposit` or the `Withdraw` form sent the total amount, it shouldn't be formatted (we were applying formatting twice).

Now large amounts can be entered and are rendered ok

<img width="468" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/5bb45793-73e8-4928-9e35-bea0b9cc9efc">
