### PR TITLE
Add troubleshooting error link

### DIFF
--- a/webapp/app/[locale]/get-started/configureNetworks.tsx
+++ b/webapp/app/[locale]/get-started/configureNetworks.tsx
@@ -230,9 +230,19 @@ export const ConfigureNetwork = function () {
         {networkConfiguration === 'automatic' && <AutomaticConfiguration />}
         {networkConfiguration === 'manual' && <ManualConfiguration />}
       </div>
-      {/* TODO add link for troubleshooting https://github.com/BVM-priv/ui-monorepo/issues/62 */}
       <p className="text-xs font-normal text-neutral-400">
-        {t('troubleshoot-other-errors')}
+        {t.rich('troubleshoot-other-errors', {
+          link: (chunk: string) => (
+            <a
+              className="cursor-pointer underline"
+              href="https://docs.hemi.xyz/support/portal"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {chunk}
+            </a>
+          ),
+        })}
       </p>
     </div>
   )

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -227,7 +227,7 @@
       "recaptcha-terms-and-conditions": "This site is protected by reCAPTCHA and the Google <privacy>Privacy Policy</privacy> and <terms>Terms of Service</terms> apply.",
       "receive-updates": "Receive marketing updates",
       "rpc-url": "RPC URL",
-      "troubleshoot-other-errors": "Having issues? Troubleshoot other common errors here",
+      "troubleshoot-other-errors": "Having issues? Troubleshoot other <link>common errors</link> here",
       "welcome-pack": "Welcome pack",
       "welcome-pack-description": "Sign up to receive our Hemi welcome pack"
     }

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -227,7 +227,7 @@
       "recaptcha-terms-and-conditions": "Este sitio está protegido por reCAPTCHA y se aplican la <privacy>Política de Privacidad</privacy> y los <terms>Términos y Condiciones</terms> del servicio de Google.",
       "receive-updates": "Quiero recibir actualizaciones de marketing",
       "rpc-url": "URL de RPC",
-      "troubleshoot-other-errors": "¿Tiene problemas? Resuelva otros errores comunes aquí.",
+      "troubleshoot-other-errors": "¿Tiene problemas? Resuelva otros <link>errores comunes</link> aquí.",
       "welcome-pack": "Pack de bienvenida",
       "welcome-pack-description": "Suscríbase para recibir nuestro paquete de bienvenida de Hemi"
     }


### PR DESCRIPTION
Closes #62

This PR adds the link to troubleshoot errors in the `get-started` page

<img width="467" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/ed3ad78b-29df-4611-ab35-794e92d841bc">


