### PR TITLE
Rename native tokens

### DIFF
--- a/hemi-metadata/index.ts
+++ b/hemi-metadata/index.ts
@@ -13,7 +13,7 @@ export const hemiTestnet = {
   nativeCurrency: {
     decimals: 18,
     name: 'Testnet Hemi Ether',
-    symbol: 'thETH',
+    symbol: 'ETH',
   },
   rpcUrls: {
     default: {

--- a/patches/viem+2.7.19.patch
+++ b/patches/viem+2.7.19.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/viem/_cjs/chains/definitions/sepolia.js b/node_modules/viem/_cjs/chains/definitions/sepolia.js
-index a5dceed..59a12b4 100644
+index a5dceed..19e54c1 100644
 --- a/node_modules/viem/_cjs/chains/definitions/sepolia.js
 +++ b/node_modules/viem/_cjs/chains/definitions/sepolia.js
 @@ -5,7 +5,7 @@ const defineChain_js_1 = require("../../utils/chain/defineChain.js");
@@ -7,12 +7,12 @@ index a5dceed..59a12b4 100644
      id: 11155111,
      name: 'Sepolia',
 -    nativeCurrency: { name: 'Sepolia Ether', symbol: 'SEP', decimals: 18 },
-+    nativeCurrency: { name: 'Sepolia Ether', symbol: 'sepETH', decimals: 18 },
++    nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
      rpcUrls: {
          default: {
              http: ['https://rpc.sepolia.org'],
 diff --git a/node_modules/viem/_esm/chains/definitions/sepolia.js b/node_modules/viem/_esm/chains/definitions/sepolia.js
-index 0a45fdf..feeecb7 100644
+index 0a45fdf..655ebc9 100644
 --- a/node_modules/viem/_esm/chains/definitions/sepolia.js
 +++ b/node_modules/viem/_esm/chains/definitions/sepolia.js
 @@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js';
@@ -20,12 +20,12 @@ index 0a45fdf..feeecb7 100644
      id: 11155111,
      name: 'Sepolia',
 -    nativeCurrency: { name: 'Sepolia Ether', symbol: 'SEP', decimals: 18 },
-+    nativeCurrency: { name: 'Sepolia Ether', symbol: 'sepETH', decimals: 18 },
++    nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
      rpcUrls: {
          default: {
              http: ['https://rpc.sepolia.org'],
 diff --git a/node_modules/viem/chains/definitions/sepolia.ts b/node_modules/viem/chains/definitions/sepolia.ts
-index 29ade81..b2898df 100644
+index 29ade81..77b7c9e 100644
 --- a/node_modules/viem/chains/definitions/sepolia.ts
 +++ b/node_modules/viem/chains/definitions/sepolia.ts
 @@ -3,7 +3,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
@@ -33,7 +33,7 @@ index 29ade81..b2898df 100644
    id: 11_155_111,
    name: 'Sepolia',
 -  nativeCurrency: { name: 'Sepolia Ether', symbol: 'SEP', decimals: 18 },
-+  nativeCurrency: { name: 'Sepolia Ether', symbol: 'sepETH', decimals: 18 },
++  nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
    rpcUrls: {
      default: {
        http: ['https://rpc.sepolia.org'],

--- a/webapp/app/[locale]/get-started/welcomePack.tsx
+++ b/webapp/app/[locale]/get-started/welcomePack.tsx
@@ -10,6 +10,7 @@ import { FormEvent, ReactNode, useState } from 'react'
 import { Button } from 'ui-common/components/button'
 import { Card } from 'ui-common/components/card'
 import { useQueryParams } from 'ui-common/hooks/useQueryParams'
+import { sepolia } from 'viem/chains'
 
 import { Btc } from './_icons/btc'
 import { Eth } from './_icons/eth'
@@ -23,7 +24,7 @@ const giveAwayTokens = hemi.testnet
       {
         amount: 0.2,
         icon: <Eth />,
-        symbol: 'sepETH',
+        symbol: sepolia.nativeCurrency.symbol,
       },
       {
         amount: 0.01,


### PR DESCRIPTION
This PR renames `thETH` and `sepETH` to plain `ETH`. 

Closes https://github.com/BVM-priv/ui-monorepo/issues/218

Note: Eventually, the `hemi sepolia` chain definition will come from [this package](https://github.com/hemilabs/hemi-viem)


![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/ce282a11-bd2c-488e-a664-863ba249db46)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/48ef7550-ae0f-4af7-8862-e32be1b5a92b)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/3e791efe-bf1d-403a-815e-91d66c9f0a1c)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/9ab665d4-d5c0-4073-a1d4-34fe9dfabce4)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/1954124d-50b6-40a6-a13d-d9995cd77270)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/fe9e1127-7e0a-4fbb-b72e-c923231f927b)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/5a3c9ee3-7021-4952-9c7c-7c77841fac6d)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/97ca1d18-880e-41cd-b3c4-8ffe06b0db1b)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/8de6c19a-ab27-4f79-9255-22e428f3bb59)

