### PR TITLE
Force deployment of claim-tokens

### DIFF
--- a/claim-tokens/package.json
+++ b/claim-tokens/package.json
@@ -32,7 +32,7 @@
     "knex": "3.1.0",
     "p-tap": "3.1.0",
     "pg": "8.11.3",
-    "snakecase-keys": "6.0.0"
+    "snakecase-keys": "8.0.0"
   },
   "engines": {
     "node": ">=16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "knex": "3.1.0",
         "p-tap": "3.1.0",
         "pg": "8.11.3",
-        "snakecase-keys": "6.0.0"
+        "snakecase-keys": "8.0.0"
       },
       "devDependencies": {
         "nock": "14.0.0-beta.5",
@@ -24275,24 +24275,24 @@
       }
     },
     "node_modules/snakecase-keys": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-6.0.0.tgz",
-      "integrity": "sha512-E5a0C3rcj+Cvq+dt41mw6tV6Wx78/JpQyR71GDiyGSXdp3jEvKxv8pIP0tOHmEMiqKVZSwflXtlWwqNn5oTbbQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-8.0.0.tgz",
+      "integrity": "sha512-qS7XvESuFxskrmD8/O9tOMdLdV9YTuPfNLdRJIvNJKNEZtH9XVPwmZioROwl4TsVDbOFqlQ/o7pURuF8MnjYsg==",
       "dependencies": {
         "map-obj": "^4.1.0",
         "snake-case": "^3.0.4",
-        "type-fest": "^3.12.0"
+        "type-fest": "^4.15.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/snakecase-keys/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"


### PR DESCRIPTION
Related to #98 

After merging #265 there were no changes in `claim-tokens`, so Lerna skipped the deployment 🤦🏽  This PR updates a dep to force the deployment