### PR TITLE
Fix connect wallet text for mobile

### DIFF
--- a/webapp/components/connectWallet.tsx
+++ b/webapp/components/connectWallet.tsx
@@ -10,7 +10,9 @@ export const ConnectWallet = ({ heading, subheading }: Props) => (
   <Card borderColor="gray" padding="large" radius="large">
     <div className="flex h-[50dvh] w-full flex-col items-center justify-center gap-y-2">
       <h3 className="text-2xl font-normal text-black">{heading}</h3>
-      <p className="text-base font-normal text-slate-500">{subheading}</p>
+      <p className="text-center text-base font-normal text-slate-500">
+        {subheading}
+      </p>
       <div className="mt-2">
         <ConnectButton />
       </div>


### PR DESCRIPTION
Screenshot:
<img width="421" alt="Captura de Tela 2024-05-13 às 15 49 52" src="https://github.com/BVM-priv/ui-monorepo/assets/36503078/a5ab2d9c-9a63-4fdd-b3e0-2e809d3b77a3">

Closes #253 