### PR TITLE
Simplify cors approach

### DIFF
--- a/claim-tokens/serverless.yml
+++ b/claim-tokens/serverless.yml
@@ -18,11 +18,7 @@ functions:
       RECAPTCHA_SECRET_KEY: ${env:RECAPTCHA_SECRET_KEY, ''}
     events:
       - http:
-          cors:
-            headers:
-              - Content-Type
-            origins:
-              - ${self:functions.claim-tokens.environment.MARKETING_DOMAIN_URL}:*
+          cors: true
           method: post
           path: /claim
     handler: ./index.post


### PR DESCRIPTION
Simplifying the `cors` approach because it doesn't work like this 😄  [Cors headers](https://github.com/BVM-priv/ui-monorepo/blob/ed2a3a40b8385e23caf249cec27beb562d002881/claim-tokens/index.js#L17) are being returned already from lambda