### PR TITLE
Fix glitching of connect to correct chain

### DIFF
--- a/webapp/components/switchToNetwork.tsx
+++ b/webapp/components/switchToNetwork.tsx
@@ -11,7 +11,7 @@ type Props = {
 }
 
 export const SwitchToNetwork = function ({ selectedNetwork }: Props) {
-  const { status } = useAccount()
+  const { chainId } = useAccount()
   const { switchChain } = useSwitchChain()
   const isConnectedToExpectedNetwork =
     useIsConnectedToExpectedNetwork(selectedNetwork)
@@ -19,8 +19,9 @@ export const SwitchToNetwork = function ({ selectedNetwork }: Props) {
   const t = useTranslations('common')
 
   const walletTargetNetwork = useChain(selectedNetwork)
-
-  if (isConnectedToExpectedNetwork || status !== 'connected') {
+  // status has different internal status to account for. If "chainId" is undefined, it is disconnected.
+  // If defined, it is connected to anything
+  if (chainId === undefined || isConnectedToExpectedNetwork) {
     return null
   }
 

--- a/webapp/hooks/useIsConnectedToExpectedNetwork.ts
+++ b/webapp/hooks/useIsConnectedToExpectedNetwork.ts
@@ -4,6 +4,6 @@ import { useAccount } from 'wagmi'
 export const useIsConnectedToExpectedNetwork = function (
   expectedChainId: Chain['id'],
 ) {
-  const { chain } = useAccount()
-  return chain?.id === expectedChainId
+  const { chainId } = useAccount()
+  return chainId === expectedChainId
 }


### PR DESCRIPTION
Closes #250

The "Connect to <correct chain>" doesn't glitch anymore when appearing

https://github.com/BVM-priv/ui-monorepo/assets/352474/f226588a-129d-4bde-914b-b8c010d59bed

