### PR TITLE
Add zappier url to claim-tokens in correct stage

### DIFF
--- a/claim-tokens/config/default.json
+++ b/claim-tokens/config/default.json
@@ -1,4 +1,7 @@
 {
+  "email": {
+    "webhook": "https://hooks.zapier.com/hooks/catch/17630282/3e9hj8q"
+  },
   "ipQualityScore": {
     "maxScore": 75,
     "url": "https://www.ipqualityscore.com/api/json"

--- a/claim-tokens/config/prod.json
+++ b/claim-tokens/config/prod.json
@@ -1,5 +1,0 @@
-{
-  "email": {
-    "webhook": "https://hooks.zapier.com/hooks/catch/17630282/3e9hj8q"
-  }
-}


### PR DESCRIPTION
The Zappier URL was set as `prod` stage, but as this is part of the testing, I am not sure if this URL will be final or not. Either way, moving it to `default` so we can properly call hubspot now