### PR TITLE
Add missing return

### DIFF
--- a/claim-tokens/index.js
+++ b/claim-tokens/index.js
@@ -168,6 +168,7 @@ const verifyIpQualityScore = ip =>
 const verifyIP = function (ip) {
   if (!config.get('ipQualityScore.enableCheck')) {
     logger.debug('IP verification is disabled')
+    return Promise.resolve()
   }
   return Promise.all([
     verifyIpQualityScore(ip),


### PR DESCRIPTION
After logging that the IP check is disabled in #284 , a `return` was missing 🤦🏽 

The disabling worked ok
<img width="718" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/f056d0f9-340d-413e-90f8-0db9e8bdd9d2">
