### PR TITLE
Fix blank space in navbar

### DIFF
--- a/webapp/app/[locale]/navbar/index.tsx
+++ b/webapp/app/[locale]/navbar/index.tsx
@@ -31,7 +31,7 @@ export const Navbar = function ({ onItemClick }: Props) {
   }
 
   return (
-    <div className="md:h-98vh flex h-[calc(100dvh-64px)] flex-col pr-5 pt-3 md:pt-0 [&>*]:md:ml-4">
+    <div className="md:h-98vh flex h-[calc(100dvh-64px)] flex-col pt-3 md:pt-0 [&>*]:pr-4 [&>*]:md:ml-4">
       <div className="mb-2 mt-8 hidden md:mb-10 md:block">
         <div className="mt-4 hidden h-10 w-28 md:block">
           <Link href="/tunnel">


### PR DESCRIPTION
After merging #289 , there was a dynamic blank space between the logos and the rest of the nav items. As I did that PR on the mac screen, it was barely noticeable (as you can't see it in the video), but on a large monitor, it is very visible.

This PR fixes that. And I also aligned the logo to the left to be aligned with the selected current page (instead of being aligned to the logo of each item)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/d1a36bc6-7389-43d4-83fa-f6915e943798)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/8c14c04a-7d9c-445b-acc8-2edd7812ebb0)

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/9222c724-8e51-4e2b-8c59-85a5a7a12814)


Closes #291 