### PR TITLE
Fix styling issue in tx status

### DIFF
--- a/webapp/components/transactionStatus.tsx
+++ b/webapp/components/transactionStatus.tsx
@@ -118,13 +118,15 @@ export const TransactionStatus = function ({ status, text, txHash }: Props) {
 
   return (
     <a
-      className={`cursor-pointer ${!txHash ? 'pointer-events-none' : ''}`}
+      className={`min-w-72 file:cursor-pointer ${
+        !txHash ? 'pointer-events-none' : ''
+      }`}
       href={`${chain.blockExplorers.default.url}/tx/${txHash}`}
       rel="noopener noreferrer"
       target="_blank"
     >
       <Card padding="medium">
-        <div className="flex min-w-72 items-start gap-x-2">
+        <div className="flex items-start gap-x-2">
           <div className="w-6">{icons[status]}</div>
           <div className="flex w-full flex-col gap-y-1">
             <p className="text-sm font-semibold leading-none">{text}</p>


### PR DESCRIPTION
This PR fixes a bug in which the Arrow for the Explorer link was outside of the toast box.

![image](https://github.com/BVM-priv/ui-monorepo/assets/352474/994697b8-b161-4daa-b6a4-2ac3c60ba5d2)

Closes https://github.com/BVM-priv/ui-monorepo/issues/299
Closes https://github.com/BVM-priv/PM-Tracking-L2/issues/253