### PR TITLE
Disable token selector when running operation

### DIFF
--- a/webapp/app/[locale]/tunnel/page.tsx
+++ b/webapp/app/[locale]/tunnel/page.tsx
@@ -106,6 +106,7 @@ const FormContent = function ({ tunnelState, isRunningOperation }: Props) {
       <div className="flex w-full items-center justify-between text-sm">
         <span>{t('form.from-network')}</span>
         <NetworkSelector
+          disabled={isRunningOperation}
           networkId={fromNetworkId}
           networks={networks.filter(chain => chain.id !== toNetworkId)}
           onSelectNetwork={updateFromNetwork}
@@ -128,6 +129,7 @@ const FormContent = function ({ tunnelState, isRunningOperation }: Props) {
           </div>
           <div className="flex basis-2/3 flex-col justify-between gap-y-3">
             <TokenSelector
+              disabled={isRunningOperation}
               onSelectToken={updateFromToken}
               selectedToken={fromToken}
               tokens={tokenList.tokens.filter(
@@ -153,6 +155,7 @@ const FormContent = function ({ tunnelState, isRunningOperation }: Props) {
       <div className="flex items-center justify-between text-sm">
         <span>{t('form.to-network')}</span>
         <NetworkSelector
+          disabled
           networkId={toNetworkId}
           networks={networks.filter(chain => chain.id !== fromNetworkId)}
           onSelectNetwork={updateToNetwork}

--- a/webapp/components/TokenSelector.tsx
+++ b/webapp/components/TokenSelector.tsx
@@ -42,6 +42,7 @@ const MagnifyingGlass = () => (
 )
 
 type Props = {
+  disabled: boolean
   onSelectToken: (token: Token) => void
   selectedToken: Token
   tokens: Token[]
@@ -103,6 +104,7 @@ const TokenList = function ({
 }
 
 export const TokenSelector = function ({
+  disabled,
   onSelectToken,
   selectedToken,
   tokens,
@@ -124,6 +126,7 @@ export const TokenSelector = function ({
     <>
       <button
         className="flex items-center justify-end gap-x-2 text-xs"
+        disabled={disabled}
         onClick={openModal}
         type="button"
       >

--- a/webapp/components/networkSelector.tsx
+++ b/webapp/components/networkSelector.tsx
@@ -7,6 +7,7 @@ import { useOnClickOutside } from 'ui-common/hooks/useOnClickOutside'
 import { type Chain } from 'viem'
 
 type Props = {
+  disabled: boolean
   networkId: Chain['id'] | undefined
   networks: Chain[]
   onSelectNetwork: (network: Chain['id']) => void
@@ -14,6 +15,7 @@ type Props = {
 }
 
 export const NetworkSelector = function ({
+  disabled,
   networkId,
   networks = [],
   onSelectNetwork,
@@ -51,6 +53,7 @@ export const NetworkSelector = function ({
     <>
       <button
         className={`${commonCss} relative cursor-pointer`}
+        disabled={disabled}
         onClick={() => setShowNetworkDropdown(true)}
         type="button"
       >


### PR DESCRIPTION
This PR blocks the Token and Network selectors so they are not opened while an operation is running. The "to" network is always disabled because you can't change the destination chain (nor the origin chain, for that matter of fact 😄 )

Closes #297 