### PR TITLE
Fix gas estimations label for ERC20 tokens

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/reviewWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewWithdrawal.tsx
@@ -240,9 +240,7 @@ const Step = function ({ gas, icon, isLoading, text, status }: StepProps) {
                 <FuelIcon />
               </div>
               <span className="text-[10px] font-normal sm:text-xs">
-                {gas.amount === '0'
-                  ? '-'
-                  : `${getFormattedValue(gas.amount)} ${gas.symbol}`}
+                {`${getFormattedValue(gas.amount)} ${gas.symbol}`}
               </span>
             </>
           ) : null}


### PR DESCRIPTION
This PR fixes the gas estimations label. The function `getFormattedValue` is already formatting the text, so we don't need the `gas.amount === '0'` render conditional (same as tunnel is doing).

![Captura de Tela 2024-05-27 às 11 28 31](https://github.com/BVM-priv/ui-monorepo/assets/36503078/5d4e2dfd-aa73-4a97-a803-8b6e62d5d006)



Closes #312 