### PR TITLE
Hide bitcoin kit link in navbar

### DIFF
--- a/webapp/app/[locale]/navbar/navData.ts
+++ b/webapp/app/[locale]/navbar/navData.ts
@@ -1,6 +1,6 @@
 import { hemi } from 'app/networks'
 import { ChecklistIcon } from 'components/icons/checklistIcon'
-import { CodeInsertIcon } from 'components/icons/codeInsertIcon'
+// import { CodeInsertIcon } from 'components/icons/codeInsertIcon'
 import { DexIcon } from 'components/icons/dexIcon'
 import { ElectroCardiogramIcon } from 'components/icons/electroCardiogramIcon'
 import { ExplorerIcon } from 'components/icons/explorerIcon'
@@ -48,11 +48,11 @@ export const navItems: NavItemData[] = [
       },
     ],
   },
-  {
-    href: '',
-    icon: CodeInsertIcon,
-    id: 'bitcoinhkit',
-  },
+  // {
+  //   href: '',
+  //   icon: CodeInsertIcon,
+  //   id: 'bitcoinhkit',
+  // },
 ]
 
 export const navItemsBottom: NavItemData[] = [


### PR DESCRIPTION
As requested by @rmilrad 


<img width="262" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/9016f4bf-2383-4880-b09f-dbb8133a5d9a">

it will be re-added once that page is defined

related to #161 