### PR TITLE
Use custom cache strategy for withdrawals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13054,9 +13054,9 @@
       }
     },
     "node_modules/eth-rpc-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eth-rpc-cache/-/eth-rpc-cache-1.0.0.tgz",
-      "integrity": "sha512-wgulGdknjGZdVQ19XYuaVimir7vNXvWIwGPQpZ1K8+E2SAGFkCwIm0g9UFg6oAC4Bjc0MZ10V0DcEtsbBjnBsQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eth-rpc-cache/-/eth-rpc-cache-2.0.0.tgz",
+      "integrity": "sha512-GK/w6hJ8IZ1l+LBTZyWKZMokV2uT/kv1jYI84JG69T5J+EsVF17x9iC3Ug9jYOs9HLA+anhDcl8KA8bhxXzYaw==",
       "dependencies": {
         "debug": "4.3.4",
         "json-stable-stringify": "1.0.1",
@@ -27137,7 +27137,7 @@
     "ui-common": {
       "version": "1.0.0",
       "dependencies": {
-        "eth-rpc-cache": "1.0.0",
+        "eth-rpc-cache": "2.0.0",
         "hemi-metadata": "1.0.0"
       },
       "devDependencies": {

--- a/ui-common/package.json
+++ b/ui-common/package.json
@@ -16,7 +16,7 @@
     "react-dom": "18.2.0"
   },
   "dependencies": {
-    "eth-rpc-cache": "1.0.0",
+    "eth-rpc-cache": "2.0.0",
     "hemi-metadata": "1.0.0"
   }
 }

--- a/ui-common/utils/cache.ts
+++ b/ui-common/utils/cache.ts
@@ -1,11 +1,16 @@
 import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
-import { createEthRpcCache } from 'eth-rpc-cache'
+import {
+  createEthRpcCache,
+  perBlockStrategy,
+  permanentStrategy,
+} from 'eth-rpc-cache'
 
 export const cacheProvider = function <
   T extends JsonRpcProvider | Web3Provider,
->(provider: T) {
-  const cached = createEthRpcCache((method, params) =>
-    provider.send(method, params),
+>(provider: T, strategies: (typeof permanentStrategy)[] = []) {
+  const cached = createEthRpcCache(
+    (method, params) => provider.send(method, params),
+    { strategies: [perBlockStrategy, permanentStrategy, ...strategies] },
   )
   const newProvider: T = {
     ...provider,

--- a/webapp/hooks/useEthersSigner.ts
+++ b/webapp/hooks/useEthersSigner.ts
@@ -3,6 +3,7 @@ import { isChainSupported } from 'app/networks'
 import { providers } from 'ethers'
 import { useMemo } from 'react'
 import { cacheProvider } from 'ui-common/utils/cache'
+import { withdrawalsStrategy } from 'utils/cacheStrategies'
 import type { Chain, HttpTransport, PublicClient } from 'viem'
 import { Config, useConnectorClient, usePublicClient } from 'wagmi'
 
@@ -17,10 +18,14 @@ function publicClientToProvider(publicClient: PublicClient) {
   if (transport.type === 'fallback')
     return new providers.FallbackProvider(
       (transport.transports as ReturnType<HttpTransport>[]).map(({ value }) =>
-        cacheProvider(new providers.JsonRpcProvider(value?.url, network)),
+        cacheProvider(new providers.JsonRpcProvider(value?.url, network), [
+          withdrawalsStrategy,
+        ]),
       ),
     )
-  return cacheProvider(new providers.JsonRpcProvider(transport.url, network))
+  return cacheProvider(new providers.JsonRpcProvider(transport.url, network), [
+    withdrawalsStrategy,
+  ])
 }
 
 // https://wagmi.sh/react/guides/ethers#connector-client-%E2%86%92-signer
@@ -34,7 +39,10 @@ function clientToSigner(client: any) {
     ensAddress: chain.contracts?.ensRegistry?.address,
     name: chain.name,
   }
-  const provider = cacheProvider(new providers.Web3Provider(transport, network))
+  const provider = cacheProvider(
+    new providers.Web3Provider(transport, network),
+    [withdrawalsStrategy],
+  )
   const signer = provider.getSigner(account.address)
   return signer
 }

--- a/webapp/utils/cacheStrategies.ts
+++ b/webapp/utils/cacheStrategies.ts
@@ -1,0 +1,64 @@
+// This strategy is used to cache some of the requests done by the OP sdk
+// when fetching data for withdrawals
+import { Hash, keccak256, isHash } from 'viem'
+
+type RpcCallParam = {
+  data: Hash
+  to: Hash
+}
+
+const isWithdrawalEthCall = function (obj: unknown): obj is RpcCallParam {
+  const casted = obj as RpcCallParam
+  return casted !== undefined && isHash(casted.data)
+}
+
+const getSignature = (method: string) =>
+  keccak256(Buffer.from(method)).slice(0, 10)
+
+const cachePerMethod = [
+  {
+    method: 'successfulMessages(bytes32)',
+    strategy: 'block',
+  },
+  {
+    method: 'failedMessages(bytes32)',
+    strategy: 'block',
+  },
+  {
+    method: 'version()',
+    strategy: 'permanent',
+  },
+  {
+    method: 'getL2OutputIndexAfter(uint256)',
+    strategy: 'block',
+  },
+  {
+    method: 'getL2Output(uint256)',
+    strategy: 'block',
+  },
+  {
+    method: 'provenWithdrawals(bytes32)',
+    strategy: 'block',
+  },
+]
+
+const cacheIndexedData = cachePerMethod.reduce(
+  (acc, { method, strategy }) => ({
+    ...acc,
+    [getSignature(method)]: strategy,
+  }),
+  {},
+)
+
+export const withdrawalsStrategy = {
+  methods: ['eth_call'],
+  name: 'withdrawals-strategy',
+  resolver(_: string, params: unknown[]) {
+    if (!isWithdrawalEthCall(params[0])) {
+      // doesn't have the structure of eth_call - do not use cache
+      return undefined
+    }
+    const { data } = params[0]
+    return cacheIndexedData[data.slice(0, 10)]
+  },
+}


### PR DESCRIPTION
Closes #199

This PR adds a custom strategy to cache some of the `eth_call` calls when requesting the status for a  withdrawal