### PR TITLE
Added tooltip to amount on transaction history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8095,6 +8095,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/accounting": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/accounting/-/accounting-0.4.1.tgz",
+      "integrity": "sha512-RU6KY9Y5wllyaCNBo1W11ZOTnTHMMgOZkIwdOOs6W5ibMTp72i4xIbEA48djxVGqMNTUNbvrP/1nWg5Af5m2gQ=="
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -24388,6 +24393,23 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/smart-round": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/smart-round/-/smart-round-1.0.0.tgz",
+      "integrity": "sha512-gniK9KmzrcotH2v3t6n+2DpHmdiUWg2YxiQ4XYphD2sgX9/w9Do1Tmgeh4I3Fk/uj2Qp+BIZRD8GmnD2fI14Dw==",
+      "dependencies": {
+        "accounting": "^0.4.1",
+        "bignumber.js": "^7.2.1"
+      }
+    },
+    "node_modules/smart-round/node_modules/bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -27303,6 +27325,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-loading-skeleton": "3.4.0",
+        "smart-round": "^1.0.0",
         "ui-common": "1.0.0",
         "viem": "2.7.19",
         "wagmi": "2.5.7",

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/amount.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/amount.tsx
@@ -1,8 +1,11 @@
 import { TunnelOperation } from 'app/context/tunnelHistoryContext/types'
 import { hemi } from 'app/networks'
+import Big from 'big.js'
 import { ChainLogo } from 'components/chainLogo'
 import { TokenLogo } from 'components/tokenLogo'
-import { getFormattedValue } from 'utils/format'
+import smartRound from 'smart-round'
+import { Token } from 'types/token'
+import { Tooltip } from 'ui-common/components/tooltip'
 import {
   getL2TokenByBridgedAddress,
   getNativeToken,
@@ -17,6 +20,61 @@ type Props = {
   operation: TunnelOperation
 }
 
+type ValueProps = {
+  amount: string
+  token: Token
+}
+
+const InfoIcon = () => (
+  <svg
+    fill="none"
+    height="16"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      className="fill-neutral-400/30"
+      clipRule="evenodd"
+      d="M1.33301 7.98991C1.33301 4.30991 4.31967 1.32324 7.99967 1.32324C11.6797 1.32324 14.6663 4.30991 14.6663 7.98991C14.6663 11.6699 11.6797 14.6566 7.99967 14.6566C4.31967 14.6566 1.33301 11.6699 1.33301 7.98991ZM2.66602 7.98958C2.66602 10.9296 5.05935 13.3229 7.99935 13.3229C10.9393 13.3229 13.3327 10.9296 13.3327 7.98958C13.3327 5.04958 10.9393 2.65625 7.99935 2.65625C5.05935 2.65625 2.66602 5.04958 2.66602 7.98958ZM7.19922 5.32344C7.19922 4.88161 7.55739 4.52344 7.99922 4.52344C8.44105 4.52344 8.79922 4.88161 8.79922 5.32344C8.79922 5.76526 8.44105 6.12344 7.99922 6.12344C7.55739 6.12344 7.19922 5.76526 7.19922 5.32344ZM7.33203 7.98991C7.33203 7.62172 7.63051 7.32324 7.9987 7.32324C8.36689 7.32324 8.66536 7.62172 8.66536 7.98991V10.6566C8.66536 11.0248 8.36689 11.3232 7.9987 11.3232C7.63051 11.3232 7.33203 11.0248 7.33203 10.6566V7.98991Z"
+      fillRule="evenodd"
+    />
+  </svg>
+)
+
+const Logo = function ({ l1ChainId, operation }: Props) {
+  const { l1Token, l2Token } = operation
+
+  const tokenAddress = (isDeposit(operation) ? l1Token : l2Token) as Address
+  const chainId = isDeposit(operation) ? l1ChainId : hemi.id
+  const token =
+    getTokenByAddress(tokenAddress, chainId) ??
+    getL2TokenByBridgedAddress(tokenAddress, chainId) ??
+    getNativeToken(chainId)
+
+  return isNativeToken(token) ? (
+    <ChainLogo chainId={chainId} />
+  ) : (
+    <TokenLogo token={token} />
+  )
+}
+
+// eslint-disable-next-line arrow-body-style
+const formatAmount = (amount, decimals) => {
+  const value = amount.replace(/,/g, '')
+
+  if (Big(value).lt('0.000001')) {
+    return '< 0.000001'
+  }
+  const rounder = smartRound(6, 0, decimals)
+
+  return rounder(value, true)
+}
+
+const Value = ({ amount, token }: ValueProps) => (
+  <span className="text-sm font-normal">{`${amount} ${token.symbol}`}</span>
+)
+
 export const Amount = function ({ l1ChainId, operation }: Props) {
   const { amount, l1Token, l2Token } = operation
 
@@ -27,16 +85,30 @@ export const Amount = function ({ l1ChainId, operation }: Props) {
     getL2TokenByBridgedAddress(tokenAddress, chainId) ??
     getNativeToken(chainId)
 
+  const originalAmount = formatUnits(BigInt(amount), token.decimals).toString()
+
+  const formattedAmount = formatAmount(originalAmount, token.decimals)
+  const showTooltip = formattedAmount.includes('<')
+
   return (
     <div className="flex items-center gap-x-1">
-      {isNativeToken(token) ? (
-        <ChainLogo chainId={chainId} />
-      ) : (
-        <TokenLogo token={token} />
+      <Logo l1ChainId={l1ChainId} operation={operation} />
+      <Value amount={formattedAmount} token={token} />
+      {showTooltip && (
+        <Tooltip
+          id="amount-tooltip"
+          overlay={
+            <div className="flex items-center gap-x-1">
+              <Logo l1ChainId={l1ChainId} operation={operation} />
+              <span className="text-sm font-normal">
+                {`${originalAmount} ${token.symbol}`}
+              </span>
+            </div>
+          }
+        >
+          <InfoIcon />
+        </Tooltip>
       )}
-      <span className="text-sm font-normal">{`${getFormattedValue(
-        formatUnits(BigInt(amount), token.decimals).toString(),
-      )} ${token.symbol}`}</span>
     </div>
   )
 }

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -176,7 +176,7 @@ const useTransactionsHistory = function () {
   }
 }
 
-const pageSize = 10
+const pageSize = 8
 
 const Body = function ({
   columns,

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -33,6 +33,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-loading-skeleton": "3.4.0",
+    "smart-round": "^1.0.0",
     "ui-common": "1.0.0",
     "viem": "2.7.19",
     "wagmi": "2.5.7",


### PR DESCRIPTION
This PR includes:
- Decrease from 10 to 8 the page size of Transaction History pagination
- New tooltip when transaction amount is less than 0.000001

Closes #300
Closes #318

<img width="859" alt="Captura de Tela 2024-06-20 às 10 57 49" src="https://github.com/BVM-priv/ui-monorepo/assets/6604965/975e1650-352a-4442-874c-45615900a7a9">
