### PR TITLE
Bump eslint-config-bloq version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@typescript-eslint/parser": "6.16.0",
         "chai": "4.4.1",
         "eslint": "8.56.0",
-        "eslint-config-bloq": "4.0.0",
+        "eslint-config-bloq": "4.1.0",
         "eslint-plugin-html": "7.1.0",
         "eslint-plugin-markdownlint": "0.5.0",
         "husky": "4.3.8",
@@ -1750,16 +1750,17 @@
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.36.1",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.38.0.tgz",
+      "integrity": "sha512-TFac4Bnv0ZYNkEeDnOWHQhaS1elWlvOCQxH06iHeu5iffs+hCaLVIZJwF+FqksQi68R4i66Pu+4DfFGvble+Uw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~3.1.0"
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+        "node": ">=16"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -8471,6 +8472,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -10109,8 +10119,9 @@
     },
     "node_modules/comment-parser": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -12270,21 +12281,19 @@
       }
     },
     "node_modules/eslint-config-bloq": {
-      "version": "4.0.0",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-bloq/-/eslint-config-bloq-4.1.0.tgz",
+      "integrity": "sha512-hEJ+y5ek5psoUKv5PBQdaiRycjIHndoLGdKIDiu0jdognd6303ubsl6RksA3IH5VyxfsGBeWpadPYMqCg2+oDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-config-next": "^13.0.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-jsdoc": "^39.3.2",
-        "eslint-plugin-mocha": "^10.0.5",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prefer-arrow": "^1.2.3",
+        "eslint-config-prettier": "^8.0.0",
+        "eslint-plugin-import": "^2.0.0",
+        "eslint-plugin-jsdoc": "^43.0.0",
+        "eslint-plugin-mocha": "^10.0.0",
+        "eslint-plugin-node": "^11.0.0",
+        "eslint-plugin-prefer-arrow": "^1.0.0",
         "eslint-plugin-promise": "^6.0.0"
-      },
-      "peerDependencies": {
-        "next": "^13.0.0"
       }
     },
     "node_modules/eslint-config-next": {
@@ -12515,20 +12524,22 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "39.9.1",
+      "version": "43.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.2.0.tgz",
+      "integrity": "sha512-Hst7XUfqh28UmPD52oTXmjaRN3d0KrmOZdgtp4h9/VHUJD3Evoo82ZGXi1TtRDWgWhvqDIRI63O49H0eH7NrZQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.36.1",
+        "@es-joy/jsdoccomment": "~0.38.0",
+        "are-docs-informative": "^0.0.2",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "semver": "^7.3.8",
+        "esquery": "^1.5.0",
+        "semver": "^7.5.0",
         "spdx-expression-parse": "^3.0.1"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+        "node": ">=16"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
@@ -16244,9 +16255,10 @@
       "dev": true
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "3.1.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@typescript-eslint/parser": "6.16.0",
     "chai": "4.4.1",
     "eslint": "8.56.0",
-    "eslint-config-bloq": "4.0.0",
+    "eslint-config-bloq": "4.1.0",
     "eslint-plugin-html": "7.1.0",
     "eslint-plugin-markdownlint": "0.5.0",
     "husky": "4.3.8",

--- a/webapp/tailwind.config.ts
+++ b/webapp/tailwind.config.ts
@@ -34,8 +34,6 @@ const config: Config = {
       },
       // See https://www.figma.com/file/4fVd9wneclsvYDYD95ApZ9/Hemi-Portal?node-id=8%3A5122&mode=dev
       colors: {
-        // Easier to read sorted like this, instead of sorting asc (as string) as the rules indicates
-        /* eslint-disable sort-keys */
         orange: {
           1: '#FF4D00',
           50: '#FFFBF8',
@@ -64,7 +62,6 @@ const config: Config = {
           900: '#1A1B1B',
           950: '#000202',
         },
-        /* eslint-disable sort-keys */
       },
       fontFamily: {
         inter: '--font-inter',


### PR DESCRIPTION
Tiny PR that updates `eslint-config-bloq` to the latest version, and removes a inline-disabling of a rule, given that now the sorting is correct