### PR TITLE
Fix review withdrawal not loading after withdraw

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/claim.tsx
+++ b/webapp/app/[locale]/tunnel/_components/claim.tsx
@@ -70,8 +70,7 @@ type Props = {
 }
 
 export const Claim = function ({ state }: Props) {
-  const { updateWithdrawalStatus, withdrawals } =
-    useContext(TunnelHistoryContext)
+  const { updateWithdrawal, withdrawals } = useContext(TunnelHistoryContext)
   const { partialWithdrawal, resetStateAfterOperation, savePartialWithdrawal } =
     state
   // If coming from the Prove form, show the prove transaction briefly
@@ -118,7 +117,7 @@ export const Claim = function ({ state }: Props) {
   )
 
   useEffect(
-    function updateWithdrawalStatusAfterConfirmation() {
+    function updateWithdrawalAfterConfirmation() {
       if (claimWithdrawalReceipt?.status !== 'success') {
         return
       }
@@ -126,7 +125,7 @@ export const Claim = function ({ state }: Props) {
       if (withdrawal?.status === MessageStatus.RELAYED) {
         return
       }
-      updateWithdrawalStatus(withdrawal, MessageStatus.RELAYED)
+      updateWithdrawal(withdrawal, { status: MessageStatus.RELAYED })
       savePartialWithdrawal({
         claimWithdrawalTxHash: claimWithdrawalReceipt.transactionHash,
       })
@@ -135,7 +134,7 @@ export const Claim = function ({ state }: Props) {
       claimWithdrawalReceipt,
       savePartialWithdrawal,
       txHash,
-      updateWithdrawalStatus,
+      updateWithdrawal,
       withdrawal,
       withdrawals,
     ],

--- a/webapp/app/[locale]/tunnel/_components/prove.tsx
+++ b/webapp/app/[locale]/tunnel/_components/prove.tsx
@@ -64,8 +64,7 @@ type Props = {
 }
 
 export const Prove = function ({ state }: Props) {
-  const { updateWithdrawalStatus, withdrawals } =
-    useContext(TunnelHistoryContext)
+  const { updateWithdrawal, withdrawals } = useContext(TunnelHistoryContext)
 
   const { partialWithdrawal, resetStateAfterOperation, savePartialWithdrawal } =
     state
@@ -114,14 +113,16 @@ export const Prove = function ({ state }: Props) {
   )
 
   useEffect(
-    function updateWithdrawalStatusAfterConfirmation() {
+    function updateWithdrawalAfterConfirmation() {
       if (withdrawalProofReceipt?.status !== 'success') {
         return
       }
       if (withdrawal?.status === MessageStatus.IN_CHALLENGE_PERIOD) {
         return
       }
-      updateWithdrawalStatus(withdrawal, MessageStatus.IN_CHALLENGE_PERIOD)
+      updateWithdrawal(withdrawal, {
+        status: MessageStatus.IN_CHALLENGE_PERIOD,
+      })
       savePartialWithdrawal({
         proveWithdrawalTxHash: withdrawalProofReceipt.transactionHash,
       })
@@ -129,7 +130,7 @@ export const Prove = function ({ state }: Props) {
     [
       savePartialWithdrawal,
       txHash,
-      updateWithdrawalStatus,
+      updateWithdrawal,
       withdrawal,
       withdrawals,
       withdrawalProofReceipt,

--- a/webapp/app/[locale]/tunnel/_hooks/useWithdraw.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useWithdraw.ts
@@ -1,13 +1,15 @@
 import { MessageDirection, MessageStatus } from '@eth-optimism/sdk'
 import { useQueryClient } from '@tanstack/react-query'
+import { TunnelHistoryContext } from 'context/tunnelHistoryContext'
 import { useWithdrawNativeToken, useWithdrawToken } from 'hooks/useL2Bridge'
 import { useReloadBalances } from 'hooks/useReloadBalances'
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
+import { NativeTokenSpecialAddressOnL2 } from 'tokenList'
 import { type EvmToken } from 'types/token'
 import { useQueryParams } from 'ui-common/hooks/useQueryParams'
 import { isNativeToken } from 'utils/token'
-import { type Chain, parseUnits, Hash } from 'viem'
-import { useWaitForTransactionReceipt } from 'wagmi'
+import { type Chain, parseUnits, Hash, zeroAddress } from 'viem'
+import { useAccount, useWaitForTransactionReceipt } from 'wagmi'
 
 import { useTunnelOperation } from './useTunnelOperation'
 
@@ -25,6 +27,8 @@ export const useWithdraw = function ({
   l1ChainId,
   toToken,
 }: UseWithdraw) {
+  const { addWithdrawalToTunnelHistory } = useContext(TunnelHistoryContext)
+  const { address } = useAccount()
   const queryClient = useQueryClient()
   const withdrawingNative = isNativeToken(fromToken)
   const { txHash } = useTunnelOperation()
@@ -51,6 +55,22 @@ export const useWithdraw = function ({
       [MessageDirection.L2_TO_L1, l1ChainId, hash, 'getMessageStatus'],
       MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE,
     )
+
+    addWithdrawalToTunnelHistory({
+      amount: toWithdraw,
+      data: '0x', // not needed
+      direction: MessageDirection.L2_TO_L1,
+      from: address,
+      l1Token: withdrawingNative ? zeroAddress : toToken.address,
+      l2Token: withdrawingNative
+        ? NativeTokenSpecialAddressOnL2
+        : fromToken.address,
+      logIndex: 0, // not needed
+      status: MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE,
+      // "to" field uses the same address as from, which is user's address
+      to: address,
+      transactionHash: hash,
+    })
   }
 
   const {

--- a/webapp/context/tunnelHistoryContext/types.ts
+++ b/webapp/context/tunnelHistoryContext/types.ts
@@ -1,12 +1,20 @@
 import { TokenBridgeMessage, MessageStatus } from '@eth-optimism/sdk'
 
-export type DepositOperation = Omit<TokenBridgeMessage, 'amount'> & {
+export type DepositOperation = Omit<
+  TokenBridgeMessage,
+  'amount' | 'blockNumber'
+> & {
   amount: string
+  blockNumber?: number
   timestamp: number
 }
 
-export type WithdrawOperation = Omit<TokenBridgeMessage, 'amount'> & {
+export type WithdrawOperation = Omit<
+  TokenBridgeMessage,
+  'amount' | 'blockNumber'
+> & {
   amount: string
+  blockNumber?: number
   status?: MessageStatus
   timestamp: number
 }

--- a/webapp/context/tunnelHistoryContext/useSyncTunnelOperations.ts
+++ b/webapp/context/tunnelHistoryContext/useSyncTunnelOperations.ts
@@ -125,20 +125,16 @@ export const useSyncTunnelOperations = function <T extends TunnelOperation>({
   // Use this function to add an operation to the local storage
   // from outside of the automatic sync process.
   const addOperationToTunnelHistory = useCallback(
-    (operation: RawTunnelOperation<T>) =>
-      // add the new operation, and update local storage.
-      addTimestampToOperation<T>(operation, chainId).then(
-        function (updatedOperation) {
-          state.setSyncBlock(function (prev) {
-            const newItems = mergeContent<T>(prev.content, [updatedOperation])
-            return {
-              ...prev,
-              content: newItems,
-            }
-          })
-        },
-      ),
-    [chainId, state],
+    (operation: T) =>
+      state.setSyncBlock(function (prev) {
+        const newItems = mergeContent<T>(prev.content, [operation])
+        return {
+          ...prev,
+          content: newItems,
+        }
+      }),
+
+    [state],
   )
 
   return useMemo(


### PR DESCRIPTION
Depends on #354  (just because that PR has many changes that would conflict with this, so it is easier to apply that fix on top of this one)

While working on ☝🏽 , I found that withdrawals weren't working. The page would go full-blank after the user confirms the TX in Metamask. This problem was likely caused by #333. In that PR, we started to get the proper component to render (`withdraw`, `prove`, `deposit`, etc) by reading the status of a withdrawal from the Context (Which is populated from the transaction history in local storage).

Once we confirmed the TX, we would update the query string with the generated hash, but as the withdrawal wasn't part of the context yet (because the `withdraw.tsx` component adds it once the TX is confirmed in a block), the page wouldn't render anything, unmounting the `withdraw.tsx` component and preventing it from adding it to the context.

The fix is to optimistically add the withdrawal without a status (nor block or timestamp, but that was the case before too), and once confirmed, update those values.

We used to do something similar before, but reading from `react-query`'s cache. Now we use only the Context as the source of truth

Withdrawals work ok now


https://github.com/BVM-priv/ui-monorepo/assets/352474/c3e08a2e-8484-44d9-adb6-5c81db2002ff

