### PR TITLE
Rename Bitcoin Tesnet to Tesnet Bitcoin

### DIFF
--- a/btc-wallet/chains/index.ts
+++ b/btc-wallet/chains/index.ts
@@ -12,7 +12,7 @@ export const bitcoinTestnet = {
     },
   },
   id: 'testnet',
-  name: 'Bitcoin Testnet',
+  name: 'Testnet Bitcoin',
   nativeCurrency: {
     decimals: 8,
     name: 'Testnet Bitcoin',


### PR DESCRIPTION
Closes #363 

Renaming requested by Ryan

<img width="385" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/e51e78c9-6e90-4b6c-8c2b-e5c9eed4cc04">

<img width="369" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/c62be4bc-6598-4902-b8d4-a9553dfc5b04">
