### PR TITLE
Move pending withdrawals to tunnel tabs

### DIFF
--- a/ui-common/components/tabs.tsx
+++ b/ui-common/components/tabs.tsx
@@ -22,12 +22,12 @@ export const Tab = function ({
   ...props
 }: TabProps) {
   const isButton = tabIsButton(props)
-  const className = `px-5 md:px-6 py-2 text-sm font-medium inline-block ${
+  const className = `px-5 md:px-6 py-2 text-sm font-medium inline-block h-full ${
     selected ? 'text-orange-950' : 'text-slate-300'
   }
   ${disabled ? 'opacity-40' : 'opacity-100'}`
   return (
-    <li className="border-y border-l border-solid border-slate-100 bg-white shadow-sm first:rounded-l-xl last:rounded-r-xl last:border-r">
+    <li className="h-full border-y border-l border-solid border-slate-100 bg-white shadow-sm first:rounded-l-xl last:rounded-r-xl last:border-r">
       {(isButton || disabled) && (
         <button
           className={className}

--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -2,7 +2,6 @@ import 'styles/globals.css'
 import '@rainbow-me/rainbowkit/styles.css'
 import 'react-loading-skeleton/dist/skeleton.css'
 
-import { TunnelHistoryProvider } from 'app/context/tunnelHistoryContext'
 import { locales, type Locale } from 'app/i18n'
 import { AppScreen } from 'components/appScreen'
 import { ErrorBoundary } from 'components/errorBoundary'
@@ -42,16 +41,14 @@ export default async function RootLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <RecaptchaContext>
             <WalletsContext locale={locale}>
-              <TunnelHistoryProvider>
-                <div className="flex h-dvh flex-nowrap justify-stretch">
-                  <div className="hidden w-1/4 max-w-56 md:block">
-                    <Navbar />
-                  </div>
-                  <AppScreen>
-                    <ErrorBoundary>{children}</ErrorBoundary>
-                  </AppScreen>
+              <div className="flex h-dvh flex-nowrap justify-stretch">
+                <div className="hidden w-1/4 max-w-56 md:block">
+                  <Navbar />
                 </div>
-              </TunnelHistoryProvider>
+                <AppScreen>
+                  <ErrorBoundary>{children}</ErrorBoundary>
+                </AppScreen>
+              </div>
             </WalletsContext>
           </RecaptchaContext>
         </NextIntlClientProvider>

--- a/webapp/app/[locale]/navbar/navData.tsx
+++ b/webapp/app/[locale]/navbar/navData.tsx
@@ -7,20 +7,11 @@ import { ExplorerIcon } from 'components/icons/explorerIcon'
 import { FiletextIcon } from 'components/icons/filetextIcon'
 import { GraduateCapIcon } from 'components/icons/graduateCapIcon'
 import { TunnelIcon } from 'components/icons/tunnelIcon'
-import dynamic from 'next/dynamic'
 
 import { NavItemData } from './_components/navItems'
 
-const ActionableWithdrawals = dynamic(
-  () =>
-    import('./_components/actionableWithdrawals').then(
-      mod => mod.ActionableWithdrawals,
-    ),
-  { ssr: false },
-)
 export const navItems: NavItemData[] = [
   {
-    alertComponent: () => <ActionableWithdrawals />,
     href: '/tunnel',
     icon: TunnelIcon,
     id: 'tunnel',

--- a/webapp/app/[locale]/tunnel/_components/actionableWithdrawals.tsx
+++ b/webapp/app/[locale]/tunnel/_components/actionableWithdrawals.tsx
@@ -16,7 +16,7 @@ export const ActionableWithdrawals = function () {
   }
 
   return (
-    <div className="-mt-1 flex aspect-square min-w-6 items-center justify-center rounded-full bg-orange-950 p-1 text-center text-xs text-white">
+    <div className="flex aspect-square min-w-6 items-center justify-center rounded-full bg-orange-950 p-1 text-center text-xs text-white">
       {actionableWithdrawals}
     </div>
   )

--- a/webapp/app/[locale]/tunnel/layout.tsx
+++ b/webapp/app/[locale]/tunnel/layout.tsx
@@ -1,9 +1,18 @@
 'use client'
 
+import { TunnelHistoryProvider } from 'app/context/tunnelHistoryContext'
 import dynamic from 'next/dynamic'
 import { useSelectedLayoutSegment } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Tabs, Tab } from 'ui-common/components/tabs'
+
+const ActionableWithdrawals = dynamic(
+  () =>
+    import('./_components/actionableWithdrawals').then(
+      mod => mod.ActionableWithdrawals,
+    ),
+  { ssr: false },
+)
 
 const TunnelHistorySyncStatus = dynamic(
   () =>
@@ -24,22 +33,27 @@ export default function Layout({ children }: Props) {
   const isInTransactionHistory = segment === 'transaction-history'
 
   return (
-    <>
+    <TunnelHistoryProvider>
       <div className="mb-3 grid grid-cols-1 justify-items-center gap-y-4 lg:grid-cols-[1fr_400px_1fr] xl:gap-x-4">
         {isInTransactionHistory ? <TunnelHistorySyncStatus /> : <div />}
         <Tabs>
           <Tab href="/tunnel" selected={segment === null}>
-            {t('title')}
+            <span className="flex h-full min-h-7 items-center">
+              {t('title')}
+            </span>
           </Tab>
           <Tab
             href="/tunnel/transaction-history"
             selected={isInTransactionHistory}
           >
-            {t('transaction-history.title')}
+            <div className="flex min-h-7 items-center justify-between gap-x-2">
+              <span>{t('transaction-history.title')}</span>
+              <ActionableWithdrawals />
+            </div>
           </Tab>
         </Tabs>
       </div>
       {children}
-    </>
+    </TunnelHistoryProvider>
   )
 }


### PR DESCRIPTION
Closes #353

This PR moves the alert notification of pending withdrawals to the Tunnel tabs

<img width="800" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/85609bb2-0a3e-40d9-b7d9-6f5ed67ab5e1">

It's not anymore on the nav bar

<img width="281" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/bec00b14-82f2-4f91-a2f7-d6d4c6049ab2">
