### PR TITLE
Add pending withdrawals to nav bar again

### DIFF
--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import 'styles/globals.css'
 import '@rainbow-me/rainbowkit/styles.css'
 import 'react-loading-skeleton/dist/skeleton.css'
 
+import { TunnelHistoryProvider } from 'app/context/tunnelHistoryContext'
 import { locales, type Locale } from 'app/i18n'
 import { AppScreen } from 'components/appScreen'
 import { ErrorBoundary } from 'components/errorBoundary'
@@ -41,14 +42,16 @@ export default async function RootLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <RecaptchaContext>
             <WalletsContext locale={locale}>
-              <div className="flex h-dvh flex-nowrap justify-stretch">
-                <div className="hidden w-1/4 max-w-56 md:block">
-                  <Navbar />
+              <TunnelHistoryProvider>
+                <div className="flex h-dvh flex-nowrap justify-stretch">
+                  <div className="hidden w-1/4 max-w-56 md:block">
+                    <Navbar />
+                  </div>
+                  <AppScreen>
+                    <ErrorBoundary>{children}</ErrorBoundary>
+                  </AppScreen>
                 </div>
-                <AppScreen>
-                  <ErrorBoundary>{children}</ErrorBoundary>
-                </AppScreen>
-              </div>
+              </TunnelHistoryProvider>
             </WalletsContext>
           </RecaptchaContext>
         </NextIntlClientProvider>

--- a/webapp/app/[locale]/navbar/navData.tsx
+++ b/webapp/app/[locale]/navbar/navData.tsx
@@ -7,11 +7,25 @@ import { ExplorerIcon } from 'components/icons/explorerIcon'
 import { FiletextIcon } from 'components/icons/filetextIcon'
 import { GraduateCapIcon } from 'components/icons/graduateCapIcon'
 import { TunnelIcon } from 'components/icons/tunnelIcon'
+import dynamic from 'next/dynamic'
 
 import { NavItemData } from './_components/navItems'
 
+const ActionableWithdrawals = dynamic(
+  () =>
+    import('../tunnel/_components/actionableWithdrawals').then(
+      mod => mod.ActionableWithdrawals,
+    ),
+  { ssr: false },
+)
+
 export const navItems: NavItemData[] = [
   {
+    alertComponent: () => (
+      <div className="-mt-1">
+        <ActionableWithdrawals />
+      </div>
+    ),
     href: '/tunnel',
     icon: TunnelIcon,
     id: 'tunnel',

--- a/webapp/app/[locale]/tunnel/layout.tsx
+++ b/webapp/app/[locale]/tunnel/layout.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { TunnelHistoryProvider } from 'app/context/tunnelHistoryContext'
 import dynamic from 'next/dynamic'
 import { useSelectedLayoutSegment } from 'next/navigation'
 import { useTranslations } from 'next-intl'
@@ -33,7 +32,7 @@ export default function Layout({ children }: Props) {
   const isInTransactionHistory = segment === 'transaction-history'
 
   return (
-    <TunnelHistoryProvider>
+    <>
       <div className="mb-3 grid grid-cols-1 justify-items-center gap-y-4 lg:grid-cols-[1fr_400px_1fr] xl:gap-x-4">
         {isInTransactionHistory ? <TunnelHistorySyncStatus /> : <div />}
         <Tabs>
@@ -54,6 +53,6 @@ export default function Layout({ children }: Props) {
         </Tabs>
       </div>
       {children}
-    </TunnelHistoryProvider>
+    </>
   )
 }


### PR DESCRIPTION
It turns out that the idea of #353 was to have the withdrawal notification in both the nav bar _and_ the tunnel tabs. So I rollbacked some of the changes applied in #373


<img width="1330" alt="image" src="https://github.com/BVM-priv/ui-monorepo/assets/352474/f56a74d0-18df-4755-bd57-f5ced3d3e08d">

Now the notifications are visible in both places, as requested by Ryan