### PR TITLE
Update 'individuals' to 'explorers' in backend

### DIFF
--- a/claim-tokens/index.js
+++ b/claim-tokens/index.js
@@ -78,7 +78,7 @@ const isReceiveUpdatesValid = receiveUpdates =>
   receiveUpdates === undefined || typeof receiveUpdates === 'boolean'
 
 const isValidProfile = profile =>
-  ['dev', 'individual', 'miner'].includes(profile)
+  ['dev', 'explorers', 'miner'].includes(profile)
 
 const verifyEmail = email =>
   createEmailRepository(db)

--- a/claim-tokens/test/index.spec.js
+++ b/claim-tokens/test/index.spec.js
@@ -591,8 +591,8 @@ describe('claim-tokens', function () {
   // eslint-disable-next-line mocha/no-setup-in-describe
   testSuccessfulEmails([
     validBody,
-    { ...validBody, profile: 'individual' },
     { ...validBody, profile: 'dev' },
+    { ...validBody, profile: 'explorers' },
     { ...validBody, receiveUpdates: false },
     { ...validBody, receiveUpdates: undefined },
   ])


### PR DESCRIPTION
Related to #358

When I updated `individuals` to `explorers` in the frontend, there was a validation in the backend that was not updated 🤦🏽 

This PR updates it.