### PR TITLE
Add bitcoin kit link to nav bar in portal

### DIFF
--- a/webapp/app/[locale]/navbar/navData.tsx
+++ b/webapp/app/[locale]/navbar/navData.tsx
@@ -65,7 +65,7 @@ export const navItems: NavItemData[] = [
   {
     href: 'https://docs.hemi.xyz/building-bitcoin-apps/hemi-bitcoin-kit-hbk',
     icon: CodeInsertIcon,
-    id: 'bitcoinhkit',
+    id: 'bitcoinkit',
   },
 ]
 

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -91,7 +91,7 @@
   },
   "common": {
     "add-hemi-to-wallet": "Add Hemi Network to your wallet",
-    "bitcoinhkit": "Bitcoin hKit",
+    "bitcoinkit": "Hemi Bitcoin Kit",
     "connect-to-network": "Connect to {network}",
     "connect-wallet": "Connect Wallet",
     "connect-wallets": "Connect Wallets",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -91,7 +91,7 @@
   },
   "common": {
     "add-hemi-to-wallet": "Añadir la red Hemi a su billetera",
-    "bitcoinhkit": "hKit de Bitcoin",
+    "bitcoinkit": "Kit de Hemi Bitcoin",
     "connect-to-network": "Conectarse a {network}",
     "connect-wallet": "Conectar Billetera",
     "connect-wallets": "Connectar Billeteras",


### PR DESCRIPTION
Closes #394 

This PR adds the Bitcoin Kit link in the portal with the new URL

<img width="474" alt="image" src="https://github.com/user-attachments/assets/385324ca-814a-4f2e-b5bc-3e4cfb5120f2">

<img width="653" alt="image" src="https://github.com/user-attachments/assets/a55aa7b6-1abe-455a-b40a-06767112c712">
