### PR TITLE
Write 'Miner' with uppercased m

### DIFF
--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -127,7 +127,7 @@
     "wait-hours": "Wait up to {hours} hours",
     "wait-minutes": "Wait up to {minutes} minutes",
     "wallets-connected": "{count} Connected {count, plural, =1 {Wallet} other {Wallets}} ",
-    "web-pop-miner": "Web PoP miner",
+    "web-pop-miner": "Web PoP Miner",
     "wrong-network": "Wrong Network"
   },
   "connect-wallets": {


### PR DESCRIPTION
A minor request from Ryan after merging #398 
The Spanish locale already had the `M` from Minero capitalized

<img width="215" alt="image" src="https://github.com/user-attachments/assets/cd781d0e-5e24-4e55-b311-e057a1c9de4a">
