### PR TITLE
Fix hemi rpc url in portal

### DIFF
--- a/webapp/app/[locale]/get-started/_components/configureNetworks.tsx
+++ b/webapp/app/[locale]/get-started/_components/configureNetworks.tsx
@@ -146,7 +146,7 @@ const ManualConfiguration = function () {
         {t('rpc-url')}
       </ConfigurationPropTitle>
       <ExternalLink
-        href={hemi.rpcUrls.public.http[0]}
+        href={hemi.rpcUrls.default.http[0]}
         order="order-2 xl:order-5 2xl:order-3"
       />
       <ConfigurationPropTitle order="order-4 xl:order-7">


### PR DESCRIPTION
Closes #400 

This PR fixes the "Manual configuration" of the network in the portal, which was broken. This was because we were trying to access the RPC URL in `hemi.rpcUrls.public.http`, but that structure belonged to `viem` 1.0, but the correct structure in `viem` 2.0 was `hemi.rpcUrls.default.http`.

You may ask "How Typescript didn't catch this?". Well, it turns out that the `rpcUrls` object is defined as

```ts
rpcUrls: {
    [key: string]: ChainRpcUrls
    default: ChainRpcUrls
  }
```

This means that any key is valid (so `.rpcUrls.public` was valid) and failed on runtime. See [source here](https://github.com/wevm/viem/blob/main/src/types/chain.ts).

With the fix, users can now see the "Manual" section of the network configuration

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/50cf8ddb-40bd-48c9-a779-4d18c6eaac7b">
