### PR TITLE
Update get-started rewards links

### DIFF
--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -182,7 +182,7 @@
         "5": {
           "title": "Rewards Program",
           "text": "Participate in activities and earn rewards.",
-          "url": "https://docs.hemi.xyz/governance/incentives"
+          "url": "https://dashboard.hemi.xyz"
         }
       },
       "explorers": {
@@ -199,7 +199,7 @@
         "3": {
           "title": "Rewards Program",
           "text": "Participate in activities and earn rewards.",
-          "url": "https://docs.hemi.xyz/governance/incentives"
+          "url": "https://dashboard.hemi.xyz"
         },
         "4": {
           "title": "Discord Access",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -182,7 +182,7 @@
         "5": {
           "title": "Programa de Recompensas",
           "text": "Participe en actividades y gane recompensas.",
-          "url": "https://docs.hemi.xyz/governance/incentives"
+          "url": "https://dashboard.hemi.xyz"
         }
       },
       "explorers": {
@@ -199,7 +199,7 @@
         "3": {
           "title": "Programa de Recompensas",
           "text": "Participe en actividades y gane recompensas.",
-          "url": "https://docs.hemi.xyz/governance/incentives"
+          "url": "https://dashboard.hemi.xyz"
         },
         "4": {
           "title": "Acceso a Discord",


### PR DESCRIPTION
Closes #401 

Reward links for Dev and Explorer profile are updated as requested by the issue. Note that the URL we're now pointing to is not live yet