### PR TITLE
Update claim service url in prod

### DIFF
--- a/.github/workflows/prod_deployment.yml
+++ b/.github/workflows/prod_deployment.yml
@@ -49,7 +49,6 @@ jobs:
           HOSTINGER_USER: ${{ secrets.HOSTINGER_USER }}
           HOSTINGER_TARGET: 'domains/hemi.xyz/public_html/app'
           # next env variables to build the portal
-          # Needs to be updated after the first deployment
-          NEXT_PUBLIC_CLAIM_TOKENS_URL: 'https://vj7c4dltid.execute-api.eu-central-1.amazonaws.com/staging'
+          NEXT_PUBLIC_CLAIM_TOKENS_URL: 'https://tf27a29m9d.execute-api.eu-central-1.amazonaws.com/prod'
           NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL: false
           NEXT_PUBLIC_RECAPTCHA_SITE_KEY: ${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY_PROD }}


### PR DESCRIPTION
Now that we deployed to prod, we generated the new URL for the claim microservice in [this job](https://github.com/BVM-priv/ui-monorepo/actions/runs/10065477131), so we must update the URL in prod. No need to force-deploy with a commit as in prod we always deploy the portal