### PR TITLE
Fix eslint warnings on Readme files

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
           "markdownlint/md004": [
             "warn",
             {
-              "style": "asterisk"
+              "style": "dash"
             }
           ],
           "markdownlint/md010": "warn",


### PR DESCRIPTION
Closes #77

As we discussed in [here](https://github.com/BVM-priv/ui-monorepo/issues/77#issuecomment-2049739941), as we can't patch `prettier` v3, we are instead updating the ESlint rule so it doesn't conflict with Prettier. However, we don't need to patch ESlint as the rule itself is configurable. Bye bye, warnings on README files!