### PR TITLE
Update rewards url again

### DIFF
--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -182,7 +182,7 @@
         "5": {
           "title": "Rewards Program",
           "text": "Participate in activities and earn rewards.",
-          "url": "https://dashboard.hemi.xyz"
+          "url": "https://points.absinthe.network/hemi/start"
         }
       },
       "explorers": {
@@ -199,7 +199,7 @@
         "3": {
           "title": "Rewards Program",
           "text": "Participate in activities and earn rewards.",
-          "url": "https://dashboard.hemi.xyz"
+          "url": "https://points.absinthe.network/hemi/start"
         },
         "4": {
           "title": "Discord Access",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -182,7 +182,7 @@
         "5": {
           "title": "Programa de Recompensas",
           "text": "Participe en actividades y gane recompensas.",
-          "url": "https://dashboard.hemi.xyz"
+          "url": "https://points.absinthe.network/hemi/start"
         }
       },
       "explorers": {
@@ -199,7 +199,7 @@
         "3": {
           "title": "Programa de Recompensas",
           "text": "Participe en actividades y gane recompensas.",
-          "url": "https://dashboard.hemi.xyz"
+          "url": "https://points.absinthe.network/hemi/start"
         },
         "4": {
           "title": "Acceso a Discord",


### PR DESCRIPTION
Closes #401

The URL for the rewards program needs to be updated again, per [this comment](https://github.com/BVM-priv/ui-monorepo/issues/401#issuecomment-2248359473)