### PR TITLE
Wording update after email sent

### DIFF
--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -251,7 +251,7 @@
       "claim-my-tokens": "Claim",
       "configure-sepolia-testnet": "Configure for Sepolia testnet",
       "currency-symbol": "Currency symbol",
-      "did-not-receive-try-again": "Didn't receive this link? <button>Try again</button>",
+      "did-not-receive-try-again": "Didn't receive this email? <button>Try again</button>",
       "email-failed": "Error submitting email",
       "email-failed-retry": "<button>Retry</button> or <link>contact us</link> at Discord <discord></discord>",
       "email-placeholder": "youremail@mail.com",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -251,7 +251,7 @@
       "claim-my-tokens": "Reclamar",
       "configure-sepolia-testnet": "Configurar la red de prueba Sepolia",
       "currency-symbol": "Símbolo de la moneda nativa",
-      "did-not-receive-try-again": "¿No recibiste este enlace? <button>Inténtalo de nuevo.</button>",
+      "did-not-receive-try-again": "¿No recibiste este email? <button>Inténtalo de nuevo.</button>",
       "email-failed": "Error al enviar el correo electrónico",
       "email-failed-retry": "<button>Inténtelo de nuevo</button> o <link>contáctenos</link> en Discord <discord></discord>.",
       "email-placeholder": "suemail@mail.com",


### PR DESCRIPTION
Closes #422

<img width="557" alt="image" src="https://github.com/user-attachments/assets/e64e67f0-7ad0-4ef0-b4d7-ea08f4ae92e5">

As an email is sent, this PR updates the wording from `link` to `email`. Link was a leftover from the first implementations