### PR TITLE
Update button for withdraw in challenge period

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/withdrawAction.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/withdrawAction.tsx
@@ -54,7 +54,7 @@ export const WithdrawAction = function ({ withdraw }: Props) {
     [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: Failed,
     [MessageStatus.STATE_ROOT_NOT_PUBLISHED]: getViewButton('prove'),
     [MessageStatus.READY_TO_PROVE]: Prove,
-    [MessageStatus.IN_CHALLENGE_PERIOD]: Claim,
+    [MessageStatus.IN_CHALLENGE_PERIOD]: getViewButton('claim'),
     [MessageStatus.READY_FOR_RELAY]: Claim,
     [MessageStatus.RELAYED]: getViewButton('view'),
   }


### PR DESCRIPTION
Closes #427 
When the withdrawal is in "Challenge Period", the button should read "View", instead of Claim

![image](https://github.com/user-attachments/assets/d741ad16-c439-443e-be79-83f7925f4445)
