### PR TITLE
Hide uniswap link

### DIFF
--- a/webapp/app/[locale]/navbar/navData.tsx
+++ b/webapp/app/[locale]/navbar/navData.tsx
@@ -1,7 +1,7 @@
 import { hemi } from 'app/networks'
 import { ChecklistIcon } from 'components/icons/checklistIcon'
 import { CodeInsertIcon } from 'components/icons/codeInsertIcon'
-import { DexIcon } from 'components/icons/dexIcon'
+// import { DexIcon } from 'components/icons/dexIcon'
 // import { ElectroCardiogramIcon } from 'components/icons/electroCardiogramIcon'
 import { ExplorerIcon } from 'components/icons/explorerIcon'
 import { FiletextIcon } from 'components/icons/filetextIcon'
@@ -31,11 +31,11 @@ export const navItems: NavItemData[] = [
     icon: TunnelIcon,
     id: 'tunnel',
   },
-  {
-    href: 'https://swap.hemi.xyz',
-    icon: DexIcon,
-    id: 'dex',
-  },
+  // {
+  //   href: 'https://swap.hemi.xyz',
+  //   icon: DexIcon,
+  //   id: 'dex',
+  // },
   {
     href: 'https://docs.hemi.xyz/building-bitcoin-apps/hemi-bitcoin-kit-hbk',
     icon: CodeInsertIcon,


### PR DESCRIPTION
Related to #429 - will be added again once it is solved

<img width="261" alt="image" src="https://github.com/user-attachments/assets/44793638-446d-4865-810e-2834d7a0beb4">

Link hidden ☝🏽 