### PR TITLE
Fix from/to in tx-history, and txs saved

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -25,7 +25,7 @@ import Skeleton from 'react-loading-skeleton'
 import { Card } from 'ui-common/components/card'
 import { useQueryParams } from 'ui-common/hooks/useQueryParams'
 import { useWindowSize } from 'ui-common/hooks/useWindowSize'
-import { isBtcDeposit, isDeposit } from 'utils/tunnel'
+import { isBtcDeposit, isDeposit, isWithdraw } from 'utils/tunnel'
 import { Chain } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -135,8 +135,7 @@ const columnsBuilder = (
       <ChainComponent
         chainId={
           // See https://github.com/BVM-priv/ui-monorepo/issues/376
-          row.original.chainId ??
-          (isDeposit(row.original) ? l1ChainId : hemi.id)
+          isWithdraw(row.original) ? hemi.id : row.original.chainId ?? l1ChainId
         }
       />
     ),

--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -111,6 +111,7 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
     getStorageKey: getTunnelHistoryDepositStorageKey,
     // TODO retrieve past operations https://github.com/BVM-priv/ui-monorepo/issues/345
     getTunnelOperations: () => Promise.resolve([]),
+    operationChainId: bitcoin.id,
   })
 
   const evmDepositState = useSyncTunnelOperations<EvmDepositOperation>({
@@ -119,6 +120,7 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
     getBlockNumber: getEvmBlockNumberFn(config, l1ChainId),
     getStorageKey: getTunnelHistoryDepositStorageKey,
     getTunnelOperations: getDeposits(crossChainMessenger),
+    operationChainId: l1ChainId,
   })
 
   const withdrawalsState = useSyncTunnelOperations<EvmWithdrawOperation>({
@@ -127,6 +129,7 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
     getBlockNumber: getEvmBlockNumberFn(config, hemi.id),
     getStorageKey: getTunnelHistoryWithdrawStorageKey,
     getTunnelOperations: getWithdrawals(crossChainMessenger),
+    operationChainId: l1ChainId,
   })
 
   const value = useMemo(

--- a/webapp/context/tunnelHistoryContext/useSyncTunnelOperations.ts
+++ b/webapp/context/tunnelHistoryContext/useSyncTunnelOperations.ts
@@ -64,6 +64,7 @@ type SyncTunnelOperationArgs<T extends TunnelOperation> = {
     fromBlock: number
     toBlock: number
   }) => Promise<RawTunnelOperation<T>[]>
+  operationChainId: RemoteChain['id']
 }
 
 export const useSyncTunnelOperations = function <T extends TunnelOperation>({
@@ -72,6 +73,7 @@ export const useSyncTunnelOperations = function <T extends TunnelOperation>({
   getBlockNumber,
   getStorageKey,
   getTunnelOperations,
+  operationChainId,
 }: SyncTunnelOperationArgs<T>) {
   const { address } = useAccount()
 
@@ -124,7 +126,13 @@ export const useSyncTunnelOperations = function <T extends TunnelOperation>({
     [address, chainId, getTunnelOperations],
   )
 
-  const mergeContent = useMemo(() => mergeContentByChainId(chainId), [chainId])
+  // Remove chain id once enough time has passed that data has auto-corrected for users
+  // See https://github.com/BVM-priv/ui-monorepo/issues/376 and
+  // https://github.com/BVM-priv/ui-monorepo/issues/431
+  const mergeContent = useMemo(
+    () => mergeContentByChainId(operationChainId),
+    [operationChainId],
+  )
 
   const state = useSyncInBlockChunks<T>({
     ...chainConfiguration[chainId],

--- a/webapp/utils/tunnel.ts
+++ b/webapp/utils/tunnel.ts
@@ -4,6 +4,7 @@ import {
   DepositTunnelOperation,
   EvmDepositOperation,
   TunnelOperation,
+  WithdrawTunnelOperation,
 } from 'app/context/tunnelHistoryContext/types'
 import { bitcoin } from 'app/networks'
 
@@ -19,3 +20,8 @@ export const isBtcDeposit = (
 export const isEvmDeposit = (
   operation: DepositTunnelOperation,
 ): operation is EvmDepositOperation => operation.chainId !== bitcoin.id
+
+export const isWithdraw = (
+  operation: TunnelOperation,
+): operation is WithdrawTunnelOperation =>
+  operation.direction === MessageDirection.L2_TO_L1


### PR DESCRIPTION
related to #431

This PR should fix the wrong "To" values in withdrawals, as they were shown as "withdrawing from 'Hemi Sepolia' to 'Hemi Sepolia'".

This was caused because as part of https://github.com/BVM-priv/ui-monorepo/issues/376 we added an auto-fix that added the `chainId` field for all operations... and it did so wrong 🤦🏽 

- For deposits, it should add the L1 chain ID where the deposit came from. Either Sepolia or Bitcoin. This was working correctly ✔️
- For withdrawals, it should add the L1 chain ID target. Again, either Sepolia or Bitcoin. This was incorrect. Although the function that saved the data into memory correctly, the auto-correct fixed on the related issue overwrote it incorrectly 🤦🏽 

With this change (which should be removed in a few days as eventually, all data is correct and not needed anymore), deposits and withdrawals should be shown correctly in the Transaction History


Ideally, in order to test this, someone should load on staging their TX history with errors, and after this is merged and deployed, enter again - upon resync, it should fix it automatically.