### PR TITLE
Add test for claiming with @bloq domains

### DIFF
--- a/claim-tokens/test/index.spec.js
+++ b/claim-tokens/test/index.spec.js
@@ -641,7 +641,7 @@ describe('claim-tokens', function () {
         const [submission, access] = await Promise.all([
           db
             .from('email_submissions')
-            .where({ email: validBody.email })
+            .where({ email: bodyScenario.email })
             .first(),
           db.from('ip_accesses').where({ ip: hashedIp }).first(),
         ])
@@ -672,5 +672,6 @@ describe('claim-tokens', function () {
     { ...validBody, profile: 'explorers' },
     { ...validBody, receiveUpdates: false },
     { ...validBody, receiveUpdates: undefined },
+    { ...validBody, email: 'myemail@bloq.com' },
   ])
 })


### PR DESCRIPTION
I had to test if the claim tokens service worked with domains different than `Gmail`. I did so using the test - committing it as it may be useful in the future.