### PR TITLE
Add DEX to navbar

### DIFF
--- a/webapp/app/[locale]/navbar/navData.tsx
+++ b/webapp/app/[locale]/navbar/navData.tsx
@@ -1,7 +1,7 @@
 import { hemi } from 'app/networks'
 import { ChecklistIcon } from 'components/icons/checklistIcon'
 import { CodeInsertIcon } from 'components/icons/codeInsertIcon'
-// import { DexIcon } from 'components/icons/dexIcon'
+import { DexIcon } from 'components/icons/dexIcon'
 // import { ElectroCardiogramIcon } from 'components/icons/electroCardiogramIcon'
 import { ExplorerIcon } from 'components/icons/explorerIcon'
 import { FiletextIcon } from 'components/icons/filetextIcon'
@@ -31,11 +31,11 @@ export const navItems: NavItemData[] = [
     icon: TunnelIcon,
     id: 'tunnel',
   },
-  // {
-  //   href: 'https://swap.hemi.xyz',
-  //   icon: DexIcon,
-  //   id: 'dex',
-  // },
+  {
+    href: 'https://swap.hemi.xyz',
+    icon: DexIcon,
+    id: 'dex',
+  },
   {
     href: 'https://docs.hemi.xyz/building-bitcoin-apps/hemi-bitcoin-kit-hbk',
     icon: CodeInsertIcon,


### PR DESCRIPTION
Closes #442 

This PR adds the `DEX` to the navbar again - the URL is https://swap.hemi.xyz

<img width="220" alt="image" src="https://github.com/user-attachments/assets/c47fc543-fae7-47f9-a8f6-4bf71b1faacf">
