### PR TITLE
Replace DetailedHTMLProps type usage

### DIFF
--- a/ui-common/components/button.tsx
+++ b/ui-common/components/button.tsx
@@ -1,3 +1,5 @@
+import { ComponentProps } from 'react'
+
 const sizes = {
   large: 'h-14',
   medium: 'h-11',
@@ -10,10 +12,10 @@ const variants = {
   tertiary: 'bg-orange-950 text-white rounded-xl',
 } as const
 
-type Props = React.DetailedHTMLProps<
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
-  HTMLButtonElement
-> & { size?: keyof typeof sizes; variant?: keyof typeof variants }
+type Props = ComponentProps<'button'> & {
+  size?: keyof typeof sizes
+  variant?: keyof typeof variants
+}
 
 export const Button = ({ disabled, size = 'large', ...props }: Props) => (
   <button

--- a/ui-common/components/card.tsx
+++ b/ui-common/components/card.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { ComponentProps } from 'react'
 
 const borderColors = {
   default: '',
@@ -24,10 +24,7 @@ const shadows = {
   soft: 'shadow-[0px_88px_25px_0px_#00000000,_0px_56px_23px_0px_#00000000,_0px_32px_19px_0px_#00000003,_0px_14px_14px_0px_#00000005,_0px_4px_8px_0px_#00000005]',
 } as const
 
-type CardProps = React.DetailedHTMLProps<
-  React.AllHTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
-> & {
+type CardProps = ComponentProps<'div'> & {
   borderColor?: keyof typeof borderColors
   padding: keyof typeof paddingVariants
   radius?: keyof typeof radiusVariants

--- a/webapp/app/[locale]/get-started/_components/configureNetworks.tsx
+++ b/webapp/app/[locale]/get-started/_components/configureNetworks.tsx
@@ -6,7 +6,7 @@ import hemiSocials from 'hemi-socials'
 import dynamic from 'next/dynamic'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import React, { useEffect } from 'react'
+import { ComponentProps, useEffect, ReactNode } from 'react'
 import { HemiSymbol } from 'ui-common/components/hemiLogo'
 import { Tabs, Tab } from 'ui-common/components/tabs'
 import { type Chain } from 'viem'
@@ -75,10 +75,7 @@ const NetworkLink = ({
   href,
   order,
   ...props
-}: { order: string } & React.DetailedHTMLProps<
-  React.AnchorHTMLAttributes<HTMLAnchorElement>,
-  HTMLAnchorElement
->) => (
+}: { order: string } & ComponentProps<'a'>) => (
   <ExternalLink
     className={`cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-rose-400 ${order}`}
     href={href}
@@ -91,7 +88,7 @@ const NetworkLink = ({
 type ChainRowProps = {
   chain: Chain
   layer: number
-  logo: React.ReactNode
+  logo: ReactNode
 }
 
 const ChainRow = function ({ chain, layer, logo }: ChainRowProps) {

--- a/webapp/components/externalLink.tsx
+++ b/webapp/components/externalLink.tsx
@@ -1,10 +1,6 @@
-type Props = Omit<
-  React.DetailedHTMLProps<
-    React.AnchorHTMLAttributes<HTMLAnchorElement>,
-    HTMLAnchorElement
-  >,
-  'rel' | 'target'
->
+import { ComponentProps } from 'react'
+
+type Props = Omit<ComponentProps<'a'>, 'rel' | 'target'>
 
 export const ExternalLink = (props: Props) => (
   <a {...props} rel="noopener noreferrer" target="_blank" />


### PR DESCRIPTION
I just learned about `ComponentProps` which works for both native and user components, and it is more readable than using `DetailedHTMLProps`  for accessing props for HTML native components... So this tiny PR updates the few usages of it.

(The only "downside" is that it seems it is not directly accessible from `React.ComponentProps` - it requires a named export)

No visual changes for the user