### PR TITLE
Replace docker-compose with docker compose

### DIFF
--- a/migrations-pg/package.json
+++ b/migrations-pg/package.json
@@ -2,8 +2,8 @@
   "name": "migrations-pg",
   "version": "1.0.0",
   "scripts": {
-    "db:start": "docker-compose up -d",
-    "db:stop": "docker-compose down",
+    "db:start": "docker compose up -d",
+    "db:stop": "docker compose down",
     "deploy": "NODE_ENV=${STAGE:-staging} POSTGRES_CONNECTION_DATABASE=$DEPLOY_POSTGRES_CONNECTION_DATABASE POSTGRES_CONNECTION_HOST=$DEPLOY_POSTGRES_CONNECTION_HOST POSTGRES_CONNECTION_PASSWORD=$DEPLOY_POSTGRES_CONNECTION_PASSWORD POSTGRES_CONNECTION_USER=$DEPLOY_POSTGRES_CONNECTION_USER npm run migrate:up",
     "migrate:up": "NODE_ENV=${NODE_ENV:-dev} ts-node ./src/migrateUp",
     "migrate:down": "NODE_ENV=${NODE_ENV:-dev} ts-node ./src/migrateDown"


### PR DESCRIPTION
This PR replaces `docker-compose up` with `docker compose up`. It seems GitHub added an upgrade and now we need to use the option without hyphen.

See https://github.com/orgs/community/discussions/116610 for further details