### PR TITLE
Fix allowance key not clearing

### DIFF
--- a/webapp/app/[locale]/tunnel/_hooks/useDepositToken.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useDepositToken.ts
@@ -63,7 +63,7 @@ export const useDepositToken = function ({
   const depositReceiptStatus = depositReceipt?.status
   useEffect(
     function invalidateAllowance() {
-      if (depositReceiptStatus === 'status' || depositReceiptError) {
+      if (depositReceiptStatus === 'success' || depositReceiptError) {
         queryClient.invalidateQueries({ queryKey })
       }
     },


### PR DESCRIPTION
A tiny bug I found while working with #466   
When approving an ERC20 token, the `allowance` should be cleared. However, that never happened because I was incorrectly checking the status of the Transaction Receipt 🤦🏽 