### PR TITLE
Enable balance check on evm only if connected

### DIFF
--- a/webapp/hooks/useBalance.ts
+++ b/webapp/hooks/useBalance.ts
@@ -7,12 +7,12 @@ export const useNativeTokenBalance = function (
   chainId: EvmToken['chainId'],
   enabled: boolean = true,
 ) {
-  const { address } = useAccount()
+  const { address, isConnected } = useAccount()
   const { data, refetch, ...rest } = useWagmiBalance({
     address,
     chainId,
     query: {
-      enabled,
+      enabled: isConnected && enabled,
     },
   })
 
@@ -27,10 +27,10 @@ export const useTokenBalance = function (
   token: EvmToken,
   enabled: boolean = true,
 ) {
-  const { address } = useAccount()
+  const { address, isConnected } = useAccount()
   const { data, refetch, ...rest } = useBalanceOf(token.address as Address, {
     args: { account: address, chainId: token.chainId },
-    query: { enabled },
+    query: { enabled: isConnected && enabled },
   })
 
   return {


### PR DESCRIPTION
Closes #460

The check of EVM-compatible chain balances wasn't disabled if the user was disconnected. This PR adds that.


https://github.com/user-attachments/assets/78e21b9a-0c3d-47ab-992e-a4b6c19a454e

