### PR TITLE
Use chainChanged event in unisat

### DIFF
--- a/btc-wallet/connectors/types.ts
+++ b/btc-wallet/connectors/types.ts
@@ -15,8 +15,8 @@ export type WalletConnector = {
   isInstalled: () => boolean
   name: string
   onAccountsChanged: (handler: (account: Account[]) => void) => () => void
-  onNetworkChanged: (
-    handler: (network: BtcSupportedNetworks) => void,
+  onChainChanged: (
+    handler: (args: { network: BtcSupportedNetworks }) => void,
   ) => () => void
   sendBitcoin: (
     to: Account,

--- a/btc-wallet/connectors/unisat.ts
+++ b/btc-wallet/connectors/unisat.ts
@@ -35,10 +35,12 @@ const unisatWalletConnector = {
     window.unisat.on('accountsChanged', handler)
     return () => window.unisat.removeListener('accountsChanged', handler)
   },
-  onNetworkChanged(handler) {
+  onChainChanged(handler) {
     assertInstalled()
-    window.unisat.on('networkChanged', handler)
-    return () => window.unisat.removeListener('networkChanged', handler)
+    // This event is not listed in the docs, but "networkChanged" doesn't fire
+    // See https://github.com/unisat-wallet/extension/issues/211#issuecomment-2290557037
+    window.unisat.on('chainChanged', handler)
+    return () => window.unisat.removeListener('chainChanged', handler)
   },
   sendBitcoin(toAddress, satoshis, options) {
     assertInstalled()

--- a/btc-wallet/hooks/queryKeys.ts
+++ b/btc-wallet/hooks/queryKeys.ts
@@ -1,0 +1,13 @@
+import { WalletConnector } from '../connectors/types'
+
+export const getAccountsQueryKey = (connector: WalletConnector | undefined) => [
+  'btc-wallet',
+  'accounts',
+  connector?.id,
+]
+
+export const getNetworksQueryKey = (connector: WalletConnector | undefined) => [
+  'btc-wallet',
+  'networks',
+  connector?.id,
+]

--- a/btc-wallet/hooks/useAccount.ts
+++ b/btc-wallet/hooks/useAccount.ts
@@ -4,6 +4,7 @@ import { useContext, useEffect, useMemo } from 'react'
 import { bitcoinChains } from '../chains'
 import { GlobalContext } from '../context/globalContext'
 
+import { getAccountsQueryKey, getNetworksQueryKey } from './queryKeys'
 import { useConfig } from './useConfig'
 
 export const useAccount = function () {
@@ -11,7 +12,7 @@ export const useAccount = function () {
   const { connectionStatus, currentConnector } = useContext(GlobalContext)
 
   const accountQueryKey = useMemo(
-    () => ['btc-wallet', 'accounts', currentConnector?.id],
+    () => getAccountsQueryKey(currentConnector),
     [currentConnector],
   )
 
@@ -39,7 +40,7 @@ export const useAccount = function () {
   )
 
   const networksQueryKey = useMemo(
-    () => ['btc-wallet', 'networks', currentConnector?.id],
+    () => getNetworksQueryKey(currentConnector),
     [currentConnector],
   )
 
@@ -54,7 +55,7 @@ export const useAccount = function () {
       if (!currentConnector) {
         return undefined
       }
-      return currentConnector.onNetworkChanged(network =>
+      return currentConnector.onChainChanged(({ network }) =>
         queryClient.setQueryData(networksQueryKey, () => network),
       )
     },

--- a/btc-wallet/hooks/useConnect.ts
+++ b/btc-wallet/hooks/useConnect.ts
@@ -1,11 +1,14 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { WalletConnector } from 'btc-wallet/connectors/types'
 import { useContext } from 'react'
 
 import { GlobalContext } from '../context/globalContext'
 
+import { getNetworksQueryKey } from './queryKeys'
+
 export const useConnect = function () {
   const { setConnectionStatus, setCurrentConnector } = useContext(GlobalContext)
+  const queryClient = useQueryClient()
 
   const { mutate: connect } = useMutation({
     mutationFn(connector: WalletConnector) {
@@ -16,7 +19,11 @@ export const useConnect = function () {
     onError() {
       setConnectionStatus('disconnected')
     },
-    onSuccess(_, connector) {
+    async onSuccess(_, connector) {
+      // update the network data in the cache before marking as "connected"
+      // to avoid being connected to "nothing" until network is loaded
+      const network = await connector.getNetwork()
+      queryClient.setQueryData(getNetworksQueryKey(connector), () => network)
       setConnectionStatus('connected')
       setCurrentConnector(connector)
     },

--- a/btc-wallet/unisat.ts
+++ b/btc-wallet/unisat.ts
@@ -11,7 +11,7 @@ export type BtcTransaction = string
 
 interface EventMap {
   accountsChanged: (accounts: Account[]) => void
-  networkChanged: (network: BtcSupportedNetworks) => void
+  chainChanged: (args: { network: BtcSupportedNetworks }) => void
 }
 
 // See https://docs.unisat.io/dev/unisat-developer-center/unisat-wallet#methods


### PR DESCRIPTION
Closes #366

This PR updates the code that listens for network changes, using the undocumented `chainChanged` event. See https://github.com/unisat-wallet/extension/issues/211 for further details (it's a new event it seems)

With that, we can fix the bug and detect chain changes from the Wallet.


https://github.com/user-attachments/assets/b169a1a4-130b-4f71-9f64-d9d660627299

