### PR TITLE
Sync bitcoin history deposits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28573,6 +28573,7 @@
         "next-recaptcha-v3": "1.3.0",
         "nuqs": "1.17.8",
         "p-all": "5.0.0",
+        "p-do-whilst": "2.0.0",
         "p-queue": "8.0.1",
         "p-throttle": "6.1.0",
         "promise-mem": "1.0.2",

--- a/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
@@ -12,6 +12,7 @@ import { useCallback, useReducer } from 'react'
 import { tokenList } from 'tokenList'
 import { type BtcToken, type EvmToken, type Token } from 'types/token'
 import { isNativeToken, getTokenByAddress } from 'utils/token'
+import { type NoPayload, type Payload } from 'utils/typeUtilities'
 import { type Chain, type Hash, isHash } from 'viem'
 
 import { useTunnelOperation } from './useTunnelOperation'
@@ -43,30 +44,21 @@ type Action<T extends string> = {
   type: T
 }
 
-type NoPayload = { payload?: never }
-
 type ResetStateAfterOperation = Action<'resetStateAfterOperation'> & NoPayload
 
-type SavePartialDeposit = Action<'savePartialDeposit'> & {
-  payload: TunnelState['partialDeposit']
-}
-type SavePartialWithdrawal = Action<'savePartialWithdrawal'> & {
-  payload: TunnelState['partialWithdrawal']
-}
-type UpdateFromNetwork = Action<'updateFromNetwork'> & {
-  payload: TunnelState['fromNetworkId']
-}
-type UpdateFromToken = Action<'updateFromToken'> & {
-  payload: TunnelState['fromToken']
-}
-type UpdateFromInput = Action<'updateFromInput'> & {
-  payload: string
-}
-type UpdateToNetwork = Action<'updateToNetwork'> & {
-  payload: TunnelState['toNetworkId']
-}
-
+type SavePartialDeposit = Action<'savePartialDeposit'> &
+  Payload<TunnelState['partialDeposit']>
+type SavePartialWithdrawal = Action<'savePartialWithdrawal'> &
+  Payload<TunnelState['partialWithdrawal']>
+type UpdateFromNetwork = Action<'updateFromNetwork'> &
+  Payload<TunnelState['fromNetworkId']>
+type UpdateFromToken = Action<'updateFromToken'> &
+  Payload<TunnelState['fromToken']>
+type UpdateFromInput = Action<'updateFromInput'> & Payload<string>
+type UpdateToNetwork = Action<'updateToNetwork'> &
+  Payload<TunnelState['toNetworkId']>
 type ToggleInput = Action<'toggleInput'> & NoPayload
+
 type Actions =
   | ResetStateAfterOperation
   | SavePartialDeposit

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -135,7 +135,7 @@ const columnsBuilder = (
     cell: ({ row }) => (
       <ChainComponent
         chainId={
-          // See https://github.com/BVM-priv/ui-monorepo/issues/376
+          // See https://github.com/hemilabs/ui-monorepo/issues/376
           isWithdraw(row.original)
             ? hemi.id
             : row.original.l1ChainId ?? l1ChainId
@@ -279,7 +279,7 @@ const Body = function ({
 }
 
 export const TransactionHistory = function () {
-  // See https://github.com/BVM-priv/ui-monorepo/issues/158
+  // See https://github.com/hemilabs/ui-monorepo/issues/158
   const l1ChainId = evmRemoteNetworks[0].id
 
   const { status } = useAccount()

--- a/webapp/app/networks.tsx
+++ b/webapp/app/networks.tsx
@@ -50,6 +50,9 @@ export const remoteNetworks: RemoteChain[] = evmRemoteNetworks.concat(
   featureFlags.btcTunnelEnabled ? [bitcoin] : [],
 )
 
+export const findChainById = (chainId: RemoteChain['id']) =>
+  networks.find(n => n.id === chainId)
+
 export const isChainSupported = (chainId: RemoteChain['id']) =>
   networks.some(({ id }) => id === chainId)
 

--- a/webapp/context/tunnelHistoryContext/syncHistoryWorker.tsx
+++ b/webapp/context/tunnelHistoryContext/syncHistoryWorker.tsx
@@ -5,7 +5,7 @@ import {
 } from 'hooks/useSyncHistory/types'
 import { type Dispatch, useEffect, useRef, useState } from 'react'
 import { type Address, type Chain } from 'viem'
-import { SyncWebWorker } from 'workers/history'
+import { AppToWebWorker } from 'workers/history'
 
 type Props = {
   address: Address
@@ -22,7 +22,7 @@ export const SyncHistoryWorker = function ({
   l1ChainId,
   l2ChainId,
 }: Props) {
-  const workerRef = useRef<SyncWebWorker>(null)
+  const workerRef = useRef<AppToWebWorker>(null)
   const [workerLoaded, setWorkerLoaded] = useState(false)
 
   useEffect(
@@ -39,7 +39,7 @@ export const SyncHistoryWorker = function ({
       workerRef.current.addEventListener('message', processWebWorkerMessage)
 
       // announce we're syncing
-      dispatch({ type: 'sync' })
+      dispatch({ payload: { chainId: l1ChainId }, type: 'sync' })
 
       return function () {
         if (!workerRef.current) {

--- a/webapp/hooks/useHemiClient.ts
+++ b/webapp/hooks/useHemiClient.ts
@@ -6,28 +6,27 @@ import {
   hemiWalletBitcoinTunnelManagerActions,
 } from 'hemi-viem'
 import { useMemo } from 'react'
-import { type Address, type Chain } from 'viem'
+import { type Address, type Chain, type PublicClient } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
 
 const localExtensions = () => ({
   // in incoming iterations, the owner address will be determined programmatically
   // from bitcoin manager, once there's a determined way to get the "most adequate" custodial
-  // See https://github.com/BVM-priv/ui-monorepo/issues/393
+  // See https://github.com/hemilabs/ui-monorepo/issues/393
   getOwner: () =>
     Promise.resolve('0xfee2f1eD73051c0f910de83d221151d9D36Ae3de' as Address),
 })
 
+export const publicClientToHemiClient = (publicClient: PublicClient) =>
+  publicClient
+    .extend(hemiPublicBitcoinKitActions())
+    .extend(hemiPublicBitcoinVaultActions())
+    .extend(hemiPublicBitcoinTunnelManagerActions())
+    .extend(localExtensions)
+
 export const useHemiClient = function (chainId: Chain['id'] = hemi.id) {
   const hemiClient = usePublicClient({ chainId })
-  return useMemo(
-    () =>
-      hemiClient
-        .extend(hemiPublicBitcoinKitActions())
-        .extend(hemiPublicBitcoinVaultActions())
-        .extend(hemiPublicBitcoinTunnelManagerActions())
-        .extend(localExtensions),
-    [hemiClient],
-  )
+  return useMemo(() => publicClientToHemiClient(hemiClient), [hemiClient])
 }
 
 export const useHemiWalletClient = function (chainId: Chain['id'] = hemi.id) {

--- a/webapp/hooks/useSyncHistory/index.ts
+++ b/webapp/hooks/useSyncHistory/index.ts
@@ -1,4 +1,10 @@
-import { remoteNetworks, hemi, type RemoteChain } from 'app/networks'
+import {
+  findChainById,
+  isEvmNetwork,
+  remoteNetworks,
+  hemi,
+  type RemoteChain,
+} from 'app/networks'
 import { useConnectedToSupportedEvmChain } from 'hooks/useConnectedToSupportedChain'
 import debounce from 'lodash/debounce'
 import { useEffect, useReducer, useState } from 'react'
@@ -18,11 +24,13 @@ import {
 } from './types'
 import {
   addOperation,
+  getSyncStatus,
   getTunnelHistoryDepositFallbackStorageKey,
   getTunnelHistoryDepositStorageKey,
   getTunnelHistoryWithdrawStorageKey,
   getTunnelHistoryWithdrawStorageKeyFallback,
   syncContent,
+  updateChainSyncStatus,
   updateOperation,
 } from './utils'
 
@@ -42,123 +50,128 @@ const historyReducer = function (
   state: HistoryReducerState,
   action: HistoryActions,
 ): HistoryReducerState {
-  const { type } = action
-  switch (type) {
-    case 'add-deposit': {
-      const { payload: newDeposit } = action
-      const deposits = addOperation(state.deposits, newDeposit)
+  const getNewState = function (): Omit<HistoryReducerState, 'status'> {
+    const { type } = action
+    switch (type) {
+      case 'add-deposit': {
+        const { payload: newDeposit } = action
+        const deposits = addOperation(state.deposits, newDeposit)
 
-      return {
-        ...state,
-        deposits,
+        return {
+          ...state,
+          deposits,
+        }
       }
-    }
-    case 'add-withdraw': {
-      const { payload: newWithdrawal } = action
-      const withdrawals = addOperation(state.withdrawals, newWithdrawal)
-      return {
-        ...state,
-        withdrawals,
+      case 'add-withdraw': {
+        const { payload: newWithdrawal } = action
+        const withdrawals = addOperation(state.withdrawals, newWithdrawal)
+        return {
+          ...state,
+          withdrawals,
+        }
       }
-    }
-    case 'reset':
-      return { ...initialState }
-    case 'restore': {
-      const { payload } = action
-      return {
-        ...state,
-        deposits: payload.deposits.map(chainDeposits => ({
-          ...chainDeposits,
-          // See https://github.com/hemilabs/ui-monorepo/issues/462
-          content: chainDeposits.content.map(
-            deposit =>
-              ({
-                ...deposit,
-                l1ChainId: deposit.l1ChainId,
-                l2ChainId: deposit.l2ChainId ?? hemi.id,
-              }) as DepositTunnelOperation,
-          ),
-        })),
-        status: 'ready',
-        withdrawals: payload.withdrawals.map(chainWithdrawals => ({
-          ...chainWithdrawals,
-          // See https://github.com/hemilabs/ui-monorepo/issues/462
-          content: chainWithdrawals.content.map(
-            withdrawal =>
-              ({
-                ...withdrawal,
-                l1ChainId: withdrawal.l1ChainId,
-                l2ChainId: withdrawal.l2ChainId ?? hemi.id,
-              }) as WithdrawTunnelOperation,
-          ),
-        })),
+      case 'reset':
+        return { ...initialState }
+      case 'restore': {
+        const { payload } = action
+        return {
+          ...state,
+          deposits: payload.deposits.map(chainDeposits => ({
+            ...chainDeposits,
+            // See https://github.com/hemilabs/ui-monorepo/issues/462
+            content: chainDeposits.content.map(
+              deposit =>
+                ({
+                  ...deposit,
+                  l1ChainId: deposit.l1ChainId,
+                  l2ChainId: deposit.l2ChainId ?? hemi.id,
+                }) as DepositTunnelOperation,
+            ),
+            status: 'ready',
+          })),
+          withdrawals: payload.withdrawals.map(chainWithdrawals => ({
+            ...chainWithdrawals,
+            // See https://github.com/hemilabs/ui-monorepo/issues/462
+            content: chainWithdrawals.content.map(
+              withdrawal =>
+                ({
+                  ...withdrawal,
+                  l1ChainId: withdrawal.l1ChainId,
+                  l2ChainId: withdrawal.l2ChainId ?? hemi.id,
+                }) as WithdrawTunnelOperation,
+            ),
+            status: 'ready',
+          })),
+        }
       }
-    }
-    case 'sync': {
-      return {
-        ...state,
-        status: 'syncing',
+      case 'sync': {
+        const { chainId } = action.payload
+        return updateChainSyncStatus(state, chainId, 'syncing')
       }
-    }
-    case 'sync-deposits': {
-      const { chainId } = action.payload
-      const deposits = state.deposits.map(currentDeposits =>
-        currentDeposits.chainId === chainId
-          ? syncContent(currentDeposits, action.payload)
-          : currentDeposits,
-      )
+      case 'sync-deposits': {
+        const { chainId } = action.payload
+        const deposits = state.deposits.map(currentDeposits =>
+          currentDeposits.chainId === chainId
+            ? syncContent(currentDeposits, action.payload)
+            : currentDeposits,
+        )
 
-      return {
-        ...state,
-        deposits,
+        return {
+          ...state,
+          deposits,
+        }
       }
-    }
-    case 'sync-finished': {
-      return {
-        ...state,
-        status: 'finished',
+      case 'sync-finished': {
+        const { chainId } = action.payload
+        return updateChainSyncStatus(state, chainId, 'finished')
       }
-    }
-    case 'sync-withdrawals': {
-      const { chainId } = action.payload
-      const withdrawals = state.withdrawals.map(chainWithdrawals =>
-        chainWithdrawals.chainId === chainId
-          ? syncContent(chainWithdrawals, action.payload)
-          : chainWithdrawals,
-      )
-      return {
-        ...state,
-        withdrawals,
+      case 'sync-withdrawals': {
+        const { chainId } = action.payload
+        const withdrawals = state.withdrawals.map(chainWithdrawals =>
+          chainWithdrawals.chainId === chainId
+            ? syncContent(chainWithdrawals, action.payload)
+            : chainWithdrawals,
+        )
+        return {
+          ...state,
+          withdrawals,
+        }
       }
-    }
-    case 'update-deposit': {
-      const { deposit, updates } = action.payload
-      const deposits = updateOperation(state.deposits, {
-        operation: deposit,
-        updates,
-      })
+      case 'update-deposit': {
+        const { deposit, updates } = action.payload
+        const deposits = updateOperation(state.deposits, {
+          operation: deposit,
+          updates,
+        })
 
-      return {
-        ...state,
-        deposits,
+        return {
+          ...state,
+          deposits,
+        }
       }
-    }
-    case 'update-withdraw': {
-      const { withdraw, updates } = action.payload
-      const withdrawals = updateOperation(state.withdrawals, {
-        operation: withdraw,
-        updates,
-      })
+      case 'update-withdraw': {
+        const { withdraw, updates } = action.payload
+        const withdrawals = updateOperation(state.withdrawals, {
+          operation: withdraw,
+          updates,
+        })
 
-      return {
-        ...state,
-        withdrawals,
+        return {
+          ...state,
+          withdrawals,
+        }
       }
+      default:
+        // if a switch statement is missing on all possible actions
+        // this will fail on compile time
+        return compilationError(type)
     }
-    default:
-      // if a switch statement is missing on all possible actions
-      // this will fail on compile time
-      return compilationError(type)
+  }
+
+  const newState = getNewState()
+  return {
+    ...newState,
+    status: getSyncStatus(newState),
   }
 }
 
@@ -177,13 +190,24 @@ const readStateFromStorage = function <T extends TunnelOperation>({
     localStorage.getItem(key) ||
     (fallbackKey ? localStorage.getItem(fallbackKey) : null)
   if (!restored) {
+    const chain = findChainById(chainId)
+    if (isEvmNetwork(chain)) {
+      return {
+        chainId,
+        chunkIndex: 0,
+        content: [],
+        fromBlock: chainConfiguration[configChainId].minBlockToSync ?? 0,
+        hasSyncToMinBlock: false,
+        toBlock: undefined,
+      }
+    }
     return {
       chainId,
-      chunkIndex: 0,
       content: [],
-      fromBlock: chainConfiguration[configChainId].minBlockToSync ?? 0,
-      hasSyncToMinBlock: false,
-      toBlock: undefined,
+      fromKnownTx: undefined,
+      hasSyncToMinTx: false,
+      toKnownTx: undefined,
+      txPivot: undefined,
     }
   }
   return {
@@ -265,27 +289,32 @@ export const useSyncHistory = function (l2ChainId: Chain['id']) {
       setLoadedFromLocalStorage(true)
       // Load all the deposits given the Hemi address
       const deposits = remoteNetworks
-        .map(({ id }) =>
-          readStateFromStorage<DepositTunnelOperation>({
-            chainId: id,
-            configChainId: id,
-            fallbackKey: getTunnelHistoryDepositFallbackStorageKey(id, address),
-            key: getTunnelHistoryDepositStorageKey(id, l2ChainId, address),
-          }),
+        .map(
+          ({ id }) =>
+            readStateFromStorage<DepositTunnelOperation>({
+              chainId: id,
+              configChainId: id,
+              fallbackKey: getTunnelHistoryDepositFallbackStorageKey(
+                id,
+                address,
+              ),
+              key: getTunnelHistoryDepositStorageKey(id, l2ChainId, address),
+            }) as StorageChain<DepositTunnelOperation>,
         )
         .filter(Boolean)
       // and we can also load withdrawals from Hemi
       const withdrawals = remoteNetworks
-        .map(({ id }) =>
-          readStateFromStorage<WithdrawTunnelOperation>({
-            chainId: id,
-            configChainId: l2ChainId,
-            fallbackKey: getTunnelHistoryWithdrawStorageKeyFallback(
-              l2ChainId,
-              address,
-            ),
-            key: getTunnelHistoryWithdrawStorageKey(id, l2ChainId, address),
-          }),
+        .map(
+          ({ id }) =>
+            readStateFromStorage<WithdrawTunnelOperation>({
+              chainId: id,
+              configChainId: l2ChainId,
+              fallbackKey: getTunnelHistoryWithdrawStorageKeyFallback(
+                l2ChainId,
+                address,
+              ),
+              key: getTunnelHistoryWithdrawStorageKey(id, l2ChainId, address),
+            }) as StorageChain<WithdrawTunnelOperation>,
         )
         .filter(Boolean)
 

--- a/webapp/hooks/useSyncHistory/utils.ts
+++ b/webapp/hooks/useSyncHistory/utils.ts
@@ -2,7 +2,13 @@ import { type RemoteChain } from 'app/networks'
 import { type TunnelOperation } from 'types/tunnel'
 import { type Address, type Chain } from 'viem'
 
-import { type StorageChain, type SyncContentPayload } from './types'
+import {
+  type HistoryReducerState,
+  type StorageChain,
+  type SyncContentPayload,
+  type SyncStatus,
+  type SyncType,
+} from './types'
 
 export const getTunnelHistoryDepositFallbackStorageKey = (
   l1ChainId: RemoteChain['id'],
@@ -41,16 +47,20 @@ const mergeContent = <T extends TunnelOperation>(
     (a, b) => b.timestamp - a.timestamp,
   )
 
-export const syncContent = function <T extends TunnelOperation>(
-  { chainId, content }: StorageChain<T>,
-  payload: SyncContentPayload<T>,
-) {
-  return {
-    chainId,
-    content: mergeContent(content, payload.content),
-    ...payload,
-  }
-}
+export const syncContent = <
+  TOperation extends TunnelOperation,
+  TSyncType extends SyncType,
+>(
+  { content, ...stored }: StorageChain<TOperation>,
+  {
+    content: newContent,
+    ...payload
+  }: SyncContentPayload<TOperation, TSyncType>,
+) => ({
+  content: mergeContent(content, newContent),
+  ...stored,
+  ...payload,
+})
 
 export const addOperation = <T extends TunnelOperation>(
   operations: StorageChain<T>[],
@@ -65,6 +75,30 @@ export const addOperation = <T extends TunnelOperation>(
       content: mergeContent(chainOperations.content, [newItem]),
     }
   })
+
+export const updateChainSyncStatus = (
+  state: HistoryReducerState,
+  chainId: RemoteChain['id'],
+  newStatus: StorageChain['status'],
+) => ({
+  ...state,
+  deposits: state.deposits.map(chainDeposits =>
+    chainDeposits.chainId === chainId
+      ? {
+          ...chainDeposits,
+          status: newStatus,
+        }
+      : chainDeposits,
+  ),
+  withdrawals: state.withdrawals.map(chainWithdrawals =>
+    chainWithdrawals.chainId === chainId
+      ? {
+          ...chainWithdrawals,
+          status: newStatus,
+        }
+      : chainWithdrawals,
+  ),
+})
 
 export const updateOperation = <T extends TunnelOperation>(
   operations: StorageChain<T>[],
@@ -83,3 +117,41 @@ export const updateOperation = <T extends TunnelOperation>(
       ),
     }
   })
+
+const isChainFinishedSyncing = (chain: StorageChain) =>
+  chain.status === 'finished'
+const isChainReady = (chain: StorageChain) => chain.status === 'ready'
+const isChainSyncing = (chain: StorageChain) => chain.status === 'syncing'
+
+export const getSyncStatus = function (
+  state: Omit<HistoryReducerState, 'status'>,
+): SyncStatus {
+  if (
+    state.deposits.some(isChainSyncing) ||
+    state.withdrawals.some(isChainSyncing)
+  ) {
+    return 'syncing'
+  }
+
+  const hasLoaded = state.deposits.length > 0 || state.withdrawals.length > 0
+
+  if (!hasLoaded) {
+    return 'idle'
+  }
+
+  if (
+    state.deposits.every(isChainFinishedSyncing) &&
+    state.withdrawals.every(isChainFinishedSyncing)
+  ) {
+    return 'finished'
+  }
+
+  if (
+    state.deposits.every(isChainReady) &&
+    state.withdrawals.every(isChainReady)
+  ) {
+    return 'ready'
+  }
+
+  return 'idle'
+}

--- a/webapp/hooks/useSyncHistory/utils.ts
+++ b/webapp/hooks/useSyncHistory/utils.ts
@@ -45,21 +45,10 @@ export const syncContent = function <T extends TunnelOperation>(
   { chainId, content }: StorageChain<T>,
   payload: SyncContentPayload<T>,
 ) {
-  const {
-    chunkIndex,
-    content: newContent,
-    fromBlock,
-    hasSyncToMinBlock,
-    toBlock,
-  } = payload
-
   return {
     chainId,
-    chunkIndex,
-    content: mergeContent(content, newContent),
-    fromBlock,
-    hasSyncToMinBlock,
-    toBlock,
+    content: mergeContent(content, payload.content),
+    ...payload,
   }
 }
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -30,6 +30,7 @@
     "next-recaptcha-v3": "1.3.0",
     "nuqs": "1.17.8",
     "p-all": "5.0.0",
+    "p-do-whilst": "2.0.0",
     "p-queue": "8.0.1",
     "p-throttle": "6.1.0",
     "promise-mem": "1.0.2",

--- a/webapp/types/tunnel.ts
+++ b/webapp/types/tunnel.ts
@@ -5,6 +5,7 @@ import {
 } from '@eth-optimism/sdk'
 import { type RemoteChain } from 'app/networks'
 import { BtcChain } from 'btc-wallet/chains'
+import { BtcTransaction } from 'btc-wallet/unisat'
 import { type Chain, type Hash } from 'viem'
 
 export const enum BtcDepositStatus {
@@ -22,7 +23,13 @@ export const enum BtcDepositStatus {
 
 type CommonOperation = Omit<
   TokenBridgeMessage,
-  'amount' | 'blockNumber' | 'chainId' | 'data' | 'direction' | 'logIndex'
+  | 'amount'
+  | 'blockNumber'
+  | 'chainId'
+  | 'data'
+  | 'direction'
+  | 'logIndex'
+  | 'transactionHash'
 > & {
   amount: string
   blockNumber?: number
@@ -31,6 +38,10 @@ type CommonOperation = Omit<
 
 type DepositDirection = {
   direction: MessageDirection.L1_TO_L2
+}
+
+type BtcTransactionHash = {
+  transactionHash: BtcTransaction
 }
 
 type EvmTransactionHash = {
@@ -42,7 +53,8 @@ type WithdrawDirection = {
 }
 
 export type BtcDepositOperation = CommonOperation &
-  DepositDirection & {
+  DepositDirection &
+  BtcTransactionHash & {
     status: BtcDepositStatus
   } & {
     l1ChainId: BtcChain['id']

--- a/webapp/utils/bitcoin.ts
+++ b/webapp/utils/bitcoin.ts
@@ -1,0 +1,12 @@
+import { MempoolJsBitcoinTransaction } from './btcApi'
+
+export const calculateDepositAmount = (
+  utxos: MempoolJsBitcoinTransaction['vout'],
+  bitcoinCustodyAddress: string,
+) =>
+  utxos
+    .filter(
+      ({ scriptpubkeyAddress }) =>
+        scriptpubkeyAddress === bitcoinCustodyAddress,
+    )
+    .reduce((acc, { value }) => acc + value, 0)

--- a/webapp/utils/btcApi.ts
+++ b/webapp/utils/btcApi.ts
@@ -18,7 +18,9 @@ type Utxo = {
 export const getAddressUtxo = (address: Account) =>
   fetch(
     `${process.env.NEXT_PUBLIC_MEMPOOL_API_URL}/address/${address}/utxo`,
-  ).then(toCamelCase) as Promise<Utxo[]>
+  ).then(utxos =>
+    utxos.map(utxo => toCamelCase({ ...utxo, txId: utxo.txid })),
+  ) as Promise<Utxo[]>
 
 // See https://mempool.space/docs/api/rest#get-block-tip-height
 export const getBlockTipHeight = () =>

--- a/webapp/utils/btcApi.ts
+++ b/webapp/utils/btcApi.ts
@@ -6,19 +6,52 @@ const toCamelCase = <T>(obj: T) => camelCaseKeys(obj, { deep: true })
 
 const apiUrl = process.env.NEXT_PUBLIC_MEMPOOL_API_URL
 
+type TransactionStatus = {
+  confirmed: boolean
+}
+
+export type MempoolJsBitcoinTransaction = {
+  status: TransactionStatus
+  txId: string
+  vin: {
+    prevout: {
+      scriptpubkeyAddress: string
+    }
+  }[]
+  vout: {
+    scriptpubkeyAsm: string
+    scriptpubkeyAddress: string
+    scriptpubkeyType: string
+    value: number
+  }[]
+}
+
 type Utxo = {
-  status: {
-    confirmed: boolean
-  }
+  status: TransactionStatus
   txId: string
   value: Satoshis
 }
 
+// See https://mempool.space/docs/api/rest#get-address-transactions
+export const getAddressTransactions = (
+  address: Account,
+  queryString?: { afterTxId: string },
+) =>
+  fetch(
+    `${apiUrl}/address/${address}/txs`,
+    queryString
+      ? {
+          // eslint-disable-next-line camelcase
+          queryString: { after_txid: queryString.afterTxId },
+        }
+      : undefined,
+  ).then(txs =>
+    txs.map(tx => toCamelCase({ ...tx, txId: tx.txid })),
+  ) as Promise<MempoolJsBitcoinTransaction[]>
+
 // See https://mempool.space/docs/api/rest#get-address-utxo (we are converting to camelCase)
 export const getAddressUtxo = (address: Account) =>
-  fetch(
-    `${process.env.NEXT_PUBLIC_MEMPOOL_API_URL}/address/${address}/utxo`,
-  ).then(utxos =>
+  fetch(`${apiUrl}/address/${address}/utxo`).then(utxos =>
     utxos.map(utxo => toCamelCase({ ...utxo, txId: utxo.txid })),
   ) as Promise<Utxo[]>
 

--- a/webapp/utils/sync-history/bitcoin.ts
+++ b/webapp/utils/sync-history/bitcoin.ts
@@ -1,0 +1,217 @@
+import { MessageDirection } from '@eth-optimism/sdk'
+import { BtcChain } from 'btc-wallet/chains'
+import { Account, BtcTransaction } from 'btc-wallet/unisat'
+import {
+  type HemiPublicClient,
+  publicClientToHemiClient,
+} from 'hooks/useHemiClient'
+import { TransactionListSyncType } from 'hooks/useSyncHistory/types'
+import pAll from 'p-all'
+import pDoWhilst from 'p-do-whilst'
+import { BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
+import { calculateDepositAmount } from 'utils/bitcoin'
+import {
+  getAddressTransactions,
+  MempoolJsBitcoinTransaction,
+} from 'utils/btcApi'
+import {
+  getBitcoinCustodyAddress,
+  getVaultAddressByOwner,
+  getHemiStatusOfBtcDeposit,
+  hemiAddressToBitcoinOpReturn,
+} from 'utils/hemi'
+import { getNativeToken } from 'utils/token'
+import { type Address, createPublicClient, http, toHex } from 'viem'
+
+import { type HistorySyncer } from './types'
+
+const discardKnownTransactions = (toKnownTx?: BtcTransaction) =>
+  function (transactions: MempoolJsBitcoinTransaction[]) {
+    if (!toKnownTx) {
+      return transactions
+    }
+    const toIndex = transactions.findIndex(tx => tx.txId === toKnownTx)
+    if (toIndex === -1) {
+      return transactions
+    }
+    return transactions.filter((_, i) => i < toIndex)
+  }
+
+const isValidDeposit = (
+  hemiAddress: Address,
+  opReturnUtxo: MempoolJsBitcoinTransaction['vout'][number],
+) =>
+  opReturnUtxo.scriptpubkeyAsm ===
+  `OP_RETURN OP_PUSHBYTES_40 ${toHex(
+    hemiAddressToBitcoinOpReturn(hemiAddress),
+  ).slice(2)}`
+
+const filterDeposits = (
+  bitcoinTransactions: MempoolJsBitcoinTransaction[],
+  hemiAddress: Address,
+  bitcoinCustodyAddress: Account,
+) =>
+  bitcoinTransactions.filter(function (transaction) {
+    // A transaction, in order to be a deposit, needs to have a utxo
+    // targeting the bitcoin custody address, and use the OP_RETURN
+    // command
+    const opReturnUtxo = transaction.vout.find(
+      ({ scriptpubkeyType }) => scriptpubkeyType === 'op_return',
+    )
+    const receiver = transaction.vout.find(
+      ({ scriptpubkeyAddress }) =>
+        scriptpubkeyAddress === bitcoinCustodyAddress,
+    )
+    if (!receiver || !opReturnUtxo) {
+      return false
+    }
+    // at this point, it is a TX where the receiver is a custodial address
+    // and it is using OP_RETURN, but in order to confirm it is a deposit
+    // we need to confirm it has the correct format.
+    return isValidDeposit(hemiAddress, opReturnUtxo)
+  })
+
+export const createBitcoinSync = function ({
+  address: hemiAddress,
+  debug,
+  depositsSyncInfo,
+  l1Chain,
+  l2Chain,
+  saveHistory,
+}: Omit<HistorySyncer<TransactionListSyncType>, 'l1Chain'> & {
+  l1Chain: BtcChain
+}) {
+  const syncDeposits = async function (hemiClient: HemiPublicClient) {
+    let localDepositSyncInfo: TransactionListSyncType = {
+      ...depositsSyncInfo,
+    }
+    debug('Getting bitcoin custody address')
+    const vaultAddress = await hemiClient
+      .getOwner()
+      .then(owner => getVaultAddressByOwner(hemiClient, owner))
+
+    const bitcoinCustodyAddress = await getBitcoinCustodyAddress(
+      hemiClient,
+      vaultAddress,
+    )
+
+    debug('Found custody address %s', bitcoinCustodyAddress)
+
+    const getTransactionsBatch = (afterTxId?: string) =>
+      getAddressTransactions(
+        bitcoinCustodyAddress,
+        afterTxId ? { afterTxId } : undefined,
+      ).then(discardKnownTransactions(localDepositSyncInfo.toKnownTx))
+
+    const processTransactions = async function (
+      unprocessedTransactions: MempoolJsBitcoinTransaction[],
+      batchPivotTx?: string,
+    ) {
+      const bitcoinDeposits = filterDeposits(
+        unprocessedTransactions,
+        hemiAddress,
+        bitcoinCustodyAddress,
+      )
+
+      const newDeposits = await pAll(
+        bitcoinDeposits.map(
+          bitcoinDeposit =>
+            async function (): Promise<BtcDepositOperation> {
+              const btc = getNativeToken(l1Chain.id)
+              const partialDeposit: Omit<BtcDepositOperation, 'status'> = {
+                amount: calculateDepositAmount(
+                  bitcoinDeposit.vout,
+                  bitcoinCustodyAddress,
+                ).toString(),
+                direction: MessageDirection.L1_TO_L2,
+                // vin should all be utxos coming from the same address...
+                // not supporting multisig for the time being (although, we are not really using
+                // the from field for anything so far)
+                from: bitcoinDeposit.vin[0].prevout.scriptpubkeyAddress,
+                l1ChainId: l1Chain.id,
+                l1Token: btc.address,
+                l2ChainId: l2Chain.id,
+                l2Token: btc.extensions.bridgeInfo[l2Chain.id].tokenAddress,
+                to: bitcoinCustodyAddress,
+                transactionHash: bitcoinDeposit.txId,
+              }
+              const status = bitcoinDeposit.status.confirmed
+                ? await getHemiStatusOfBtcDeposit({
+                    deposit: partialDeposit,
+                    hemiClient,
+                    vaultAddress,
+                  })
+                : BtcDepositStatus.TX_PENDING
+              return { ...partialDeposit, status }
+            },
+        ),
+        { concurrency: 3 },
+      )
+      debug('Got %s new deposits', newDeposits.length)
+
+      const hasSyncToMinTx = unprocessedTransactions.length === 0
+
+      localDepositSyncInfo = {
+        ...localDepositSyncInfo,
+        fromKnownTx: hasSyncToMinTx
+          ? undefined
+          : localDepositSyncInfo.fromKnownTx ?? unprocessedTransactions[0].txId,
+        hasSyncToMinTx,
+        toKnownTx: hasSyncToMinTx
+          ? localDepositSyncInfo.fromKnownTx ?? localDepositSyncInfo.toKnownTx
+          : localDepositSyncInfo.toKnownTx,
+        txPivot: hasSyncToMinTx ? undefined : batchPivotTx,
+      }
+
+      saveHistory({
+        payload: {
+          chainId: l1Chain.id,
+          content: newDeposits,
+          ...localDepositSyncInfo,
+        },
+        type: 'sync-deposits',
+      })
+    }
+
+    let pivotTxId =
+      localDepositSyncInfo.txPivot ?? localDepositSyncInfo.fromKnownTx
+
+    return pDoWhilst(
+      async function () {
+        const formattedTxId = pivotTxId ?? 'last available transaction'
+        debug('Getting transactions batch starting from %s', formattedTxId)
+        const transactions = await getTransactionsBatch(pivotTxId)
+
+        debug(
+          'Found %s transactions starting from %s',
+          transactions.length,
+          formattedTxId,
+        )
+        pivotTxId =
+          transactions.length > 0 ? transactions.at(-1).txId : undefined
+
+        await processTransactions(transactions, pivotTxId)
+        return transactions
+      },
+      transactions => transactions.length > 0,
+    )
+  }
+
+  const syncHistory = function () {
+    const l2PublicClient = createPublicClient({
+      chain: l2Chain,
+      transport: http(),
+    })
+
+    const hemiClient = publicClientToHemiClient(l2PublicClient)
+
+    return Promise.all([
+      syncDeposits(hemiClient).then(() => debug('Deposits sync finished')),
+      // syncWithdrawals().then(() => debug('Withdrawals sync finished')),
+    ]).then(function () {
+      debug('Sync process finished')
+    })
+  }
+
+  return { syncHistory }
+}

--- a/webapp/utils/sync-history/chainConfiguration.ts
+++ b/webapp/utils/sync-history/chainConfiguration.ts
@@ -3,8 +3,7 @@ import { sepolia } from 'viem/chains'
 
 export const chainConfiguration = {
   [bitcoin.id]: {
-    // TODO define proper block windows size https://github.com/hemilabs/ui-monorepo/issues/345
-    blockWindowSize: 3500,
+    // bitcoin API doesn't allow to set a block window size
   },
   [hemi.id]: {
     blockWindowSize: 3500, // Approximately 1/2 day

--- a/webapp/utils/sync-history/common.ts
+++ b/webapp/utils/sync-history/common.ts
@@ -1,16 +1,15 @@
+import { type BlockSyncType } from 'hooks/useSyncHistory/types'
 import { CreateSlidingBlockWindow } from 'sliding-block-window/src'
 
-import { type SyncInfo } from './types'
-
-export const getPayload = function ({
+export const getBlockPayload = function ({
   canMove,
   fromBlock,
   lastBlock,
   nextState,
 }: {
   canMove: boolean
-  fromBlock: SyncInfo['fromBlock']
-  lastBlock: number
+  fromBlock: BlockSyncType['fromBlock']
+  lastBlock: BlockSyncType['toBlock']
   nextState: Parameters<CreateSlidingBlockWindow['onChange']>[0]['nextState']
 }) {
   const hasSyncToMinBlock = !canMove

--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -250,6 +250,8 @@ export const createEvmSync = function ({
   }
 
   const syncHistory = function () {
+    // EVM chains use Ethers providers because that's what
+    // the cross-chain messenger expects
     debug('Creating providers')
     const l1Provider = createPublicProvider(
       l1Chain.rpcUrls.default.http[0],

--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -1,6 +1,5 @@
 import { type TokenBridgeMessage } from '@eth-optimism/sdk'
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { Debugger } from 'debug'
 import pAll from 'p-all'
 import {
   createSlidingBlockWindow,
@@ -20,11 +19,7 @@ import { createPublicProvider } from 'utils/providers'
 import { type Chain } from 'viem'
 
 import { getPayload } from './common'
-import {
-  type EvmSyncParameters,
-  type ExtendedSyncInfo,
-  type SaveHistory,
-} from './types'
+import { type HistorySyncer } from './types'
 
 const toOperation =
   <T extends TunnelOperation>(l1ChainId: Chain['id'], l2ChainId: Chain['id']) =>
@@ -48,14 +43,7 @@ export const createEvmSync = function ({
   l2Chain,
   saveHistory,
   withdrawalsSyncInfo,
-}: Pick<EvmSyncParameters, 'address'> & {
-  debug: Debugger
-  depositsSyncInfo: ExtendedSyncInfo
-  l1Chain: Chain
-  l2Chain: Chain
-  saveHistory: SaveHistory
-  withdrawalsSyncInfo: ExtendedSyncInfo
-}) {
+}: HistorySyncer) {
   const getBlockNumber = async function (
     toBlock: number,
     provider: JsonRpcProvider,

--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -1,5 +1,6 @@
 import { type TokenBridgeMessage } from '@eth-optimism/sdk'
 import { JsonRpcProvider } from '@ethersproject/providers'
+import { BlockSyncType } from 'hooks/useSyncHistory/types'
 import pAll from 'p-all'
 import {
   createSlidingBlockWindow,
@@ -18,7 +19,7 @@ import { getEvmBlock } from 'utils/evmApi'
 import { createPublicProvider } from 'utils/providers'
 import { type Chain } from 'viem'
 
-import { getPayload } from './common'
+import { getBlockPayload } from './common'
 import { type HistorySyncer } from './types'
 
 const toOperation =
@@ -43,7 +44,7 @@ export const createEvmSync = function ({
   l2Chain,
   saveHistory,
   withdrawalsSyncInfo,
-}: HistorySyncer) {
+}: HistorySyncer<BlockSyncType>) {
   const getBlockNumber = async function (
     toBlock: number,
     provider: JsonRpcProvider,
@@ -128,7 +129,7 @@ export const createEvmSync = function ({
       // save the deposits
       saveHistory({
         payload: {
-          ...getPayload({
+          ...getBlockPayload({
             canMove,
             fromBlock: depositsSyncInfo.fromBlock,
             lastBlock,
@@ -227,7 +228,7 @@ export const createEvmSync = function ({
       // save the withdrawals
       saveHistory({
         payload: {
-          ...getPayload({
+          ...getBlockPayload({
             canMove,
             fromBlock: withdrawalsSyncInfo.fromBlock,
             lastBlock,

--- a/webapp/utils/sync-history/slidingTransactionList.ts
+++ b/webapp/utils/sync-history/slidingTransactionList.ts
@@ -1,0 +1,35 @@
+import pDoWhilst from 'p-do-whilst'
+
+type CreateSlidingTransactionList<T> = {
+  getTransactionsBatch: (pivotTxId: string) => Promise<T[]>
+  pivotTxId: string
+  processTransactions: (transactions: T[], pivotTxId: string) => Promise<void>
+  txIdGetter: (transactions: T[]) => string
+}
+
+export const createSlidingTransactionList = function <T>({
+  getTransactionsBatch,
+  pivotTxId,
+  processTransactions,
+  txIdGetter,
+}: CreateSlidingTransactionList<T>) {
+  let innerPivotTxId = pivotTxId
+
+  const run = () =>
+    pDoWhilst(
+      async function () {
+        const transactions = await getTransactionsBatch(innerPivotTxId)
+
+        innerPivotTxId =
+          transactions.length > 0 ? txIdGetter(transactions) : undefined
+
+        await processTransactions(transactions, innerPivotTxId)
+        return transactions
+      },
+      transactions => transactions.length > 0,
+    )
+
+  return {
+    run,
+  }
+}

--- a/webapp/utils/sync-history/types.ts
+++ b/webapp/utils/sync-history/types.ts
@@ -1,44 +1,40 @@
-import { BtcChain } from 'btc-wallet/chains'
-import { type Account } from 'btc-wallet/unisat'
+import { RemoteChain } from 'app/networks'
 import { Debugger } from 'debug'
-import { HistoryActions, type StorageChain } from 'hooks/useSyncHistory/types'
+import {
+  type BlockSyncType,
+  type HistoryActions,
+  type SyncType,
+} from 'hooks/useSyncHistory/types'
 import { TunnelOperation } from 'types/tunnel'
 import { type Address, type Chain } from 'viem'
 
-export type SyncInfo = Pick<
-  StorageChain<TunnelOperation>,
-  'chunkIndex' | 'content' | 'fromBlock' | 'hasSyncToMinBlock' | 'toBlock'
->
+export type SyncInfo<TSyncType extends SyncType> = {
+  content: TunnelOperation[]
+} & TSyncType
 
-export type BtcSyncParameters = {
-  address: Account
-  l1ChainId: BtcChain['id']
-  l2ChainId: Chain['id']
-}
+export type ExtendedSyncInfo<TSyncType extends SyncType> = TSyncType &
+  (TSyncType extends BlockSyncType
+    ? {
+        blockWindowSize: number
+        minBlockToSync?: number
+      }
+    : Record<string, never>)
 
-export type EvmSyncParameters = {
+export type HistorySyncer<TSyncType extends SyncType> = {
   address: Address
-  l1ChainId: Chain['id']
-  l2ChainId: Chain['id']
-}
-
-export type SyncHistoryParameters = (EvmSyncParameters | BtcSyncParameters) & {
-  l2ChainId: Chain['id']
-} & {
-  depositsSyncInfo: Omit<SyncInfo, 'content'>
-  withdrawalsSyncInfo: Omit<SyncInfo, 'content'>
-}
-
-type ExtendedSyncInfo = Omit<SyncInfo, 'content'> & {
-  blockWindowSize: number
-  minBlockToSync?: number
-}
-
-export type HistorySyncer = Pick<EvmSyncParameters, 'address'> & {
   debug: Debugger
-  depositsSyncInfo: ExtendedSyncInfo
+  depositsSyncInfo: ExtendedSyncInfo<TSyncType>
   l1Chain: Chain
   l2Chain: Chain
   saveHistory: (action: HistoryActions) => void
-  withdrawalsSyncInfo: ExtendedSyncInfo
+  withdrawalsSyncInfo: ExtendedSyncInfo<TSyncType>
+}
+
+export type SyncHistoryCombinations = {
+  l1ChainId: RemoteChain['id']
+  l2ChainId: Chain['id']
+  address: Address
+} & {
+  depositsSyncInfo: SyncType
+  withdrawalsSyncInfo: SyncType
 }

--- a/webapp/utils/sync-history/types.ts
+++ b/webapp/utils/sync-history/types.ts
@@ -1,5 +1,6 @@
 import { BtcChain } from 'btc-wallet/chains'
 import { type Account } from 'btc-wallet/unisat'
+import { Debugger } from 'debug'
 import { HistoryActions, type StorageChain } from 'hooks/useSyncHistory/types'
 import { TunnelOperation } from 'types/tunnel'
 import { type Address, type Chain } from 'viem'
@@ -8,10 +9,6 @@ export type SyncInfo = Pick<
   StorageChain<TunnelOperation>,
   'chunkIndex' | 'content' | 'fromBlock' | 'hasSyncToMinBlock' | 'toBlock'
 >
-
-export type HistorySyncer = {
-  syncHistory: () => Promise<void>
-}
 
 export type BtcSyncParameters = {
   address: Account
@@ -25,8 +22,6 @@ export type EvmSyncParameters = {
   l2ChainId: Chain['id']
 }
 
-export type SaveHistory = (action: HistoryActions) => void
-
 export type SyncHistoryParameters = (EvmSyncParameters | BtcSyncParameters) & {
   l2ChainId: Chain['id']
 } & {
@@ -34,7 +29,16 @@ export type SyncHistoryParameters = (EvmSyncParameters | BtcSyncParameters) & {
   withdrawalsSyncInfo: Omit<SyncInfo, 'content'>
 }
 
-export type ExtendedSyncInfo = Omit<SyncInfo, 'content'> & {
+type ExtendedSyncInfo = Omit<SyncInfo, 'content'> & {
   blockWindowSize: number
   minBlockToSync?: number
+}
+
+export type HistorySyncer = Pick<EvmSyncParameters, 'address'> & {
+  debug: Debugger
+  depositsSyncInfo: ExtendedSyncInfo
+  l1Chain: Chain
+  l2Chain: Chain
+  saveHistory: (action: HistoryActions) => void
+  withdrawalsSyncInfo: ExtendedSyncInfo
 }

--- a/webapp/utils/typeUtilities.ts
+++ b/webapp/utils/typeUtilities.ts
@@ -1,0 +1,8 @@
+// Exclude optionality from object fields, and prevent the fields from accepting null or undefined values
+export type DefinedFields<T extends object> = {
+  [P in keyof T]-?: Exclude<T[P], null | undefined>
+}
+
+export type NoPayload = { payload?: never }
+
+export type Payload<T> = { payload: T }

--- a/webapp/workers/history.ts
+++ b/webapp/workers/history.ts
@@ -3,10 +3,7 @@ import debugConstructor from 'debug'
 import { HistoryActions } from 'hooks/useSyncHistory/types'
 import { chainConfiguration } from 'utils/sync-history/chainConfiguration'
 import { createEvmSync } from 'utils/sync-history/evm'
-import {
-  type HistorySyncer,
-  type SyncHistoryParameters,
-} from 'utils/sync-history/types'
+import { type SyncHistoryParameters } from 'utils/sync-history/types'
 import { type Address, type Chain } from 'viem'
 import { sepolia } from 'viem/chains'
 
@@ -32,7 +29,7 @@ const createSyncer = function ({
   l1ChainId,
   l2ChainId,
   withdrawalsSyncInfo,
-}: SyncHistoryParameters): HistorySyncer {
+}: SyncHistoryParameters) {
   const l1Chain = networks.find(n => n.id === l1ChainId)
   // L2 are always EVM
   const l2Chain = networks.find(n => n.id === l2ChainId) as Chain

--- a/webapp/workers/history.ts
+++ b/webapp/workers/history.ts
@@ -1,27 +1,40 @@
-import { networks } from 'app/networks'
+import { bitcoin, findChainById } from 'app/networks'
 import debugConstructor from 'debug'
-import { HistoryActions } from 'hooks/useSyncHistory/types'
+import {
+  type BlockSyncType,
+  type HistoryActions,
+  type TransactionListSyncType,
+} from 'hooks/useSyncHistory/types'
+import { createBitcoinSync } from 'utils/sync-history/bitcoin'
 import { chainConfiguration } from 'utils/sync-history/chainConfiguration'
 import { createEvmSync } from 'utils/sync-history/evm'
-import { type SyncHistoryParameters } from 'utils/sync-history/types'
+import {
+  type ExtendedSyncInfo,
+  type SyncHistoryCombinations,
+} from 'utils/sync-history/types'
 import { type Address, type Chain } from 'viem'
 import { sepolia } from 'viem/chains'
 
 type EnableDebug = { type: 'enable-debug'; payload: string }
-type StartSyncing = SyncHistoryParameters & { type: 'start' }
+type StartSyncing = { type: 'start' } & SyncHistoryCombinations
 
-type HistoryWorkerEvents = MessageEvent<
-  EnableDebug | HistoryActions | StartSyncing
->
+type AppToWebWorkerActions = EnableDebug | StartSyncing
 
 // Worker is typed with "any", so force type safety for the messages
 // (as in runtime all types are stripped, this will continue to work)
-export type SyncWebWorker = Omit<Worker, 'postMessage'> & {
-  postMessage: (event: HistoryWorkerEvents['data']) => void
+export type AppToWebWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  onmessage: (event: MessageEvent<HistoryActions>) => void
+  postMessage: (message: AppToWebWorkerActions) => void
+}
+type SyncWebWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  onmessage: (event: MessageEvent<AppToWebWorkerActions>) => void
+  postMessage: (event: HistoryActions) => void
 }
 
 // See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
 const worker = self as unknown as SyncWebWorker
+
+const saveHistory = (action: HistoryActions) => worker.postMessage(action)
 
 const createSyncer = function ({
   address,
@@ -29,36 +42,41 @@ const createSyncer = function ({
   l1ChainId,
   l2ChainId,
   withdrawalsSyncInfo,
-}: SyncHistoryParameters) {
-  const l1Chain = networks.find(n => n.id === l1ChainId)
+}: SyncHistoryCombinations) {
+  const l1Chain = findChainById(l1ChainId)
   // L2 are always EVM
-  const l2Chain = networks.find(n => n.id === l2ChainId) as Chain
+  const l2Chain = findChainById(l2ChainId) as Chain
 
   const debug = debugConstructor(
     `history-sync-worker:l1:${l1ChainId}:l2:${l2ChainId}`,
   )
 
   switch (l1Chain.id) {
-    // See https://github.com/hemilabs/ui-monorepo/issues/345
-    // case bitcoin.id:
-    //   return createBitcoinSync({
-    //     address,
-    //     debug,
-    //     chain,
-    //   })
+    case bitcoin.id:
+      return createBitcoinSync({
+        address,
+        debug,
+        depositsSyncInfo:
+          depositsSyncInfo as ExtendedSyncInfo<TransactionListSyncType>,
+        l1Chain,
+        l2Chain,
+        saveHistory,
+        withdrawalsSyncInfo:
+          withdrawalsSyncInfo as ExtendedSyncInfo<TransactionListSyncType>,
+      })
     case sepolia.id:
       return createEvmSync({
         address: address as Address,
         debug,
         depositsSyncInfo: {
-          ...depositsSyncInfo,
+          ...(depositsSyncInfo as BlockSyncType),
           ...chainConfiguration[l1Chain.id],
         },
         l1Chain,
         l2Chain,
-        saveHistory: action => worker.postMessage(action),
+        saveHistory,
         withdrawalsSyncInfo: {
-          ...withdrawalsSyncInfo,
+          ...(withdrawalsSyncInfo as BlockSyncType),
           ...chainConfiguration[l2Chain.id],
         },
       })
@@ -66,15 +84,18 @@ const createSyncer = function ({
       throw new Error(`Unsupported syncer for L1 chainId ${l1ChainId}`)
   }
 }
-async function syncTunnelHistory(parameters: SyncHistoryParameters) {
+async function syncTunnelHistory(parameters: StartSyncing) {
   const syncer = createSyncer(parameters)
 
   await syncer.syncHistory()
-  worker.postMessage({ type: 'sync-finished' })
+  worker.postMessage({
+    payload: { chainId: parameters.l1ChainId },
+    type: 'sync-finished',
+  })
 }
 
 // wait for the UI to send chain and address once ready
-worker.onmessage = function runWorker(e: HistoryWorkerEvents) {
+worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
   if (e.data.type === 'start') {
     syncTunnelHistory(e.data)
   }


### PR DESCRIPTION
Depends on #468 being merged first
Related to #345 

This PR allows us to bring past Bitcoin deposit operations as part of resyncing in the transaction history. A change in comparison to #345 is that I am now tracking the sync status (ready, syncing, finished, etc) per chain, instead of as a global enum, but I also calculate a global sync status by checking all chains.

I also had to use Mempool Api, which uses pagination per Tx [See docs here](https://mempool.space/docs/api/rest#get-address-transactions) - which means I cannot paginate the Deposits with the From/To blocks strategy.

### Conceptual implementation

To bring past deposits, what I do is bring all TXs involved with the BTC addresses of the vault (so far there's one, in the future it should include all vaults), and filter the TXs where that custody address is:

- The destination (And not the origin)
- it has a UTXO which is OP_RETURN and
- and I check that the above UTXO has a script pub key of `OP_RETURN OP_PUSHBYTES_40 ${Hemi-Address}`, where the HemiAddress needs a few transformations (it gets converted into uppercase, then from string to hex, removing the `0x` part)

For those, we can calculate the deposit amount by filtering the destination UTXOs (`vout` field), which have the Script pubKey address set to the bitcoin custody address, and add up all those satoshis.


From there, the rest is to track the last TX used in the query, so the next time we don't request them all again.

Similar to the previous PR, the worker just sends batches of newly found TXs and these are offloaded into Local Storage.


The Next step is to sync withdrawals.