### PR TITLE
Disconnect programatically from unisat

### DIFF
--- a/btc-wallet/connectors/types.ts
+++ b/btc-wallet/connectors/types.ts
@@ -8,6 +8,7 @@ import {
 
 export type WalletConnector = {
   connect: () => Promise<void>
+  disconnect: () => Promise<void>
   getAccounts: () => Promise<Account[]>
   getBalance: () => Promise<Balance>
   getNetwork: () => Promise<BtcSupportedNetworks>

--- a/btc-wallet/connectors/unisat.ts
+++ b/btc-wallet/connectors/unisat.ts
@@ -15,15 +15,19 @@ const unisatWalletConnector = {
     // will be prompted to connect
     await window.unisat.requestAccounts()
   },
-  async getAccounts() {
+  disconnect() {
+    assertInstalled()
+    return window.unisat.disconnect()
+  },
+  getAccounts() {
     assertInstalled()
     return window.unisat.getAccounts()
   },
-  async getBalance() {
+  getBalance() {
     assertInstalled()
     return window.unisat.getBalance()
   },
-  async getNetwork() {
+  getNetwork() {
     assertInstalled()
     return window.unisat.getNetwork()
   },

--- a/btc-wallet/hooks/useDisconnect.ts
+++ b/btc-wallet/hooks/useDisconnect.ts
@@ -1,24 +1,33 @@
-import { useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useContext } from 'react'
 
 import { GlobalContext } from '../context/globalContext'
 
 export const useDisconnect = function () {
-  const { setConnectionStatus, setCurrentConnector } = useContext(GlobalContext)
+  const { currentConnector, setConnectionStatus, setCurrentConnector } =
+    useContext(GlobalContext)
 
   const queryClient = useQueryClient()
 
-  const disconnect = function () {
-    // set as disconnected
-    setConnectionStatus('disconnected')
-    // remove the connector
-    setCurrentConnector(undefined)
-    const predicate = query => query.queryKey[0] === 'btc-wallet'
-    // now empty all caches from btc-wallet
-    queryClient.removeQueries({ predicate })
-    // and all mutation states
-    queryClient.resetQueries({ predicate })
-  }
+  const { mutate: disconnect } = useMutation({
+    mutationFn() {
+      // before disconnecting, clear the connection status
+      // otherwise, queries may run before the status is updated
+      // prompting again to connect
+      setConnectionStatus('disconnected')
+      setCurrentConnector(undefined)
+      // now, disconnect
+      return currentConnector.disconnect()
+    },
+    mutationKey: ['btc-wallet', 'disconnect'],
+    onSuccess() {
+      const predicate = query => query.queryKey[0] === 'btc-wallet'
+      // now empty all caches from btc-wallet
+      queryClient.removeQueries({ predicate })
+      // and all mutation states
+      queryClient.resetQueries({ predicate })
+    },
+  })
 
   return {
     disconnect,

--- a/btc-wallet/unisat.ts
+++ b/btc-wallet/unisat.ts
@@ -16,6 +16,7 @@ interface EventMap {
 
 // See https://docs.unisat.io/dev/unisat-developer-center/unisat-wallet#methods
 export interface Unisat {
+  disconnect(): Promise<void>
   getAccounts(): Promise<Account[]>
   getBalance(): Promise<Balance>
   getNetwork(): Promise<BtcSupportedNetworks>


### PR DESCRIPTION
Closes #471

Now that Unisat has added the feature to disconnect programmatically, we can do so and be prompted again when reconnecting (Like Metamask does). Before this PR, when users reconnected, it would do so automatically, without prompting which account should connect (as if, from Unisat point of view, the app was never disconnected).


https://github.com/user-attachments/assets/bf42c061-bf9a-43d5-8b4c-cf6172df428e

