### PR TITLE
Update README's env variables

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -5,24 +5,31 @@
 ### Environment variables
 
 The environment variables are defined in the `.env` file at the root of the project.
-The prefix `NEXT_PUBLIC_` is required for the variables to be available in the browser. A few variables need to be set to run locally (in a `.env.local`), in addition to the ones already defined in the `.env`
+The prefix `NEXT_PUBLIC_` is required for the variables to be available in the browser. A few variables can be set locally (in a `.env.local`), in addition to the ones already defined in the `.env`
 
 ```bash
-NEXT_PUBLIC_CLAIM_TOKENS_URL="<claim-tokens-url>"
-NEXT_PUBLIC_RECAPTCHA_SITE_KEY="<recaptcha-v3-key>"
+NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL=<true|false> # Enable the bitcoin tunnel feature
+NEXT_PUBLIC_WORKERS_DEBUG_ENABLE=<true|false> # enable logging on web workers
+# The following variables could be used to customize the contracts addresses used by Hemi (for example, for testing with a forked blockchain):
+NEXT_PUBLIC_ADDRESS_MANAGER=<address>
+NEXT_PUBLIC_L2_BRIDGE=<address>
+NEXT_PUBLIC_L2_OUTPUT_ORACLE_PROXY=<address>
+NEXT_PUBLIC_OPTIMISM_PORTAL_PROXY=<address>
+NEXT_PUBLIC_PROXY_OVM_L1_CROSS_DOMAIN_MESSENGER=<address>
+NEXT_PUBLIC_PROXY_OVM_L1_STANDARD_BRIDGE=<address>
 ```
 
-The recaptcha v3 key can be generated [in this page](https://www.google.com/recaptcha/admin/create).
+If not defined, the contracts addresses used will be the ones defined in [hemi-viem](https://github.com/hemilabs/hemi-viem).
 
 ## Deployment
 
 Inside the `webapp` folder, create a `.env.production` with the following configuration:
 
 ```sh
-NEXT_PUBLIC_CLAIM_TOKENS_URL="<claim-tokens-url>"
-NEXT_PUBLIC_RECAPTCHA_SITE_KEY="<recaptcha-v3-key>"
-NEXT_PUBLIC_TESTNET_MODE=true|false # Depending on which network is being deployed
+NEXT_PUBLIC_TESTNET_MODE=<true|false> # Depending on which network is being deployed
 ```
+
+(as well as any other env variable of the list defined above)
 
 and then run the following command:
 

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  basePath: process.env.BASE_PATH || '',
   experimental: {
     instrumentationHook: true,
   },


### PR DESCRIPTION
A bit of cleanup:

- 16a6c39cf8302b0122df6d12dae019822a78be44 removes `BASE_PATH` configuration from next.config.js as we no longer use that option
- d34e9eed2211d61567efa008f956abf7ed847251 Updates the `webapp/README.md` with the env variables that can be set, as well as removing some of the old env variables that no longer should be set (Related to https://github.com/hemilabs/ui-monorepo/issues/453)