### PR TITLE
Add htaccess to add security headers to portal page

### DIFF
--- a/webapp/.htaccess
+++ b/webapp/.htaccess
@@ -1,0 +1,27 @@
+<IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header always set X-Frame-Options "SAMEORIGIN"
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header always set X-Content-Type-Options "nosniff"
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header always set X-XSS-Protection "1; mode=block"
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header always set X-Download-Options "noopen"
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header always set Expect-CT "max-age=86400, enforce"
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header always set Referrer-Policy "no-referrer-when-downgrade"
+</IfModule>

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "scripts": {
     "build": "next build",
+    "copy:htaccess": "cp .htaccess out/.htaccess",
     "dev": "next dev",
     "dev:wifi": "WIFI=true LOCAL_IP=$(ipconfig getifaddr en0) PORT=3000 npm run dev",
     "deploy": "npm run build",
+    "postbuild": "npm run copy:htaccess",
     "preserve": "npm run build",
     "serve": "serve out"
   },


### PR DESCRIPTION
Closes #477 

This PR adds a `.htaccess` with some basic security headers. Tested on staging (Thanks @dhidalgX !)

The `.htaccess` is copied to the `out` folder than later is pushed to Hostinger as part of the deployment step