### PR TITLE
Get hemi id from querystring

### DIFF
--- a/webapp/app/[locale]/demos/page.tsx
+++ b/webapp/app/[locale]/demos/page.tsx
@@ -1,13 +1,33 @@
 'use client'
 
-import { hemi } from 'app/networks'
+import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
+import { Suspense } from 'react'
 
 import cryptochordsImg from '../../../public/demos/cryptochords.png'
 import hemihatchlingspixelatedImg from '../../../public/demos/hemihatchlingspixelated.png'
 import purefinanceImg from '../../../public/demos/purefinance.png'
 
 import { DemoCard } from './_components/demoCard'
+
+const HemiHatchlings = function () {
+  const hemi = useHemi()
+  const t = useTranslations('demos')
+
+  return (
+    <DemoCard
+      altText="hemi hatchlings"
+      heading={t('hemihatchlings.heading')}
+      href={
+        hemi.testnet
+          ? 'https://hemihatchlings-test.hemi.xyz'
+          : 'https://hemihatchlings.hemi.xyz'
+      }
+      imageSrc={hemihatchlingspixelatedImg}
+      subHeading={t('hemihatchlings.sub-heading')}
+    />
+  )
+}
 
 const GraduateCapIcon = () => (
   <svg fill="none" height="29" width="36" xmlns="http://www.w3.org/2000/svg">
@@ -37,17 +57,9 @@ const Demos = function () {
           className="flex flex-col gap-y-4 md:w-full 
           md:flex-row md:justify-center md:gap-x-4"
         >
-          <DemoCard
-            altText="hemi hatchlings"
-            heading={t('hemihatchlings.heading')}
-            href={
-              hemi.testnet
-                ? 'https://hemihatchlings-test.hemi.xyz'
-                : 'https://hemihatchlings.hemi.xyz'
-            }
-            imageSrc={hemihatchlingspixelatedImg}
-            subHeading={t('hemihatchlings.sub-heading')}
-          />
+          <Suspense>
+            <HemiHatchlings />
+          </Suspense>
           <DemoCard
             altText="cryptochords"
             heading={t('cryptochords.heading')}

--- a/webapp/app/[locale]/get-started/_components/configureNetworks.tsx
+++ b/webapp/app/[locale]/get-started/_components/configureNetworks.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { evmRemoteNetworks, hemi } from 'app/networks'
+import { evmRemoteNetworks } from 'app/networks'
 import { ExternalLink } from 'components/externalLink'
 import hemiSocials from 'hemi-socials'
+import { useHemi } from 'hooks/useHemi'
 import dynamic from 'next/dynamic'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
@@ -101,6 +102,7 @@ const ChainRow = function ({ chain, layer, logo }: ChainRowProps) {
 
 const AutomaticConfiguration = function () {
   const ethereum = evmRemoteNetworks.at(-1)
+  const hemi = useHemi()
 
   return (
     <div className="flex flex-col gap-y-6 py-2 lg:gap-y-9">
@@ -119,6 +121,7 @@ const AutomaticConfiguration = function () {
 }
 
 const ManualConfiguration = function () {
+  const hemi = useHemi()
   const t = useTranslations('get-started.network')
   const ethereum = evmRemoteNetworks.at(-1)
 

--- a/webapp/app/[locale]/get-started/_components/welcomePack.tsx
+++ b/webapp/app/[locale]/get-started/_components/welcomePack.tsx
@@ -1,44 +1,46 @@
 'use client'
 
-import { hemi } from 'app/networks'
 import { bitcoinTestnet } from 'btc-wallet/chains'
 import { ExternalLink } from 'components/externalLink'
 import hemiSocials from 'hemi-socials'
+import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
+import { type Chain } from 'viem'
 import { sepolia } from 'viem/chains'
 
 import { Btc } from './icons/btc'
 import { Eth } from './icons/eth'
 import { Hemi } from './icons/hemi'
 
-const giveAwayTokens = hemi.testnet
-  ? [
-      {
-        amount: 0.2,
-        icon: <Eth />,
-        symbol: `${sepolia.nativeCurrency.symbol} (Sepolia Ether)`,
-      },
-      {
-        amount: 0.2,
-        icon: <Eth />,
-        symbol: `${hemi.nativeCurrency.symbol} (Tunneled Sepolia Ether)`,
-      },
-      {
-        amount: 0.1,
-        icon: <Btc />,
-        symbol: `${bitcoinTestnet.nativeCurrency.symbol} (Testnet Bitcoin)`,
-      },
-      {
-        amount: 1,
-        icon: <Hemi />,
-        symbol: 'tHEMI (Testnet Hemi)',
-      },
-      {
-        symbol: 'Hemi Hatchling NFT',
-      },
-    ]
-  : // mainnet capsules not confirmed
-    []
+const giveAwayTokens = (chain: Chain) =>
+  chain.testnet
+    ? [
+        {
+          amount: 0.2,
+          icon: <Eth />,
+          symbol: `${sepolia.nativeCurrency.symbol} (Sepolia Ether)`,
+        },
+        {
+          amount: 0.2,
+          icon: <Eth />,
+          symbol: `${chain.nativeCurrency.symbol} (Tunneled Sepolia Ether)`,
+        },
+        {
+          amount: 0.1,
+          icon: <Btc />,
+          symbol: `${bitcoinTestnet.nativeCurrency.symbol} (Testnet Bitcoin)`,
+        },
+        {
+          amount: 1,
+          icon: <Hemi />,
+          symbol: 'tHEMI (Testnet Hemi)',
+        },
+        {
+          symbol: 'Hemi Hatchling NFT',
+        },
+      ]
+    : // mainnet capsules not confirmed
+      []
 
 const CoinRow = ({
   amount,
@@ -60,6 +62,7 @@ const CoinRow = ({
 const { discordUrl } = hemiSocials
 
 export const WelcomePack = function () {
+  const hemi = useHemi()
   const t = useTranslations('get-started')
 
   return (
@@ -75,7 +78,7 @@ export const WelcomePack = function () {
         })}
       </p>
       <div className="flex flex-col gap-y-2 py-8">
-        {giveAwayTokens.map(({ amount, icon, symbol }) => (
+        {giveAwayTokens(hemi).map(({ amount, icon, symbol }) => (
           <CoinRow amount={amount} icon={icon} key={symbol} symbol={symbol} />
         ))}
       </div>

--- a/webapp/app/[locale]/get-started/page.tsx
+++ b/webapp/app/[locale]/get-started/page.tsx
@@ -71,9 +71,11 @@ const NetworkPage = function () {
           </Suspense>
         </div>
         <div className="md:basis-1/3">
-          <Card borderColor="gray" padding="medium" radius="large">
-            <WelcomePack />
-          </Card>
+          <Suspense fallback={<Skeleton className="h-80 w-full" />}>
+            <Card borderColor="gray" padding="medium" radius="large">
+              <WelcomePack />
+            </Card>
+          </Suspense>
         </div>
       </main>
       <Suspense>

--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -41,6 +41,10 @@ export default async function RootLayout({
     <html lang={locale}>
       <body className={`${inter.className} w-svw overflow-y-hidden`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
+          {/* This suspense wrapper is needed because, from this point downwards, rendering depends on 
+          getting mainnet|testnet from query string, and using useSearchParams (through nuqs) requires so to compile.
+          However, there's no change at all in the UI, so no fallback seems to be needed, as it isn't an async request
+          or something that requires showing something. */}
           <Suspense>
             <WalletsContext locale={locale}>
               <TunnelHistoryProvider>

--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from 'components/errorBoundary'
 import { WalletsContext } from 'context/walletsContext'
 import { notFound } from 'next/navigation'
 import { NextIntlClientProvider } from 'next-intl'
+import { Suspense } from 'react'
 
 import { inter } from '../fonts'
 
@@ -40,20 +41,22 @@ export default async function RootLayout({
     <html lang={locale}>
       <body className={`${inter.className} w-svw overflow-y-hidden`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
-          <WalletsContext locale={locale}>
-            <TunnelHistoryProvider>
-              <ConnectWalletDrawerProvider>
-                <div className="flex h-dvh flex-nowrap justify-stretch">
-                  <div className="hidden w-1/4 max-w-56 md:block">
-                    <Navbar />
+          <Suspense>
+            <WalletsContext locale={locale}>
+              <TunnelHistoryProvider>
+                <ConnectWalletDrawerProvider>
+                  <div className="flex h-dvh flex-nowrap justify-stretch">
+                    <div className="hidden w-1/4 max-w-56 md:block">
+                      <Navbar />
+                    </div>
+                    <AppScreen>
+                      <ErrorBoundary>{children}</ErrorBoundary>
+                    </AppScreen>
                   </div>
-                  <AppScreen>
-                    <ErrorBoundary>{children}</ErrorBoundary>
-                  </AppScreen>
-                </div>
-              </ConnectWalletDrawerProvider>
-            </TunnelHistoryProvider>
-          </WalletsContext>
+                </ConnectWalletDrawerProvider>
+              </TunnelHistoryProvider>
+            </WalletsContext>
+          </Suspense>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/webapp/app/[locale]/navbar/index.tsx
+++ b/webapp/app/[locale]/navbar/index.tsx
@@ -1,22 +1,24 @@
 'use client'
 
 import { FooterSocials } from 'components/footerSocials'
+import { useHemi } from 'hooks/useHemi'
 import { usePathname } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import Link from 'next-intl/link'
-import React from 'react'
+import React, { Suspense } from 'react'
 import { Button } from 'ui-common/components/button'
 import { HemiLogoFull } from 'ui-common/components/hemiLogo'
 
 import { NavGetStarted } from './_components/navGetStarted'
 import { NavItems, type NavItemData } from './_components/navItems'
-import { navItems, navItemsBottom } from './navData'
+import { getNavItems, navItemsBottom } from './navData'
 
 type Props = {
   onItemClick?: (item?: NavItemData) => void
 }
 
-export const Navbar = function ({ onItemClick }: Props) {
+const NavbarImplementation = function ({ onItemClick }: Props) {
+  const hemi = useHemi()
   const t = useTranslations('common')
   const pathname = usePathname()
 
@@ -44,7 +46,7 @@ export const Navbar = function ({ onItemClick }: Props) {
         <NavItems
           color="slate-200"
           isSelectable={true}
-          navItems={navItems}
+          navItems={getNavItems(hemi)}
           onItemClick={handleItemClick}
           selectedItem={getCurrentPath()}
         />
@@ -73,3 +75,9 @@ export const Navbar = function ({ onItemClick }: Props) {
     </div>
   )
 }
+
+export const Navbar = ({ onItemClick }: Props) => (
+  <Suspense>
+    <NavbarImplementation onItemClick={onItemClick} />
+  </Suspense>
+)

--- a/webapp/app/[locale]/navbar/navData.tsx
+++ b/webapp/app/[locale]/navbar/navData.tsx
@@ -1,4 +1,3 @@
-import { hemi } from 'app/networks'
 import { ChecklistIcon } from 'components/icons/checklistIcon'
 import { CodeInsertIcon } from 'components/icons/codeInsertIcon'
 import { DexIcon } from 'components/icons/dexIcon'
@@ -9,6 +8,7 @@ import { GraduateCapIcon } from 'components/icons/graduateCapIcon'
 import { PoPMinerIcon } from 'components/icons/popMinerIcon'
 import { TunnelIcon } from 'components/icons/tunnelIcon'
 import dynamic from 'next/dynamic'
+import { type Chain } from 'viem'
 
 import { NavItemData } from './_components/navItems'
 
@@ -20,7 +20,7 @@ const ActionableOperations = dynamic(
   { ssr: false },
 )
 
-export const navItems: NavItemData[] = [
+export const getNavItems = (hemi: Chain): NavItemData[] => [
   {
     alertComponent: () => (
       <div className="-mt-1">

--- a/webapp/app/[locale]/tunnel/_components/claim.tsx
+++ b/webapp/app/[locale]/tunnel/_components/claim.tsx
@@ -1,9 +1,10 @@
 import { MessageStatus } from '@eth-optimism/sdk'
-import { evmRemoteNetworks, hemi } from 'app/networks'
+import { evmRemoteNetworks } from 'app/networks'
 import { useBtcDeposits } from 'hooks/useBtcDeposits'
 import { useClaimBitcoinDeposit } from 'hooks/useBtcTunnel'
 import { useChain } from 'hooks/useChain'
 import { useEstimateFees } from 'hooks/useEstimateFees'
+import { useHemi } from 'hooks/useHemi'
 import { useGetClaimWithdrawalTxHash } from 'hooks/useL2Bridge'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useTranslations } from 'next-intl'
@@ -85,6 +86,7 @@ const BtcSubmitButton = function ({
   isClaiming: boolean
   isReadyToClaim: boolean
 }) {
+  const hemi = useHemi()
   const t = useTranslations('tunnel-page.submit-button')
 
   const disabled = isClaiming || !isReadyToClaim
@@ -120,6 +122,7 @@ export const BtcClaim = function ({
     claimBitcoinDepositTxHash,
     clearClaimBitcoinDepositState,
   } = useClaimBitcoinDeposit()
+  const hemi = useHemi()
   const estimatedFees = useEstimateFees({
     chainId: hemi.id,
     enabled: isConnected,

--- a/webapp/app/[locale]/tunnel/_components/form.tsx
+++ b/webapp/app/[locale]/tunnel/_components/form.tsx
@@ -1,7 +1,8 @@
 import { TokenLogo } from 'app/components/tokenLogo'
 import { TokenSelector } from 'app/components/tokenSelector'
-import { hemi, networks, type RemoteChain } from 'app/networks'
+import { networks, type RemoteChain } from 'app/networks'
 import Big from 'big.js'
+import { useHemi } from 'hooks/useHemi'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { FormEvent, ReactNode } from 'react'
@@ -138,6 +139,7 @@ export const FormContent = function ({
     toToken,
   } = tunnelState
 
+  const hemi = useHemi()
   const t = useTranslations('tunnel-page')
 
   return (

--- a/webapp/app/[locale]/tunnel/_components/prove.tsx
+++ b/webapp/app/[locale]/tunnel/_components/prove.tsx
@@ -1,6 +1,7 @@
 import { MessageStatus } from '@eth-optimism/sdk'
-import { evmRemoteNetworks, hemi } from 'app/networks'
+import { evmRemoteNetworks } from 'app/networks'
 import { useChain } from 'hooks/useChain'
+import { useHemi } from 'hooks/useHemi'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
@@ -72,13 +73,14 @@ export const Prove = function ({ state }: Props) {
 
   const [isProving, setIsProving] = useState(false)
 
-  // https://github.com/BVM-priv/ui-monorepo/issues/158
+  // https://github.com/hemilabs/ui-monorepo/issues/158
   const l1ChainId = evmRemoteNetworks[0].id
 
   const t = useTranslations()
   const txHash = useTunnelOperation().txHash as Hash
 
   const fromChain = useChain(l1ChainId)
+  const hemi = useHemi()
 
   const {
     clearProveWithdrawalState,

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -1,6 +1,7 @@
 import { MessageStatus } from '@eth-optimism/sdk'
-import { evmRemoteNetworks, hemi } from 'app/networks'
+import { evmRemoteNetworks } from 'app/networks'
 import { TransactionStatus } from 'components/transactionStatus'
+import { useHemi } from 'hooks/useHemi'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useTranslations } from 'next-intl'
 import { FormEvent, ReactNode } from 'react'
@@ -95,15 +96,20 @@ const WithdrawAmount = function ({
 }: {
   withdrawal?: EvmWithdrawOperation
 }) {
+  const hemi = useHemi()
   if (!withdrawal) {
     return <Skeleton containerClassName="w-5" />
   }
   const token =
-    getTokenByAddress(withdrawal.l2Token as Address, hemi.id) ??
+    getTokenByAddress(
+      withdrawal.l2Token as Address,
+      // See https://github.com/hemilabs/ui-monorepo/issues/376
+      withdrawal.l2ChainId ?? hemi.id,
+    ) ??
     getL2TokenByBridgedAddress(
       withdrawal.l2Token as Address,
-      // TODO https://github.com/BVM-priv/ui-monorepo/issues/158
-      evmRemoteNetworks[0].id,
+      // TODO https://github.com/hemilabs/ui-monorepo/issues/158
+      withdrawal.l1ChainId ?? evmRemoteNetworks[0].id,
     )
 
   return <Amount token={token} value={withdrawal.amount} />

--- a/webapp/app/[locale]/tunnel/_components/view.tsx
+++ b/webapp/app/[locale]/tunnel/_components/view.tsx
@@ -1,6 +1,7 @@
-import { bitcoin, evmRemoteNetworks, hemi } from 'app/networks'
+import { bitcoin, evmRemoteNetworks } from 'app/networks'
 import { ExternalLink } from 'components/externalLink'
 import { useBtcDeposits } from 'hooks/useBtcDeposits'
+import { useHemi } from 'hooks/useHemi'
 import { useGetClaimWithdrawalTxHash } from 'hooks/useL2Bridge'
 import { useTranslations } from 'next-intl'
 import Skeleton from 'react-loading-skeleton'
@@ -28,6 +29,7 @@ const BtcViewDeposit = function ({
 }) {
   const { partialDeposit } = state
   const deposits = useBtcDeposits()
+  const hemi = useHemi()
   const t = useTranslations()
   const { txHash } = useTunnelOperation()
 

--- a/webapp/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/webapp/app/[locale]/tunnel/_components/withdraw.tsx
@@ -1,5 +1,5 @@
 import { MessageStatus } from '@eth-optimism/sdk'
-import { RemoteChain, hemi, isEvmNetwork } from 'app/networks'
+import { RemoteChain, isEvmNetwork } from 'app/networks'
 import { Big } from 'big.js'
 import { addTimestampToOperation } from 'context/tunnelHistoryContext/operations'
 import { useAccounts } from 'hooks/useAccounts'
@@ -207,7 +207,7 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
     <TunnelForm
       bottomSection={<WalletsConnected />}
       expectedChainId={state.fromNetworkId}
-      explorerUrl={hemi.blockExplorers.default.url}
+      explorerUrl={fromChain.blockExplorers.default.url}
       formContent={
         <FormContent
           isRunningOperation={isWithdrawing}

--- a/webapp/app/[locale]/tunnel/_hooks/useDepositToken.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useDepositToken.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useApproveToken } from 'hooks/useApproveToken'
+import { useHemi } from 'hooks/useHemi'
 import { useDepositErc20Token } from 'hooks/useL2Bridge'
 import { useEffect } from 'react'
 import { type EvmToken } from 'types/token'
@@ -28,12 +29,14 @@ export const useDepositToken = function ({
   extendedApproval = false,
   token,
 }: UseDepositToken) {
-  const toDeposit = parseUnits(amount, token.decimals).toString()
+  const { address: owner } = useAccount()
+  const hemi = useHemi()
   const queryClient = useQueryClient()
 
-  const { address: owner } = useAccount()
+  const toDeposit = parseUnits(amount, token.decimals).toString()
 
   const l1StandardBridgeAddress = getTunnelContracts(
+    hemi,
     token.chainId,
   ).L1StandardBridge
 

--- a/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
@@ -2,12 +2,12 @@ import { featureFlags } from 'app/featureFlags'
 import {
   bitcoin,
   evmRemoteNetworks,
-  hemi,
   networks,
   type RemoteChain,
 } from 'app/networks'
 import { type BtcChain } from 'btc-wallet/chains'
 import { BtcTransaction } from 'btc-wallet/unisat'
+import { useHemi } from 'hooks/useHemi'
 import { useCallback, useReducer } from 'react'
 import { type BtcToken, type EvmToken, type Token } from 'types/token'
 import { getNativeToken, getTokenByAddress } from 'utils/token'
@@ -161,10 +161,10 @@ const reducer = function (state: TunnelState, action: Actions): TunnelState {
   }
 }
 
-const getDefaultNetworksOrder = function ({
-  operation,
-  txHash,
-}: ReturnType<typeof useTunnelOperation>) {
+const getDefaultNetworksOrder = function (
+  { operation, txHash }: ReturnType<typeof useTunnelOperation>,
+  hemi: Chain,
+) {
   const bitcoinFromL1ToL2 = {
     fromNetworkId: bitcoin.id,
     toNetworkId: hemi.id,
@@ -214,9 +214,10 @@ export const useTunnelState = function (): TunnelState & {
     payload?: Extract<Actions, { type: K }>['payload'],
   ) => void
 } {
+  const hemi = useHemi()
   const tunnelOperation = useTunnelOperation()
 
-  const initial = getDefaultNetworksOrder(tunnelOperation)
+  const initial = getDefaultNetworksOrder(tunnelOperation, hemi)
 
   const [state, dispatch] = useReducer(reducer, {
     fromInput: '0',
@@ -326,7 +327,7 @@ export const useTunnelState = function (): TunnelState & {
 
         dispatch({ payload: newToken, type: 'updateFromToken' })
       },
-      [dispatch],
+      [dispatch, hemi.id],
     ),
   }
 }

--- a/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
@@ -9,18 +9,14 @@ import {
 import { type BtcChain } from 'btc-wallet/chains'
 import { BtcTransaction } from 'btc-wallet/unisat'
 import { useCallback, useReducer } from 'react'
-import { tokenList } from 'tokenList'
 import { type BtcToken, type EvmToken, type Token } from 'types/token'
-import { isNativeToken, getTokenByAddress } from 'utils/token'
+import { getNativeToken, getTokenByAddress } from 'utils/token'
 import { type NoPayload, type Payload } from 'utils/typeUtilities'
 import { type Chain, type Hash, isHash } from 'viem'
 
 import { useTunnelOperation } from './useTunnelOperation'
 
 export type Operation = 'claim' | 'deposit' | 'prove' | 'withdraw' | 'view'
-
-const getNativeToken = (chain: RemoteChain['id']) =>
-  tokenList.tokens.find(t => t.chainId === chain && isNativeToken(t))
 
 export type TunnelState = {
   fromInput: string

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/amount.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/amount.tsx
@@ -1,7 +1,8 @@
-import { evmRemoteNetworks, hemi } from 'app/networks'
+import { evmRemoteNetworks } from 'app/networks'
 import Big from 'big.js'
 import { ChainLogo } from 'components/chainLogo'
 import { TokenLogo } from 'components/tokenLogo'
+import { useHemi } from 'hooks/useHemi'
 import smartRound from 'smart-round'
 import { Token } from 'types/token'
 import { TunnelOperation } from 'types/tunnel'
@@ -64,6 +65,7 @@ const Value = ({ amount, token }: ValueProps) => (
 
 export const Amount = function ({ operation }: Props) {
   const { amount, l1Token, l2Token } = operation
+  const hemi = useHemi()
 
   const tokenAddress = (isDeposit(operation) ? l1Token : l2Token) as Address
   const chainId = isDeposit(operation)

--- a/webapp/app/networks.tsx
+++ b/webapp/app/networks.tsx
@@ -22,7 +22,7 @@ export type RemoteChain = BtcChain | EvmChain
 
 const testnetMode = (process.env.NEXT_PUBLIC_TESTNET_MODE ?? 'false') === 'true'
 
-export const hemi: EvmChain = {
+const hemi: EvmChain = {
   ...(testnetMode ? hemiTestnet : hemiMainnet),
   iconBackground: '#FFFFFF',
   iconUrl: () =>

--- a/webapp/components/addNetworkToWallet.tsx
+++ b/webapp/components/addNetworkToWallet.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { hemi } from 'app/networks'
+import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
 import { useAccount, useWalletClient } from 'wagmi'
 
 export function AddNetworkToWallet() {
   const { chain, isConnected } = useAccount()
+  const hemi = useHemi()
   const t = useTranslations()
   const { data: walletClient, status } = useWalletClient()
 

--- a/webapp/components/chainLogo.tsx
+++ b/webapp/components/chainLogo.tsx
@@ -1,29 +1,23 @@
-import {
-  bitcoin,
-  evmRemoteNetworks,
-  hemi,
-  type RemoteChain,
-} from 'app/networks'
+import { bitcoin, evmRemoteNetworks, type RemoteChain } from 'app/networks'
+import { hemi as hemiMainnet, hemiSepolia as hemiSepolia } from 'hemi-viem'
 import { BtcLogo } from 'ui-common/components/btcLogo'
 import { EthLogo } from 'ui-common/components/ethLogo'
 import { HemiTokenWithBackground } from 'ui-common/components/hemiLogo'
-
-const Logos = {
-  [bitcoin.id]: BtcLogo,
-  [hemi.id]: HemiTokenWithBackground,
-  // Extend with multichain support
-  // See https://github.com/BVM-priv/ui-monorepo/issues/158
-  [evmRemoteNetworks[0].id]: EthLogo,
-}
 
 export const ChainLogo = function ({
   chainId,
 }: {
   chainId: RemoteChain['id']
 }) {
-  const Logo = Logos[chainId]
-  if (!Logo) {
-    return <HemiTokenWithBackground />
+  switch (chainId) {
+    case bitcoin.id:
+      return <BtcLogo />
+    case hemiMainnet.id:
+    case hemiSepolia.id:
+      return <HemiTokenWithBackground />
+    case evmRemoteNetworks[0].id:
+      return <EthLogo />
+    default:
+      return <HemiTokenWithBackground />
   }
-  return <Logo />
 }

--- a/webapp/components/connectedWallet/evmLogo.tsx
+++ b/webapp/components/connectedWallet/evmLogo.tsx
@@ -1,4 +1,4 @@
-import { hemi } from 'app/networks'
+import { useHemi } from 'hooks/useHemi'
 import { Chain } from 'viem'
 
 import { EthLogo } from './ethLogo'
@@ -8,6 +8,8 @@ type Props = {
   chainId: Chain['id']
 }
 
-//See https://github.com/BVM-priv/ui-monorepo/issues/158
-export const EvmLogo = ({ chainId }: Props) =>
-  chainId === hemi.id ? <HemiLogo /> : <EthLogo />
+//See https://github.com/hemilabs/ui-monorepo/issues/158
+export const EvmLogo = function ({ chainId }: Props) {
+  const hemi = useHemi()
+  return chainId === hemi.id ? <HemiLogo /> : <EthLogo />
+}

--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { featureFlags } from 'app/featureFlags'
-import { bitcoin, hemi, type RemoteChain, remoteNetworks } from 'app/networks'
+import { bitcoin, type RemoteChain, remoteNetworks } from 'app/networks'
+import { useHemi } from 'hooks/useHemi'
 import { useSyncHistory } from 'hooks/useSyncHistory'
 import {
   SyncStatus,
@@ -84,8 +85,7 @@ type Props = {
 export const TunnelHistoryProvider = function ({ children }: Props) {
   const { address, isConnected } = useAccount()
 
-  // See https://github.com/hemilabs/ui-monorepo/issues/462
-  const l2ChainId = hemi.id
+  const l2ChainId = useHemi().id
 
   const [history, dispatch] = useSyncHistory(l2ChainId)
 

--- a/webapp/context/tunnelHistoryContext/withdrawalsStateUpdater.tsx
+++ b/webapp/context/tunnelHistoryContext/withdrawalsStateUpdater.tsx
@@ -1,14 +1,16 @@
 import { MessageStatus } from '@eth-optimism/sdk'
-import { QueryClient, useQuery } from '@tanstack/react-query'
-import { evmRemoteNetworks, hemi } from 'app/networks'
+import { useQuery } from '@tanstack/react-query'
+import { evmRemoteNetworks } from 'app/networks'
 import { hemi as hemiMainnet, hemiSepolia as hemiTestnet } from 'hemi-viem'
 import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
+import { useHemi } from 'hooks/useHemi'
 import { useConnectedChainCrossChainMessenger } from 'hooks/useL2Bridge'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import PQueue from 'p-queue'
 import { EvmWithdrawOperation } from 'types/tunnel'
 import { CrossChainMessengerProxy } from 'utils/crossChainMessenger'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
+import { type Chain } from 'viem'
 import { useAccount } from 'wagmi'
 
 const queue = new PQueue({ concurrency: 2 })
@@ -41,7 +43,7 @@ const refetchInterval = {
   },
 } satisfies { [chainId: number]: { [status: number]: number | false } }
 
-const getBlockTimestamp = (withdrawal: EvmWithdrawOperation) =>
+const getBlockTimestamp = (withdrawal: EvmWithdrawOperation, hemi: Chain) =>
   async function (
     blockNumber: number | undefined,
   ): Promise<[number?, number?]> {
@@ -65,8 +67,7 @@ const getTransactionBlockNumber = function (withdrawal: EvmWithdrawOperation) {
   }
   return getEvmTransactionReceipt(
     withdrawal.transactionHash,
-    // See https://github.com/hemilabs/ui-monorepo/issues/462
-    withdrawal.l2ChainId ?? hemi.id,
+    withdrawal.l2ChainId,
   ).then(transactionReceipt =>
     // return undefined if TX is not found - might have not been confirmed yet
     transactionReceipt ? Number(transactionReceipt.blockNumber) : undefined,
@@ -75,11 +76,12 @@ const getTransactionBlockNumber = function (withdrawal: EvmWithdrawOperation) {
 
 const pollUpdateWithdrawal = async ({
   crossChainMessenger,
+  hemi,
   updateWithdrawal,
   withdrawal,
 }: {
   crossChainMessenger: CrossChainMessengerProxy
-  queryClient: QueryClient
+  hemi: Chain
   updateWithdrawal: (
     w: EvmWithdrawOperation,
     updates: Partial<EvmWithdrawOperation>,
@@ -99,7 +101,7 @@ const pollUpdateWithdrawal = async ({
           withdrawal.direction,
         ),
         getTransactionBlockNumber(withdrawal).then(
-          getBlockTimestamp(withdrawal),
+          getBlockTimestamp(withdrawal, hemi),
         ),
       ])
       const changes: Partial<EvmWithdrawOperation> = {}
@@ -135,19 +137,30 @@ const pollUpdateWithdrawal = async ({
   )
 
 const WatchEvmWithdrawal = function ({
-  queryFn,
   withdrawal,
 }: {
-  queryFn: () => Promise<MessageStatus>
   withdrawal: EvmWithdrawOperation
 }) {
+  const { crossChainMessenger, crossChainMessengerStatus } =
+    useConnectedChainCrossChainMessenger(l1ChainId)
+  const { updateWithdrawal } = useTunnelHistory()
+
+  const hemi = useHemi()
   // This is a hacky usage of useQuery. I am using it this way because it provides automatic refetching,
   // request deduping, and conditional refetch depending on the state of the withdrawal.
   // I am not interested in the actual result of the query, but in the side effect of the queryFn
   useQuery({
-    queryFn,
+    enabled: crossChainMessengerStatus === 'success',
+    queryFn: () =>
+      pollUpdateWithdrawal({
+        crossChainMessenger,
+        hemi,
+        updateWithdrawal,
+        withdrawal,
+      }),
     queryKey: [
       'withdrawaStateUpdater',
+      // See https://github.com/hemilabs/ui-monorepo/issues/462
       withdrawal.l2ChainId ?? hemi.id,
       withdrawal.transactionHash,
     ],
@@ -160,18 +173,11 @@ const WatchEvmWithdrawal = function ({
 
 export const WithdrawalsStateUpdater = function () {
   const { isConnected } = useAccount()
-  const { updateWithdrawal, withdrawals = [] } = useTunnelHistory()
+  const { withdrawals = [] } = useTunnelHistory()
 
   const unsupportedChain = useConnectedToUnsupportedEvmChain()
 
-  const { crossChainMessenger, crossChainMessengerStatus } =
-    useConnectedChainCrossChainMessenger(l1ChainId)
-
-  if (
-    !isConnected ||
-    crossChainMessengerStatus !== 'success' ||
-    unsupportedChain
-  ) {
+  if (!isConnected || unsupportedChain) {
     return null
   }
 
@@ -200,18 +206,7 @@ export const WithdrawalsStateUpdater = function () {
   return (
     <>
       {withdrawalsToWatch.map(w => (
-        <WatchEvmWithdrawal
-          key={w.transactionHash}
-          queryFn={() =>
-            // @ts-expect-error unsure why it adds void, but actual result is not needed
-            pollUpdateWithdrawal({
-              crossChainMessenger,
-              updateWithdrawal,
-              withdrawal: w,
-            })
-          }
-          withdrawal={w}
-        />
+        <WatchEvmWithdrawal key={w.transactionHash} withdrawal={w} />
       ))}
     </>
   )

--- a/webapp/context/tunnelHistoryContext/withdrawalsStateUpdater.tsx
+++ b/webapp/context/tunnelHistoryContext/withdrawalsStateUpdater.tsx
@@ -55,7 +55,7 @@ const getBlockTimestamp = (withdrawal: EvmWithdrawOperation, hemi: Chain) =>
     }
     const { timestamp } = await getEvmBlock(
       blockNumber,
-      // See https://github.com/hemilabs/ui-monorepo/issues/462
+      // See https://github.com/hemilabs/ui-monorepo/issues/376
       withdrawal.l2ChainId ?? hemi.id,
     )
     return [blockNumber, Number(timestamp)]
@@ -160,7 +160,7 @@ const WatchEvmWithdrawal = function ({
       }),
     queryKey: [
       'withdrawaStateUpdater',
-      // See https://github.com/hemilabs/ui-monorepo/issues/462
+      // See https://github.com/hemilabs/ui-monorepo/issues/376
       withdrawal.l2ChainId ?? hemi.id,
       withdrawal.transactionHash,
     ],

--- a/webapp/hooks/useBtcTunnel.ts
+++ b/webapp/hooks/useBtcTunnel.ts
@@ -1,7 +1,7 @@
 import { MessageDirection, MessageStatus } from '@eth-optimism/sdk'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTunnelOperation } from 'app/[locale]/tunnel/_hooks/useTunnelOperation'
-import { bitcoin, hemi } from 'app/networks'
+import { bitcoin } from 'app/networks'
 import { BtcChain } from 'btc-wallet/chains'
 import { useAccount as useBtcAccount } from 'btc-wallet/hooks/useAccount'
 import { Satoshis } from 'btc-wallet/unisat'
@@ -184,8 +184,9 @@ export const useWithdrawBitcoin = function () {
         l1ChainId,
         l1Token: zeroAddress,
         l2ChainId,
-        l2Token: getNativeToken(bitcoin.id).extensions.bridgeInfo[hemi.id]
-          .tokenAddress,
+        l2Token: getNativeToken(bitcoin.id).extensions.bridgeInfo[
+          hemiClient.chain.id
+        ].tokenAddress,
         status: MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE,
         to: btcAddress,
         transactionHash,

--- a/webapp/hooks/useHemi.tsx
+++ b/webapp/hooks/useHemi.tsx
@@ -1,0 +1,30 @@
+import { type Chain as RainbowKitChain } from '@rainbow-me/rainbowkit'
+import { hemi as hemiMainnet, hemiSepolia as hemiTestnet } from 'hemi-viem'
+import { useMemo } from 'react'
+import { renderToString } from 'react-dom/server'
+import { HemiSymbolWhite } from 'ui-common/components/hemiLogo'
+import { type Chain } from 'viem'
+
+import { useNetworkType } from './useNetworkType'
+
+type EvmChain = Omit<Chain, 'fees' | 'serializers'> &
+  Pick<RainbowKitChain, 'iconBackground' | 'iconUrl'>
+
+export const useHemi = function () {
+  const [type] = useNetworkType()
+  return useMemo(
+    () =>
+      ({
+        ...(type === 'testnet' ? hemiTestnet : hemiMainnet),
+        // See https://github.com/hemilabs/ui-monorepo/issues/478 for when to remove
+        iconBackground: '#FFFFFF',
+        iconUrl: () =>
+          Promise.resolve(
+            `data:image/svg+xml;base64,${btoa(
+              renderToString(<HemiSymbolWhite />),
+            )}`,
+          ),
+      }) satisfies EvmChain,
+    [type],
+  )
+}

--- a/webapp/hooks/useHemiClient.ts
+++ b/webapp/hooks/useHemiClient.ts
@@ -1,4 +1,3 @@
-import { hemi } from 'app/networks'
 import {
   hemiPublicBitcoinKitActions,
   hemiPublicBitcoinTunnelManagerActions,
@@ -6,8 +5,10 @@ import {
   hemiWalletBitcoinTunnelManagerActions,
 } from 'hemi-viem'
 import { useMemo } from 'react'
-import { type Address, type Chain, type PublicClient } from 'viem'
+import { type Address, type PublicClient } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
+
+import { useHemi } from './useHemi'
 
 const localExtensions = () => ({
   // in incoming iterations, the owner address will be determined programmatically
@@ -24,14 +25,16 @@ export const publicClientToHemiClient = (publicClient: PublicClient) =>
     .extend(hemiPublicBitcoinTunnelManagerActions())
     .extend(localExtensions)
 
-export const useHemiClient = function (chainId: Chain['id'] = hemi.id) {
-  const hemiClient = usePublicClient({ chainId })
+export const useHemiClient = function () {
+  const hemi = useHemi()
+  const hemiClient = usePublicClient({ chainId: hemi.id })
   return useMemo(() => publicClientToHemiClient(hemiClient), [hemiClient])
 }
 
-export const useHemiWalletClient = function (chainId: Chain['id'] = hemi.id) {
+export const useHemiWalletClient = function () {
+  const hemi = useHemi()
   const { data: hemiWalletClient, ...rest } = useWalletClient({
-    chainId,
+    chainId: hemi.id,
     query: {
       select: walletClient =>
         walletClient.extend(hemiWalletBitcoinTunnelManagerActions()),

--- a/webapp/hooks/useNetworkType.ts
+++ b/webapp/hooks/useNetworkType.ts
@@ -1,0 +1,12 @@
+import { useQueryState, parseAsStringLiteral } from 'nuqs'
+
+// Add mainnet and, once mainnet goes live,
+// default should be changed to mainnet
+// See https://github.com/hemilabs/ui-monorepo/issues/479
+const networkTypes = ['testnet'] as const
+
+export const useNetworkType = () =>
+  useQueryState(
+    'networkType',
+    parseAsStringLiteral(networkTypes).withDefault(networkTypes[0]),
+  )

--- a/webapp/hooks/useSyncHistory/index.ts
+++ b/webapp/hooks/useSyncHistory/index.ts
@@ -2,9 +2,9 @@ import {
   findChainById,
   isEvmNetwork,
   remoteNetworks,
-  hemi,
   type RemoteChain,
 } from 'app/networks'
+import { hemiSepolia } from 'hemi-viem'
 import { useConnectedToSupportedEvmChain } from 'hooks/useConnectedToSupportedChain'
 import debounce from 'lodash/debounce'
 import { useEffect, useReducer, useState } from 'react'
@@ -84,7 +84,7 @@ const historyReducer = function (
                 ({
                   ...deposit,
                   l1ChainId: deposit.l1ChainId,
-                  l2ChainId: deposit.l2ChainId ?? hemi.id,
+                  l2ChainId: deposit.l2ChainId ?? hemiSepolia.id,
                 }) as DepositTunnelOperation,
             ),
             status: 'ready',
@@ -97,7 +97,7 @@ const historyReducer = function (
                 ({
                   ...withdrawal,
                   l1ChainId: withdrawal.l1ChainId,
-                  l2ChainId: withdrawal.l2ChainId ?? hemi.id,
+                  l2ChainId: withdrawal.l2ChainId ?? hemiSepolia.id,
                 }) as WithdrawTunnelOperation,
             ),
             status: 'ready',

--- a/webapp/hooks/useSyncHistory/index.ts
+++ b/webapp/hooks/useSyncHistory/index.ts
@@ -78,7 +78,7 @@ const historyReducer = function (
           ...state,
           deposits: payload.deposits.map(chainDeposits => ({
             ...chainDeposits,
-            // See https://github.com/hemilabs/ui-monorepo/issues/462
+            // See https://github.com/hemilabs/ui-monorepo/issues/376
             content: chainDeposits.content.map(
               deposit =>
                 ({
@@ -91,7 +91,7 @@ const historyReducer = function (
           })),
           withdrawals: payload.withdrawals.map(chainWithdrawals => ({
             ...chainWithdrawals,
-            // See https://github.com/hemilabs/ui-monorepo/issues/462
+            // See https://github.com/hemilabs/ui-monorepo/issues/376
             content: chainWithdrawals.content.map(
               withdrawal =>
                 ({

--- a/webapp/tokenList.ts
+++ b/webapp/tokenList.ts
@@ -1,8 +1,8 @@
 import hemilabsTokenList from '@hemilabs/token-list'
 import { featureFlags } from 'app/featureFlags'
-import { hemi } from 'app/networks'
 import { bitcoinTestnet } from 'btc-wallet/chains'
-import { Token } from 'types/token'
+import { hemi as hemiMainnet, hemiSepolia } from 'hemi-viem'
+import { type EvmToken, type Token } from 'types/token'
 import { Address } from 'viem'
 import { mainnet, sepolia } from 'wagmi/chains'
 
@@ -15,8 +15,8 @@ export const NativeTokenSpecialAddressOnL2 =
 const btcLogoUri = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Cg clip-path='url(%23clip0_2772_63828)'%3E%3Cpath d='M12 24.0107C18.6274 24.0107 24 18.6382 24 12.0107C24 5.38333 18.6274 0.0107422 12 0.0107422C5.37258 0.0107422 0 5.38333 0 12.0107C0 18.6382 5.37258 24.0107 12 24.0107Z' fill='%238A8A8A'/%3E%3Cpath d='M17.5202 10.6307C17.7668 9.10674 16.6882 8.40141 16.0828 8.01208C15.4802 7.62274 14.5588 7.34274 14.5588 7.34274L15.1482 4.96941L13.7882 4.62808L13.1988 7.00141L12.1122 6.72674L12.7015 4.35341L11.3255 4.01074L10.7362 6.38408L7.86016 5.66141L7.51083 7.06941C7.51083 7.06941 8.93083 7.42408 9.08683 7.46541C9.24683 7.50408 9.2255 7.58541 9.21216 7.63874C9.19883 7.69208 7.4255 14.8454 7.39883 14.9401C7.3775 15.0361 7.3615 15.0907 7.2295 15.0601L5.7215 14.6814L5.3335 16.2454L8.1175 16.9427L7.5535 19.2121L9.0375 19.5841L9.6015 17.3134L10.5255 17.5454L9.9615 19.8161L11.3748 20.1707L11.9402 17.9014L13.0042 18.1681C13.7108 18.3454 16.3962 18.3787 16.9802 16.0201C17.5655 13.6601 15.6308 12.6614 15.6308 12.6614C15.6308 12.6614 17.2708 12.1547 17.5202 10.6307ZM14.2975 15.0067C14.0175 16.1361 12.7575 16.2227 12.4708 16.1494L9.94416 15.5174L10.6908 12.5014L13.3108 13.1574C13.8135 13.2854 14.5788 13.8774 14.2975 15.0067ZM14.7642 10.4134C14.4655 11.6161 13.2655 11.5614 12.8868 11.4681L11.0402 11.0054L11.7522 8.13474L13.4375 8.55608C13.7255 8.62808 15.0642 9.21208 14.7642 10.4134Z' fill='white'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_2772_63828'%3E%3Crect width='24' height='24' fill='white' transform='translate(0 -0.00878906)'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E`
 const ethLogoUri = `data:image/svg+xml,%3Csvg fill='none' height='24' width='25' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23627EEA' d='M12.5 24c6.627 0 12-5.373 12-12s-5.373-12-12-12S.5 5.373.5 12s5.373 12 12 12Z' /%3E%3Cg fill='%23fff'%3E%3Cpath d='M12.873 3v6.652l5.623 2.513L12.873 3Z' fill-opacity='0.602' /%3E%3Cpath d='M12.873 3 7.25 12.165l5.623-2.512V3Z' /%3E%3Cpath d='M12.873 16.476v4.52l5.627-7.784-5.627 3.264Z' fill-opacity='0.602' /%3E%3Cpath d='M12.873 20.996v-4.52L7.25 13.211l5.623 7.784Z' /%3E%3Cpath d='m12.873 15.43 5.623-3.265-5.623-2.51v5.775Z' fill-opacity='0.2' /%3E%3Cpath d='m7.25 12.165 5.623 3.265V9.654L7.25 12.165Z' fill-opacity='0.602' /%3E%3C/g%3E%3C/svg%3E`
 
-const hemiTokens: Token[] = (hemilabsTokenList.tokens as Token[])
-  .filter(t => t.chainId === hemi.id)
+const hemiTokens: Token[] = (hemilabsTokenList.tokens as EvmToken[])
+  .filter(t => t.chainId === hemiMainnet.id || t.chainId === hemiSepolia.id)
   // WETH cannot be tunneled, so we must exclude it
   .filter(t => t.symbol !== 'WETH')
 
@@ -39,7 +39,6 @@ const l1HemiTokens = hemiTokens
       symbol: t.symbol
         // Remove the ".e" suffix
         .replace('.e', '')
-
         .trim(),
     })),
   )
@@ -54,7 +53,7 @@ const nativeTokens: Token[] = [
     extensions: {
       bridgeInfo: {
         // Leaving intentionally empty as there's no token address for native ETH in hemi
-        [hemi.id]: {},
+        [hemiMainnet.id]: {},
       },
     },
     logoURI: ethLogoUri,
@@ -68,7 +67,7 @@ const nativeTokens: Token[] = [
     extensions: {
       bridgeInfo: {
         // Leaving intentionally empty as there's no token address for native ETH in hemi
-        [hemi.id]: {},
+        [hemiSepolia.id]: {},
       },
     },
     logoURI: ethLogoUri,
@@ -76,26 +75,37 @@ const nativeTokens: Token[] = [
     symbol: sepolia.nativeCurrency.symbol,
   },
   {
-    address: hemi.nativeCurrency.symbol,
-    chainId: hemi.id,
-    decimals: hemi.nativeCurrency.decimals,
+    address: hemiMainnet.nativeCurrency.symbol,
+    chainId: hemiMainnet.id,
+    decimals: hemiMainnet.nativeCurrency.decimals,
     extensions: {
       bridgeInfo: {
         [mainnet.id]: {
           tokenAddress: NativeTokenSpecialAddressOnL2,
         },
+      },
+    },
+    name: hemiMainnet.nativeCurrency.name,
+    symbol: hemiMainnet.nativeCurrency.symbol,
+  },
+  {
+    address: hemiSepolia.nativeCurrency.symbol,
+    chainId: hemiSepolia.id,
+    decimals: hemiSepolia.nativeCurrency.decimals,
+    extensions: {
+      bridgeInfo: {
         [sepolia.id]: {
           tokenAddress: NativeTokenSpecialAddressOnL2,
         },
       },
     },
-    name: hemi.nativeCurrency.name,
-    symbol: hemi.nativeCurrency.symbol,
+    name: hemiSepolia.nativeCurrency.name,
+    symbol: hemiSepolia.nativeCurrency.symbol,
   },
 ]
 
 if (featureFlags.btcTunnelEnabled) {
-  // TODO needs to be added to the token list https://github.com/BVM-priv/ui-monorepo/issues/356
+  // TODO needs to be added to the token list https://github.com/hemilabs/ui-monorepo/issues/356
   const btcTokenAddress = '0x1b70FbDf46EB3e0AD5B34706d1984dc7e0265907'
   nativeTokens.push({
     address: bitcoinTestnet.nativeCurrency.symbol,
@@ -103,7 +113,7 @@ if (featureFlags.btcTunnelEnabled) {
     decimals: bitcoinTestnet.nativeCurrency.decimals,
     extensions: {
       bridgeInfo: {
-        [hemi.id]: {
+        [hemiSepolia.id]: {
           tokenAddress: btcTokenAddress,
         },
       },
@@ -114,7 +124,7 @@ if (featureFlags.btcTunnelEnabled) {
   })
   tokens.push({
     address: btcTokenAddress,
-    chainId: hemi.id,
+    chainId: hemiSepolia.id,
     decimals: 8,
     extensions: {
       bridgeInfo: {

--- a/webapp/utils/sync-history/chainConfiguration.ts
+++ b/webapp/utils/sync-history/chainConfiguration.ts
@@ -1,15 +1,18 @@
-import { bitcoin, hemi } from 'app/networks'
+import { hemi as hemiMainnet, hemiSepolia as hemiTestnet } from 'hemi-viem'
 import { sepolia } from 'viem/chains'
 
+// Approximately 1/2 day
+const opBasedEvmBlockWindowSize = 3500
+
 export const chainConfiguration = {
-  [bitcoin.id]: {
-    // bitcoin API doesn't allow to set a block window size
+  [hemiMainnet.id]: {
+    blockWindowSize: opBasedEvmBlockWindowSize,
   },
-  [hemi.id]: {
-    blockWindowSize: 3500, // Approximately 1/2 day
+  [hemiTestnet.id]: {
+    blockWindowSize: opBasedEvmBlockWindowSize,
   },
   [sepolia.id]: {
-    blockWindowSize: 3500, // Approximately 1/2 day
+    blockWindowSize: opBasedEvmBlockWindowSize,
     minBlockToSync: 5_294_649, // Approximately hemi testnet birth.
   },
 } as const

--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -267,6 +267,7 @@ export const createEvmSync = function ({
     const crossChainMessengerPromise = createCrossChainMessenger({
       l1ChainId: l1Chain.id,
       l1Signer: l1Provider,
+      l2Chain,
       l2Signer: l2Provider,
     })
 

--- a/webapp/utils/token.ts
+++ b/webapp/utils/token.ts
@@ -1,4 +1,4 @@
-import { hemi } from 'app/networks'
+import { hemi, hemiSepolia } from 'hemi-viem'
 import { tokenList } from 'tokenList'
 import { EvmToken, Token } from 'types/token'
 import { Address, isAddressEqual } from 'viem'
@@ -29,7 +29,7 @@ export const getL2TokenByBridgedAddress = (
 ) =>
   tokenList.tokens.find(
     token =>
-      token.chainId === hemi.id &&
+      (token.chainId === hemi.id || token.chainId === hemiSepolia.id) &&
       token.extensions?.bridgeInfo?.[l1ChainId]?.tokenAddress &&
       isAddressEqual(
         token.extensions.bridgeInfo[l1ChainId].tokenAddress,


### PR DESCRIPTION
As part of preparing the code for `mainnet`, this PR removes importing `hemi` in many places and adds a new hook which, reading from the query string, returns the appropriate `hemi` instance.

There are a few scenarios where `hemi-sepolia` is directly used as getting the hook could be complicated and there are temporary solutions anyway (See https://github.com/hemilabs/ui-monorepo/issues/376 )

The next step is getting all the networks / evm networks and other chain arrays based on this setting. 

Related to https://github.com/hemilabs/ui-monorepo/issues/462