### PR TITLE
Save timestamp when syncing bitcoin history

### DIFF
--- a/webapp/utils/btcApi.ts
+++ b/webapp/utils/btcApi.ts
@@ -7,6 +7,7 @@ const toCamelCase = <T>(obj: T) => camelCaseKeys(obj, { deep: true })
 const apiUrl = process.env.NEXT_PUBLIC_MEMPOOL_API_URL
 
 type TransactionStatus = {
+  blockTime?: number
   confirmed: boolean
 }
 

--- a/webapp/utils/sync-history/bitcoin.ts
+++ b/webapp/utils/sync-history/bitcoin.ts
@@ -143,6 +143,7 @@ export const createBitcoinSync = function ({
                 l1Token: btc.address,
                 l2ChainId: l2Chain.id,
                 l2Token: btc.extensions.bridgeInfo[l2Chain.id].tokenAddress,
+                timestamp: bitcoinDeposit.status.blockTime,
                 to: bitcoinCustodyAddress,
                 transactionHash: bitcoinDeposit.txId,
               }


### PR DESCRIPTION
Related to https://github.com/hemilabs/ui-monorepo/issues/345

When syncing Bitcoin deposits, I forgot to add the operation's timestamp 🤦🏽 
Undetected by Typescript because this field is defined as optional... (because we save the deposit as unconfirmed until the TX in Bitcoin is confirmed)