### PR TITLE
Remove box when switching page/tabs in tx history

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -390,9 +390,7 @@ export const TransactionHistory = function () {
           )}
         </>
       )}
-      {['connecting', 'reconnecting'].includes(status) && (
-        <Skeleton className="h-4/5 w-full" />
-      )}
+      {status === 'connecting' && <Skeleton className="h-4/5 w-full" />}
       {status === 'disconnected' && (
         <ConnectWallet
           heading={translate('common.connect-your-wallet')}


### PR DESCRIPTION
Closes https://github.com/hemilabs/ui-monorepo/issues/457

As I learned, when navigating between pages, `wagmi` performs a quick reconnect on every page (makes sense). It is just that Next makes it so good on the transitions that you forget that there are different pages. Due to this `reconnecting` (which I thought meant something different), we were showing the "Loading" box when switching between pages in the Tx history, or when switching from Tunnel <-> Transaction History.

Not anymore!


https://github.com/user-attachments/assets/e00ddef4-2e71-4c32-acd8-7db88ab6ad07

