### PR TITLE
Improve cross chain messenger concurrency

### DIFF
--- a/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useTunnelState.ts
@@ -199,7 +199,7 @@ const getDefaultNetworksOrder = function ({
   if (!['claim', 'deposit'].includes(operation)) {
     // for non-deposits, the withdrawals work ok
     // Needs to be updated once btc withdrawals are enabled
-    // https://github.com/BVM-priv/ui-monorepo/issues/343
+    // https://github.com/hemilabs/ui-monorepo/issues/343
     return evmFromL2ToL1
   }
   if (operation === 'claim') {

--- a/webapp/app/[locale]/tunnel/page.tsx
+++ b/webapp/app/[locale]/tunnel/page.tsx
@@ -103,7 +103,7 @@ const Operation = function ({
           subheading={t('tunnel-page.connect-wallet-to-review')}
         />
       )}
-      {/* Add better loading indicator https://github.com/BVM-priv/ui-monorepo/issues/157 */}
+      {/* Add better loading indicator https://github.com/hemilabs/ui-monorepo/issues/157 */}
       {!stateLoaded && <span>...</span>}
     </>
   )

--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -149,10 +149,11 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
 
   return (
     <TunnelHistoryContext.Provider value={value}>
-      {/* This could be done in a background process https://github.com/hemilabs/ui-monorepo/issues/390 */}
+      {/* Move to web worker https://github.com/hemilabs/ui-monorepo/issues/487 */}
       {/* Track updates on bitcoin deposits, in bitcoin or in Hemi */}
       {featureFlags.btcTunnelEnabled && <BitcoinDepositsStatusUpdater />}
       {/* Track updates on withdrawals from Hemi */}
+      {/* Move to web worker https://github.com/hemilabs/ui-monorepo/issues/486 */}
       <WithdrawalsStateUpdater />
       {children}
       {/* Sync the transaction history per chain in the background */}

--- a/webapp/hooks/useL2Bridge.ts
+++ b/webapp/hooks/useL2Bridge.ts
@@ -13,8 +13,8 @@ import { useJsonRpcProvider, useWeb3Provider } from 'hooks/useEthersSigner'
 import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
 import { Token } from 'types/token'
 import {
-  createCrossChainMessenger,
   type CrossChainMessengerProxy,
+  createIsolatedCrossChainMessenger,
 } from 'utils/crossChainMessenger'
 import { type Chain, type Hash, isHash } from 'viem'
 import { useAccount } from 'wagmi'
@@ -58,7 +58,7 @@ const useCrossChainMessenger = function ({
     useQuery({
       enabled: isConnectedToCorrectChain && !!l1Signer && !!l2Signer,
       queryFn: () =>
-        createCrossChainMessenger({
+        createIsolatedCrossChainMessenger({
           l1ChainId,
           l1Signer,
           l2Chain: hemi,


### PR DESCRIPTION
This PR is easier to review by commit.

After some testing in production with the web workers, this adds some tweaking to avoid overloading RPC calls when syncing past operations:

- 8d2a6445f704cf6020563328cd63c079cbbe9514 Adds better throttling when syncing EVM operations, tweaks a little bit the concurrency numbers after some testing, and also renames the functions used to instantiate `cross-chain-messenger`. Plus, now the hooks to deposit/withdraw do not share the global queue that syncing uses, so depositing/withdrawing is not delayed by syncing operations. (syncing will be a bit slower with the throttling, but as it happens in the background while the user is on the page, there are no hurries...). For the future, throttling should probably be solved at RPC level - See https://github.com/hemilabs/ui-monorepo/issues/489)
- bee0abaf88b32f5e03bd443161c3cf7baba32629 Updates some ticket references to move more sync code to web workers
- e192e9d853dba4548c3f1fb43f87d43e4c4c467b Updates references from old issues to the appropriate ones!