### PR TITLE
Remove HH from welcome pack

### DIFF
--- a/webapp/app/[locale]/get-started/_components/welcomePack.tsx
+++ b/webapp/app/[locale]/get-started/_components/welcomePack.tsx
@@ -35,9 +35,6 @@ const giveAwayTokens = (chain: Chain) =>
           icon: <Hemi />,
           symbol: 'tHEMI (Testnet Hemi)',
         },
-        {
-          symbol: 'Hemi Hatchling NFT',
-        },
       ]
     : // mainnet capsules not confirmed
       []


### PR DESCRIPTION
Closes https://github.com/hemilabs/ui-monorepo/issues/490

The capsule is no longer returning the HH, so this PR updates the UI to hide it.

![image](https://github.com/user-attachments/assets/7f2eabe7-0bfa-4046-9ae8-19edd1f6cc93)
