### PR TITLE
Allow resync tx history

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/reloadHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/reloadHistory.tsx
@@ -1,0 +1,29 @@
+import { useTunnelHistory } from 'hooks/useTunnelHistory'
+import { useTranslations } from 'next-intl'
+
+const ReloadIcon = () => (
+  <svg fill="none" height={14} width={14} xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M2.917 4.667h-.584v.583h.584v-.583ZM3.5 2.334V1.75H2.333v.583H3.5ZM5.25 5.25h.583V4.083H5.25V5.25Zm5.257 6.417v.583h1.167v-.583h-1.167Zm.583-2.333h.584V8.75h-.584v.584ZM8.757 8.75h-.584v1.167h.584V8.75ZM7 11.084A4.083 4.083 0 0 1 2.917 7H1.75c0 2.9 2.35 5.25 5.25 5.25v-1.166Zm0-8.167A4.083 4.083 0 0 1 11.083 7h1.167c0-2.9-2.35-5.25-5.25-5.25v1.167ZM3.422 4.959A4.15 4.15 0 0 1 7 2.917V1.75a5.316 5.316 0 0 0-4.588 2.625l1.01.584ZM2.917 7c0-.173.01-.344.031-.511l-1.157-.144c-.027.215-.041.433-.041.655h1.167Zm8.166 0c0 .174-.01.344-.031.511l1.157.145c.027-.215.04-.434.04-.656h-1.166Zm-.505 2.041A4.15 4.15 0 0 1 7 11.084v1.166a5.316 5.316 0 0 0 4.588-2.624l-1.01-.585ZM2.333 2.333v2.334H3.5V2.334H2.333Zm.584 2.917H5.25V4.083H2.917V5.25Zm8.757 6.417V9.334h-1.167v2.333h1.167ZM11.09 8.75H8.757v1.167h2.333V8.75Z"
+      fill="#737373"
+    />
+  </svg>
+)
+
+export const ReloadHistory = function () {
+  const t = useTranslations()
+  const { resyncHistory } = useTunnelHistory()
+
+  return (
+    <button
+      className="flex cursor-pointer items-center gap-x-1 rounded-full bg-neutral-100 px-4 py-1"
+      onClick={resyncHistory}
+      type="button"
+    >
+      <ReloadIcon />
+      <span className="text-sm font-medium text-neutral-600">
+        {t('tunnel-page.transaction-history.column-headers.reload')}
+      </span>
+    </button>
+  )
+}

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -35,6 +35,7 @@ import { Amount } from './amount'
 import { Chain as ChainComponent } from './chain'
 import { DepositAction } from './depositAction'
 import { Paginator } from './paginator'
+import { ReloadHistory } from './reloadHistory'
 import { TxLink } from './txLink'
 import { TxStatus } from './txStatus'
 import { TxTime } from './txTime'
@@ -192,7 +193,7 @@ const columnsBuilder = (
       ) : (
         <WithdrawAction withdraw={row.original} />
       ),
-    header: () => <Header />,
+    header: () => <ReloadHistory />,
     id: 'action',
   },
 ]

--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -56,6 +56,7 @@ type TunnelHistoryContext = {
     withdrawal: Omit<EvmWithdrawOperation, 'timestamp'>,
   ) => void
   deposits: DepositTunnelOperation[]
+  resyncHistory: () => void
   syncStatus: HistoryReducerState['status']
   updateDeposit: (
     deposit: DepositTunnelOperation,
@@ -72,6 +73,7 @@ export const TunnelHistoryContext = createContext<TunnelHistoryContext>({
   addDepositToTunnelHistory: () => undefined,
   addWithdrawalToTunnelHistory: () => undefined,
   deposits: [],
+  resyncHistory: () => undefined,
   syncStatus: 'idle',
   updateDeposit: () => undefined,
   updateWithdrawal: () => undefined,

--- a/webapp/hooks/useSyncHistory/index.ts
+++ b/webapp/hooks/useSyncHistory/index.ts
@@ -1,4 +1,3 @@
-import { hemiSepolia } from 'hemi-viem'
 import { useConnectedToSupportedEvmChain } from 'hooks/useConnectedToSupportedChain'
 import { useNetworks } from 'hooks/useNetworks'
 import debounce from 'lodash/debounce'
@@ -14,163 +13,14 @@ import { chainConfiguration } from 'utils/sync-history/chainConfiguration'
 import { type Address, type Chain } from 'viem'
 import { useAccount } from 'wagmi'
 
+import { historyReducer, initialState } from './reducer'
+import { type HistoryReducerState, type StorageChain } from './types'
 import {
-  type HistoryActions,
-  type HistoryReducerState,
-  type StorageChain,
-} from './types'
-import {
-  addOperation,
-  getSyncStatus,
   getTunnelHistoryDepositFallbackStorageKey,
   getTunnelHistoryDepositStorageKey,
   getTunnelHistoryWithdrawStorageKey,
   getTunnelHistoryWithdrawStorageKeyFallback,
-  syncContent,
-  updateChainSyncStatus,
-  updateOperation,
 } from './utils'
-
-// the _:never is used to fail compilation if a case is missing
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const compilationError = function (_: never): never {
-  throw new Error('Missing implementation of action in reducer')
-}
-
-const initialState: HistoryReducerState = {
-  deposits: [],
-  status: 'idle',
-  withdrawals: [],
-}
-
-const historyReducer = function (
-  state: HistoryReducerState,
-  action: HistoryActions,
-): HistoryReducerState {
-  const getNewState = function (): Omit<HistoryReducerState, 'status'> {
-    const { type } = action
-    switch (type) {
-      case 'add-deposit': {
-        const { payload: newDeposit } = action
-        const deposits = addOperation(state.deposits, newDeposit)
-
-        return {
-          ...state,
-          deposits,
-        }
-      }
-      case 'add-withdraw': {
-        const { payload: newWithdrawal } = action
-        const withdrawals = addOperation(state.withdrawals, newWithdrawal)
-        return {
-          ...state,
-          withdrawals,
-        }
-      }
-      case 'reset':
-        return { ...initialState }
-      case 'restore': {
-        const { payload } = action
-        return {
-          ...state,
-          deposits: payload.deposits.map(chainDeposits => ({
-            ...chainDeposits,
-            // See https://github.com/hemilabs/ui-monorepo/issues/376
-            content: chainDeposits.content.map(
-              deposit =>
-                ({
-                  ...deposit,
-                  l1ChainId: deposit.l1ChainId,
-                  l2ChainId: deposit.l2ChainId ?? hemiSepolia.id,
-                }) as DepositTunnelOperation,
-            ),
-            status: 'ready',
-          })),
-          withdrawals: payload.withdrawals.map(chainWithdrawals => ({
-            ...chainWithdrawals,
-            // See https://github.com/hemilabs/ui-monorepo/issues/376
-            content: chainWithdrawals.content.map(
-              withdrawal =>
-                ({
-                  ...withdrawal,
-                  l1ChainId: withdrawal.l1ChainId,
-                  l2ChainId: withdrawal.l2ChainId ?? hemiSepolia.id,
-                }) as WithdrawTunnelOperation,
-            ),
-            status: 'ready',
-          })),
-        }
-      }
-      case 'sync': {
-        const { chainId } = action.payload
-        return updateChainSyncStatus(state, chainId, 'syncing')
-      }
-      case 'sync-deposits': {
-        const { chainId } = action.payload
-        const deposits = state.deposits.map(currentDeposits =>
-          currentDeposits.chainId === chainId
-            ? syncContent(currentDeposits, action.payload)
-            : currentDeposits,
-        )
-
-        return {
-          ...state,
-          deposits,
-        }
-      }
-      case 'sync-finished': {
-        const { chainId } = action.payload
-        return updateChainSyncStatus(state, chainId, 'finished')
-      }
-      case 'sync-withdrawals': {
-        const { chainId } = action.payload
-        const withdrawals = state.withdrawals.map(chainWithdrawals =>
-          chainWithdrawals.chainId === chainId
-            ? syncContent(chainWithdrawals, action.payload)
-            : chainWithdrawals,
-        )
-        return {
-          ...state,
-          withdrawals,
-        }
-      }
-      case 'update-deposit': {
-        const { deposit, updates } = action.payload
-        const deposits = updateOperation(state.deposits, {
-          operation: deposit,
-          updates,
-        })
-
-        return {
-          ...state,
-          deposits,
-        }
-      }
-      case 'update-withdraw': {
-        const { withdraw, updates } = action.payload
-        const withdrawals = updateOperation(state.withdrawals, {
-          operation: withdraw,
-          updates,
-        })
-
-        return {
-          ...state,
-          withdrawals,
-        }
-      }
-      default:
-        // if a switch statement is missing on all possible actions
-        // this will fail on compile time
-        return compilationError(type)
-    }
-  }
-
-  const newState = getNewState()
-  return {
-    ...newState,
-    status: getSyncStatus(newState),
-  }
-}
 
 const readStateFromStorage = function <T extends TunnelOperation>({
   chainId,

--- a/webapp/hooks/useSyncHistory/reducer.ts
+++ b/webapp/hooks/useSyncHistory/reducer.ts
@@ -1,0 +1,155 @@
+import { hemiSepolia } from 'hemi-viem'
+import {
+  type DepositTunnelOperation,
+  type WithdrawTunnelOperation,
+} from 'types/tunnel'
+
+import { type HistoryActions, type HistoryReducerState } from './types'
+import {
+  addOperation,
+  getSyncStatus,
+  syncContent,
+  updateChainSyncStatus,
+  updateOperation,
+} from './utils'
+
+// the _:never is used to fail compilation if a case is missing
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const compilationError = function (_: never): never {
+  throw new Error('Missing implementation of action in reducer')
+}
+
+export const initialState: HistoryReducerState = {
+  deposits: [],
+  status: 'idle',
+  withdrawals: [],
+}
+
+export const historyReducer = function (
+  state: HistoryReducerState,
+  action: HistoryActions,
+): HistoryReducerState {
+  const getNewState = function (): Omit<HistoryReducerState, 'status'> {
+    const { type } = action
+    switch (type) {
+      case 'add-deposit': {
+        const { payload: newDeposit } = action
+        const deposits = addOperation(state.deposits, newDeposit)
+
+        return {
+          ...state,
+          deposits,
+        }
+      }
+      case 'add-withdraw': {
+        const { payload: newWithdrawal } = action
+        const withdrawals = addOperation(state.withdrawals, newWithdrawal)
+        return {
+          ...state,
+          withdrawals,
+        }
+      }
+      case 'reset':
+        return { ...initialState }
+      case 'restore': {
+        const { payload } = action
+        return {
+          ...state,
+          deposits: payload.deposits.map(chainDeposits => ({
+            ...chainDeposits,
+            // See https://github.com/hemilabs/ui-monorepo/issues/376
+            content: chainDeposits.content.map(
+              deposit =>
+                ({
+                  ...deposit,
+                  l1ChainId: deposit.l1ChainId,
+                  l2ChainId: deposit.l2ChainId ?? hemiSepolia.id,
+                }) as DepositTunnelOperation,
+            ),
+            status: 'ready',
+          })),
+          withdrawals: payload.withdrawals.map(chainWithdrawals => ({
+            ...chainWithdrawals,
+            // See https://github.com/hemilabs/ui-monorepo/issues/376
+            content: chainWithdrawals.content.map(
+              withdrawal =>
+                ({
+                  ...withdrawal,
+                  l1ChainId: withdrawal.l1ChainId,
+                  l2ChainId: withdrawal.l2ChainId ?? hemiSepolia.id,
+                }) as WithdrawTunnelOperation,
+            ),
+            status: 'ready',
+          })),
+        }
+      }
+      case 'sync': {
+        const { chainId } = action.payload
+        return updateChainSyncStatus(state, chainId, 'syncing')
+      }
+      case 'sync-deposits': {
+        const { chainId } = action.payload
+        const deposits = state.deposits.map(currentDeposits =>
+          currentDeposits.chainId === chainId
+            ? syncContent(currentDeposits, action.payload)
+            : currentDeposits,
+        )
+
+        return {
+          ...state,
+          deposits,
+        }
+      }
+      case 'sync-finished': {
+        const { chainId } = action.payload
+        return updateChainSyncStatus(state, chainId, 'finished')
+      }
+      case 'sync-withdrawals': {
+        const { chainId } = action.payload
+        const withdrawals = state.withdrawals.map(chainWithdrawals =>
+          chainWithdrawals.chainId === chainId
+            ? syncContent(chainWithdrawals, action.payload)
+            : chainWithdrawals,
+        )
+        return {
+          ...state,
+          withdrawals,
+        }
+      }
+      case 'update-deposit': {
+        const { deposit, updates } = action.payload
+        const deposits = updateOperation(state.deposits, {
+          operation: deposit,
+          updates,
+        })
+
+        return {
+          ...state,
+          deposits,
+        }
+      }
+      case 'update-withdraw': {
+        const { withdraw, updates } = action.payload
+        const withdrawals = updateOperation(state.withdrawals, {
+          operation: withdraw,
+          updates,
+        })
+
+        return {
+          ...state,
+          withdrawals,
+        }
+      }
+      default:
+        // if a switch statement is missing on all possible actions
+        // this will fail on compile time
+        return compilationError(type)
+    }
+  }
+
+  const newState = getNewState()
+  return {
+    ...newState,
+    status: getSyncStatus(newState),
+  }
+}

--- a/webapp/hooks/useSyncHistory/utils.ts
+++ b/webapp/hooks/useSyncHistory/utils.ts
@@ -10,11 +10,6 @@ import {
   type SyncType,
 } from './types'
 
-export const getTunnelHistoryDepositFallbackStorageKey = (
-  l1ChainId: RemoteChain['id'],
-  address: Address,
-) => `portal.transaction-history-L1-${l1ChainId}-${address}-deposits`
-
 export const getTunnelHistoryDepositStorageKey = (
   l1ChainId: RemoteChain['id'],
   l2ChainId: Chain['id'],
@@ -27,11 +22,6 @@ export const getTunnelHistoryWithdrawStorageKey = (
   address: Address,
 ) =>
   `portal.transaction-history-${l1ChainId}-${l2ChainId}-${address}-withdrawals`
-
-export const getTunnelHistoryWithdrawStorageKeyFallback = (
-  l2ChainId: Chain['id'],
-  address: Address,
-) => `portal.transaction-history-L2-${l2ChainId}-${address}-withdrawals`
 
 const removeDuplicates = <T extends TunnelOperation>(merged: T[]) =>
   Array.from(new Set(merged.map(({ transactionHash }) => transactionHash))).map(

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -68,6 +68,7 @@
       "column-headers": {
         "amount": "Amount",
         "from": "From",
+        "reload": "Reload",
         "status": "Status",
         "time": "Time",
         "to": "To",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -68,6 +68,7 @@
       "column-headers": {
         "amount": "Monto",
         "from": "Desde",
+        "reload": "Recargar",
         "status": "Estado",
         "time": "Hora",
         "to": "Hacia",


### PR DESCRIPTION
Closes https://github.com/hemilabs/ui-monorepo/issues/440

This PR adds a button to resync back the history. This is useful when, for some reason, the history is in a bad state and needs to be solved again.

This PR may be easier to review commit by commit:

- 1599ebb20f5ef0a473de3b442e583b6f1a9f4caf The reducer of `useSyncHistory` is moved into its own file (`reducer.ts`)
- 789896c54f28a3041c5493b20003cce640e28dee moves the definition of the Tunnel History context inside of `useSyncHistory`. After all, all the functions shared in the `TunnelHistoryContext` are based on the state/dispatch from the `useReducer` in `useSyncHistory.ts`
- 97e652136b8c1101bd01ac971fa76093e58e25f5 adds the code that allows for resync. The fallbacks were removed because they would conflict when clearing the local storage. It is not a problem because, after all
- 0cfccdabb7aa4303a906ad8df49a53b8040da1d6 applies the UI changes to resync the history

Resync can be performed even when the TX history hasn't finished resyncing.

See video:


https://github.com/user-attachments/assets/7dd93790-8dc4-4f44-8468-2b9405ee0b4f


