### PR TITLE
Add testnet indicator

### DIFF
--- a/webapp/app/[locale]/_components/appLayout.tsx
+++ b/webapp/app/[locale]/_components/appLayout.tsx
@@ -11,6 +11,22 @@ type Props = {
   children: React.ReactNode
 }
 
+const TestnetIndicator = function () {
+  const [networkType] = useNetworkType()
+  if (networkType !== 'testnet') {
+    return null
+  }
+
+  return (
+    <span
+      className="text-ms absolute left-1/2 -translate-x-1/2 rounded-b 
+    bg-orange-500 px-2 font-medium leading-5 text-white"
+    >
+      Testnet
+    </span>
+  )
+}
+
 export const AppLayout = function ({ children }: Props) {
   const [networkType] = useNetworkType()
   const pathname = usePathname()
@@ -30,31 +46,38 @@ export const AppLayout = function ({ children }: Props) {
 
   return (
     <div
-      className={`shadow-hemi-layout backdrop-blur-20 lg:100-dvh
-        lg:h-97vh flex w-3/4 flex-1 flex-col self-stretch overflow-y-hidden bg-neutral-50
+      className={`shadow-hemi-layout backdrop-blur-20 lg:h-97vh flex
+        h-full w-3/4 flex-1 flex-col self-stretch overflow-y-hidden bg-neutral-50 md:border-solid
     ${
       networkType === 'testnet'
-        ? 'md:border-2 md:border-solid md:border-orange-500'
+        ? 'md:border-2 md:border-orange-500'
         : 'md:border'
     }
     md:my-3 md:mr-2 md:w-[calc(75%-8px)] md:rounded-2xl md:pb-0`}
     >
+      <div className="relative hidden md:block">
+        <TestnetIndicator />
+      </div>
       <Header isMenuOpen={isMenuOpen} toggleMenu={toggleMenu} />
       <div
-        className={`max-h-[calc(100vh-1rem)] flex-grow
+        // 7rem comes from header + footer heights
+        className={`box-border max-h-[calc(100dvh-7rem)]
+          flex-grow md:max-h-[calc(100dvh-1rem)]
+          ${hiddenClass}
           ${
             networkType === 'testnet'
-              ? 'max-md:border-3  max-md:border-solid max-md:border-orange-500'
+              ? 'max-md:border-3 max-md:border-solid max-md:border-orange-500'
               : ''
-          }
-        overflow-y-auto px-5 pt-4
-        ${hiddenClass} pb-3`}
+          }`}
       >
-        {children}
+        <div className="relative md:hidden">
+          <TestnetIndicator />
+        </div>
+        <div className="h-full overflow-y-auto px-5 pb-3 pt-4">{children}</div>
       </div>
       <div className="h-14 md:hidden">
         {/* See https://github.com/hemilabs/ui-monorepo/issues/502 */}
-        <footer>Footer</footer>
+        <footer></footer>
       </div>
       {isMenuOpen && (
         <div className="md:hidden">

--- a/webapp/app/[locale]/_components/appLayout.tsx
+++ b/webapp/app/[locale]/_components/appLayout.tsx
@@ -30,15 +30,31 @@ export const AppLayout = function ({ children }: Props) {
 
   return (
     <div
-      className={`bg-hemi-layout bg-hemi-color-layout shadow-hemi-layout backdrop-blur-20 lg:100-dvh lg:h-97vh
-    flex w-3/4 flex-1 flex-col self-stretch overflow-y-hidden border-slate-100
-    md:my-3 md:mr-2 md:w-[calc(75%-8px)] md:rounded-3xl md:border md:pb-0`}
+      className={`shadow-hemi-layout backdrop-blur-20 lg:100-dvh
+        lg:h-97vh flex w-3/4 flex-1 flex-col self-stretch overflow-y-hidden bg-neutral-50
+    ${
+      networkType === 'testnet'
+        ? 'md:border-2 md:border-solid md:border-orange-500'
+        : 'md:border'
+    }
+    md:my-3 md:mr-2 md:w-[calc(75%-8px)] md:rounded-2xl md:pb-0`}
     >
       <Header isMenuOpen={isMenuOpen} toggleMenu={toggleMenu} />
       <div
-        className={`max-h-[calc(100vh-1rem)] flex-grow overflow-y-auto px-5 pt-4 ${hiddenClass} pb-3`}
+        className={`max-h-[calc(100vh-1rem)] flex-grow
+          ${
+            networkType === 'testnet'
+              ? 'max-md:border-3  max-md:border-solid max-md:border-orange-500'
+              : ''
+          }
+        overflow-y-auto px-5 pt-4
+        ${hiddenClass} pb-3`}
       >
         {children}
+      </div>
+      <div className="h-14 md:hidden">
+        {/* See https://github.com/hemilabs/ui-monorepo/issues/502 */}
+        <footer>Footer</footer>
       </div>
       {isMenuOpen && (
         <div className="md:hidden">

--- a/webapp/app/[locale]/_components/appLayout.tsx
+++ b/webapp/app/[locale]/_components/appLayout.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useAccounts } from 'hooks/useAccounts'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { usePathname } from 'next/navigation'
 import React, { useEffect, useState } from 'react'
@@ -28,6 +29,7 @@ const TestnetIndicator = function () {
 }
 
 export const AppLayout = function ({ children }: Props) {
+  const { allDisconnected } = useAccounts()
   const [networkType] = useNetworkType()
   const pathname = usePathname()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -43,6 +45,11 @@ export const AppLayout = function ({ children }: Props) {
     },
     [networkType, pathname, setIsMenuOpen],
   )
+
+  {
+    /* Footer is only visible if at least one chain is connected */
+  }
+  const showFooter = !allDisconnected
 
   return (
     <div
@@ -60,8 +67,12 @@ export const AppLayout = function ({ children }: Props) {
       </div>
       <Header isMenuOpen={isMenuOpen} toggleMenu={toggleMenu} />
       <div
-        // 7rem comes from header + footer heights
-        className={`box-border max-h-[calc(100dvh-7rem)]
+        // 7rem comes from header (3.5) + footer (3.5) heights
+        className={`box-border ${
+          showFooter
+            ? 'max-h-[calc(100dvh-7rem)]'
+            : 'max-h-[calc(100dvh-3.5rem)]'
+        }
           flex-grow md:max-h-[calc(100dvh-1rem)]
           ${hiddenClass}
           ${
@@ -75,10 +86,13 @@ export const AppLayout = function ({ children }: Props) {
         </div>
         <div className="h-full overflow-y-auto px-5 pb-3 pt-4">{children}</div>
       </div>
-      <div className="h-14 md:hidden">
-        {/* See https://github.com/hemilabs/ui-monorepo/issues/502 */}
-        <footer></footer>
-      </div>
+
+      {showFooter && (
+        <div className="h-14 md:hidden">
+          {/* See https://github.com/hemilabs/ui-monorepo/issues/502 */}
+          <footer></footer>
+        </div>
+      )}
       {isMenuOpen && (
         <div className="md:hidden">
           <Navbar />

--- a/webapp/app/[locale]/_components/header.tsx
+++ b/webapp/app/[locale]/_components/header.tsx
@@ -19,7 +19,10 @@ type Props = {
 }
 
 export const Header = ({ isMenuOpen, toggleMenu }: Props) => (
-  <header className="flex h-14 items-center border-b border-solid border-slate-100 bg-white px-3 py-3 md:h-auto md:border-b-0 md:bg-transparent md:px-0">
+  <header
+    className="md:h-17 md:py-4.5 flex h-14 items-center border-b border-solid
+     border-slate-100 bg-white px-3 py-3 md:border-b-0 md:bg-transparent md:px-0"
+  >
     <div className="h-6 w-6 md:hidden">
       <Link href="/tunnel">
         <HemiSymbol />

--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -49,7 +49,7 @@ export default async function RootLayout({
             <WalletsContext locale={locale}>
               <TunnelHistoryProvider>
                 <ConnectWalletDrawerProvider>
-                  <div className="flex h-dvh flex-nowrap justify-stretch">
+                  <div className="flex h-dvh flex-nowrap justify-stretch bg-white">
                     <div className="hidden w-1/4 max-w-64 md:block">
                       <Navbar />
                     </div>

--- a/webapp/tailwind.config.ts
+++ b/webapp/tailwind.config.ts
@@ -16,15 +16,12 @@ const config: Config = {
       backdropBlur: {
         '20': '20px',
       },
-      backgroundColor: {
-        'hemi-color-footer': '#F9F2F0',
-        'hemi-color-layout': '#F9F9F9',
-      },
       backgroundImage: {
         'hemi-gradient':
           'linear-gradient(143deg, #F16063 -3.27%, rgba(116, 96, 241, 0.00) 130.65%)',
-        'hemi-layout':
-          'linear-gradient(180deg, rgba(255, 77, 0, 0.00) 50%, rgba(255, 77, 0, 0.05) 100%)',
+      },
+      borderWidth: {
+        '3': '3px',
       },
       boxShadow: {
         'hemi-layout':

--- a/webapp/tailwind.config.ts
+++ b/webapp/tailwind.config.ts
@@ -64,6 +64,7 @@ const config: Config = {
         ms: '0.8125rem',
       },
       height: {
+        '17': '4.25rem',
         '97vh': '97vh',
         '98vh': '98vh',
         // 96px from header (height + padding), 40px from container's padding top in > md screns
@@ -81,6 +82,9 @@ const config: Config = {
         '16': '16',
         '17': '17',
         '18': '18',
+      },
+      padding: {
+        '4.5': '1.125rem',
       },
     },
   },


### PR DESCRIPTION
Follow-up of #501
Closes #500

This PR adds a testnet indicator.

Mobile  implementation           |  Mobile design
:-------------------------:|:-------------------------:
<img width="357" alt="image" src="https://github.com/user-attachments/assets/b455a77f-e7b8-4c71-aa4e-b9bf69d8274c">  |  <img width="256" alt="image" src="https://github.com/user-attachments/assets/6a70610a-88e8-42a3-ae3a-0ed67015664c">

(The footer will be updated as part of #502)

Desktop implementation |  Desktop design
:-------------------------:|:-------------------------:
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/f7522cd4-0af2-4da3-b564-feddffe500bb"> | <img width="768" alt="image" src="https://github.com/user-attachments/assets/0ca3b9be-ec90-4922-a366-cac53b770649">
