### PR TITLE
Fix Drawer not closing when clicking outside

### DIFF
--- a/webapp/components/connectWallets/connectWalletsDrawer.tsx
+++ b/webapp/components/connectWallets/connectWalletsDrawer.tsx
@@ -20,7 +20,7 @@ type Props = {
 export const ConnectWalletsDrawer = function ({ closeDrawer }: Props) {
   const { accountModalOpen } = useAccountModal()
   const { chainModalOpen } = useChainModal()
-  const { openConnectModal } = useConnectModal()
+  const { connectModalOpen } = useConnectModal()
   const t = useTranslations()
 
   // Rainbow kit's modals appear on top of the drawer. By clicking on those
@@ -29,7 +29,7 @@ export const ConnectWalletsDrawer = function ({ closeDrawer }: Props) {
   // Luckily, there are some hooks to detect that those modals are opened,
   // and prevent this scenario.
   const onClose = function () {
-    if (accountModalOpen || chainModalOpen || openConnectModal) {
+    if (accountModalOpen || chainModalOpen || connectModalOpen) {
       return
     }
     closeDrawer()


### PR DESCRIPTION
While developing the new design, I just happened to notice that the drawer doesn't close when clicking outside. This is due to a bad check when trying to run the `onClose` function because I check if any of the Rainbow Kit modals are opened (to prevent double-closing). However, for that check, I was checking the variable `openConnectModal`, which is a function... so it is always true 🤦🏽  The proper variable to check was `connectModalOpen`

Now the drawer will be closed when clicking outside, or when pressing `ESC` key


https://github.com/user-attachments/assets/b7563564-fab4-4aa0-9d23-c3b6294bdb0b


