### PR TITLE
Deploy redesign on test url

### DIFF
--- a/.github/workflows/redesign_deployment.yml
+++ b/.github/workflows/redesign_deployment.yml
@@ -1,0 +1,40 @@
+name: Deploy Redesigned portal app
+
+# Will limit one workflow at the same time
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - portal-ui-redesign
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # Can't only bring commits since ${{ github.event.before }} yet https://github.com/actions/checkout/issues/1444
+          fetch-depth: 0
+
+      - name: Setup env
+        uses: ./.github/actions/setup-env
+
+      - name: Deploy portal
+        uses: ./.github/actions/deploy-portal
+        with:
+          # hostinger env variables
+          HOSTINGER_HOST: ${{ secrets.HOSTINGER_HOST }}
+          HOSTINGER_PORT: ${{ secrets.HOSTINGER_PORT }}
+          HOSTINGER_SSH_KEY: ${{ secrets.HOSTINGER_SSH_KEY }}
+          HOSTINGER_USER: ${{ secrets.HOSTINGER_USER }}
+          # Staging domain is correct, as the deployment is a subdomain of staging domain
+          HOSTINGER_TARGET: 'domains/${{ vars.HEMI_DOMAIN_STAGING }}/public_html/test'
+          # next env variables to build the portal
+          NEXT_PUBLIC_CLAIM_TOKENS_URL: 'https://vj7c4dltid.execute-api.eu-central-1.amazonaws.com/staging'
+          NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL: true
+          NEXT_PUBLIC_RECAPTCHA_SITE_KEY: ${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY }}


### PR DESCRIPTION
With this temporal github action, we should be able to deploy the redesign page as we merge it, so we can test it.