### PR TITLE
Reorder imports for customizing chain with rpc

### DIFF
--- a/webapp/networks/mainnet.ts
+++ b/webapp/networks/mainnet.ts
@@ -1,4 +1,4 @@
-import { overrideRpcUrl } from 'utils/chain'
+import { overrideRpcUrl } from 'networks/utils'
 import { mainnet as mainnetDefinition } from 'viem/chains'
 
 export const mainnet = overrideRpcUrl(

--- a/webapp/networks/sepolia.ts
+++ b/webapp/networks/sepolia.ts
@@ -1,4 +1,4 @@
-import { overrideRpcUrl } from 'utils/chain'
+import { overrideRpcUrl } from 'networks/utils'
 import { sepolia as sepoliaDefinition } from 'viem/chains'
 
 export const sepolia = overrideRpcUrl(

--- a/webapp/networks/utils.ts
+++ b/webapp/networks/utils.ts
@@ -1,0 +1,17 @@
+import { type Chain as ViemChain } from 'viem'
+import { defineChain } from 'viem/utils'
+
+export const overrideRpcUrl = function (chain: ViemChain, rpcUrl?: string) {
+  const isValidCustomSepoliaRpc = !!rpcUrl && rpcUrl.startsWith('https')
+  if (isValidCustomSepoliaRpc) {
+    return defineChain({
+      ...chain,
+      rpcUrls: {
+        default: {
+          http: [rpcUrl],
+        },
+      },
+    })
+  }
+  return chain
+}


### PR DESCRIPTION
Closes #510

The fix for customizing a RPC URL for Sepolia applied in #511  broke in web workers - apparently due to some circular reference issues. This PR fixes it.