### PR TITLE
Hardcode gasLimit for deposit/prove/claim

### DIFF
--- a/patches/@eth-optimism+sdk+3.2.1.patch
+++ b/patches/@eth-optimism+sdk+3.2.1.patch
@@ -14,9 +14,27 @@ index 743d4b4..6eafe8d 100644
      waitForMessageReceipt(message: MessageLike, opts?: {
          fromBlockOrBlockHash?: BlockTag;
 diff --git a/node_modules/@eth-optimism/sdk/dist/cross-chain-messenger.js b/node_modules/@eth-optimism/sdk/dist/cross-chain-messenger.js
-index 01ac898..bc760d9 100644
+index 01ac898..fcaeb3c 100644
 --- a/node_modules/@eth-optimism/sdk/dist/cross-chain-messenger.js
 +++ b/node_modules/@eth-optimism/sdk/dist/cross-chain-messenger.js
+@@ -113,7 +113,7 @@ class CrossChainMessenger {
+                     return legacyL1XDM.populateTransaction.relayMessage(resolved.target, resolved.sender, resolved.message, resolved.messageNonce, proof, (opts === null || opts === void 0 ? void 0 : opts.overrides) || {});
+                 }
+             },
+-            depositETH: async (amount, opts, isEstimatingGas = false) => {
++            depositETH: async (amount, opts, isEstimatingGas = true) => {
+                 const getOpts = async () => {
+                     if (isEstimatingGas) {
+                         return opts;
+@@ -130,7 +130,7 @@ class CrossChainMessenger {
+                 const bridge = await this.getBridgeForTokenPair(l1Token, l2Token);
+                 return bridge.populateTransaction.approve(l1Token, l2Token, amount, opts);
+             },
+-            depositERC20: async (l1Token, l2Token, amount, opts, isEstimatingGas = false) => {
++            depositERC20: async (l1Token, l2Token, amount, opts, isEstimatingGas = true) => {
+                 const bridge = await this.getBridgeForTokenPair(l1Token, l2Token);
+                 const getOpts = async () => {
+                     var _a, _b, _c, _d;
 @@ -439,7 +439,7 @@ class CrossChainMessenger {
              return b.blockNumber - a.blockNumber;
          });
@@ -56,7 +74,7 @@ index 01ac898..bc760d9 100644
          const messageHashV1 = (0, core_utils_1.hashCrossDomainMessagev1)(resolved.messageNonce, resolved.sender, resolved.target, resolved.value, resolved.minGasLimit, resolved.message);
          const messenger = resolved.direction === interfaces_1.MessageDirection.L1_TO_L2
 diff --git a/node_modules/@eth-optimism/sdk/src/cross-chain-messenger.ts b/node_modules/@eth-optimism/sdk/src/cross-chain-messenger.ts
-index 7d17f33..60a9f9e 100644
+index 7d17f33..61f6ee6 100644
 --- a/node_modules/@eth-optimism/sdk/src/cross-chain-messenger.ts
 +++ b/node_modules/@eth-optimism/sdk/src/cross-chain-messenger.ts
 @@ -620,7 +620,8 @@ export class CrossChainMessenger {
@@ -102,3 +120,21 @@ index 7d17f33..60a9f9e 100644
      // legacy withdrawals relayed prebedrock are v1
      const messageHashV0 = hashCrossDomainMessagev0(
        resolved.target,
+@@ -2150,7 +2154,7 @@ export class CrossChainMessenger {
+         l2GasLimit?: NumberLike
+         overrides?: PayableOverrides
+       },
+-      isEstimatingGas: boolean = false
++      isEstimatingGas: boolean = true
+     ): Promise<TransactionRequest> => {
+       const getOpts = async () => {
+         if (isEstimatingGas) {
+@@ -2240,7 +2244,7 @@ export class CrossChainMessenger {
+         l2GasLimit?: NumberLike
+         overrides?: CallOverrides
+       },
+-      isEstimatingGas: boolean = false
++      isEstimatingGas: boolean = true
+     ): Promise<TransactionRequest> => {
+       const bridge = await this.getBridgeForTokenPair(l1Token, l2Token)
+       // we need extra buffer for gas limit


### PR DESCRIPTION
Related to #539

Currently, there are high prices in Sepolia. In addition to that, it seems there's an over-estimation of the gas units needed to deposit/claim/prove, which causes crazy amounts of fees that are later not paid at all. However, this prevents some users from submitting transactions.

@max-sanchez  analyzed several transactions, and he concluded that setting a fixed gas limit of `2.000.000` should work for all the operations in Sepolia.

For doing so, all the OP-SDK methods offer a parameter named `overrides` where consumers of the SDK can override the `gasLimit` value. This worked well for `proveMessage` (prove step) and `finalizeMessage` (claim step).


However, this caused an error message `Execution Reverted` when trying to deposit. For that, I had to patch the `cross-chain-messenger` in the OP SDK.

The change is simple: you can see [here](https://github.com/ethereum-optimism/ecosystem/blob/2ab98949a55a2cb6fd50502eb71f9888071b9a50/packages/sdk/src/cross-chain-messenger.ts#L2380) that the SDK overrides the `gasLimit` provided by the consumer (it overrides my overrides 😄 ), and there's no way to avoid that because to skip the `gasEstimation` that would eventually override my `gasLimit` setting, it checks the parameter [isEstimatingGas](https://github.com/ethereum-optimism/ecosystem/blob/2ab98949a55a2cb6fd50502eb71f9888071b9a50/packages/sdk/src/cross-chain-messenger.ts#L2369), which is defaulted to `false`... and it is not provided when depositing (see [here](https://github.com/ethereum-optimism/ecosystem/blob/2ab98949a55a2cb6fd50502eb71f9888071b9a50/packages/sdk/src/cross-chain-messenger.ts#L1962)).  
The same principle applies to `depositERC20`.

The patch, then, changes that default. value so it allows me to override the value


After merging this PR, there are no changes visible to the user, except that now fees are calculated a bit differently (and the gas limit of `2.000.000` is visible in MM)


https://github.com/user-attachments/assets/5014fce0-8750-43bd-a856-e9353b34977d


