### PR TITLE
Update serve dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8788,11 +8788,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/@zeit/schemas": {
-      "version": "2.29.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@zkochan/js-yaml": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
@@ -24432,30 +24427,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/serve": {
-      "version": "14.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@zeit/schemas": "2.29.0",
-        "ajv": "8.11.0",
-        "arg": "5.0.2",
-        "boxen": "7.0.0",
-        "chalk": "5.0.1",
-        "chalk-template": "0.4.0",
-        "clipboardy": "3.0.0",
-        "compression": "1.7.4",
-        "is-port-reachable": "4.0.0",
-        "serve-handler": "6.1.5",
-        "update-check": "1.5.4"
-      },
-      "bin": {
-        "serve": "build/main.js"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/serve-handler": {
       "version": "6.1.5",
       "dev": true,
@@ -24509,37 +24480,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/serve/node_modules/ajv": {
-      "version": "8.11.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/serve/node_modules/chalk": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/serve/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/serverless": {
       "version": "3.38.0",
@@ -28563,7 +28503,7 @@
         "autoprefixer": "10.4.16",
         "postcss": "8.4.32",
         "qrcode-terminal": "0.12.0",
-        "serve": "14.2.1",
+        "serve": "14.2.3",
         "tailwindcss": "3.4.0",
         "typescript": "5.3.3"
       }
@@ -28721,6 +28661,28 @@
         "undici-types": "~5.26.4"
       }
     },
+    "webapp/node_modules/@zeit/schemas": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "dev": true
+    },
+    "webapp/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "webapp/node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -28749,6 +28711,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "webapp/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "webapp/node_modules/debug": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -28764,6 +28738,12 @@
           "optional": true
         }
       }
+    },
+    "webapp/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "webapp/node_modules/next": {
       "version": "14.2.3",
@@ -28902,6 +28882,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "webapp/node_modules/serve": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.3.tgz",
+      "integrity": "sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==",
+      "dev": true,
+      "dependencies": {
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.12.0",
+        "arg": "5.0.2",
+        "boxen": "7.0.0",
+        "chalk": "5.0.1",
+        "chalk-template": "0.4.0",
+        "clipboardy": "3.0.0",
+        "compression": "1.7.4",
+        "is-port-reachable": "4.0.0",
+        "serve-handler": "6.1.5",
+        "update-check": "1.5.4"
+      },
+      "bin": {
+        "serve": "build/main.js"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "webapp/node_modules/type-fest": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -57,7 +57,7 @@
     "autoprefixer": "10.4.16",
     "postcss": "8.4.32",
     "qrcode-terminal": "0.12.0",
-    "serve": "14.2.1",
+    "serve": "14.2.3",
     "tailwindcss": "3.4.0",
     "typescript": "5.3.3"
   }


### PR DESCRIPTION
Related to #539 

As part of the PR for that issue (#540 ), I had to patch the OP SDK. However, the job that deployed [read the OP SDK from the cache](https://github.com/hemilabs/ui-monorepo/actions/runs/11002911448/job/30550874070), which prevents the workflow from applying the patch. The only way is to clear the cache by updating any dependency (So the `package-lock.json` file gets updated). This PR updates the dev dependency `serve`