### PR TITLE
Improvements on getting native tokens

### DIFF
--- a/webapp/utils/token.ts
+++ b/webapp/utils/token.ts
@@ -2,9 +2,11 @@ import { hemiMainnet } from 'networks/hemiMainnet'
 import { hemiTestnet } from 'networks/hemiTestnet'
 import { tokenList } from 'tokenList'
 import { EvmToken, Token } from 'types/token'
-import { Address, isAddressEqual } from 'viem'
+import { Address, isAddress, isAddressEqual, zeroAddress } from 'viem'
 
-const isNativeAddress = (address: string) => !address.startsWith('0x')
+const isNativeAddress = (address: string) =>
+  address === zeroAddress || !address.startsWith('0x')
+
 export const isNativeToken = (token: Token) => isNativeAddress(token.address)
 
 export const getNativeToken = (chainId: Token['chainId']) =>
@@ -20,7 +22,11 @@ export const getTokenByAddress = function (
     return getNativeToken(chainId)
   }
   return tokenList.tokens.find(
-    token => token.chainId === chainId && token.address === address,
+    token =>
+      token.chainId === chainId &&
+      isAddress(token.address) &&
+      // @ts-expect-error we already checked "address" is not native, so string is `0x${string}`
+      isAddressEqual(token.address, address),
   )
 }
 


### PR DESCRIPTION
As part of the redesign, I made some modifications to the method that detects native tokens. It turns out OP marks the native token in its history (The one retrieved by the OP SDK) as the zero address, so this PR is updated to reflect that scenario.

Bringing this to the main, as it may be a useful fix (This wasn't a bug because there's no view for Completed Deposits, but...)

Related to #529 