### PR TITLE
Use esplora-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13693,6 +13693,14 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/esplora-client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esplora-client/-/esplora-client-1.1.0.tgz",
+      "integrity": "sha512-b4BAqeh271kfZmILSYac9DMY8pqYP8SgcZHwkJ+oK50JupBXIcCtlzk4rYgnrpYRV1fVafjSy89ct3lJVqu9LA==",
+      "dependencies": {
+        "fetch-plus-plus": "^1.0.0"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "dev": true,
@@ -28468,6 +28476,7 @@
         "btc-wallet": "1.0.0",
         "camelcase-keys": "7.0.2",
         "debug": "4.3.6",
+        "esplora-client": "1.1.0",
         "hemi-socials": "1.0.0",
         "hemi-viem": "1.5.0",
         "javascript-time-ago": "2.5.10",

--- a/package.json
+++ b/package.json
@@ -203,7 +203,17 @@
         }
       }
     ],
-    "root": true
+    "root": true,
+    "rules": {
+      "camelcase": [
+        "warn",
+        {
+          "allow": [
+            "after_txid"
+          ]
+        }
+      ]
+    }
   },
   "husky": {
     "hooks": {

--- a/webapp/.env
+++ b/webapp/.env
@@ -1,6 +1,7 @@
 NEXT_PUBLIC_BTC_INPUTS_SIZE=105
 NEXT_PUBLIC_BTC_OUTPUTS_SIZE=25
 # Once mainnet is published, these values below may go into .env.development as they belong to hemi's testnet
+NEXT_PUBLIC_BITCOIN_NETWORK=testnet
 NEXT_PUBLIC_MEMPOOL_API_URL="https://mempool.space/testnet/api"
 NEXT_PUBLIC_RAINBOW_APP_NAME=Hemi
 NEXT_PUBLIC_RAINBOW_PROJECT_ID=THE_PROJECT_ID

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,6 +22,7 @@
     "btc-wallet": "1.0.0",
     "camelcase-keys": "7.0.2",
     "debug": "4.3.6",
+    "esplora-client": "1.1.0",
     "hemi-socials": "1.0.0",
     "hemi-viem": "1.5.0",
     "javascript-time-ago": "2.5.10",


### PR DESCRIPTION
Update the bitcoin API logic to use [`esplora-client`](https://github.com/hemilabs/esplora-client) instead of custom logic to query mempool.space or blockstream.info.