### PR TITLE
Enable EVM deposits with drawer

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/form.tsx
+++ b/webapp/app/[locale]/tunnel/_components/form.tsx
@@ -84,11 +84,13 @@ export const FormContent = function ({
 
 type TunnelFormProps = {
   bottomSection?: ReactNode
-  explorerUrl: string
+  // TODO remove after all modals are replaced with drawers
+  explorerUrl?: string
   formContent: ReactNode
   onSubmit: () => void
   belowForm?: React.ReactNode
   submitButton?: ReactNode
+  // TODO remove after all modals are replaced with drawers
   transactionsList?: {
     id: string
     status: React.ComponentProps<typeof TransactionStatus>['status']

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/seeOnExplorer.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/seeOnExplorer.tsx
@@ -9,8 +9,13 @@ type Props = {
   txHash: string
 }
 export const SeeOnExplorer = function ({ chainId, txHash }: Props) {
-  const t = useTranslations('tunnel-page.transaction-status')
   const blockExplorer = useChain(chainId).blockExplorers.default
+  const t = useTranslations('tunnel-page.transaction-status')
+
+  if (!txHash) {
+    return null
+  }
+
   return (
     <ExternalLink
       className="text-ms group/see-on-explorer flex items-center gap-x-1 font-medium leading-5 text-orange-500"


### PR DESCRIPTION
Related to #529
Follow-up of #552 

This PR adds the missing pieces to enable the drawer when depositing. Here there was no dialog to replace 😄  This PR saves in memory the approval tx hash and switches between steps. 

Note: It's pending to prevent users from closing the drawer while the operation is in progress. 

https://github.com/user-attachments/assets/3142c6c9-7a8f-4f17-876f-062838a57408

https://github.com/user-attachments/assets/60c0c330-fb38-4066-abc5-2e7e6e2d848d

