### PR TITLE
Save prove and claim tx hashes

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/actionableOperations.tsx
+++ b/webapp/app/[locale]/tunnel/_components/actionableOperations.tsx
@@ -1,12 +1,12 @@
 import { MessageStatus } from '@eth-optimism/sdk'
 import { featureFlags } from 'app/featureFlags'
 import { useBtcDeposits } from 'hooks/useBtcDeposits'
-import { useTunnelHistory } from 'hooks/useTunnelHistory'
+import { useToEvmWithdrawals } from 'hooks/useToEvmWithdrawals'
 import { BtcDepositStatus } from 'types/tunnel'
 
 export const ActionableOperations = function () {
   const deposits = useBtcDeposits()
-  const { withdrawals } = useTunnelHistory()
+  const withdrawals = useToEvmWithdrawals()
 
   const actionableWithdrawals = withdrawals.filter(w =>
     [MessageStatus.READY_TO_PROVE, MessageStatus.READY_FOR_RELAY].includes(

--- a/webapp/app/[locale]/tunnel/_components/claim.tsx
+++ b/webapp/app/[locale]/tunnel/_components/claim.tsx
@@ -6,10 +6,11 @@ import { useEstimateFees } from 'hooks/useEstimateFees'
 import { useHemi } from 'hooks/useHemi'
 import { useGetClaimWithdrawalTxHash } from 'hooks/useL2Bridge'
 import { useNetworks } from 'hooks/useNetworks'
+import { useToEvmWithdrawals } from 'hooks/useToEvmWithdrawals'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
-import { BtcDepositStatus, EvmWithdrawOperation } from 'types/tunnel'
+import { BtcDepositStatus, ToEvmWithdrawOperation } from 'types/tunnel'
 import { Button } from 'ui-common/components/button'
 import { getFormattedValue } from 'utils/format'
 import { getTokenByAddress } from 'utils/token'
@@ -42,7 +43,7 @@ const EvmSubmitButton = function ({
   l1ChainId: Chain['id']
   isClaiming: boolean
   isReadyToClaim: boolean
-  withdrawal: EvmWithdrawOperation
+  withdrawal: ToEvmWithdrawOperation
 }) {
   const t = useTranslations()
   const txHash = useTunnelOperation().txHash as Hash
@@ -254,7 +255,8 @@ type EvmClaimProps = {
 
 export const EvmClaim = function ({ state }: EvmClaimProps) {
   const { evmRemoteNetworks } = useNetworks()
-  const { updateWithdrawal, withdrawals } = useTunnelHistory()
+  const { updateWithdrawal } = useTunnelHistory()
+  const withdrawals = useToEvmWithdrawals()
   const { partialWithdrawal, resetStateAfterOperation, savePartialWithdrawal } =
     state
 
@@ -299,7 +301,10 @@ export const EvmClaim = function ({ state }: EvmClaimProps) {
       if (withdrawal?.status === MessageStatus.RELAYED) {
         return
       }
-      updateWithdrawal(withdrawal, { status: MessageStatus.RELAYED })
+      updateWithdrawal(withdrawal, {
+        claimTxHash: claimWithdrawalReceipt.transactionHash,
+        status: MessageStatus.RELAYED,
+      })
       savePartialWithdrawal({
         claimWithdrawalTxHash: claimWithdrawalReceipt.transactionHash,
       })

--- a/webapp/app/[locale]/tunnel/_components/prove.tsx
+++ b/webapp/app/[locale]/tunnel/_components/prove.tsx
@@ -2,10 +2,11 @@ import { MessageStatus } from '@eth-optimism/sdk'
 import { useChain } from 'hooks/useChain'
 import { useHemi } from 'hooks/useHemi'
 import { useNetworks } from 'hooks/useNetworks'
+import { useToEvmWithdrawals } from 'hooks/useToEvmWithdrawals'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
-import { EvmWithdrawOperation } from 'types/tunnel'
+import { ToEvmWithdrawOperation } from 'types/tunnel'
 import { Button } from 'ui-common/components/button'
 import { formatNumber } from 'utils/format'
 import { getL2TokenByBridgedAddress, getTokenByAddress } from 'utils/token'
@@ -31,7 +32,7 @@ const SubmitButton = function ({
   isReadyToProve: boolean
   l1ChainId: Chain['id']
   proveWithdrawalTxHash: Hash
-  withdrawal: EvmWithdrawOperation
+  withdrawal: ToEvmWithdrawOperation
 }) {
   const t = useTranslations()
 
@@ -67,7 +68,8 @@ type Props = {
 
 export const Prove = function ({ state }: Props) {
   const { evmRemoteNetworks } = useNetworks()
-  const { updateWithdrawal, withdrawals } = useTunnelHistory()
+  const { updateWithdrawal } = useTunnelHistory()
+  const withdrawals = useToEvmWithdrawals()
 
   const { partialWithdrawal, resetStateAfterOperation, savePartialWithdrawal } =
     state
@@ -114,6 +116,7 @@ export const Prove = function ({ state }: Props) {
         return
       }
       updateWithdrawal(withdrawal, {
+        proveTxHash: withdrawalProofReceipt.transactionHash,
         status: MessageStatus.IN_CHALLENGE_PERIOD,
       })
       savePartialWithdrawal({

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -2,11 +2,11 @@ import { MessageStatus } from '@eth-optimism/sdk'
 import { TransactionStatus } from 'components/transactionStatus'
 import { useHemi } from 'hooks/useHemi'
 import { useNetworks } from 'hooks/useNetworks'
-import { useTunnelHistory } from 'hooks/useTunnelHistory'
+import { useToEvmWithdrawals } from 'hooks/useToEvmWithdrawals'
 import { useTranslations } from 'next-intl'
 import { FormEvent, ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
-import { EvmWithdrawOperation } from 'types/tunnel'
+import { ToEvmWithdrawOperation } from 'types/tunnel'
 import { Card } from 'ui-common/components/card'
 import { Modal } from 'ui-common/components/modal'
 import { getL2TokenByBridgedAddress, getTokenByAddress } from 'utils/token'
@@ -94,7 +94,7 @@ const ProveIcon = () => (
 const WithdrawAmount = function ({
   withdrawal,
 }: {
-  withdrawal?: EvmWithdrawOperation
+  withdrawal?: ToEvmWithdrawOperation
 }) {
   const hemi = useHemi()
   const { evmRemoteNetworks } = useNetworks()
@@ -145,7 +145,7 @@ export const ReviewEvmWithdrawal = function ({
 
   const t = useTranslations()
   const { operation, txHash } = useTunnelOperation()
-  const { withdrawals } = useTunnelHistory()
+  const withdrawals = useToEvmWithdrawals()
 
   const foundWithdrawal = withdrawals.find(w => w.transactionHash === txHash)
   const messageStatus = foundWithdrawal.status

--- a/webapp/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/webapp/app/[locale]/tunnel/_components/withdraw.tsx
@@ -12,6 +12,7 @@ import { useTranslations } from 'next-intl'
 import { useCallback, useState } from 'react'
 import { type RemoteChain } from 'types/chain'
 import { Token } from 'types/token'
+import { BtcWithdrawStatus } from 'types/tunnel'
 import { Button } from 'ui-common/components/button'
 import { isEvmNetwork } from 'utils/chain'
 import { formatBtcAddress, getFormattedValue } from 'utils/format'
@@ -134,8 +135,9 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
       // eslint-disable-next-line promise/catch-or-return
       addTimestampToOperation(extendedWithdrawal, fromNetworkId).then(
         ({ timestamp }) =>
-          updateWithdrawal(extendedWithdrawal, {
-            status: MessageStatus.RELAYED,
+          updateWithdrawal(withdrawalFound, {
+            blockNumber: Number(withdrawBitcoinReceipt.blockNumber),
+            status: BtcWithdrawStatus.TX_CONFIRMED,
             timestamp,
           }),
       )

--- a/webapp/app/[locale]/tunnel/page.tsx
+++ b/webapp/app/[locale]/tunnel/page.tsx
@@ -6,7 +6,7 @@ import { isBtcTxHash } from 'btc-wallet/utils/hash'
 import { ConnectWallet } from 'components/connectWallet'
 import { useBtcDeposits } from 'hooks/useBtcDeposits'
 import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
-import { useTunnelHistory } from 'hooks/useTunnelHistory'
+import { useToEvmWithdrawals } from 'hooks/useToEvmWithdrawals'
 import { useTranslations } from 'next-intl'
 import { Suspense, useEffect } from 'react'
 import { BtcDepositStatus } from 'types/tunnel'
@@ -111,7 +111,7 @@ const Operation = function ({
 
 const Tunnel = function () {
   const deposits = useBtcDeposits()
-  const { withdrawals } = useTunnelHistory()
+  const withdrawals = useToEvmWithdrawals()
   const { operation, txHash, updateOperation } = useTunnelOperation()
   const tunnelState = useTunnelState()
 

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -21,13 +21,18 @@ import { useMemo } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import {
   BtcDepositStatus,
-  EvmWithdrawOperation,
   DepositTunnelOperation,
   TunnelOperation,
+  WithdrawTunnelOperation,
 } from 'types/tunnel'
 import { Card } from 'ui-common/components/card'
 import { useWindowSize } from 'ui-common/hooks/useWindowSize'
-import { isBtcDeposit, isDeposit, isWithdraw } from 'utils/tunnel'
+import {
+  isBtcDeposit,
+  isDeposit,
+  isToEvmWithdraw,
+  isWithdraw,
+} from 'utils/tunnel'
 import { Chain } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -73,10 +78,16 @@ const DepositStatus = function ({
 const WithdrawStatus = function ({
   withdrawal,
 }: {
-  withdrawal: EvmWithdrawOperation
+  withdrawal: WithdrawTunnelOperation
 }) {
   const t = useTranslations()
   const waitMinutes = t('common.wait-minutes', { minutes: 20 })
+
+  if (!isToEvmWithdraw(withdrawal)) {
+    // Bitcoin withdrawals are always successful if tx was confirmed
+    return <TxStatus.Success />
+  }
+
   const statuses = {
     // This status should never be rendered, but just to be defensive
     // let's render the next status:

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/withdrawAction.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/withdrawAction.tsx
@@ -1,16 +1,23 @@
 import { MessageStatus } from '@eth-optimism/sdk'
 import { useTranslations } from 'next-intl'
 import Skeleton from 'react-loading-skeleton'
-import { EvmWithdrawOperation } from 'types/tunnel'
+import { type WithdrawTunnelOperation } from 'types/tunnel'
+import { isToEvmWithdraw } from 'utils/tunnel'
 
 import { CallToAction } from './callToAction'
 
 type Props = {
-  withdraw: EvmWithdrawOperation
+  withdraw: WithdrawTunnelOperation
 }
 
 export const WithdrawAction = function ({ withdraw }: Props) {
   const t = useTranslations('tunnel-page.transaction-history.actions')
+
+  if (!isToEvmWithdraw(withdraw)) {
+    // Bitcoin withdrawals do not have a view option, just like EVM deposits
+    // this will change in the design, though.
+    return null
+  }
 
   if (withdraw.status === undefined) {
     return <Skeleton className="h-9 w-24" />

--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -13,7 +13,7 @@ import { createContext, ReactNode } from 'react'
 import { type RemoteChain } from 'types/chain'
 import {
   type DepositTunnelOperation,
-  type EvmWithdrawOperation,
+  type WithdrawTunnelOperation,
 } from 'types/tunnel'
 import { useAccount } from 'wagmi'
 
@@ -53,7 +53,7 @@ const isChainReadyOrSyncing =
 type TunnelHistoryContext = {
   addDepositToTunnelHistory: (deposit: DepositTunnelOperation) => void
   addWithdrawalToTunnelHistory: (
-    withdrawal: Omit<EvmWithdrawOperation, 'timestamp'>,
+    withdrawal: Omit<WithdrawTunnelOperation, 'timestamp'>,
   ) => void
   deposits: DepositTunnelOperation[]
   resyncHistory: () => void
@@ -63,10 +63,10 @@ type TunnelHistoryContext = {
     updates: Partial<DepositTunnelOperation>,
   ) => void
   updateWithdrawal: (
-    withdrawal: EvmWithdrawOperation,
-    updates: Partial<EvmWithdrawOperation>,
+    withdrawal: WithdrawTunnelOperation,
+    updates: Partial<WithdrawTunnelOperation>,
   ) => void
-  withdrawals: EvmWithdrawOperation[]
+  withdrawals: WithdrawTunnelOperation[]
 }
 
 export const TunnelHistoryContext = createContext<TunnelHistoryContext>({

--- a/webapp/hooks/useBtcTunnel.ts
+++ b/webapp/hooks/useBtcTunnel.ts
@@ -1,11 +1,15 @@
-import { MessageDirection, MessageStatus } from '@eth-optimism/sdk'
+import { MessageDirection } from '@eth-optimism/sdk'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTunnelOperation } from 'app/[locale]/tunnel/_hooks/useTunnelOperation'
 import { BtcChain } from 'btc-wallet/chains'
 import { useAccount as useBtcAccount } from 'btc-wallet/hooks/useAccount'
 import { Satoshis } from 'btc-wallet/unisat'
 import { useCallback } from 'react'
-import { BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
+import {
+  BtcDepositOperation,
+  BtcDepositStatus,
+  BtcWithdrawStatus,
+} from 'types/tunnel'
 import {
   claimBtcDeposit,
   initiateBtcDeposit,
@@ -188,7 +192,7 @@ export const useWithdrawBitcoin = function () {
         l2Token: getNativeToken(bitcoin.id).extensions.bridgeInfo[
           hemiClient.chain.id
         ].tokenAddress,
-        status: MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE,
+        status: BtcWithdrawStatus.TX_PENDING,
         to: btcAddress,
         transactionHash,
       })

--- a/webapp/hooks/useToEvmWithdrawals.ts
+++ b/webapp/hooks/useToEvmWithdrawals.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react'
+import { isToEvmWithdraw } from 'utils/tunnel'
+
+import { useWithdrawals } from './useWithdrawals'
+
+export const useToEvmWithdrawals = function () {
+  const withdrawals = useWithdrawals()
+  return useMemo(() => withdrawals.filter(isToEvmWithdraw), [withdrawals])
+}

--- a/webapp/hooks/useWithdrawals.ts
+++ b/webapp/hooks/useWithdrawals.ts
@@ -1,0 +1,3 @@
+import { useTunnelHistory } from './useTunnelHistory'
+
+export const useWithdrawals = () => useTunnelHistory().withdrawals

--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -9,7 +9,7 @@ import {
 } from 'sliding-block-window/src'
 import {
   EvmDepositOperation,
-  EvmWithdrawOperation,
+  ToEvmWithdrawOperation,
   TunnelOperation,
 } from 'types/tunnel'
 import {
@@ -194,7 +194,7 @@ export const createEvmSync = function ({
           fromBlock,
           toBlock,
         })
-        .then(toOperation<EvmWithdrawOperation>(l1Chain.id, l2Chain.id))
+        .then(toOperation<ToEvmWithdrawOperation>(l1Chain.id, l2Chain.id))
         .then(withdrawals =>
           pAll(
             withdrawals.map(
@@ -209,6 +209,8 @@ export const createEvmSync = function ({
                       withdrawal.direction,
                     ),
                   ])
+                  // TODO Bring the Prove and Claim transaction hashes.
+                  // See https://github.com/hemilabs/ui-monorepo/issues/558
                   return {
                     ...withdrawal,
                     status,

--- a/webapp/utils/tunnel.ts
+++ b/webapp/utils/tunnel.ts
@@ -1,10 +1,11 @@
 import { MessageDirection } from '@eth-optimism/sdk'
 import {
-  BtcDepositOperation,
-  DepositTunnelOperation,
-  EvmDepositOperation,
-  TunnelOperation,
-  WithdrawTunnelOperation,
+  type BtcDepositOperation,
+  type DepositTunnelOperation,
+  type EvmDepositOperation,
+  type ToEvmWithdrawOperation,
+  type TunnelOperation,
+  type WithdrawTunnelOperation,
 } from 'types/tunnel'
 
 export const isDeposit = (
@@ -12,15 +13,25 @@ export const isDeposit = (
 ): operation is DepositTunnelOperation =>
   operation.direction === MessageDirection.L1_TO_L2
 
+export const isBtcOperation = (operation: TunnelOperation) =>
+  typeof operation.l1ChainId === 'string'
+
+export const isEvmOperation = (operation: TunnelOperation) =>
+  typeof operation.l1ChainId === 'number'
+
 export const isBtcDeposit = (
   operation: DepositTunnelOperation,
-): operation is BtcDepositOperation => typeof operation.l1ChainId === 'string'
+): operation is BtcDepositOperation => isBtcOperation(operation)
 
 export const isEvmDeposit = (
   operation: DepositTunnelOperation,
-): operation is EvmDepositOperation => typeof operation.l1ChainId === 'number'
+): operation is EvmDepositOperation => isEvmOperation(operation)
 
 export const isWithdraw = (
   operation: TunnelOperation,
 ): operation is WithdrawTunnelOperation =>
   operation.direction === MessageDirection.L2_TO_L1
+
+export const isToEvmWithdraw = (
+  withdraw: WithdrawTunnelOperation,
+): withdraw is ToEvmWithdrawOperation => isEvmOperation(withdraw)


### PR DESCRIPTION
Adding some changes to `main` as they are not strictly related to the UI, but are required for the redesign branch (and it is easier to review, in smaller PRs 😄 ).

This PR:

- Saves the prove and claim transaction hash, so they can be shown when viewing the whole Withdrawal flow (in the redesign)
- For that, I now need to split the `EvmWithdrawOperation` into two types: `ToEvmWithdrawOperation` (when L1 is EVM compatible) and `ToBtcWithdrawOperation`(when L1 is bitcoin)
- For that, the types are updated in a few places, and the `withdrawals` are read, in most places where the L1 is an EVM-compatible with `useToEvmWithdrawals`  instead of directly reading them from the Tunnel History, as doing so already types them in the proper type
- I took advantage of this change and now Bitcoin withdrawals use `BtcWithdrawStatus`, an enum I've created instead of using the `MessageStatus` from OP which has extra statuses that are not valid for Bitcoin


The issue https://github.com/hemilabs/ui-monorepo/issues/558  was created as well. 

No visible changes for the UI of the user