### PR TITLE
View evm withdrawals drawer (Part 1)

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/claim.tsx
+++ b/webapp/app/[locale]/tunnel/_components/claim.tsx
@@ -30,7 +30,7 @@ import {
 } from '../_hooks/useTunnelState'
 
 import { ReviewBtcDeposit } from './reviewOperation/reviewBtcDeposit'
-import { ReviewEvmWithdrawal } from './reviewOperation/reviewEvmWithdrawal'
+import { ReviewEvmWithdrawal } from './reviewOperation/reviewEvmWithdrawalOld'
 
 const EvmSubmitButton = function ({
   claimTxHash: inMemoryClaimTxHash,

--- a/webapp/app/[locale]/tunnel/_components/prove.tsx
+++ b/webapp/app/[locale]/tunnel/_components/prove.tsx
@@ -19,7 +19,7 @@ import { useTransactionsList } from '../_hooks/useTransactionsList'
 import { useTunnelOperation } from '../_hooks/useTunnelOperation'
 import { useTunnelState } from '../_hooks/useTunnelState'
 
-import { ReviewEvmWithdrawal } from './reviewOperation/reviewEvmWithdrawal'
+import { ReviewEvmWithdrawal } from './reviewOperation/reviewEvmWithdrawalOld'
 
 const SubmitButton = function ({
   isProving,

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/operation.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/operation.tsx
@@ -30,7 +30,8 @@ export const Operation = ({
         className="mt-4 flex flex-col gap-y-8"
         // use this to prevent layout shift for the gray container
         // calculate the max height depending on the number of steps
-        style={{ height: `${144 * steps.length}px` }}
+        // and add 20px for the "total" section
+        style={{ height: `${144 * steps.length + 20}px` }}
       >
         {steps.map((stepProps, index) => (
           <Step key={index} position={index + 1} {...stepProps} />

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -1,291 +1,175 @@
 import { MessageStatus } from '@eth-optimism/sdk'
-import { Modal } from 'components/modal'
-import { TransactionStatus } from 'components/transactionStatus'
-import { useHemi } from 'hooks/useHemi'
-import { useNetworks } from 'hooks/useNetworks'
-import { useToEvmWithdrawals } from 'hooks/useToEvmWithdrawals'
+import { useChain } from 'hooks/useChain'
 import { useTranslations } from 'next-intl'
-import { FormEvent, ReactNode } from 'react'
-import Skeleton from 'react-loading-skeleton'
+import { ComponentProps } from 'react'
+import { EvmToken } from 'types/token'
 import { ToEvmWithdrawOperation } from 'types/tunnel'
-import { Card } from 'ui-common/components/card'
-import { getL2TokenByBridgedAddress, getTokenByAddress } from 'utils/token'
-import { Address } from 'viem'
-import { useAccount } from 'wagmi'
+import { formatGasFees } from 'utils/format'
+import { getNativeToken, getTokenByAddress, isNativeToken } from 'utils/token'
+import { formatUnits } from 'viem'
 
-import { useTunnelOperation } from '../../_hooks/useTunnelOperation'
+import { useClaimTransaction } from '../../_hooks/useClaimTransaction'
+import { useProveTransaction } from '../../_hooks/useProveTransaction'
+import { useWithdraw } from '../../_hooks/useWithdraw'
 
-import { Amount } from './amount'
-import { ClaimIcon } from './claimIcon'
-import { Step, SubStep } from './steps'
-import { VerticalLine } from './verticalLine'
+import { Operation } from './operation'
+import { ProgressStatus } from './progressStatus'
+import { Step } from './step'
 
 const ExpectedWithdrawalWaitTimeMinutes = 20
 const ExpectedProofWaitTimeHours = 3
 
-const CloseIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    fill="none"
-    height="25"
-    viewBox="0 0 25 25"
-    width="25"
-    xmlns="http://www.w3.org/2000/svg"
-    {...props}
-  >
-    <path
-      d="M5.5 5.5L19.5 19.5M19.5 5.5L5.5 19.5"
-      stroke="black"
-      strokeLinecap="round"
-      strokeWidth="2"
-    />
-  </svg>
-)
-
-const CursorIcon = () => (
-  <svg
-    fill="none"
-    height="17"
-    viewBox="0 0 17 17"
-    width="17"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M9.25197 14.6016C9.4207 15.2483 10.3301 15.2721 10.5324 14.6352L13.9444 3.89363C14.1081 3.37832 13.6226 2.89274 13.1072 3.05643L2.36573 6.46843C1.72874 6.67077 1.75257 7.58022 2.39928 7.74889L7.45604 9.06802C7.68957 9.12895 7.8719 9.31135 7.93284 9.54482L9.25197 14.6016Z"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.5"
-    />
-  </svg>
-)
-
-const FuelIcon = () => (
-  <svg
-    fill="none"
-    height="17"
-    viewBox="0 0 17 17"
-    width="17"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M9.83333 13.8333H10.5M9.83333 13.8333V7.16663M9.83333 13.8333H3.16667M9.83333 7.16663V4.49996C9.83333 3.76358 9.2364 3.16663 8.5 3.16663H4.5C3.76362 3.16663 3.16667 3.76358 3.16667 4.49996V13.8333M9.83333 7.16663H11.1667C11.9031 7.16663 12.5 7.76356 12.5 8.49996V10.8333C12.5 11.3856 12.9477 11.8333 13.5 11.8333C14.0523 11.8333 14.5 11.3856 14.5 10.8333V6.38558C14.5 6.03195 14.3595 5.69282 14.1095 5.44277L13.1667 4.49996M3.16667 13.8333H2.5M7.83333 7.16663H5.16667"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.33333"
-    />
-  </svg>
-)
-
-const ProveIcon = () => (
-  <svg
-    fill="none"
-    height="19"
-    viewBox="0 0 19 19"
-    width="19"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M7.62634 9.87518L8.48615 10.735C8.63263 10.8815 8.87008 10.8815 9.01648 10.735L11.3764 8.37518M7.19494 4.44473L5.66095 4.20139C5.19705 4.1278 4.77532 4.48168 4.76724 4.9513L4.74051 6.50424C4.73592 6.7708 4.59426 7.01617 4.36571 7.15342L3.03419 7.95304C2.63152 8.19488 2.53592 8.73698 2.8316 9.10193L3.80934 10.3088C3.97716 10.5159 4.02636 10.7949 3.9395 11.047L3.43348 12.5154C3.28046 12.9595 3.55572 13.4363 4.01681 13.5257L5.54152 13.8218C5.80322 13.8725 6.02026 14.0546 6.11575 14.3036L6.672 15.7538C6.84022 16.1923 7.35754 16.3805 7.76829 16.1528L9.12658 15.3995C9.35968 15.2701 9.64303 15.2701 9.87613 15.3995L11.2344 16.1528C11.6452 16.3805 12.1625 16.1923 12.3307 15.7538L12.8869 14.3036C12.9824 14.0546 13.1995 13.8725 13.4612 13.8218L14.9859 13.5257C15.447 13.4363 15.7222 12.9595 15.5692 12.5154L15.0632 11.047C14.9764 10.7949 15.0256 10.5159 15.1933 10.3088L16.1711 9.10193C16.4668 8.73698 16.3711 8.19488 15.9685 7.95304L14.637 7.15342C14.4085 7.01617 14.2668 6.7708 14.2622 6.50424L14.2354 4.9513C14.2273 4.48168 13.8056 4.1278 13.3417 4.20139L11.8078 4.44473C11.5444 4.48651 11.2782 4.3896 11.1034 4.18836L10.0847 3.01592C9.7766 2.66136 9.2261 2.66136 8.918 3.01592L7.89933 4.18836C7.72447 4.3896 7.45824 4.4865 7.19494 4.44473Z"
-      strokeLinecap="round"
-      strokeWidth="1.5"
-    />
-  </svg>
-)
-
-const WithdrawAmount = function ({
-  withdrawal,
-}: {
-  withdrawal?: ToEvmWithdrawOperation
-}) {
-  const hemi = useHemi()
-  const { evmRemoteNetworks } = useNetworks()
-  if (!withdrawal) {
-    return <Skeleton containerClassName="w-5" />
-  }
-  const token =
-    getTokenByAddress(
-      withdrawal.l2Token as Address,
-      // See https://github.com/hemilabs/ui-monorepo/issues/376
-      withdrawal.l2ChainId ?? hemi.id,
-    ) ??
-    getL2TokenByBridgedAddress(
-      withdrawal.l2Token as Address,
-      // TODO https://github.com/hemilabs/ui-monorepo/issues/158
-      withdrawal.l1ChainId ?? evmRemoteNetworks[0].id,
-    )
-
-  return <Amount token={token} value={withdrawal.amount} />
+type Props = {
+  onClose: () => void
+  withdrawal: ToEvmWithdrawOperation
 }
 
-type ReviewEvmWithdrawalProps = {
-  gas?: {
-    amount: string
-    symbol: string
-  }
-  isRunningOperation: boolean
-  onClose?: () => void
-  onSubmit?: () => void
-  submitButton?: ReactNode
-  transactionsList?: {
-    id: string
-    status: React.ComponentProps<typeof TransactionStatus>['status']
-    text: string
-    txHash: string
-  }[]
-}
+export const ReviewEvmWithdrawal = function ({ onClose, withdrawal }: Props) {
+  const toToken = getTokenByAddress(
+    withdrawal.l1Token,
+    withdrawal.l1ChainId,
+  ) as EvmToken
 
-export const ReviewEvmWithdrawal = function ({
-  gas,
-  isRunningOperation,
-  onClose,
-  onSubmit,
-  submitButton,
-  transactionsList = [],
-}: ReviewEvmWithdrawalProps) {
-  const { chain } = useAccount()
+  // L2 native tunneled token is on a special address, so it is easier to get the native token
+  const fromToken = (
+    isNativeToken(toToken)
+      ? getNativeToken(withdrawal.l2ChainId)
+      : getTokenByAddress(withdrawal.l2Token, withdrawal.l2ChainId)
+  ) as EvmToken
 
-  const t = useTranslations()
-  const { operation, txHash } = useTunnelOperation()
-  const withdrawals = useToEvmWithdrawals()
+  const fromChain = useChain(withdrawal.l2ChainId)
+  const toChain = useChain(withdrawal.l1ChainId)
+  const t = useTranslations('tunnel-page.review-withdraw')
+  const tCommon = useTranslations('common')
 
-  const foundWithdrawal = withdrawals.find(w => w.transactionHash === txHash)
-  const messageStatus = foundWithdrawal.status
+  const { claimWithdrawalTokenGasFees } = useClaimTransaction({
+    l1ChainId: withdrawal.l1ChainId,
+    withdrawTxHash: withdrawal.transactionHash,
+  })
 
-  const getClaimStatus = function () {
-    if (messageStatus < MessageStatus.READY_FOR_RELAY) return 'idle'
-    if (messageStatus === MessageStatus.RELAYED) return 'completed'
-    if (isRunningOperation) return 'progress'
-    return 'ready'
-  }
+  const { proveWithdrawalTokenGasFees } = useProveTransaction({
+    l1ChainId: withdrawal.l1ChainId,
+    withdrawTxHash: withdrawal.transactionHash,
+  })
+
+  const { withdrawGasFees } = useWithdraw({
+    // only estimate fees for the first step
+    canWithdraw:
+      withdrawal.status === MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE,
+    fromInput: formatUnits(BigInt(withdrawal.amount), fromToken.decimals),
+    fromToken,
+    l1ChainId: toToken.chainId,
+    l2ChainId: fromToken.chainId,
+    toToken,
+  })
+
+  const steps: Omit<ComponentProps<typeof Step>, 'position'>[] = []
+
+  const getInitiateWithdrawStep = () => ({
+    description: t('initiate-withdrawal'),
+    explorerChainId: withdrawal.l2ChainId,
+    fees:
+      withdrawGasFees !== undefined
+        ? {
+            amount: formatGasFees(
+              withdrawGasFees,
+              fromChain.nativeCurrency.decimals,
+            ),
+            symbol: fromChain.nativeCurrency.symbol,
+          }
+        : undefined,
+    postAction: {
+      description: tCommon('wait-minutes', {
+        minutes: ExpectedWithdrawalWaitTimeMinutes,
+      }),
+      status:
+        withdrawal.status >= MessageStatus.READY_TO_PROVE
+          ? ProgressStatus.COMPLETED
+          : withdrawal.status === MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE
+            ? ProgressStatus.PROGRESS
+            : ProgressStatus.NOT_READY,
+    },
+    status:
+      withdrawal.status >= MessageStatus.STATE_ROOT_NOT_PUBLISHED
+        ? ProgressStatus.COMPLETED
+        : ProgressStatus.PROGRESS,
+    txHash: withdrawal.transactionHash,
+  })
 
   const getProveStatus = function () {
-    if (messageStatus < MessageStatus.READY_TO_PROVE) return 'idle'
-    if (messageStatus > MessageStatus.READY_TO_PROVE) return 'completed'
-    if (isRunningOperation) return 'progress'
-    return 'ready'
+    if (withdrawal.status < MessageStatus.READY_TO_PROVE)
+      return ProgressStatus.NOT_READY
+    if (withdrawal.status === MessageStatus.READY_TO_PROVE)
+      return ProgressStatus.READY
+    return ProgressStatus.COMPLETED
   }
 
-  const getWithdrawalProgress = () =>
-    messageStatus >= MessageStatus.STATE_ROOT_NOT_PUBLISHED
-      ? 'completed'
-      : 'progress'
+  const getProveStep = () => ({
+    description: t('prove-withdrawal'),
+    explorerChainId: withdrawal.l1ChainId,
+    fees:
+      proveWithdrawalTokenGasFees !== undefined
+        ? {
+            amount: formatGasFees(
+              proveWithdrawalTokenGasFees,
+              toChain.nativeCurrency.decimals,
+            ),
+            symbol: toChain.nativeCurrency.symbol,
+          }
+        : undefined,
+    postAction: {
+      description: tCommon('wait-hours', {
+        hours: ExpectedProofWaitTimeHours,
+      }),
+      status:
+        withdrawal.status >= MessageStatus.READY_FOR_RELAY
+          ? ProgressStatus.COMPLETED
+          : getProveStatus() === ProgressStatus.COMPLETED
+            ? ProgressStatus.READY
+            : ProgressStatus.NOT_READY,
+    },
+    status: getProveStatus(),
+    transactionHash: withdrawal.proveTxHash,
+  })
 
-  const getWaitReadyToProveStatus = function () {
-    if (messageStatus >= MessageStatus.READY_TO_PROVE) {
-      return 'completed'
-    }
-    const withdrawalStatus = getWithdrawalProgress()
-    if (withdrawalStatus === 'completed') {
-      return 'progress'
-    }
-    return 'idle'
-  }
+  const getClaimStep = () => ({
+    description: t('claim-withdrawal'),
+    explorerChainId: withdrawal.l1ChainId,
+    fees:
+      claimWithdrawalTokenGasFees !== undefined
+        ? {
+            amount: formatGasFees(
+              claimWithdrawalTokenGasFees,
+              toChain.nativeCurrency.decimals,
+            ),
+            symbol: toChain.nativeCurrency.symbol,
+          }
+        : undefined,
+    status:
+      withdrawal.status === MessageStatus.RELAYED
+        ? ProgressStatus.COMPLETED
+        : withdrawal.status === MessageStatus.READY_FOR_RELAY
+          ? ProgressStatus.READY
+          : ProgressStatus.NOT_READY,
+    transactionHash: withdrawal.claimTxHash,
+  })
 
-  const getWaitReadyToClaimStatus = function () {
-    if (
-      [MessageStatus.READY_FOR_RELAY, MessageStatus.RELAYED].includes(
-        messageStatus,
-      )
-    ) {
-      return 'completed'
-    }
-    const proveStatus = getProveStatus()
-    if (proveStatus === 'completed') {
-      return 'progress'
-    }
-    return 'idle'
-  }
-
-  const isClaim = operation === 'claim'
-  const isProve = operation === 'prove'
-  const isWithdraw = operation === 'withdraw'
-
-  const handleSubmit = function (e: FormEvent) {
-    e.preventDefault()
-    onSubmit()
-  }
-
-  const closeModal = function () {
-    // prevent closing if running an operation
-    if (isRunningOperation) {
-      return
-    }
-    onClose?.()
-    window.history.back()
-  }
-
-  const feesIcon = <FuelIcon />
+  steps.push(getInitiateWithdrawStep())
+  steps.push(getProveStep())
+  steps.push(getClaimStep())
 
   return (
-    <Modal onClose={closeModal}>
-      <div className="flex w-96 flex-col gap-y-4">
-        <Card padding="large">
-          <div className="flex items-center justify-between pb-2">
-            <h4 className="text-base font-medium text-slate-950 lg:text-xl">
-              {t('tunnel-page.review-withdraw.heading')}
-            </h4>
-            <CloseIcon className="cursor-pointer" onClick={closeModal} />
-          </div>
-          <div className="flex items-center justify-between py-4">
-            <span className="text-xs font-medium text-slate-500">
-              {t('common.total-amount')}
-            </span>
-            <WithdrawAmount withdrawal={foundWithdrawal} />
-          </div>
-          <Step
-            fees={isWithdraw && gas}
-            feesIcon={feesIcon}
-            icon={<CursorIcon />}
-            status={getWithdrawalProgress()}
-            text={t('tunnel-page.review-withdraw.initiate-withdrawal')}
-          />
-          <VerticalLine />
-          <SubStep
-            status={getWaitReadyToProveStatus()}
-            text={t('common.wait-minutes', {
-              minutes: ExpectedWithdrawalWaitTimeMinutes,
-            })}
-          />
-          <VerticalLine />
-          <Step
-            fees={isProve && gas}
-            feesIcon={feesIcon}
-            icon={<ProveIcon />}
-            status={getProveStatus()}
-            text={t('tunnel-page.review-withdraw.prove-withdrawal')}
-          />
-          <VerticalLine />
-          <SubStep
-            status={getWaitReadyToClaimStatus()}
-            text={t('common.wait-hours', {
-              hours: ExpectedProofWaitTimeHours,
-            })}
-          />
-          <VerticalLine />
-          <Step
-            fees={isClaim && gas}
-            feesIcon={feesIcon}
-            icon={<ClaimIcon />}
-            status={getClaimStatus()}
-            text={t('tunnel-page.review-withdraw.claim-withdrawal')}
-          />
-          <form className="mt-6" onSubmit={handleSubmit}>
-            {submitButton}
-          </form>
-        </Card>
-        {transactionsList.length > 0 && (
-          <div className="flex flex-col gap-y-4">
-            {transactionsList.map(transaction => (
-              <TransactionStatus
-                explorerUrl={chain.blockExplorers.default.url}
-                key={transaction.id}
-                status={transaction.status}
-                text={transaction.text}
-                txHash={transaction.txHash}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    </Modal>
+    <Operation
+      amount={withdrawal.amount}
+      onClose={onClose}
+      steps={steps}
+      subtitle={
+        withdrawal.status === MessageStatus.RELAYED
+          ? t('withdraw-completed')
+          : t('withdraw-on-its-way')
+      }
+      title={t('heading')}
+      token={fromToken}
+    />
   )
 }

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawalOld.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawalOld.tsx
@@ -1,0 +1,291 @@
+import { MessageStatus } from '@eth-optimism/sdk'
+import { Modal } from 'components/modal'
+import { TransactionStatus } from 'components/transactionStatus'
+import { useHemi } from 'hooks/useHemi'
+import { useNetworks } from 'hooks/useNetworks'
+import { useToEvmWithdrawals } from 'hooks/useToEvmWithdrawals'
+import { useTranslations } from 'next-intl'
+import { FormEvent, ReactNode } from 'react'
+import Skeleton from 'react-loading-skeleton'
+import { ToEvmWithdrawOperation } from 'types/tunnel'
+import { Card } from 'ui-common/components/card'
+import { getL2TokenByBridgedAddress, getTokenByAddress } from 'utils/token'
+import { Address } from 'viem'
+import { useAccount } from 'wagmi'
+
+import { useTunnelOperation } from '../../_hooks/useTunnelOperation'
+
+import { Amount } from './amount'
+import { ClaimIcon } from './claimIcon'
+import { Step, SubStep } from './steps'
+import { VerticalLine } from './verticalLine'
+
+const ExpectedWithdrawalWaitTimeMinutes = 20
+const ExpectedProofWaitTimeHours = 3
+
+const CloseIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    fill="none"
+    height="25"
+    viewBox="0 0 25 25"
+    width="25"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M5.5 5.5L19.5 19.5M19.5 5.5L5.5 19.5"
+      stroke="black"
+      strokeLinecap="round"
+      strokeWidth="2"
+    />
+  </svg>
+)
+
+const CursorIcon = () => (
+  <svg
+    fill="none"
+    height="17"
+    viewBox="0 0 17 17"
+    width="17"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M9.25197 14.6016C9.4207 15.2483 10.3301 15.2721 10.5324 14.6352L13.9444 3.89363C14.1081 3.37832 13.6226 2.89274 13.1072 3.05643L2.36573 6.46843C1.72874 6.67077 1.75257 7.58022 2.39928 7.74889L7.45604 9.06802C7.68957 9.12895 7.8719 9.31135 7.93284 9.54482L9.25197 14.6016Z"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+    />
+  </svg>
+)
+
+const FuelIcon = () => (
+  <svg
+    fill="none"
+    height="17"
+    viewBox="0 0 17 17"
+    width="17"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M9.83333 13.8333H10.5M9.83333 13.8333V7.16663M9.83333 13.8333H3.16667M9.83333 7.16663V4.49996C9.83333 3.76358 9.2364 3.16663 8.5 3.16663H4.5C3.76362 3.16663 3.16667 3.76358 3.16667 4.49996V13.8333M9.83333 7.16663H11.1667C11.9031 7.16663 12.5 7.76356 12.5 8.49996V10.8333C12.5 11.3856 12.9477 11.8333 13.5 11.8333C14.0523 11.8333 14.5 11.3856 14.5 10.8333V6.38558C14.5 6.03195 14.3595 5.69282 14.1095 5.44277L13.1667 4.49996M3.16667 13.8333H2.5M7.83333 7.16663H5.16667"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.33333"
+    />
+  </svg>
+)
+
+const ProveIcon = () => (
+  <svg
+    fill="none"
+    height="19"
+    viewBox="0 0 19 19"
+    width="19"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M7.62634 9.87518L8.48615 10.735C8.63263 10.8815 8.87008 10.8815 9.01648 10.735L11.3764 8.37518M7.19494 4.44473L5.66095 4.20139C5.19705 4.1278 4.77532 4.48168 4.76724 4.9513L4.74051 6.50424C4.73592 6.7708 4.59426 7.01617 4.36571 7.15342L3.03419 7.95304C2.63152 8.19488 2.53592 8.73698 2.8316 9.10193L3.80934 10.3088C3.97716 10.5159 4.02636 10.7949 3.9395 11.047L3.43348 12.5154C3.28046 12.9595 3.55572 13.4363 4.01681 13.5257L5.54152 13.8218C5.80322 13.8725 6.02026 14.0546 6.11575 14.3036L6.672 15.7538C6.84022 16.1923 7.35754 16.3805 7.76829 16.1528L9.12658 15.3995C9.35968 15.2701 9.64303 15.2701 9.87613 15.3995L11.2344 16.1528C11.6452 16.3805 12.1625 16.1923 12.3307 15.7538L12.8869 14.3036C12.9824 14.0546 13.1995 13.8725 13.4612 13.8218L14.9859 13.5257C15.447 13.4363 15.7222 12.9595 15.5692 12.5154L15.0632 11.047C14.9764 10.7949 15.0256 10.5159 15.1933 10.3088L16.1711 9.10193C16.4668 8.73698 16.3711 8.19488 15.9685 7.95304L14.637 7.15342C14.4085 7.01617 14.2668 6.7708 14.2622 6.50424L14.2354 4.9513C14.2273 4.48168 13.8056 4.1278 13.3417 4.20139L11.8078 4.44473C11.5444 4.48651 11.2782 4.3896 11.1034 4.18836L10.0847 3.01592C9.7766 2.66136 9.2261 2.66136 8.918 3.01592L7.89933 4.18836C7.72447 4.3896 7.45824 4.4865 7.19494 4.44473Z"
+      strokeLinecap="round"
+      strokeWidth="1.5"
+    />
+  </svg>
+)
+
+const WithdrawAmount = function ({
+  withdrawal,
+}: {
+  withdrawal?: ToEvmWithdrawOperation
+}) {
+  const hemi = useHemi()
+  const { evmRemoteNetworks } = useNetworks()
+  if (!withdrawal) {
+    return <Skeleton containerClassName="w-5" />
+  }
+  const token =
+    getTokenByAddress(
+      withdrawal.l2Token as Address,
+      // See https://github.com/hemilabs/ui-monorepo/issues/376
+      withdrawal.l2ChainId ?? hemi.id,
+    ) ??
+    getL2TokenByBridgedAddress(
+      withdrawal.l2Token as Address,
+      // TODO https://github.com/hemilabs/ui-monorepo/issues/158
+      withdrawal.l1ChainId ?? evmRemoteNetworks[0].id,
+    )
+
+  return <Amount token={token} value={withdrawal.amount} />
+}
+
+type ReviewEvmWithdrawalProps = {
+  gas?: {
+    amount: string
+    symbol: string
+  }
+  isRunningOperation: boolean
+  onClose?: () => void
+  onSubmit?: () => void
+  submitButton?: ReactNode
+  transactionsList?: {
+    id: string
+    status: React.ComponentProps<typeof TransactionStatus>['status']
+    text: string
+    txHash: string
+  }[]
+}
+
+export const ReviewEvmWithdrawal = function ({
+  gas,
+  isRunningOperation,
+  onClose,
+  onSubmit,
+  submitButton,
+  transactionsList = [],
+}: ReviewEvmWithdrawalProps) {
+  const { chain } = useAccount()
+
+  const t = useTranslations()
+  const { operation, txHash } = useTunnelOperation()
+  const withdrawals = useToEvmWithdrawals()
+
+  const foundWithdrawal = withdrawals.find(w => w.transactionHash === txHash)
+  const messageStatus = foundWithdrawal.status
+
+  const getClaimStatus = function () {
+    if (messageStatus < MessageStatus.READY_FOR_RELAY) return 'idle'
+    if (messageStatus === MessageStatus.RELAYED) return 'completed'
+    if (isRunningOperation) return 'progress'
+    return 'ready'
+  }
+
+  const getProveStatus = function () {
+    if (messageStatus < MessageStatus.READY_TO_PROVE) return 'idle'
+    if (messageStatus > MessageStatus.READY_TO_PROVE) return 'completed'
+    if (isRunningOperation) return 'progress'
+    return 'ready'
+  }
+
+  const getWithdrawalProgress = () =>
+    messageStatus >= MessageStatus.STATE_ROOT_NOT_PUBLISHED
+      ? 'completed'
+      : 'progress'
+
+  const getWaitReadyToProveStatus = function () {
+    if (messageStatus >= MessageStatus.READY_TO_PROVE) {
+      return 'completed'
+    }
+    const withdrawalStatus = getWithdrawalProgress()
+    if (withdrawalStatus === 'completed') {
+      return 'progress'
+    }
+    return 'idle'
+  }
+
+  const getWaitReadyToClaimStatus = function () {
+    if (
+      [MessageStatus.READY_FOR_RELAY, MessageStatus.RELAYED].includes(
+        messageStatus,
+      )
+    ) {
+      return 'completed'
+    }
+    const proveStatus = getProveStatus()
+    if (proveStatus === 'completed') {
+      return 'progress'
+    }
+    return 'idle'
+  }
+
+  const isClaim = operation === 'claim'
+  const isProve = operation === 'prove'
+  const isWithdraw = operation === 'withdraw'
+
+  const handleSubmit = function (e: FormEvent) {
+    e.preventDefault()
+    onSubmit()
+  }
+
+  const closeModal = function () {
+    // prevent closing if running an operation
+    if (isRunningOperation) {
+      return
+    }
+    onClose?.()
+    window.history.back()
+  }
+
+  const feesIcon = <FuelIcon />
+
+  return (
+    <Modal onClose={closeModal}>
+      <div className="flex w-96 flex-col gap-y-4">
+        <Card padding="large">
+          <div className="flex items-center justify-between pb-2">
+            <h4 className="text-base font-medium text-slate-950 lg:text-xl">
+              {t('tunnel-page.review-withdraw.heading')}
+            </h4>
+            <CloseIcon className="cursor-pointer" onClick={closeModal} />
+          </div>
+          <div className="flex items-center justify-between py-4">
+            <span className="text-xs font-medium text-slate-500">
+              {t('common.total-amount')}
+            </span>
+            <WithdrawAmount withdrawal={foundWithdrawal} />
+          </div>
+          <Step
+            fees={isWithdraw && gas}
+            feesIcon={feesIcon}
+            icon={<CursorIcon />}
+            status={getWithdrawalProgress()}
+            text={t('tunnel-page.review-withdraw.initiate-withdrawal')}
+          />
+          <VerticalLine />
+          <SubStep
+            status={getWaitReadyToProveStatus()}
+            text={t('common.wait-minutes', {
+              minutes: ExpectedWithdrawalWaitTimeMinutes,
+            })}
+          />
+          <VerticalLine />
+          <Step
+            fees={isProve && gas}
+            feesIcon={feesIcon}
+            icon={<ProveIcon />}
+            status={getProveStatus()}
+            text={t('tunnel-page.review-withdraw.prove-withdrawal')}
+          />
+          <VerticalLine />
+          <SubStep
+            status={getWaitReadyToClaimStatus()}
+            text={t('common.wait-hours', {
+              hours: ExpectedProofWaitTimeHours,
+            })}
+          />
+          <VerticalLine />
+          <Step
+            fees={isClaim && gas}
+            feesIcon={feesIcon}
+            icon={<ClaimIcon />}
+            status={getClaimStatus()}
+            text={t('tunnel-page.review-withdraw.claim-withdrawal')}
+          />
+          <form className="mt-6" onSubmit={handleSubmit}>
+            {submitButton}
+          </form>
+        </Card>
+        {transactionsList.length > 0 && (
+          <div className="flex flex-col gap-y-4">
+            {transactionsList.map(transaction => (
+              <TransactionStatus
+                explorerUrl={chain.blockExplorers.default.url}
+                key={transaction.id}
+                status={transaction.status}
+                text={transaction.text}
+                txHash={transaction.txHash}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/step.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/step.tsx
@@ -47,6 +47,7 @@ const Completed = function ({
   description,
   explorerChainId,
   position,
+  postAction,
   txHash,
 }: Props) {
   const t = useTranslations('common.transaction-status')
@@ -68,6 +69,11 @@ const Completed = function ({
           <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
         </div>
       </div>
+      {!!postAction && (
+        <div className="left-2.25 absolute bottom-6">
+          <LongVerticalLine stroke="stroke-orange-500" />
+        </div>
+      )}
     </>
   )
 }

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/viewWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/viewWithdrawal.tsx
@@ -1,28 +1,17 @@
-'use client'
-
-import { Drawer } from 'components/drawer'
 import { WithdrawTunnelOperation } from 'types/tunnel'
-import { isEvmOperation } from 'utils/tunnel'
+import { isToEvmWithdraw } from 'utils/tunnel'
 
-import { useTunnelOperation } from '../../_hooks/useTunnelOperation'
+import { ReviewEvmWithdrawal } from './reviewEvmWithdrawal'
 
 type Props = {
+  onClose: () => void
   withdrawal: WithdrawTunnelOperation
 }
 
-// TODO will be implemented in incoming PRs
-export const ViewWithdrawal = function ({ withdrawal }: Props) {
-  const { updateTxHash } = useTunnelOperation()
-
-  const onClose = function () {
-    updateTxHash(null)
+export const ViewWithdrawal = function ({ onClose, withdrawal }: Props) {
+  if (isToEvmWithdraw(withdrawal)) {
+    return <ReviewEvmWithdrawal onClose={onClose} withdrawal={withdrawal} />
   }
-
-  return (
-    <Drawer onClose={onClose}>
-      <div className="h-full w-80 bg-white">{`${
-        isEvmOperation(withdrawal) ? 'EVM' : 'BTC'
-      } Withdrawal ${withdrawal.transactionHash}`}</div>
-    </Drawer>
-  )
+  // Bitcoin withdrawals Will be implemented in incoming PRs
+  return null
 }

--- a/webapp/app/[locale]/tunnel/_components/view.tsx
+++ b/webapp/app/[locale]/tunnel/_components/view.tsx
@@ -21,7 +21,7 @@ import {
 } from '../_hooks/useTunnelState'
 
 import { ReviewBtcDeposit } from './reviewOperation/reviewBtcDeposit'
-import { ReviewEvmWithdrawal } from './reviewOperation/reviewEvmWithdrawal'
+import { ReviewEvmWithdrawal } from './reviewOperation/reviewEvmWithdrawalOld'
 
 const BtcViewDeposit = function ({
   state,

--- a/webapp/app/[locale]/tunnel/_components/viewOperation.tsx
+++ b/webapp/app/[locale]/tunnel/_components/viewOperation.tsx
@@ -56,7 +56,7 @@ const Operation = function () {
         {isDeposit(tunnelOperation) ? (
           <ViewDeposit deposit={tunnelOperation} onClose={onClose} />
         ) : (
-          <ViewWithdrawal withdrawal={tunnelOperation} />
+          <ViewWithdrawal onClose={onClose} withdrawal={tunnelOperation} />
         )}
       </div>
     </Drawer>

--- a/webapp/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/webapp/app/[locale]/tunnel/_components/withdraw.tsx
@@ -42,7 +42,7 @@ const MinBitcoinWithdraw = '0.005'
 
 const ReviewEvmWithdrawal = dynamic(
   () =>
-    import('./reviewOperation/reviewEvmWithdrawal').then(
+    import('./reviewOperation/reviewEvmWithdrawalOld').then(
       mod => mod.ReviewEvmWithdrawal,
     ),
   {

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -256,7 +256,9 @@
       "initiate-withdrawal": "Initiate withdrawal",
       "prove-withdrawal": "Prove withdrawal",
       "total-to-withdraw": "Total to withdraw",
-      "view-tx": "View"
+      "view-tx": "View",
+      "withdraw-completed": "Your withdrawal is complete.",
+      "withdraw-on-its-way": "You're almost there! Complete the remaining steps to claim your withdrawal."
     },
     "submit-button": {
       "approve-and-deposit": "Approve and Deposit",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -256,7 +256,9 @@
       "initiate-withdrawal": "Iniciar retiro",
       "prove-withdrawal": "Probar retiro",
       "total-to-withdraw": "Total a retirar",
-      "view-tx": "View"
+      "view-tx": "View",
+      "withdraw-completed": "Su retiro ha sido completado.",
+      "withdraw-on-its-way": "¡Ya falta poco! Complete el resto de los pasos para reclamar su retiro."
     },
     "submit-button": {
       "approve-and-deposit": "Aprobar y Depositar",


### PR DESCRIPTION
Related to #529

This is Part 1 to replace the Dialogs with Drawers for withdrawals. After this PR, users will be able to see the withdrawal state in the drawer. Note that there is no call to action: For that, I need to move some code of the Prove/Claim components.

Note that while the file `webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx` shows as a very large diff, actually it is a brand new file, which _happens_ to share the file name with the previous version. However, removing the original file would make it complicated to review this PR (or merge it partially) because it contains the logic of the previous modal, which also had code for proving/claiming.

To make this easier for you folks to review, I'm then renaming the original `reviewEvmWithdrawal.tsx` to `reviewEvmWithdrawalOld.tsx` in the same folder, updating the references, and then it will be removed in the next PR. Not ideal, but it will make it easier for all of you to review. This way, I can send a 2nd part with the Call to Action added to the drawer.

In summary, this PR is a set of changes + `webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx` which should be reviewed as a full new file.

Incoming PR with Part 2, where the drawer has the Call to Action!



https://github.com/user-attachments/assets/af68776e-b427-47b5-a334-ade851bbaf5f


Some screenshots for mobile

<img width="534" alt="image" src="https://github.com/user-attachments/assets/1fa62ff9-ae2e-431e-a79b-f393e7f829c1">


<img width="516" alt="image" src="https://github.com/user-attachments/assets/3ec073b0-2d83-4002-abb1-a72d6fecda55">
