### PR TITLE
Handle errors deposit withdrawal

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/claimEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/claimEvmWithdrawal.tsx
@@ -6,7 +6,7 @@ import { ToEvmWithdrawOperation } from 'types/tunnel'
 import { ToEvmWithdrawalContext } from '../_context/toEvmWithdrawalContext'
 import { useClaimTransaction } from '../_hooks/useClaimTransaction'
 
-import { SubmitWhenConnectedToChain } from './submitWhenConnectedToChain'
+import { DrawerCallToAction } from './reviewOperation/drawerCallToAction'
 
 type Props = {
   withdrawal: ToEvmWithdrawOperation
@@ -75,15 +75,14 @@ export const ClaimEvmWithdrawal = function ({ withdrawal }: Props) {
   }
 
   return (
-    <form className="flex [&>button]:w-full" onSubmit={handleClaim}>
-      <SubmitWhenConnectedToChain
-        chainId={withdrawal.l1ChainId}
-        submitButton={
-          <Button disabled={!isReadyToClaim || isClaiming} type="submit">
-            {t(getText())}
-          </Button>
-        }
-      />
-    </form>
+    <DrawerCallToAction
+      expectedChainId={withdrawal.l1ChainId}
+      onSubmit={handleClaim}
+      submitButton={
+        <Button disabled={!isReadyToClaim || isClaiming} type="submit">
+          {t(getText())}
+        </Button>
+      }
+    />
   )
 }

--- a/webapp/app/[locale]/tunnel/_components/claimEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/claimEvmWithdrawal.tsx
@@ -15,7 +15,7 @@ type Props = {
 export const ClaimEvmWithdrawal = function ({ withdrawal }: Props) {
   const { claimWithdrawal, claimWithdrawalReceipt, isReadyToClaim } =
     useClaimTransaction(withdrawal)
-  const [operationRunning, setOperationRunning] = useContext(
+  const [operationStatus, setOperationStatus] = useContext(
     ToEvmWithdrawalContext,
   )
   const t = useTranslations()
@@ -24,22 +24,22 @@ export const ClaimEvmWithdrawal = function ({ withdrawal }: Props) {
     function clearAfterSuccessfulClaim() {
       if (
         claimWithdrawalReceipt?.status !== 'success' ||
-        operationRunning !== 'claim'
+        operationStatus !== 'claiming'
       ) {
         return
       }
-      setOperationRunning('idle')
+      setOperationStatus('idle')
     },
-    [claimWithdrawalReceipt, operationRunning, setOperationRunning],
+    [claimWithdrawalReceipt, operationStatus, setOperationStatus],
   )
 
   const handleClaim = function (e: FormEvent) {
     e.preventDefault()
-    setOperationRunning('claim')
+    setOperationStatus('claiming')
     claimWithdrawal()
   }
 
-  const isClaiming = operationRunning === 'claim'
+  const isClaiming = operationStatus === 'claiming'
 
   return (
     <form className="flex [&>button]:w-full" onSubmit={handleClaim}>

--- a/webapp/app/[locale]/tunnel/_components/proveEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/proveEvmWithdrawal.tsx
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export const ProveWithdrawal = function ({ withdrawal }: Props) {
-  const [operationRunning, setOperationRunning] = useContext(
+  const [operationStatus, setOperationStatus] = useContext(
     ToEvmWithdrawalContext,
   )
   const { isReadyToProve, proveWithdrawal, withdrawalProofReceipt } =
@@ -24,20 +24,20 @@ export const ProveWithdrawal = function ({ withdrawal }: Props) {
     function clearAfterSuccessfulProve() {
       if (
         withdrawalProofReceipt?.status !== 'success' ||
-        operationRunning !== 'prove'
+        operationStatus !== 'proving'
       ) {
         return
       }
-      setOperationRunning('idle')
+      setOperationStatus('idle')
     },
-    [operationRunning, setOperationRunning, withdrawalProofReceipt],
+    [operationStatus, setOperationStatus, withdrawalProofReceipt],
   )
 
-  const isProving = operationRunning === 'prove'
+  const isProving = operationStatus === 'proving'
 
   const handleProve = function (e: FormEvent) {
     e.preventDefault()
-    setOperationRunning('prove')
+    setOperationStatus('proving')
     proveWithdrawal()
   }
 

--- a/webapp/app/[locale]/tunnel/_components/proveEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/proveEvmWithdrawal.tsx
@@ -6,7 +6,7 @@ import { ToEvmWithdrawOperation } from 'types/tunnel'
 import { ToEvmWithdrawalContext } from '../_context/toEvmWithdrawalContext'
 import { useProveTransaction } from '../_hooks/useProveTransaction'
 
-import { SubmitWhenConnectedToChain } from './submitWhenConnectedToChain'
+import { DrawerCallToAction } from './reviewOperation/drawerCallToAction'
 
 type Props = {
   withdrawal: ToEvmWithdrawOperation
@@ -75,15 +75,14 @@ export const ProveWithdrawal = function ({ withdrawal }: Props) {
   }
 
   return (
-    <form className="flex [&>button]:w-full" onSubmit={handleProve}>
-      <SubmitWhenConnectedToChain
-        chainId={withdrawal.l1ChainId}
-        submitButton={
-          <Button disabled={!isReadyToProve || isProving} type="submit">
-            {t(getText())}
-          </Button>
-        }
-      />
-    </form>
+    <DrawerCallToAction
+      expectedChainId={withdrawal.l1ChainId}
+      onSubmit={handleProve}
+      submitButton={
+        <Button disabled={!isReadyToProve || isProving} type="submit">
+          {t(getText())}
+        </Button>
+      }
+    />
   )
 }

--- a/webapp/app/[locale]/tunnel/_components/retryEvmDeposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/retryEvmDeposit.tsx
@@ -1,0 +1,83 @@
+import { Button } from 'components/button'
+import { useTranslations } from 'next-intl'
+import { type FormEvent, useContext, useEffect } from 'react'
+import { EvmToken } from 'types/token'
+import { EvmDepositOperation } from 'types/tunnel'
+import { getNativeToken, getTokenByAddress, isNativeToken } from 'utils/token'
+import { formatUnits } from 'viem'
+
+import { EvmDepositContext } from '../_context/evmDepositContext'
+import { useDeposit } from '../_hooks/useDeposit'
+
+import { DrawerCallToAction } from './reviewOperation/drawerCallToAction'
+
+type Props = {
+  deposit: EvmDepositOperation
+}
+
+export const RetryEvmDeposit = function ({ deposit }: Props) {
+  const [operationStatus, setOperationStatus] = useContext(EvmDepositContext)
+
+  const t = useTranslations('tunnel-page.submit-button')
+
+  const fromToken = getTokenByAddress(
+    deposit.l1Token,
+    deposit.l1ChainId,
+  ) as EvmToken
+
+  // L2 native tunneled token is on a special address, so it is easier to get the native token
+  const toToken = (
+    isNativeToken(fromToken)
+      ? getNativeToken(deposit.l2ChainId)
+      : getTokenByAddress(deposit.l2Token, deposit.l2ChainId)
+  ) as EvmToken
+
+  // this component tries to initiate a new deposit, based on the failed one
+  const { deposit: runDeposit, depositError } = useDeposit({
+    canDeposit: true,
+    extendedErc20Approval: false,
+    fromInput: formatUnits(
+      BigInt(deposit.amount),
+      fromToken.decimals,
+    ).toString(),
+    fromToken,
+    toToken,
+  })
+
+  useEffect(
+    // on unmounting the component, reset the context
+    () => () => setOperationStatus('idle'),
+    [setOperationStatus],
+  )
+
+  const isDepositing = operationStatus === 'depositing'
+
+  // Success and failure are not needed to be handled here, as a new tx hash is generated, so this component
+  // is unmounted and a "new" withdrawal cycle starts
+  useEffect(
+    function handleUserRejection() {
+      if (depositError && isDepositing) {
+        setOperationStatus('rejected')
+      }
+    },
+    [depositError, isDepositing, setOperationStatus],
+  )
+
+  const handleRetry = function (e: FormEvent) {
+    e.preventDefault()
+    setOperationStatus('depositing')
+    runDeposit()
+  }
+
+  return (
+    <DrawerCallToAction
+      expectedChainId={deposit.l1ChainId}
+      onSubmit={handleRetry}
+      submitButton={
+        <Button disabled={isDepositing}>
+          {t(isDepositing ? 'depositing' : 'try-again')}
+        </Button>
+      }
+    />
+  )
+}

--- a/webapp/app/[locale]/tunnel/_components/retryEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/retryEvmWithdrawal.tsx
@@ -1,0 +1,80 @@
+import { Button } from 'components/button'
+import { useTranslations } from 'next-intl'
+import { type FormEvent, useContext, useEffect } from 'react'
+import { EvmToken } from 'types/token'
+import { ToEvmWithdrawOperation } from 'types/tunnel'
+import { getNativeToken, getTokenByAddress, isNativeToken } from 'utils/token'
+import { formatUnits } from 'viem'
+
+import { ToEvmWithdrawalContext } from '../_context/toEvmWithdrawalContext'
+import { useWithdraw } from '../_hooks/useWithdraw'
+
+import { DrawerCallToAction } from './reviewOperation/drawerCallToAction'
+
+type Props = {
+  withdrawal: ToEvmWithdrawOperation
+}
+
+export const RetryEvmWithdrawal = function ({ withdrawal }: Props) {
+  const [operationStatus, setOperationStatus] = useContext(
+    ToEvmWithdrawalContext,
+  )
+
+  const t = useTranslations('tunnel-page.submit-button')
+
+  const toToken = getTokenByAddress(
+    withdrawal.l1Token,
+    withdrawal.l1ChainId,
+  ) as EvmToken
+
+  // L2 native tunneled token is on a special address, so it is easier to get the native token
+  const fromToken = (
+    isNativeToken(toToken)
+      ? getNativeToken(withdrawal.l2ChainId)
+      : getTokenByAddress(withdrawal.l2Token, withdrawal.l2ChainId)
+  ) as EvmToken
+
+  // this component tries to initiate a new withdrawal, based on the failed one
+  const { withdraw, withdrawError } = useWithdraw({
+    canWithdraw: true,
+    fromInput: formatUnits(
+      BigInt(withdrawal.amount),
+      fromToken.decimals,
+    ).toString(),
+    fromToken,
+    l1ChainId: withdrawal.l1ChainId,
+    l2ChainId: withdrawal.l2ChainId,
+    toToken,
+  })
+
+  const isWithdrawing = operationStatus === 'withdrawing'
+
+  // Success and failure are not needed to be handled here, as a new tx hash is generated, so this component
+  // is unmounted and a "new" withdrawal cycle starts
+  useEffect(
+    function handleUserRejection() {
+      if (withdrawError && isWithdrawing) {
+        setOperationStatus('rejected')
+      }
+    },
+    [isWithdrawing, setOperationStatus, withdrawError],
+  )
+
+  const handleRetry = function (e: FormEvent) {
+    e.preventDefault()
+    setOperationStatus('withdrawing')
+    withdraw()
+  }
+
+  return (
+    <DrawerCallToAction
+      expectedChainId={withdrawal.l2ChainId}
+      onSubmit={handleRetry}
+      submitButton={
+        <Button disabled={isWithdrawing}>
+          {t(isWithdrawing ? 'withdrawing' : 'try-again')}
+        </Button>
+      }
+    />
+  )
+}

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/box.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/box.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react'
+
+const commonCss =
+  'h-13 w-full rounded-lg border border-solid border-neutral-300/55 p-4 flex items-center'
+
+type BoxProps = {
+  bgColor: 'bg-neutral-50' | 'bg-neutral-100' | 'bg-white'
+  children: ReactNode
+}
+
+export const OneRowBox = ({ bgColor, children }: BoxProps) => (
+  <div className={`${commonCss} ${bgColor}`}>{children}</div>
+)
+
+export const TwoRowBox = ({
+  bottom,
+  top,
+}: {
+  bottom: ReactNode
+  top: BoxProps
+}) => (
+  <div className="flex w-full flex-col">
+    <div className={`${commonCss} z-10 -mb-3 justify-between ${top.bgColor}`}>
+      {top.children}
+    </div>
+    <div
+      className="flex h-14 w-full items-center gap-x-1 rounded-lg
+  border border-solid border-neutral-300/55 bg-neutral-100 px-4 pb-4 pt-6"
+    >
+      {bottom}
+    </div>
+  </div>
+)

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/drawerCallToAction.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/drawerCallToAction.tsx
@@ -1,0 +1,23 @@
+import { FormEvent, ReactNode } from 'react'
+import { type Chain } from 'viem'
+
+import { SubmitWhenConnectedToChain } from '../submitWhenConnectedToChain'
+
+type Props = {
+  expectedChainId: Chain['id']
+  onSubmit: (e: FormEvent) => void
+  submitButton: ReactNode
+}
+
+export const DrawerCallToAction = ({
+  expectedChainId,
+  onSubmit,
+  submitButton,
+}: Props) => (
+  <form className="flex [&>button]:w-full" onSubmit={onSubmit}>
+    <SubmitWhenConnectedToChain
+      chainId={expectedChainId}
+      submitButton={submitButton}
+    />
+  </form>
+)

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/icons/error.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/icons/error.tsx
@@ -1,0 +1,11 @@
+export const ErrorIcon = () => (
+  <svg fill="none" height={16} width={16} xmlns="http://www.w3.org/2000/svg">
+    <rect fill="#fff" height={16} rx={8} width={16} />
+    <path
+      clipRule="evenodd"
+      d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM6.495 5.567a.656.656 0 0 0-.928.928L7.072 8 5.567 9.505a.656.656 0 1 0 .928.927L8 8.927l1.505 1.505a.656.656 0 1 0 .927-.927L8.927 8l1.505-1.505a.656.656 0 0 0-.927-.928L8 7.072 6.495 5.567Z"
+      fill="#F43F5E"
+      fillRule="evenodd"
+    />
+  </svg>
+)

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/operation.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/operation.tsx
@@ -22,7 +22,7 @@ export const Operation = ({
   title,
   token,
 }: Props) => (
-  <div className="flex flex-col py-6">
+  <div className="flex h-full flex-col py-6">
     <div className="mb-6 px-4">
       <Header onClose={onClose} subtitle={subtitle} title={title} />
     </div>
@@ -40,6 +40,6 @@ export const Operation = ({
         ))}
       </div>
     </div>
-    {!!callToAction && <div className="px-4 pt-12">{callToAction}</div>}
+    {!!callToAction && <div className="mt-auto px-4">{callToAction}</div>}
   </div>
 )

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/progressStatus.ts
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/progressStatus.ts
@@ -3,4 +3,6 @@ export const enum ProgressStatus {
   READY = 1,
   PROGRESS = 2,
   COMPLETED = 3,
+  FAILED = 4,
+  REJECTED = 5,
 }

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -80,6 +80,15 @@ const ReviewContent = function ({ onClose, withdrawal }: Props) {
     toToken,
   })
 
+  const getWithdrawalStatus = function () {
+    const map = {
+      [MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE]: ProgressStatus.NOT_READY,
+      [MessageStatus.STATE_ROOT_NOT_PUBLISHED]: ProgressStatus.PROGRESS,
+      [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: ProgressStatus.FAILED,
+    }
+    return map[withdrawal.status] ?? ProgressStatus.COMPLETED
+  }
+
   const steps: StepPropsWithoutPosition[] = []
 
   const getInitiateWithdrawStep = (): StepPropsWithoutPosition => ({
@@ -99,17 +108,14 @@ const ReviewContent = function ({ onClose, withdrawal }: Props) {
       description: tCommon('wait-minutes', {
         minutes: ExpectedWithdrawalWaitTimeMinutes,
       }),
-      status:
-        withdrawal.status === MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE
-          ? ProgressStatus.NOT_READY
-          : withdrawal.status === MessageStatus.STATE_ROOT_NOT_PUBLISHED
-            ? ProgressStatus.PROGRESS
-            : ProgressStatus.COMPLETED,
+      status: getWithdrawalStatus(),
     },
     status:
-      withdrawal.status >= MessageStatus.STATE_ROOT_NOT_PUBLISHED
-        ? ProgressStatus.COMPLETED
-        : ProgressStatus.PROGRESS,
+      withdrawal.status === MessageStatus.FAILED_L1_TO_L2_MESSAGE
+        ? ProgressStatus.FAILED
+        : withdrawal.status >= MessageStatus.STATE_ROOT_NOT_PUBLISHED
+          ? ProgressStatus.COMPLETED
+          : ProgressStatus.PROGRESS,
     txHash: withdrawal.transactionHash,
   })
 

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -117,7 +117,7 @@ const ReviewContent = function ({ onClose, withdrawal }: Props) {
     if (withdrawal.status === MessageStatus.RELAYED) {
       return ProgressStatus.COMPLETED
     }
-    if (operationRunning === 'claim') {
+    if (operationRunning === 'claiming') {
       return ProgressStatus.PROGRESS
     }
     return withdrawal.status === MessageStatus.READY_FOR_RELAY
@@ -128,7 +128,7 @@ const ReviewContent = function ({ onClose, withdrawal }: Props) {
   const getProveStatus = function () {
     if (withdrawal.status < MessageStatus.READY_TO_PROVE)
       return ProgressStatus.NOT_READY
-    if (operationRunning === 'prove') {
+    if (operationRunning === 'proving') {
       return ProgressStatus.PROGRESS
     }
     if (withdrawal.status === MessageStatus.READY_TO_PROVE) {

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -17,6 +17,7 @@ import { useProveTransaction } from '../../_hooks/useProveTransaction'
 import { useWithdraw } from '../../_hooks/useWithdraw'
 import { ClaimEvmWithdrawal } from '../claimEvmWithdrawal'
 import { ProveWithdrawal } from '../proveEvmWithdrawal'
+import { RetryEvmWithdrawal } from '../retryEvmWithdrawal'
 
 import { Operation } from './operation'
 import { ProgressStatus } from './progressStatus'
@@ -25,21 +26,16 @@ import { type StepPropsWithoutPosition } from './step'
 const ExpectedWithdrawalWaitTimeMinutes = 20
 const ExpectedProofWaitTimeHours = 3
 
-const getCallToAction = function (withdrawal: ToEvmWithdrawOperation) {
-  if (
-    ![MessageStatus.READY_TO_PROVE, MessageStatus.READY_FOR_RELAY].includes(
-      withdrawal.status,
-    )
-  ) {
-    return null
-  }
-
-  return withdrawal.status === MessageStatus.READY_TO_PROVE ? (
-    <ProveWithdrawal withdrawal={withdrawal} />
-  ) : (
-    <ClaimEvmWithdrawal withdrawal={withdrawal} />
-  )
-}
+const getCallToAction = (withdrawal: ToEvmWithdrawOperation) =>
+  ({
+    [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: (
+      <RetryEvmWithdrawal withdrawal={withdrawal} />
+    ),
+    [MessageStatus.READY_TO_PROVE]: <ProveWithdrawal withdrawal={withdrawal} />,
+    [MessageStatus.READY_FOR_RELAY]: (
+      <ClaimEvmWithdrawal withdrawal={withdrawal} />
+    ),
+  })[withdrawal.status]
 
 type Props = {
   onClose: () => void

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/step.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/step.tsx
@@ -67,9 +67,7 @@ const Completed = function ({
         top={{
           bgColor: 'bg-neutral-50',
           children: (
-            <>
-              <span className="mr-auto text-neutral-600">{description}</span>
-            </>
+            <span className="mr-auto text-neutral-600">{description}</span>
           ),
         }}
       />

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/step.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/step.tsx
@@ -3,7 +3,9 @@ import { ComponentProps } from 'react'
 import { RemoteChain } from 'types/chain'
 import { getFormattedValue } from 'utils/format'
 
+import { OneRowBox, TwoRowBox } from './box'
 import { ClockIcon } from './icons/clockIcon'
+import { ErrorIcon } from './icons/error'
 import { FeesIcon } from './icons/feesIcon'
 import { GreenCheckIcon } from './icons/greenCheckIcon'
 import { PositionStatus } from './positionStatus'
@@ -28,12 +30,6 @@ type Props = {
   }
   txHash?: string
 }
-
-const upperBoxCommonCss =
-  'rounded-lg border border-solid border-neutral-300/55 bg-neutral-100 p-4 h-13 w-full'
-
-const bottomBoxCommonCss = `flex h-14 items-center rounded-lg w-full gap-x-1
-  border border-solid border-neutral-300/55 bg-neutral-100 px-4 pt-6 pb-4`
 
 const Fees = ({ amount, symbol }: Props['fees']) => (
   <>
@@ -60,16 +56,23 @@ const Completed = function ({
       <div className="mt-4">
         <PositionStatus position={position} status={ProgressStatus.COMPLETED} />
       </div>
-      <div className="flex w-full flex-col">
-        <div className={`${upperBoxCommonCss} z-10 -mb-3 bg-neutral-50`}>
-          <span className="mr-auto text-neutral-500">{description}</span>
-        </div>
-        <div className={bottomBoxCommonCss}>
-          <GreenCheckIcon />
-          <span className="mr-auto text-emerald-500">{t('confirmed')}</span>
-          <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
-        </div>
-      </div>
+      <TwoRowBox
+        bottom={
+          <>
+            <GreenCheckIcon />
+            <span className="mr-auto text-emerald-500">{t('confirmed')}</span>
+            <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+          </>
+        }
+        top={{
+          bgColor: 'bg-neutral-50',
+          children: (
+            <>
+              <span className="mr-auto text-neutral-600">{description}</span>
+            </>
+          ),
+        }}
+      />
       {!!postAction && (
         <div className="left-2.25 absolute bottom-6">
           <LongVerticalLine stroke="stroke-orange-500" />
@@ -87,9 +90,9 @@ const NotReady = ({ description, position, postAction }: Props) => (
     <div className="mt-4">
       <PositionStatus position={position} status={ProgressStatus.NOT_READY} />
     </div>
-    <div className={`${upperBoxCommonCss} bg-neutral-100`}>
+    <OneRowBox bgColor="bg-neutral-100">
       <span className="text-neutral-600">{description}</span>
-    </div>
+    </OneRowBox>
     {!!postAction && (
       <div className="left-2.25 absolute bottom-6">
         <ShortVerticalLine stroke="stroke-neutral-300/55" />
@@ -115,19 +118,24 @@ const Progress = function ({
       <div className="mt-4">
         <PositionStatus position={position} status={ProgressStatus.PROGRESS} />
       </div>
-      <div className="flex w-full flex-col">
-        <div
-          className={`${upperBoxCommonCss} z-10 -mb-3 flex items-center justify-between bg-white`}
-        >
-          <span className="mr-auto text-orange-500">{description}</span>
-          {fees && <Fees {...fees} />}
-        </div>
-        <div className={bottomBoxCommonCss}>
-          <ClockIcon />
-          <span className="mr-auto text-neutral-500">{t('pending')}</span>
-          <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
-        </div>
-      </div>
+      <TwoRowBox
+        bottom={
+          <>
+            <ClockIcon />
+            <span className="mr-auto text-neutral-500">{t('pending')}</span>
+            <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+          </>
+        }
+        top={{
+          bgColor: 'bg-white',
+          children: (
+            <>
+              <span className="mr-auto text-orange-500">{description}</span>
+              {fees && <Fees {...fees} />}
+            </>
+          ),
+        }}
+      />
       {!!postAction && (
         <div className="left-2.25 absolute bottom-6">
           <LongVerticalLine stroke="stroke-neutral-300/55" />
@@ -145,10 +153,10 @@ const Ready = ({ description, fees, position, postAction }: Props) => (
     <div className="mt-4">
       <PositionStatus position={position} status={ProgressStatus.READY} />
     </div>
-    <div className={`${upperBoxCommonCss} flex items-center bg-white`}>
+    <OneRowBox bgColor="bg-white">
       <span className="mr-auto text-orange-500">{description}</span>
       {fees && <Fees {...fees} />}
-    </div>
+    </OneRowBox>
     {!!postAction && (
       <div className="left-2.25 absolute bottom-6">
         <ShortVerticalLine stroke="stroke-neutral-300/55" />
@@ -157,11 +165,93 @@ const Ready = ({ description, fees, position, postAction }: Props) => (
   </>
 )
 
+const Failed = function ({
+  description,
+  explorerChainId,
+  fees,
+  position,
+  postAction,
+  txHash,
+}: Props) {
+  const t = useTranslations('common.transaction-status')
+  return (
+    <>
+      <div className="left-2.25 absolute top-0.5">
+        <ShortVerticalLine stroke="stroke-orange-500" />
+      </div>
+      <div className="mt-4">
+        <PositionStatus position={position} status={ProgressStatus.FAILED} />
+      </div>
+      <TwoRowBox
+        bottom={
+          <>
+            <ErrorIcon />
+            <span className="mr-auto text-rose-500">{t('error')}</span>
+            <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+          </>
+        }
+        top={{
+          bgColor: 'bg-white',
+          children: (
+            <>
+              <span className="mr-auto text-orange-500">{description}</span>
+              {fees && <Fees {...fees} />}
+            </>
+          ),
+        }}
+      />
+      {!!postAction && (
+        <div className="left-2.25 absolute bottom-6">
+          <ShortVerticalLine stroke="stroke-neutral-300/55" />
+        </div>
+      )}
+    </>
+  )
+}
+
+const Rejected = function ({ description, fees, position, postAction }: Props) {
+  const t = useTranslations('common.transaction-status')
+  return (
+    <>
+      <div className="left-2.25 absolute top-0.5">
+        <ShortVerticalLine stroke="stroke-orange-500" />
+      </div>
+      <div className="mt-4">
+        <PositionStatus position={position} status={ProgressStatus.REJECTED} />
+      </div>
+      <TwoRowBox
+        bottom={
+          <>
+            <ErrorIcon />
+            <span className="mr-auto text-rose-500">{t('rejected')}</span>
+          </>
+        }
+        top={{
+          bgColor: 'bg-white',
+          children: (
+            <>
+              <span className="mr-auto text-orange-500">{description}</span>
+              {fees && <Fees {...fees} />}
+            </>
+          ),
+        }}
+      />
+      {!!postAction && (
+        <div className="left-2.25 absolute bottom-6">
+          <ShortVerticalLine stroke="stroke-neutral-300/55" />
+        </div>
+      )}
+    </>
+  )
+}
+
 const statusMap = {
   [ProgressStatus.NOT_READY]: NotReady,
   [ProgressStatus.READY]: Ready,
   [ProgressStatus.PROGRESS]: Progress,
   [ProgressStatus.COMPLETED]: Completed,
+  [ProgressStatus.FAILED]: Failed,
+  [ProgressStatus.REJECTED]: Rejected,
 }
 
 export const Step = function ({

--- a/webapp/app/[locale]/tunnel/_context/evmDepositContext.tsx
+++ b/webapp/app/[locale]/tunnel/_context/evmDepositContext.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { createContext, ReactNode, useState } from 'react'
+
+type EvmDepositOperationStatuses = 'idle' | 'depositing' | 'failed' | 'rejected'
+
+type EvmDepositContext = ReturnType<
+  typeof useState<EvmDepositOperationStatuses>
+>
+
+export const EvmDepositContext = createContext<EvmDepositContext>([
+  'idle',
+  () => 'idle',
+])
+
+export const EvmDepositProvider = function ({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const state = useState<EvmDepositOperationStatuses>('idle')
+
+  return (
+    <EvmDepositContext.Provider value={state}>
+      {children}
+    </EvmDepositContext.Provider>
+  )
+}

--- a/webapp/app/[locale]/tunnel/_context/toEvmWithdrawalContext.tsx
+++ b/webapp/app/[locale]/tunnel/_context/toEvmWithdrawalContext.tsx
@@ -2,7 +2,12 @@
 
 import { createContext, ReactNode, useState } from 'react'
 
-type ToEvmWithdrawOperationStatuses = 'idle' | 'proving' | 'claiming'
+type ToEvmWithdrawOperationStatuses =
+  | 'idle'
+  | 'proving'
+  | 'claiming'
+  | 'failed'
+  | 'rejected'
 
 type ToEvmWithdrawalContext = ReturnType<
   typeof useState<ToEvmWithdrawOperationStatuses>

--- a/webapp/app/[locale]/tunnel/_context/toEvmWithdrawalContext.tsx
+++ b/webapp/app/[locale]/tunnel/_context/toEvmWithdrawalContext.tsx
@@ -2,10 +2,10 @@
 
 import { createContext, ReactNode, useState } from 'react'
 
-type ToEvmWithdrawOperations = 'idle' | 'prove' | 'claim'
+type ToEvmWithdrawOperationStatuses = 'idle' | 'proving' | 'claiming'
 
 type ToEvmWithdrawalContext = ReturnType<
-  typeof useState<ToEvmWithdrawOperations>
+  typeof useState<ToEvmWithdrawOperationStatuses>
 >
 
 export const ToEvmWithdrawalContext = createContext<ToEvmWithdrawalContext>([
@@ -18,7 +18,7 @@ export const ToEvmWithdrawalProvider = function ({
 }: {
   children: ReactNode
 }) {
-  const state = useState<ToEvmWithdrawOperations>('idle')
+  const state = useState<ToEvmWithdrawOperationStatuses>('idle')
 
   return (
     <ToEvmWithdrawalContext.Provider value={state}>

--- a/webapp/app/[locale]/tunnel/_context/toEvmWithdrawalContext.tsx
+++ b/webapp/app/[locale]/tunnel/_context/toEvmWithdrawalContext.tsx
@@ -4,6 +4,7 @@ import { createContext, ReactNode, useState } from 'react'
 
 type ToEvmWithdrawOperationStatuses =
   | 'idle'
+  | 'withdrawing'
   | 'proving'
   | 'claiming'
   | 'failed'

--- a/webapp/app/[locale]/tunnel/_hooks/useClaimTransaction.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useClaimTransaction.ts
@@ -87,8 +87,6 @@ export const useClaimTransaction = function (
     claimWithdrawalReceipt,
     claimWithdrawalReceiptError,
     claimWithdrawalTokenGasFees: finalizeWithdrawalTokenGasFees,
-    claimWithdrawalTxHash: finalizeWithdrawalTxHash,
-    clearClaimWithdrawalState,
     isReadyToClaim,
   }
 }

--- a/webapp/app/[locale]/tunnel/_hooks/useClaimTransaction.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useClaimTransaction.ts
@@ -39,9 +39,12 @@ export const useClaimTransaction = function (
   })
 
   const handleClaimWithdrawal = function () {
-    if (isReadyToClaim) {
-      finalizeWithdrawal()
+    if (!isReadyToClaim) {
+      return
     }
+    // clear any previous transaction hash, which may come from failed attempts
+    updateWithdrawal(withdrawal, { claimTxHash: undefined })
+    finalizeWithdrawal()
   }
 
   const clearClaimWithdrawalState = useCallback(

--- a/webapp/app/[locale]/tunnel/_hooks/useProveTransaction.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useProveTransaction.ts
@@ -28,7 +28,6 @@ export const useProveTransaction = function (
     data: withdrawalProofReceipt,
     error: withdrawalProofReceiptError,
     queryKey: withdrawalProofQueryKey,
-    status: withdrawalProofTxStatus,
   } = useWaitForTransactionReceipt({
     hash: rest.proveWithdrawalTxHash,
   })
@@ -77,12 +76,10 @@ export const useProveTransaction = function (
   }
 
   return {
-    clearProveWithdrawalState,
     isReadyToProve,
     proveWithdrawal: handleProveWithdrawal,
     withdrawalProofReceipt,
     withdrawalProofReceiptError,
-    withdrawalProofTxStatus,
     ...rest,
   }
 }

--- a/webapp/app/[locale]/tunnel/_hooks/useProveTransaction.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useProveTransaction.ts
@@ -68,9 +68,12 @@ export const useProveTransaction = function (
   )
 
   const handleProveWithdrawal = function () {
-    if (isReadyToProve) {
-      proveWithdrawal()
+    if (!isReadyToProve) {
+      return
     }
+    // clear any previous transaction hash, which may come from failed attempts
+    updateWithdrawal(withdrawal, { proveTxHash: undefined })
+    proveWithdrawal()
   }
 
   return {

--- a/webapp/app/[locale]/tunnel/_hooks/useWithdraw.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useWithdraw.ts
@@ -146,7 +146,8 @@ export const useWithdraw = function ({
       }
       const withdrawal = withdrawals.find(
         w =>
-          w.transactionHash === withdrawReceipt.transactionHash && !w.timestamp,
+          w.transactionHash === withdrawReceipt.transactionHash &&
+          !w.blockNumber,
       )
 
       if (!withdrawal) {

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/txStatus.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/txStatus.tsx
@@ -4,24 +4,18 @@ const Container = ({ children }: { children: React.ReactNode }) => (
   <div className="flex items-center gap-x-1.5">{children}</div>
 )
 
+const Dot = ({ className }: { className: string }) => (
+  <div
+    className={`h-1.5 w-1.5 rounded-full border border-solid ${className}`}
+  />
+)
+
 const Failed = function () {
   const t = useTranslations()
   return (
     <Container>
-      <svg
-        fill="none"
-        height="13"
-        viewBox="0 0 13 13"
-        width="13"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M3.35693 2.7002L10.3569 9.7002M10.3569 2.7002L3.35693 9.7002"
-          stroke="#FF3232"
-          strokeLinecap="round"
-        />
-      </svg>
-      <span className="text-xs font-medium text-green-600">
+      <Dot className="border-rose-950/25 bg-rose-500" />
+      <span className="text-xs font-medium text-rose-500">
         {t('common.failed')}
       </span>
     </Container>
@@ -30,10 +24,7 @@ const Failed = function () {
 
 const InStatus = ({ text }: { text: string }) => (
   <Container>
-    <div
-      className="h-1.5 w-1.5 rounded-full border border-solid
-        border-amber-800/25 bg-amber-400"
-    />
+    <Dot className="border-amber-800/25 bg-amber-400" />
     <span className="text-[#F59E0B]">{text}</span>
   </Container>
 )
@@ -42,10 +33,7 @@ const Success = function () {
   const t = useTranslations()
   return (
     <Container>
-      <div
-        className="h-1.5 w-1.5 rounded-full border border-solid
-        border-emerald-900/25 bg-emerald-500"
-      />
+      <Dot className="border-emerald-900/25 bg-emerald-500" />
       <span className="text-emerald-500">{t('common.success')}</span>
     </Container>
   )

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/withdrawAction.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/withdrawAction.tsx
@@ -28,7 +28,7 @@ export const WithdrawAction = function ({ withdraw }: Props) {
   const Failed = (
     <CallToAction
       networkType={networkType}
-      text={t('retry')}
+      text={t('view')}
       txHash={withdraw.transactionHash}
       variant="secondary"
     />

--- a/webapp/hooks/useEvmDeposits.ts
+++ b/webapp/hooks/useEvmDeposits.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react'
+import { isEvmDeposit } from 'utils/tunnel'
+
+import { useDeposits } from './useDeposits'
+
+export const useEvmDeposits = function () {
+  const deposits = useDeposits()
+  return useMemo(() => deposits.filter(isEvmDeposit), [deposits])
+}

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -277,6 +277,7 @@
       "initiate-withdrawal": "Initiate Withdrawal",
       "prove-withdrawal": "Prove withdrawal",
       "proving-withdrawal": "Proving...",
+      "try-again": "Try again",
       "withdrawing": "Withdrawing..."
     },
     "title": "Tunnel",

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -285,7 +285,6 @@
       "actions": {
         "claim": "Claim",
         "prove": "Prove",
-        "retry": "Retry",
         "view": "View"
       },
       "column-headers": {

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -277,6 +277,7 @@
       "initiate-withdrawal": "Iniciar Retiro",
       "prove-withdrawal": "Probar retiro",
       "proving-withdrawal": "Probando...",
+      "try-again": "Intentar de nuevo",
       "withdrawing": "Retirando..."
     },
     "title": "Túnel",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -285,7 +285,6 @@
       "actions": {
         "claim": "Reclamar",
         "prove": "Probar",
-        "retry": "Reintentar",
         "view": "Ver"
       },
       "column-headers": {

--- a/webapp/types/tunnel.ts
+++ b/webapp/types/tunnel.ts
@@ -36,6 +36,10 @@ export const enum EvmDepositStatus {
   DEPOSIT_TX_PENDING = 2,
   // Transaction deposit confirmed
   DEPOSIT_TX_CONFIRMED = 3,
+  // Deposit tx reverted
+  DEPOSIT_TX_FAILED = 4,
+  // Approval failed
+  APPROVAL_TX_FAILED = 5,
 }
 
 type CommonOperation = Omit<


### PR DESCRIPTION
Related to #529 

This PR adds error handling and re-tries for Ethereum Deposits and Withdrawals. After this PR, the Sepolia flow should be completed. It is pending to implement it for bitcoin

### Some screenshots

State updated in the transaction history

<img width="1130" alt="image" src="https://github.com/user-attachments/assets/7ba05314-9dd5-40ca-9441-ddfb392101c4">

Failed operations are listed if users want to retry them, at any step

<img width="1287" alt="image" src="https://github.com/user-attachments/assets/6fb95ddd-5c4a-4cd9-a1dc-5325a75a65a6">


<img width="1310" alt="image" src="https://github.com/user-attachments/assets/e9fbcccb-3ce0-4870-afc3-e8e6d81bc7e5">


<img width="1119" alt="image" src="https://github.com/user-attachments/assets/3cdaf1c5-2099-4792-9c7a-91954a1636c7">
