### PR TITLE
Hide mainnet and bitcoin

### DIFF
--- a/webapp/app/[locale]/_components/navbar/index.tsx
+++ b/webapp/app/[locale]/_components/navbar/index.tsx
@@ -16,7 +16,7 @@ import { HemiLogoFull } from 'ui-common/components/hemiLogo'
 
 import { GetStarted } from './_components/getStarted'
 import { HemiExplorerLink } from './_components/hemiExplorerLink'
-import { ItemLink, ItemWithSubmenu, NetworkSwitch } from './_components/navItem'
+import { ItemLink, ItemWithSubmenu } from './_components/navItem'
 import { SocialLinks } from './_components/socialLinks'
 import { TermsAndConditions } from './_components/termsAndConditions'
 
@@ -125,9 +125,9 @@ export const Navbar = function () {
             text={t('hemidocs')}
           />
         </li>
-        <li className="md:order-13 order-12">
+        {/* <li className="md:order-13 order-12">
           <NetworkSwitch />
-        </li>
+        </li> */}
         <li className="order-13 md:hidden">
           <Separator />
         </li>

--- a/webapp/components/connectWallets/connectWalletsDrawer.tsx
+++ b/webapp/components/connectWallets/connectWalletsDrawer.tsx
@@ -48,8 +48,11 @@ export const ConnectWalletsDrawer = function ({ closeDrawer }: Props) {
               <CloseIcon className="[&>path]:hover:stroke-black" />
             </button>
           </div>
-          {featureFlags.btcTunnelEnabled && (
+          {featureFlags.btcTunnelEnabled ? (
             <P text={t('connect-wallets.description')} />
+          ) : (
+            // Prevent layout shift when text is not shown
+            <div className="invisible min-w-[400px]"></div>
           )}
           <div className="mb-3 mt-5">
             <EvmWallet />

--- a/webapp/components/connectedWallet/connectedChains.tsx
+++ b/webapp/components/connectedWallet/connectedChains.tsx
@@ -10,7 +10,9 @@ export const ConnectedChains = function () {
 
   return (
     <div className="flex items-center gap-x-3">
-      {evmWalletStatus === 'connected' && <ConnectedEvmChain />}
+      {['connected', 'reconnecting'].includes(evmWalletStatus) && (
+        <ConnectedEvmChain />
+      )}
       {allConnected && featureFlags.btcTunnelEnabled && <Separator />}
       {btcWalletStatus === 'connected' && featureFlags.btcTunnelEnabled && (
         <ConnectedBtcChain />


### PR DESCRIPTION
Related to https://github.com/hemilabs/ui-monorepo/issues/567

Prior to merging the new design into staging, this PR makes a few changes to adjust the Bitcoin stuff correctly, and hides the mainnet/testnet selector

Testnet/mainnet selector removed

<img width="302" alt="image" src="https://github.com/user-attachments/assets/7ac2d683-e4d3-4cf6-af69-48e8a73c85b3">

<img width="751" alt="image" src="https://github.com/user-attachments/assets/8045d004-e981-4e3c-a92a-907bf3be8c8f">


This was validated by Nahuel


I also added a fix in [f2fa1c3](https://github.com/hemilabs/ui-monorepo/pull/568/commits/f2fa1c32e52d0dd5d14163c46104c608621490f6) in which the "Chain selector" would tilt between shallow navigations of the page