### PR TITLE
Fix overflow of eth chains menu

### DIFF
--- a/webapp/components/connectedWallet/evmChainsMenu.tsx
+++ b/webapp/components/connectedWallet/evmChainsMenu.tsx
@@ -1,5 +1,6 @@
 import { CheckMark } from 'components/icons/checkMark'
 import { Menu } from 'components/menu'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { useAccount, useSwitchChain as useSwitchEvmChain } from 'wagmi'
 
 import { EvmLogo } from './evmLogo'
@@ -11,8 +12,43 @@ export const EvmChainsMenu = function ({
 }) {
   const { chainId } = useAccount()
   const { chains, switchChain } = useSwitchEvmChain()
+
+  const menuContainerRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState({ bottom: 0 })
+
+  useLayoutEffect(
+    function preventMenuOverflow() {
+      const adjustPosition = function () {
+        if (!menuContainerRef.current) {
+          return
+        }
+        const rect = menuContainerRef.current.getBoundingClientRect()
+        const newPosition = { bottom: 0 }
+
+        if (rect.bottom > window.innerHeight) {
+          // Container is using h-8, which is 32px. And each chain is 32px.
+          // If we overflow the bottom container (only scenario possible, due to location of the component)
+          // we want to move "up" the size of the menu (which is N chains * 32px) + the size of the button that opens the menu (32px)
+          newPosition.bottom = 32 + chains.length * 32
+        }
+
+        setPosition(newPosition)
+      }
+
+      adjustPosition()
+      window.addEventListener('resize', adjustPosition)
+
+      return () => window.removeEventListener('resize', adjustPosition)
+    },
+    [chains.length, menuContainerRef, setPosition],
+  )
+
   return (
-    <div className="absolute bottom-0 right-0 z-20 translate-y-[calc(100%-5px)]">
+    <div
+      className="absolute bottom-0 right-0 z-20 translate-y-[calc(100%-5px)]"
+      ref={menuContainerRef}
+      style={{ bottom: position.bottom }}
+    >
       <Menu
         items={chains.map(c => ({
           content: (


### PR DESCRIPTION
Closes #528

This fix prevents the chain's menu to overflow

### Before

![image](https://github.com/user-attachments/assets/d9cc45a3-9090-4bed-a482-1c35a7b7d2c7)


### Now

<img width="432" alt="image" src="https://github.com/user-attachments/assets/67da5649-da2d-4f5a-832f-8430f54b179b">

<img width="446" alt="image" src="https://github.com/user-attachments/assets/d20ceac2-2231-49fa-8711-3aec2252397f">
