### PR TITLE
Add network status link to navbar

### DIFF
--- a/webapp/app/[locale]/_components/navbar/index.tsx
+++ b/webapp/app/[locale]/_components/navbar/index.tsx
@@ -4,7 +4,7 @@ import { BitcoinKitIcon } from 'components/icons/bitcoinKit'
 import { DemosPageIcon } from 'components/icons/demosPageIcon'
 import { DexIcon } from 'components/icons/dexIcon'
 import { DocsIcon } from 'components/icons/docsIcon'
-// import { ElectroCardiogramIcon } from 'components/icons/electroCardiogramIcon'
+import { ElectroCardiogramIcon } from 'components/icons/electroCardiogramIcon'
 import { PoPMinerIcon } from 'components/icons/popMinerIcon'
 import { ToolsIcon } from 'components/icons/toolsIcon'
 import { TunnelIcon } from 'components/icons/tunnelIcon'
@@ -110,14 +110,13 @@ export const Navbar = function () {
         <li className="order-9 mb-auto">
           <ItemLink href="/demos" icon={<DemosPageIcon />} text={t('demos')} />
         </li>
-        {/* TBD if network status will be available */}
-        {/* <li className="order-10 md:order-11">
+        <li className="order-10 md:order-11">
           <ItemLink
-            href=""
+            href="https://hemistatus.com"
             icon={<ElectroCardiogramIcon />}
             text={t('network-status')}
           />
-        </li> */}
+        </li>
         <li className="order-11 md:order-12">
           <ItemLink
             href="https://docs.hemi.xyz"


### PR DESCRIPTION
Closes #576

This PR adds the network status to the navbar

<img width="447" alt="image" src="https://github.com/user-attachments/assets/dab3d5d1-6591-4fb3-8f24-c63094f11927">

<img width="427" alt="image" src="https://github.com/user-attachments/assets/edf7d329-d566-4602-a3a3-6aa47417752e">
