### PR TITLE
Add hover to imgs in get-started page

### DIFF
--- a/webapp/app/[locale]/get-started/_components/startUsingHemi.tsx
+++ b/webapp/app/[locale]/get-started/_components/startUsingHemi.tsx
@@ -34,12 +34,12 @@ const Box = function ({
   }
 
   return (
-    <div className="flex-1 cursor-pointer" onClick={handleClick}>
+    <div className="group/image flex-1 cursor-pointer" onClick={handleClick}>
       <Card>
         <div className="text-ms flex flex-col gap-y-4 p-2 pb-4 font-medium leading-5">
           <Image
             alt={alt}
-            className="rounded-2xl"
+            className="rounded-2xl opacity-60 group-hover/image:opacity-100"
             height={300}
             priority={true}
             src={image}


### PR DESCRIPTION
Closes #581

This PR adds the hover effect on the images in the "Get Started" section, subsection "Start using Hemi" 


https://github.com/user-attachments/assets/8115fa5a-d09b-4edf-86b2-352e7802f8dd

