### PR TITLE
Close menu after switching chain

### DIFF
--- a/webapp/components/connectedWallet/evmChainsMenu.tsx
+++ b/webapp/components/connectedWallet/evmChainsMenu.tsx
@@ -55,7 +55,8 @@ export const EvmChainsMenu = function ({
             <button
               className="flex items-center gap-x-2"
               disabled={chainId === c.id}
-              onClick={function () {
+              onClick={function (e) {
+                e.stopPropagation()
                 switchChain({ chainId: c.id })
                 onSwitchChain()
               }}


### PR DESCRIPTION
Closes #592

This PR fixes the bug in which after clicking a chain to switch in the chain selector, it wouldn't close.


https://github.com/user-attachments/assets/68ecced4-a91a-44bf-9ed2-92715bafd897

