### PR TITLE
Fix effect not firing on deposit success

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/deposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/deposit.tsx
@@ -378,7 +378,10 @@ const EvmDeposit = function ({ state }: EvmDepositProps) {
 
   useEffect(
     function handleSuccess() {
-      if (depositReceipt?.status !== 'success' || operationRunning !== 'idle') {
+      if (
+        depositReceipt?.status !== 'success' ||
+        operationRunning !== 'depositing'
+      ) {
         return
       }
       setOperationRunning('idle')


### PR DESCRIPTION
I found a bug while working on analytics. The effect that should fire after a successful deposit wasn't firing. Now it does.

