### PR TITLE
Remove extra quote from chevron icon

### DIFF
--- a/webapp/components/icons/chevron.tsx
+++ b/webapp/components/icons/chevron.tsx
@@ -37,7 +37,7 @@ const Right = (props: Props) => (
 )
 
 const Left = ({ className = '' }: Props) => (
-  <Right className={`rotate-180 ${className}"`} />
+  <Right className={`rotate-180 ${className}`} />
 )
 
 const Up = ({ className = '' }: Props) => (


### PR DESCRIPTION
### Description

This PR removes the extra quote on chevron icon. It was breaking the className sintax.

