### PR TITLE
Hide btc faucet until bitcoin is enabled

### DIFF
--- a/webapp/app/[locale]/get-started/_components/fundWallet.tsx
+++ b/webapp/app/[locale]/get-started/_components/fundWallet.tsx
@@ -1,3 +1,4 @@
+import { featureFlags } from 'app/featureFlags'
 import { ExternalLink } from 'components/externalLink'
 import { ArrowDownLeftIcon } from 'components/icons/arrowDownLeftIcon'
 import hemiSocials from 'hemi-socials'
@@ -55,11 +56,13 @@ export const FundWallet = function () {
           name={t('ethereum-faucet')}
           url="https://sepolia-faucet.pk910.de"
         />
-        <Faucet
-          icon={<BtcFaucetIcon />}
-          name={t('bitcoin-faucet')}
-          url="https://coinfaucet.eu/en/btc-testnet/"
-        />
+        {featureFlags.btcTunnelEnabled && (
+          <Faucet
+            icon={<BtcFaucetIcon />}
+            name={t('bitcoin-faucet')}
+            url="https://coinfaucet.eu/en/btc-testnet/"
+          />
+        )}
       </div>
     </Section>
   )


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR hides the BTC faucet behind the bitcoin feature flag, just like everything bitcoin related

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No longer visible (as the feature flag is not enabled)

<img width="1302" alt="image" src="https://github.com/user-attachments/assets/45e795cb-504d-4c17-a019-ec4b7f2fc34d">


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #596 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
