### PR TITLE
Add missing shadow on network selectors

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/networkSelector.tsx
+++ b/webapp/app/[locale]/tunnel/_components/networkSelector.tsx
@@ -52,7 +52,7 @@ export const NetworkSelector = function ({
     onSelectNetwork(id)
   }
 
-  const commonCss = `flex items-center border border-solid border-neutral-300/55
+  const commonCss = `flex items-center border border-solid border-neutral-300/55 shadow-soft
     text-ms font-medium leading-5 text-neutral-950 rounded-lg bg-white p-2 gap-x-2`
 
   if (readonly || networks.length === 1) {
@@ -76,7 +76,7 @@ export const NetworkSelector = function ({
     <Container>
       <Label text={label} />
       <button
-        className={`${commonCss} group/network-selector shadow-soft relative cursor-pointer hover:bg-neutral-100`}
+        className={`${commonCss} group/network-selector relative cursor-pointer hover:bg-neutral-100`}
         disabled={disabled || networks.length < 2}
         onClick={() => setShowNetworkDropdown(prev => !prev)}
         ref={ref}

--- a/webapp/app/[locale]/tunnel/_components/networkSelectors.tsx
+++ b/webapp/app/[locale]/tunnel/_components/networkSelectors.tsx
@@ -6,7 +6,7 @@ import { RemoteChain } from 'types/chain'
 import { type TunnelState } from '../_hooks/useTunnelState'
 
 import { NetworkSelector } from './networkSelector'
-import { ToggleButton } from './ToggleButton'
+import { ToggleNetwork } from './toggleNetwork'
 
 type Props = {
   isRunningOperation: boolean
@@ -39,7 +39,7 @@ export const NetworkSelectors = function ({
           readonly={fromNetworkId === hemi.id}
         />
       </div>
-      <ToggleButton disabled={isRunningOperation} toggle={toggleInput} />
+      <ToggleNetwork disabled={isRunningOperation} toggle={toggleInput} />
       <div className="w-[calc(50%-38px-0.75rem)] flex-grow">
         <NetworkSelector
           disabled={isRunningOperation}

--- a/webapp/app/[locale]/tunnel/_components/toggleNetwork.tsx
+++ b/webapp/app/[locale]/tunnel/_components/toggleNetwork.tsx
@@ -15,9 +15,9 @@ type Props = {
   toggle: () => void
 }
 
-export const ToggleButton = ({ disabled, toggle }: Props) => (
+export const ToggleNetwork = ({ disabled, toggle }: Props) => (
   <button
-    className={`mx-auto rounded-lg border border-solid border-neutral-300/55 bg-white p-2 shadow-sm hover:bg-neutral-100 ${
+    className={`shadow-soft mx-auto rounded-lg border border-solid border-neutral-300/55 bg-white p-2 hover:bg-neutral-100 ${
       disabled ? 'cursor-not-allowed' : 'cursor-pointer'
     }`}
     disabled={disabled}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adding soft shadows on the network selectors, matching the design.   
I also take a moment to rename `ToggleButton` to `toggleNetwork`, matching the camelCase convention we've been using for the codebase.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

![image](https://github.com/user-attachments/assets/d9c5ce9d-a746-4e61-90c4-ed33124534ff)


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #605 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
