### PR TITLE
Fix loading svg width in tx history table

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/table.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/table.tsx
@@ -240,7 +240,7 @@ export const Table = function ({ containerRef, data, loading }: TableProps) {
         data.length === 0 && loading
           ? {
               ...c,
-              cell: () => <Skeleton className="w-24" />,
+              cell: () => <Skeleton className="w-16" />,
             }
           : c,
       ),


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The "loading" animation was wider than the columns, causing the table to overflow and not be properly aligned. This PR fixes that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/ed52815e-add1-49c2-a28f-1defc01bd5d5


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #551

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
