### PR TITLE
Read hemi-socials links from npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This repository contains the various apps and websites related to the Hemi Netwo
 
 [claim-tokens](./claim-tokens/README.md) The microservice used to claim tokens in the portal's `get-started` page.
 
-[hemi-socials](./hemi-socials) Tiny package containing Hemi social links.
-
 [migrations-pg](./migrations-pg/README.md) The migrations used for the database maintained for the claim tokens microservice.
 
 [portal](./webapp) The portal app living in `https://app.hemi.xyz`.

--- a/hemi-socials/package.json
+++ b/hemi-socials/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "hemi-socials",
-  "version": "1.0.0",
-  "description": "Tiny package containing Hemi social links",
-  "main": "socials.json"
-}

--- a/hemi-socials/socials.json
+++ b/hemi-socials/socials.json
@@ -1,7 +1,0 @@
-{
-  "discordUrl": "https://discord.gg/hemixyz",
-  "githubUrl": "https://github.com/hemilabs",
-  "linkedinUrl": "https://www.linkedin.com/company/hemi-xyz",
-  "twitterUrl": "https://twitter.com/hemi_xyz/",
-  "youtubeUrl": "https://www.youtube.com/@HemiLabs"
-}

--- a/hemi-socials/tsconfig.json
+++ b/hemi-socials/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": {
-    "baseUrl": "./"
-  },
-  "extends": "../tsconfig.base.json",
-  "exclude": ["node_modules"],
-  "include": ["**/*.ts", "**/*.tsx"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "workspaces": [
         "btc-wallet",
         "claim-tokens",
-        "hemi-socials",
         "migrations-pg",
         "sliding-block-window",
         "ui-common",
@@ -35,9 +34,6 @@
         "patch-package": "8.0.0",
         "prettier": "3.1.1",
         "prettier-plugin-tailwindcss": "0.5.9"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "btc-wallet": {
@@ -146,7 +142,8 @@
       }
     },
     "hemi-socials": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "extraneous": true
     },
     "marketing": {
       "version": "1.0.0",
@@ -15506,8 +15503,9 @@
       }
     },
     "node_modules/hemi-socials": {
-      "resolved": "hemi-socials",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hemi-socials/-/hemi-socials-1.0.0.tgz",
+      "integrity": "sha512-f1hiPt90QXTPXX9jb8fRuGvzWMkbBpBO/45m3s024Aa0JoSpeVt9AodkxHAnCfK5uTRDdKvbIB8dPU1sbGhOdA=="
     },
     "node_modules/hemi-viem": {
       "version": "1.5.0",
@@ -28551,6 +28549,9 @@
         "serve": "14.2.3",
         "tailwindcss": "3.4.0",
         "typescript": "5.3.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "webapp/node_modules/@next/swc-darwin-arm64": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "workspaces": [
     "btc-wallet",
     "claim-tokens",
-    "hemi-socials",
     "migrations-pg",
     "sliding-block-window",
     "ui-common",
@@ -92,7 +91,6 @@
         ],
         "files": [
           "btc-wallet/**/*.{js,ts,tsx}",
-          "hemi-socials/**/*.{js,ts,tsx}",
           "sliding-block-window/**/*.{js,ts}",
           "ui-common/**/*.{js,ts,tsx}",
           "wagmi-erc20-hooks/**/*.{js,ts,tsx}",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR removes the `hemi-socials` from the workspace list, and uses the now-published version in npm. As the package name, API and version matches, the only change is removing the original package and updating the `package-lock.json` file

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes for the user

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
