### PR TITLE
When analytics are disabled, the site is broken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,6 @@
         "patch-package": "8.0.0",
         "prettier": "3.1.1",
         "prettier-plugin-tailwindcss": "0.5.9"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "btc-wallet": {
@@ -26690,9 +26687,9 @@
       }
     },
     "node_modules/umami-analytics-next": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/umami-analytics-next/-/umami-analytics-next-1.0.0.tgz",
-      "integrity": "sha512-6HgUbrsqmGOQjmHP43wP3XztbQwd/UnXnugZHmFmyO1oRskhHSRJWLNh52tOJnb4C+V/pOLpbzH6o1FNPgCh6g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/umami-analytics-next/-/umami-analytics-next-1.0.1.tgz",
+      "integrity": "sha512-0Vm4ds9C+o8rxoH0yBYcT7dmHOyIlzbaGvmMig0IcIEgj6SEhCS/HncX8mC8h9GZ5RZvMjzq6+IryVBLaEAIIw==",
       "engines": {
         "node": ">=16.9.0"
       },
@@ -28532,7 +28529,7 @@
         "sliding-block-window": "1.0.0",
         "smart-round": "1.0.0",
         "ui-common": "1.0.0",
-        "umami-analytics-next": "1.0.0",
+        "umami-analytics-next": "1.0.1",
         "viem": "2.7.19",
         "wagmi": "2.5.7",
         "wagmi-erc20-hooks": "1.0.0"
@@ -28551,6 +28548,9 @@
         "serve": "14.2.3",
         "tailwindcss": "3.4.0",
         "typescript": "5.3.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "webapp/node_modules/@next/swc-darwin-arm64": {

--- a/webapp/app/[locale]/_components/analytics.tsx
+++ b/webapp/app/[locale]/_components/analytics.tsx
@@ -83,10 +83,6 @@ const GlobalTracking = function () {
 export const Analytics = function ({ children }: { children: ReactNode }) {
   const locale = useLocale()
 
-  if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS !== 'true') {
-    return <>{children}</>
-  }
-
   const removeLocaleAndTrailingSlash = (url: string) =>
     (url.endsWith('/') ? url.slice(0, -1) : url).replace(`/${locale}`, '')
 
@@ -94,8 +90,10 @@ export const Analytics = function ({ children }: { children: ReactNode }) {
     <UmamiAnalyticsProvider
       autoTrack={false}
       processUrl={removeLocaleAndTrailingSlash}
-      src={process.env.NEXT_PUBLIC_ANALYTICS_URL}
-      websiteId={process.env.NEXT_PUBLIC_ANALYTICS_WEBSITE_ID}
+      {...(process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true' && {
+        src: process.env.NEXT_PUBLIC_ANALYTICS_URL,
+        websiteId: process.env.NEXT_PUBLIC_ANALYTICS_WEBSITE_ID,
+      })}
     >
       <GlobalTracking />
       {children}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,10 +4,10 @@
   "scripts": {
     "build": "next build",
     "postbuild": "npm run generate:htaccess",
-    "generate:htaccess": "NEXT_PUBLIC_ENABLE_ANALYTICS=${NEXT_PUBLIC_ENABLE_ANALYTICS:-false} NEXT_PUBLIC_ANALYTICS_URL=${NEXT_PUBLIC_ANALYTICS_URL:-''} node ./scripts/generateHeaders.js",
     "deploy": "npm run build",
     "dev": "next dev",
     "dev:wifi": "WIFI=true LOCAL_IP=$(ipconfig getifaddr en0) PORT=3000 npm run dev",
+    "generate:htaccess": "NEXT_PUBLIC_ENABLE_ANALYTICS=${NEXT_PUBLIC_ENABLE_ANALYTICS:-false} NEXT_PUBLIC_ANALYTICS_URL=${NEXT_PUBLIC_ANALYTICS_URL:-''} node ./scripts/generateHeaders.js",
     "preserve": "npm run build",
     "serve": "serve out"
   },
@@ -44,7 +44,7 @@
     "sliding-block-window": "1.0.0",
     "smart-round": "1.0.0",
     "ui-common": "1.0.0",
-    "umami-analytics-next": "1.0.0",
+    "umami-analytics-next": "1.0.1",
     "viem": "2.7.19",
     "wagmi": "2.5.7",
     "wagmi-erc20-hooks": "1.0.0"

--- a/webapp/scripts/generateHeaders.js
+++ b/webapp/scripts/generateHeaders.js
@@ -49,6 +49,9 @@ const domain = getDomain(process.env.NEXT_PUBLIC_ANALYTICS_URL)
 if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true' && domain !== null) {
   htaccess += `
 <IfModule mod_headers.c>
+    Header always set Access-Control-Allow-Origin "https://${domain}"
+    Header always set Access-Control-Allow-Methods "POST, OPTIONS"
+    Header always set Access-Control-Allow-Headers "Content-Type"
     Header always set Content-Security-Policy "script-src 'self' "${domain}"
 </IfModule>`
 }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR fixes the case in which Analytics are disabled, which broke our staging environment. That's fixed on 819a87687c95b88677c903a52ebb5a5edc03a9b4 - In addition to that, I also added some headers that I believe are needed so XmlHttpRequests for Analytics are allowed aef8b39de270dc3d20658dabd2ddd39c034271d2

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
