### PR TITLE
Improve tailwind theme definition

### DIFF
--- a/ui-common/components/tabs.tsx
+++ b/ui-common/components/tabs.tsx
@@ -30,7 +30,7 @@ export const Tab = function ({
   return (
     <li
       className={`
-      text-ms box-border flex h-7 items-center rounded-md px-2 py-1 font-medium
+      box-border flex h-7 items-center rounded-md px-2 py-1 text-sm font-medium
       ${
         selected
           ? 'border border-solid border-neutral-300/55 bg-white text-neutral-950 shadow-sm'

--- a/webapp/app/[locale]/_components/appLayout.tsx
+++ b/webapp/app/[locale]/_components/appLayout.tsx
@@ -21,8 +21,8 @@ const TestnetIndicator = function () {
 
   return (
     <span
-      className="text-ms absolute left-1/2 z-10 -translate-x-1/2 rounded-b
-    bg-orange-500 px-2 font-medium leading-5 text-white"
+      className="absolute left-1/2 z-10 -translate-x-1/2 rounded-b bg-orange-500
+    px-2 text-sm font-medium text-white"
     >
       Testnet
     </span>

--- a/webapp/app/[locale]/_components/navbar/_components/navItem.tsx
+++ b/webapp/app/[locale]/_components/navbar/_components/navItem.tsx
@@ -89,8 +89,8 @@ const ItemText = ({
   text,
 }: Pick<Props, 'text'> & Selectable) => (
   <span
-    className={`md:text-ms text-base font-medium capitalize leading-5 transition-colors
-      duration-300 group-hover/item:text-neutral-950 ${
+    className={`text-base font-medium capitalize transition-colors duration-300
+      group-hover/item:text-neutral-950 md:text-sm ${
         selected ? 'text-neutral-950' : 'text-neutral-600'
       }`}
   >

--- a/webapp/app/[locale]/demos/_components/demoCard.tsx
+++ b/webapp/app/[locale]/demos/_components/demoCard.tsx
@@ -70,7 +70,7 @@ export const DemoCard = function ({
             {heading}
           </h4>
           <p
-            className={`text-ms mt-1 leading-5 ${
+            className={`mt-1 text-sm font-medium ${
               colorVariants[subHeadingColor] ?? colorVariants[headingColor]
             }`}
           >

--- a/webapp/app/[locale]/get-started/_components/addChainAutomatically.tsx
+++ b/webapp/app/[locale]/get-started/_components/addChainAutomatically.tsx
@@ -100,8 +100,8 @@ export const AddChainAutomatically = function ({ chain, layer }: Props) {
 
   return (
     <div
-      className={`border-neutral/55 text-ms flex flex-col rounded-xl border
-      border-solid p-4 font-medium leading-5 ${
+      className={`border-neutral/55 flex flex-col rounded-xl border border-solid
+      p-4 text-sm font-medium ${
         isConnected && (isChainAdded || connectedToChain)
           ? ''
           : 'cursor-pointer hover:bg-gray-50'

--- a/webapp/app/[locale]/get-started/_components/addChainManually.tsx
+++ b/webapp/app/[locale]/get-started/_components/addChainManually.tsx
@@ -19,8 +19,8 @@ const DataSection = ({
   value: string
 }) => (
   <div
-    className="text-ms flex flex-row flex-wrap items-center gap-x-2 gap-y-2 border-t border-solid
-      border-neutral-300/55 py-6 font-medium leading-5 last:pb-0 md:flex-nowrap md:py-4"
+    className="flex flex-row flex-wrap items-center gap-x-2 gap-y-2 border-t border-solid border-neutral-300/55
+      py-6 text-sm font-medium last:pb-0 md:flex-nowrap md:py-4"
   >
     <span className="flex-shrink-0 rounded bg-neutral-50 px-4 py-1 text-neutral-500">
       {label}
@@ -38,7 +38,7 @@ const DataSection = ({
 export const AddChainManually = function ({ chain, layer }: Props) {
   const t = useTranslations('get-started')
   return (
-    <div className="border-neutral/55 text-ms flex flex-col rounded-xl border border-solid p-4 font-medium leading-5">
+    <div className="border-neutral/55 flex flex-col rounded-xl border border-solid p-4 text-sm font-medium">
       <div className="flex flex-row gap-x-1">
         <ChainLogo chainId={chain.id} />
         <span className="ml-1 text-neutral-950">{chain.name}</span>

--- a/webapp/app/[locale]/get-started/_components/configurationUrl.tsx
+++ b/webapp/app/[locale]/get-started/_components/configurationUrl.tsx
@@ -26,7 +26,7 @@ export const ConfigurationUrl = function ({
   )
 
   const overlay = (
-    <div className="text-ms flex items-center gap-x-1 px-2 font-medium leading-5 text-white">
+    <div className="flex items-center gap-x-1 px-2 text-sm font-medium text-white">
       <span>{t(`${copied ? 'copied' : 'copy'}`)}</span>
       {copied && <CheckMark className="[&>path]:stroke-emerald-500" />}
     </div>

--- a/webapp/app/[locale]/get-started/_components/fundWallet.tsx
+++ b/webapp/app/[locale]/get-started/_components/fundWallet.tsx
@@ -29,8 +29,8 @@ const Faucet = function ({
 
   return (
     <ExternalLink
-      className="group/link text-ms flex w-full items-center gap-x-1 rounded-xl border border-solid
-        border-neutral-300/55 p-4 font-medium leading-5 text-orange-500 hover:bg-neutral-50 hover:text-orange-700"
+      className="group/link flex w-full items-center gap-x-1 rounded-xl border border-solid border-neutral-300/55
+        p-4 text-sm font-medium text-orange-500 hover:bg-neutral-50 hover:text-orange-700"
       href={url}
       onClick={addTracking()}
     >

--- a/webapp/app/[locale]/get-started/_components/learnMore.tsx
+++ b/webapp/app/[locale]/get-started/_components/learnMore.tsx
@@ -21,7 +21,7 @@ const Box = function ({ event, heading, href, subheading }: Props) {
   return (
     <div className="rounded-2xl border border-solid border-neutral-300/55 bg-white hover:bg-gray-50">
       <ExternalLink
-        className="text-ms block cursor-pointer p-4 font-medium leading-5"
+        className="block cursor-pointer p-4 text-sm font-medium"
         href={href}
         onClick={addTracking()}
       >
@@ -136,10 +136,10 @@ export const LearnMore = function () {
 
   return (
     <>
-      <h2 className="leading-6.5 text-xl font-medium text-neutral-950">
+      <h2 className="text-xl font-medium text-neutral-950">
         {t('learn-more-about-hemi')}
       </h2>
-      <p className="text-ms mb-6 font-medium leading-5 text-neutral-600 md:mb-8">
+      <p className="mb-6 text-sm font-medium text-neutral-600 md:mb-8">
         {t('subheading')}
       </p>
       <Card>
@@ -154,7 +154,7 @@ export const LearnMore = function () {
           <div className="mt-4 flex flex-col gap-y-2 px-2 md:mt-6 md:flex-row md:gap-x-6">
             <div className="mb-6">
               <h4 className="text-base text-neutral-950">{t('tutorials')}</h4>
-              <p className="text-ms leading-5 text-neutral-600">
+              <p className="text-sm text-neutral-600">
                 {t('tutorials-subheading')}
               </p>
               <div className="mt-3 hidden w-fit md:block">

--- a/webapp/app/[locale]/get-started/_components/section.tsx
+++ b/webapp/app/[locale]/get-started/_components/section.tsx
@@ -19,9 +19,7 @@ export const Section = ({ children, step, ...props }: Props) => (
         <div className="flex flex-col gap-y-6 p-4 font-medium md:flex-row md:justify-between md:p-6">
           <div>
             <h3 className="text-base text-neutral-950">{props.heading}</h3>
-            <p className="text-ms mt-1 leading-5 text-neutral-600">
-              {props.subheading}
-            </p>
+            <p className="mt-1 text-sm text-neutral-600">{props.subheading}</p>
           </div>
           {children}
         </div>

--- a/webapp/app/[locale]/get-started/_components/startUsingHemi.tsx
+++ b/webapp/app/[locale]/get-started/_components/startUsingHemi.tsx
@@ -41,7 +41,7 @@ const Box = function ({
   return (
     <div className="group/image flex-1 cursor-pointer" onClick={handleClick}>
       <Card>
-        <div className="text-ms flex flex-col gap-y-4 p-2 pb-4 font-medium leading-5">
+        <div className="flex flex-col gap-y-4 p-2 pb-4 text-sm font-medium">
           <Image
             alt={alt}
             className="rounded-2xl opacity-60 group-hover/image:opacity-100"

--- a/webapp/app/[locale]/get-started/_components/step.tsx
+++ b/webapp/app/[locale]/get-started/_components/step.tsx
@@ -16,9 +16,7 @@ export const Step = ({ description, position }: Props) => (
           {position}
         </span>
       </div>
-      <h4 className="text-ms font-medium leading-5 text-orange-500">
-        {description}
-      </h4>
+      <h4 className="text-sm font-medium text-orange-500">{description}</h4>
     </div>
   </div>
 )

--- a/webapp/app/[locale]/get-started/page.tsx
+++ b/webapp/app/[locale]/get-started/page.tsx
@@ -12,12 +12,10 @@ const GetStarted = function () {
 
   return (
     <>
-      <h1 className="mb-1 text-2xl font-medium leading-8 text-neutral-950">
+      <h1 className="mb-1 text-2xl font-medium text-neutral-950">
         {t('heading')}
       </h1>
-      <p className="text-ms font-medium leading-5 text-neutral-600">
-        {t('subheading')}
-      </p>
+      <p className="text-sm font-medium text-neutral-600">{t('subheading')}</p>
       <AddHemiWallet />
       <FundWallet />
       <StartUsingHemi />

--- a/webapp/app/[locale]/tunnel/_components/btcFees.tsx
+++ b/webapp/app/[locale]/tunnel/_components/btcFees.tsx
@@ -4,7 +4,7 @@ import { getFormattedValue } from 'utils/format'
 export const BtcFees = function ({ fees }: { fees: string }) {
   const t = useTranslations('common')
   return (
-    <div className="text-ms flex flex-col gap-y-1 px-8 py-4 md:px-10">
+    <div className="flex flex-col gap-y-1 px-8 py-4 text-sm md:px-10">
       <div className="flex items-center justify-between">
         <span className="text-neutral-500">{t('fees')}</span>
         <span className="text-neutral-950">{`${

--- a/webapp/app/[locale]/tunnel/_components/erc20TokenApproval.tsx
+++ b/webapp/app/[locale]/tunnel/_components/erc20TokenApproval.tsx
@@ -46,9 +46,9 @@ export const Erc20TokenApproval = function ({
   const t = useTranslations('common')
   return (
     <div
-      className={`text-ms ${
+      className={`text-sm ${
         disabled ? 'cursor-not-allowed' : ''
-      } flex items-center gap-x-2 font-medium leading-5 text-neutral-950`}
+      } flex items-center gap-x-2 font-medium text-neutral-950`}
     >
       <div className="flex items-center gap-x-1">
         <span>{t('erc20-extra-approval')}</span>
@@ -58,7 +58,7 @@ export const Erc20TokenApproval = function ({
           id="erc20-approval-tooltip"
           overlay={
             <div className="p-4 font-medium">
-              <h5 className="mb-1.5 text-base leading-5 text-white">
+              <h5 className="mb-1.5 text-base text-white">
                 {t('erc20-approve-10x-deposits')}
               </h5>
               <p className="text-xs text-neutral-400">

--- a/webapp/app/[locale]/tunnel/_components/evmSummary.tsx
+++ b/webapp/app/[locale]/tunnel/_components/evmSummary.tsx
@@ -16,7 +16,7 @@ export const EvmSummary = function ({
 }) {
   const t = useTranslations()
   return (
-    <div className="text-ms flex flex-col gap-y-1 px-8 py-4 md:px-10">
+    <div className="flex flex-col gap-y-1 px-8 py-4 text-sm md:px-10">
       <div className="flex items-center justify-between">
         <span className="text-neutral-500">{gas.label}</span>
         <span className="text-neutral-950">{`${getFormattedValue(gas.amount)} ${

--- a/webapp/app/[locale]/tunnel/_components/form.tsx
+++ b/webapp/app/[locale]/tunnel/_components/form.tsx
@@ -52,7 +52,7 @@ export const FormContent = function ({
     <>
       {showToast && <SwitchToNetworkToast chainId={fromNetworkId} />}
       <div className="flex items-center justify-between gap-x-2">
-        <h3 className="leading-6.5 text-xl font-medium capitalize text-neutral-950">
+        <h3 className="text-xl font-medium capitalize text-neutral-950">
           {t('title')}
         </h3>
         {tokenApproval}

--- a/webapp/app/[locale]/tunnel/_components/networkSelector.tsx
+++ b/webapp/app/[locale]/tunnel/_components/networkSelector.tsx
@@ -13,7 +13,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 )
 
 const Label = ({ text }: { text: string }) => (
-  <span className="text-ms font-medium leading-5 text-neutral-500">{text}</span>
+  <span className="text-sm font-medium text-neutral-500">{text}</span>
 )
 
 const Network = ({ children }: { children: string }) => (
@@ -60,7 +60,7 @@ export const NetworkSelector = function ({
   }
 
   const commonCss = `flex items-center border border-solid border-neutral-300/55 shadow-soft
-    text-ms font-medium leading-5 text-neutral-950 rounded-lg bg-white p-2 gap-x-2`
+    text-sm font-medium text-neutral-950 rounded-lg bg-white p-2 gap-x-2`
 
   if (readonly || networks.length === 1) {
     return (

--- a/webapp/app/[locale]/tunnel/_components/receivingAddress.tsx
+++ b/webapp/app/[locale]/tunnel/_components/receivingAddress.tsx
@@ -13,10 +13,8 @@ export const ReceivingAddress = ({
   tooltipText,
 }: Props) => (
   <div
-    className="text-ms px-auto flex h-24
-    flex-col items-center rounded-b-2xl
-    border border-solid border-neutral-300/55 bg-neutral-100
-    pb-3 pt-11 font-medium leading-5"
+    className="px-auto flex h-24 flex-col items-center rounded-b-2xl border
+    border-solid border-neutral-300/55 bg-neutral-100 pb-3 pt-11 text-sm font-medium"
   >
     <div className="flex items-center gap-x-2">
       <span className="text-neutral-600">{receivingText}</span>
@@ -25,9 +23,7 @@ export const ReceivingAddress = ({
         id="target-address"
         overlay={
           <div className="max-w-64 p-4">
-            <p className="text-ms font-medium leading-5 text-white">
-              {tooltipText}
-            </p>
+            <p className="text-sm font-medium text-white">{tooltipText}</p>
           </div>
         }
       >

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/amount.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/amount.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const Amount = function ({ token, value }: Props) {
   const t = useTranslations('common')
   return (
-    <div className="text-ms flex items-center justify-between font-medium leading-5">
+    <div className="flex items-center justify-between text-sm font-medium">
       <span className="text-neutral-500">{t('total-amount')}</span>
       <span className="text-neutral-950">
         {`${getFormattedValue(

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/header.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/header.tsx
@@ -9,14 +9,12 @@ type Props = {
 export const Header = ({ onClose, subtitle, title }: Props) => (
   <>
     <div className="flex items-center justify-between font-medium">
-      <h2 className="text-2xl leading-8 text-neutral-950">{title}</h2>
+      <h2 className="text-2xl text-neutral-950">{title}</h2>
       <CloseIcon
         className="cursor-pointer [&>path]:hover:stroke-neutral-950"
         onClick={onClose}
       />
     </div>
-    <p className="text-ms mt-3 h-10 font-medium leading-5 text-neutral-500">
-      {subtitle}
-    </p>
+    <p className="mt-3 h-10 text-sm font-medium text-neutral-500">{subtitle}</p>
   </>
 )

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/seeOnExplorer.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/seeOnExplorer.tsx
@@ -18,7 +18,7 @@ export const SeeOnExplorer = function ({ chainId, txHash }: Props) {
 
   return (
     <ExternalLink
-      className="text-ms group/see-on-explorer flex items-center gap-x-1 font-medium leading-5 text-orange-500"
+      className="group/see-on-explorer flex items-center gap-x-1 text-sm font-medium text-orange-500"
       href={`${blockExplorer.url}/tx/${txHash}`}
     >
       <span className="group-hover/see-on-explorer:text-orange-700">

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/step.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/step.tsx
@@ -258,7 +258,7 @@ export const Step = function ({
 }: Props & { status: ProgressStatus }) {
   const StatusStep = statusMap[status]
   return (
-    <div className="text-ms relative flex flex-col gap-y-1 font-medium leading-5">
+    <div className="relative flex flex-col gap-y-1 text-sm font-medium">
       <div className="flex items-start gap-x-3 py-3">
         <StatusStep {...props} />
       </div>

--- a/webapp/app/[locale]/tunnel/_components/setMaxBalance.tsx
+++ b/webapp/app/[locale]/tunnel/_components/setMaxBalance.tsx
@@ -20,7 +20,7 @@ const MaxButton = function ({
     <button
       className={`${
         disabled ? 'cursor-not-allowed' : 'cursor-pointer'
-      } text-ms font-medium uppercase leading-5 text-orange-500 hover:text-orange-700`}
+      } text-sm font-medium uppercase text-orange-500 hover:text-orange-700`}
       disabled={disabled}
       onClick={onClick}
       type="button"

--- a/webapp/app/[locale]/tunnel/_components/tokenInput.tsx
+++ b/webapp/app/[locale]/tunnel/_components/tokenInput.tsx
@@ -46,14 +46,14 @@ export const TokenInput = function ({
   return (
     <div
       className="h-[120px] rounded-lg border border-solid border-transparent bg-neutral-50
-      p-4 font-medium leading-5 text-neutral-500 hover:border-neutral-300/55"
+      p-4 font-medium text-neutral-500 hover:border-neutral-300/55"
     >
       <div className="flex h-full items-center justify-between">
         <div className="flex flex-shrink flex-grow flex-col items-start">
-          <span className="text-ms">{label}</span>
+          <span className="text-sm">{label}</span>
           <input
             className={`
-            text-3.25xl max-w-1/2 w-full bg-transparent leading-10 ${
+            text-3.25xl max-w-1/2 w-full bg-transparent ${
               Big(value).gt(0) ? 'text-neutral-950' : 'text-neutral-600'
             }
             outline-none focus:text-neutral-950`}
@@ -63,7 +63,7 @@ export const TokenInput = function ({
             value={value}
           />
         </div>
-        <div className="text-ms flex h-full flex-col items-end justify-end gap-y-3">
+        <div className="flex h-full flex-col items-end justify-end gap-y-3 text-sm">
           {readOnly ? (
             <div className="flex items-center justify-between gap-x-2">
               <div className="h-5 w-5">
@@ -83,7 +83,7 @@ export const TokenInput = function ({
               )}
             />
           )}
-          <div className="text-ms flex items-center justify-end gap-x-2">
+          <div className="flex items-center justify-end gap-x-2 text-sm">
             <span className="text-neutral-500">{t('form.balance')}:</span>
             <span className="text-neutral-950">
               <Balance token={token} />

--- a/webapp/app/[locale]/tunnel/_components/walletsConnected.tsx
+++ b/webapp/app/[locale]/tunnel/_components/walletsConnected.tsx
@@ -12,7 +12,7 @@ const Wallet = function ({
   const t = useTranslations('connect-wallets.status')
 
   return (
-    <div className="text-ms flex items-center gap-x-1 font-medium leading-5">
+    <div className="flex items-center gap-x-1 text-sm font-medium">
       <span className="text-neutral-600">{`${title}:`}</span>
       <span
         className={

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/amount.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/amount.tsx
@@ -68,7 +68,7 @@ export const Amount = function ({ operation }: Props) {
         <Tooltip
           id="amount-tooltip"
           overlay={
-            <div className="text-ms flex items-center gap-x-1 px-2 font-medium leading-5 text-white">
+            <div className="flex items-center gap-x-1 px-2 text-sm font-medium text-white">
               <div className="h-4 w-4">
                 <Logo token={token} />
               </div>

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/emptyState.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/emptyState.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const EmptyState = ({ action, icon, subtitle, title }: Props) => (
   <div className="flex h-full w-full flex-col items-center justify-center gap-y-1">
     <div className="relative h-8 w-8 rounded-full bg-orange-50">{icon}</div>
-    <h4 className="max-w-4/5 mt-1 text-center text-lg leading-6 text-neutral-950">
+    <h4 className="max-w-4/5 mt-1 text-center text-lg text-neutral-950">
       {title}
     </h4>
     <p className="max-w-4/5 mb-3 text-center text-neutral-500">{subtitle}</p>

--- a/webapp/app/[locale]/tunnel/transaction-history/page.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/page.tsx
@@ -32,7 +32,7 @@ const Page = function () {
         subtitle={t('transaction-history.subtitle')}
         title={t('transaction-history.title')}
       />
-      <div className="rounded-2.5xl text-ms mt-6 bg-neutral-100 p-1 font-medium leading-5 md:mt-8">
+      <div className="rounded-2.5xl mt-6 bg-neutral-100 p-1 text-sm font-medium md:mt-8">
         <TopBar
           filterOption={filterOption}
           onFilterOptionChange={setFilterOption}

--- a/webapp/components/actionableOperations.tsx
+++ b/webapp/components/actionableOperations.tsx
@@ -32,7 +32,7 @@ export const ActionableOperations = function () {
 
   return (
     <span
-      className={`text-ms flex ${extraStyles} h-4 items-center justify-center rounded-full bg-orange-500 text-center font-medium leading-3 text-white`}
+      className={`flex text-sm ${extraStyles} h-4 items-center justify-center rounded-full bg-orange-500 text-center font-medium leading-3 text-white`}
     >
       {actionableOperations}
     </span>

--- a/webapp/components/button.tsx
+++ b/webapp/components/button.tsx
@@ -4,8 +4,8 @@ import { isRelativeUrl } from 'utils/url'
 
 import { ExternalLink } from './externalLink'
 
-const commonCss = `text-ms box-content flex items-center justify-center
-  rounded-lg border border-solid px-3 py-1.5 font-medium leading-5 disabled:opacity-40`
+const commonCss = `text-sm box-content flex items-center justify-center
+  rounded-lg border border-solid px-3 py-1.5 font-medium disabled:opacity-40`
 
 const variants = {
   primary: `border-orange-700/55 from-orange-500 to-orange-600 text-white hover:border-orange-700/70  

--- a/webapp/components/connectWallets/balance.tsx
+++ b/webapp/components/connectWallets/balance.tsx
@@ -6,10 +6,10 @@ type Props = {
 export const Balance = ({ balance, symbol }: Props) => (
   <div className="px-2 pb-2 pt-8 md:pb-0 md:pt-12">
     <div className="flex items-baseline gap-x-1 font-medium">
-      <span className="text-3.25xl leading-10 text-neutral-950">
+      <span className="text-3.25xl text-neutral-950">
         {balance ? balance : '...'}
       </span>
-      <span className="leading-5 text-neutral-500">{symbol}</span>
+      <span className="text-sm text-neutral-500">{symbol}</span>
     </div>
   </div>
 )

--- a/webapp/components/connectWallets/box.tsx
+++ b/webapp/components/connectWallets/box.tsx
@@ -20,7 +20,7 @@ export const Box = function ({
 
   return (
     <div className="flex flex-col gap-y-2">
-      <div className="text-ms flex items-center justify-between leading-5 text-neutral-500">
+      <div className="flex items-center justify-between text-sm text-neutral-500">
         <span>{walletType}</span>
         <span>
           {t.rich('connected-with-wallet', {

--- a/webapp/components/connectWallets/connectToSupportedChain.tsx
+++ b/webapp/components/connectWallets/connectToSupportedChain.tsx
@@ -6,7 +6,7 @@ export const ConnectToSupportedChain = function () {
   const t = useTranslations()
   return (
     <div className="flex h-full items-center justify-center">
-      <p className="text-ms font-medium leading-5 text-neutral-500">
+      <p className="text-sm font-medium text-neutral-500">
         {t('connect-wallets.connect-to-see-balance')}
       </p>
     </div>

--- a/webapp/components/connectWallets/connectWalletsDrawer.tsx
+++ b/webapp/components/connectWallets/connectWalletsDrawer.tsx
@@ -13,7 +13,7 @@ import { CloseIcon } from 'ui-common/components/closeIcon'
 import { BtcWallet, EvmWallet } from './wallets'
 
 const P = ({ text }: { text: string }) => (
-  <p className="text-ms font-medium leading-5 text-neutral-500">{text}</p>
+  <p className="text-sm font-medium text-neutral-500">{text}</p>
 )
 
 type Props = {
@@ -47,7 +47,7 @@ export const ConnectWalletsDrawer = function ({ closeDrawer }: Props) {
       <div className="pb-18 h-full bg-white px-4 pt-6 md:max-w-md md:p-6 md:px-6">
         <div className="flex h-full flex-col gap-y-3">
           <div className="flex items-center justify-between">
-            <h2 className="text-2xl font-medium leading-8 text-neutral-950">
+            <h2 className="text-2xl font-medium text-neutral-950">
               {t('common.connect-wallets')}
             </h2>
             <button className="cursor-pointer" onClick={closeDrawer}>

--- a/webapp/components/connectWallets/index.tsx
+++ b/webapp/components/connectWallets/index.tsx
@@ -58,8 +58,8 @@ export const WalletConnection = function () {
           <ConnectedChains />
         </div>
         <button
-          className="text-ms flex h-8 items-center gap-x-2 rounded-lg border border-solid border-neutral-300/55 
-          bg-white py-1.5 pl-2 pr-4 font-medium leading-normal shadow-sm hover:bg-neutral-100"
+          className="flex h-8 items-center gap-x-2 rounded-lg border border-solid border-neutral-300/55 bg-white 
+          py-1.5 pl-2 pr-4 text-sm font-medium shadow-sm hover:bg-neutral-100"
           onClick={onConnectWalletsClick}
         >
           {walletsConnected.length === 0 && (

--- a/webapp/components/connectWallets/wallets.tsx
+++ b/webapp/components/connectWallets/wallets.tsx
@@ -57,9 +57,7 @@ const ConnectWalletButton = function ({
       }}
     >
       {icon}
-      <span className="text-base font-medium leading-normal text-neutral-950">
-        {text}
-      </span>
+      <span className="text-base font-medium text-neutral-950">{text}</span>
       {rightIcon || (
         <div className="ml-auto">
           <Chevron.Right />
@@ -73,7 +71,7 @@ const InstallUnisat = function ({ connector }: { connector: ConnectorGroup }) {
   const t = useTranslations()
   return (
     <ExternalLink
-      className="ml-auto rounded-full bg-black px-3 py-1 text-sm font-medium leading-normal text-white"
+      className="ml-auto rounded-full bg-black px-3 py-1 text-sm font-medium text-white"
       href={
         // Unisat only supports chrome and android - no other browser nor mobile OS - See https://unisat.io/
         isAndroid

--- a/webapp/components/connectedWallet/connectedAccount.tsx
+++ b/webapp/components/connectedWallet/connectedAccount.tsx
@@ -58,7 +58,7 @@ const ConnectedChain = function ({
     >
       <div className="flex cursor-pointer items-center justify-between gap-x-1 rounded-md">
         {icon}
-        <span className="text-ms mr-2 font-medium leading-5 text-neutral-950">
+        <span className="mr-2 text-sm font-medium text-neutral-950">
           {name}
         </span>
         {menu !== undefined &&
@@ -107,14 +107,14 @@ const ConnectedWallet = function ({
   return (
     <div
       className="group/connected-wallet relative flex h-8 cursor-pointer items-center rounded-lg
-        p-2 text-sm font-medium leading-normal text-neutral-950 hover:bg-neutral-100"
+        p-2 text-sm font-medium text-neutral-950 hover:bg-neutral-100"
       ref={ref}
     >
       <div
         className="flex cursor-pointer items-center justify-between gap-x-1 rounded-md"
         onClick={() => setMenuOpen(prev => !prev)}
       >
-        <span className="text-ms">{formattedAddress}</span>
+        <span className="text-sm">{formattedAddress}</span>
         {menuOpen ? (
           <Chevron.Up className={chevronCss} />
         ) : (
@@ -132,7 +132,7 @@ const ConnectedWallet = function ({
                     onClick={copyAddress}
                   >
                     <CopyLogo className="[&>path]:group-hover/menu-item:fill-neutral-950" />
-                    <span className="text-ms w-max">{t('copy-address')}</span>
+                    <span className="w-max text-sm">{t('copy-address')}</span>
                   </button>
                 ),
                 id: 'copy',
@@ -144,7 +144,7 @@ const ConnectedWallet = function ({
                     onClick={disconnect}
                   >
                     <DisconnectLogo className="[&>g>path]:group-hover/menu-item:fill-neutral-950" />
-                    <span className="text-ms">{t('disconnect')}</span>
+                    <span className="text-sm">{t('disconnect')}</span>
                   </button>
                 ),
                 id: 'disconnect',

--- a/webapp/components/connectedWallet/wrongNetwork.tsx
+++ b/webapp/components/connectedWallet/wrongNetwork.tsx
@@ -17,8 +17,8 @@ export const WrongNetwork = function ({
   const t = useTranslations('common')
   return (
     <button
-      className="text-ms group/wrong-network flex items-center gap-x-2 bg-transparent py-2 font-medium
-        leading-5 text-rose-600 duration-150 hover:scale-105 hover:text-rose-700"
+      className="group/wrong-network flex items-center gap-x-2 bg-transparent py-2 text-sm font-medium
+        text-rose-600 duration-150 hover:scale-105 hover:text-rose-700"
       onClick={onClick}
     >
       <span>{t('wrong-type-network', { type })}</span>

--- a/webapp/components/inputText.tsx
+++ b/webapp/components/inputText.tsx
@@ -1,8 +1,8 @@
 import { ComponentProps, ReactNode } from 'react'
 
-const inputCss = `shadow-soft text-ms placeholder:text-ms w-full cursor-pointer rounded-lg border
-  border-solid border-neutral-300/55 bg-white px-3 py-2 font-medium leading-5 text-neutral-950 hover:border-neutral-300/90
-  placeholder:font-medium placeholder:leading-5 placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none`
+const inputCss = `shadow-soft text-sm placeholder:text-sm w-full cursor-pointer rounded-lg border
+  border-solid border-neutral-300/55 bg-white px-3 py-2 font-medium text-neutral-950 hover:border-neutral-300/90
+ placeholder:font-medium placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none`
 
 const CloseIcon = (props: ComponentProps<'svg'>) => (
   <svg

--- a/webapp/components/pageTitle.tsx
+++ b/webapp/components/pageTitle.tsx
@@ -5,11 +5,9 @@ type Props = {
 
 export const PageTitle = ({ subtitle, title }: Props) => (
   <div className="flex flex-col gap-y-1">
-    <h1 className="text-2xl font-medium leading-8 text-neutral-950">{title}</h1>
+    <h1 className="text-2xl font-medium text-neutral-950">{title}</h1>
     {subtitle && (
-      <p className="text-ms font-medium leading-5 text-neutral-600">
-        {subtitle}
-      </p>
+      <p className="text-sm font-medium text-neutral-600">{subtitle}</p>
     )}
   </div>
 )

--- a/webapp/components/switchToNetworkToast.tsx
+++ b/webapp/components/switchToNetworkToast.tsx
@@ -59,13 +59,15 @@ export const SwitchToNetworkToast = function ({ chainId }: Props) {
 
   return (
     <div
-      className="text-ms shadow-soft fixed bottom-20 left-4 right-4 z-10 flex justify-between gap-x-3 rounded-xl
-    border border-solid border-black/85 bg-neutral-800 p-3.5 font-medium leading-5
-    text-white md:bottom-auto md:left-auto md:right-8 md:top-20"
+      className="shadow-soft fixed bottom-20 left-4 right-4 z-10 flex justify-between
+      gap-x-3 rounded-xl border border-solid border-black/85 bg-neutral-800 p-3.5
+    text-sm font-medium text-white md:bottom-auto md:left-auto md:right-8 md:top-20"
     >
-      <WarningIcon />
+      <div className="mt-[5px]">
+        <WarningIcon />
+      </div>
       <div className="flex flex-col items-start gap-y-1.5">
-        <h5 className="text-base leading-4">{t('wrong-network')}</h5>
+        <h5 className="text-base">{t('wrong-network')}</h5>
         <p className="text-neutral-400 md:max-w-72">
           {t('network-does-not-match')}
         </p>

--- a/webapp/components/tokenSelector/index.tsx
+++ b/webapp/components/tokenSelector/index.tsx
@@ -39,8 +39,8 @@ export const TokenSelector = function ({
   return (
     <>
       <button
-        className="text-ms shadow-soft group/token-selector flex items-center gap-x-2 rounded-lg
-        border border-solid border-neutral-300/55 bg-white p-2 font-medium hover:bg-neutral-100"
+        className="shadow-soft group/token-selector flex items-center gap-x-2 rounded-lg border
+        border-solid border-neutral-300/55 bg-white p-2 text-sm font-medium hover:bg-neutral-100"
         disabled={disabled || tokens.length < 2}
         onClick={openModal}
         type="button"

--- a/webapp/components/tokenSelector/tokenList.tsx
+++ b/webapp/components/tokenSelector/tokenList.tsx
@@ -48,7 +48,7 @@ const List = function ({ onSelectToken, tokens }: Omit<Props, 'closeModal'>) {
                 transform: `translateY(${virtualItem.start}px)`,
               }}
             >
-              <div className="text-ms flex items-center gap-x-3 p-2 font-medium leading-5 text-neutral-950">
+              <div className="flex items-center gap-x-3 p-2 text-sm font-medium text-neutral-950">
                 <div className="h-8 w-8 flex-shrink-0 flex-grow-0">
                   <TokenLogo token={token} />
                 </div>
@@ -91,7 +91,7 @@ export const TokenList = function ({
   const content = (
     <div className="flex h-[357px] w-full flex-col gap-x-3 bg-white p-6 px-4 md:w-96 md:px-6">
       <div className="flex items-center justify-between">
-        <h3 className="leading-6.5 text-xl font-medium text-neutral-950">
+        <h3 className="text-xl font-medium text-neutral-950">
           {t('select-token')}
         </h3>
         <CloseIcon
@@ -116,7 +116,7 @@ export const TokenList = function ({
           tokens={tokensToList}
         />
       ) : (
-        <span className="text-ms text-center font-medium leading-5 text-neutral-500">
+        <span className="text-center text-sm font-medium text-neutral-500">
           {t.rich('no-results-for', {
             search: () => (
               <span className="text-neutral-950">{searchText}</span>

--- a/webapp/tailwind.config.ts
+++ b/webapp/tailwind.config.ts
@@ -72,13 +72,112 @@ const config: Config = {
         inter: '--font-inter',
       },
       fontSize: {
-        '3.25xl': '2rem',
-        'ms': '0.8125rem',
+        // Prefer ordering by font size instead of keys
+        /* eslint-disable sort-keys */
+        'xs': [
+          '0.75rem', // 12px,
+          {
+            letterSpacing: '-0.24px',
+            lineHeight: '16px',
+          },
+        ],
+        'sm': [
+          '0.8125rem', // 13px
+          {
+            letterSpacing: '-0.28px',
+            lineHeight: '20px',
+          },
+        ],
+        'base': [
+          '1rem', // 16px
+          {
+            letterSpacing: '-0.32px',
+            lineHeight: '24px',
+          },
+        ],
+        'lg': [
+          '1.125rem', // 18px
+          {
+            letterSpacing: '-0.36px',
+            lineHeight: '24px',
+          },
+        ],
+        'xl': [
+          '1.25rem', // 20px
+          {
+            letterSpacing: '-0.4px',
+            lineHeight: '26px',
+          },
+        ],
+        '2xl': [
+          '1.5rem', // 24px
+          {
+            letterSpacing: '-0.48px',
+            lineHeight: '32px',
+          },
+        ],
+        '3xl': [
+          '1.875rem', // 30px
+          {
+            letterSpacing: '-0.6px',
+            lineHeight: '40px',
+          },
+        ],
+        '3.25xl': [
+          '2rem', // 32px
+          {
+            letterSpacing: '-0.64px',
+            lineHeight: '40px',
+          },
+        ],
+        '4xl': [
+          '2.25rem', // 40px
+          {
+            letterSpacing: '-0.72px',
+            lineHeight: '44px',
+          },
+        ],
+        '5xl': [
+          '3rem', // 48px
+          {
+            letterSpacing: '-0.96px',
+            lineHeight: '56px',
+          },
+        ],
+        '6xl': [
+          '3.75rem', // 60px
+          {
+            letterSpacing: '-1.2px',
+            lineHeight: '60px',
+          },
+        ],
+        '7xl': [
+          '4.5rem', // 72px
+          {
+            letterSpacing: '-1.44px',
+            lineHeight: '72px',
+          },
+        ],
+        '8xl': [
+          '6rem', // 96px
+          {
+            letterSpacing: '-1.92px',
+            lineHeight: '96px',
+          },
+        ],
+        '9xl': [
+          '8rem', // 128px
+          {
+            letterSpacing: '-2.56px',
+            lineHeight: '128px',
+          },
+        ],
+        /* eslint-enable sort-keys */
       },
       height: {
         '97vh': '97vh',
         '98vh': '98vh',
-        // 96px from header (height + padding), 40px from container's padding top in > md screns
+        // 96px from header (height + padding), 40px from container's padding top in > md screens
         'fit-rest-screen': 'calc(100dvh - 96px) md:calc(100dvh - 96px - 40px)',
         // 67px from header, 24px from container margin's top, and 28px twice from body y-padding
         'fit-rest-screen-desktop': 'calc(100vh - 67px - 24px - 28px - 28px)',


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR updates the tailwind theme, by rewriting the following properties: `font-size`, `line-height`, and `letter-spacing`. In many pages, these 3 classes were set at the same time for an element, so by setting for each property a default value we are now able to remove lots of `leading-*` declarations. This also helped us to find inconsistencies, and properly fix the theme. This way, now when setting `text-sm`, the 3 CSS values are set, instead of only `font-size`.

In addition to that, I removed the custom class `text-ms` and replaced it with the tailwind's `text-sm`, so I had to update the naming all over. I did so as Nahuel confirmed he will never ever use `text-sm` (Which I wanted to keep, so that's why I created the `text-ms`)

To sum up, the changes are:

- Replace `text-ms` with `text-sm`
- Remove many `leading-*` class usages
- Add a few `font-*` that were missing
- Update tailwind theme

Due to ☝🏽  some components may see their css class list reordered

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

App looks the same for the regular eye

<img width="1914" alt="image" src="https://github.com/user-attachments/assets/1298bbfa-d293-4535-8929-36936c5080e6">

<img width="1912" alt="image" src="https://github.com/user-attachments/assets/743525a9-98f9-4298-9938-ecf923a2b22f">


For the trained eye (?), there is a slight change in spacing between characters

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #531

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
