### PR TITLE
Add image-src and style-src headers for CSP

### DIFF
--- a/webapp/scripts/generateHeaders.js
+++ b/webapp/scripts/generateHeaders.js
@@ -109,7 +109,7 @@ const serveJson = {
           key: 'Content-Security-Policy',
           value: `default-src 'self'; script-src 'self' 'unsafe-inline' ${downloadScriptsDomains.join(
             ' ',
-          )}; connect-src 'self' ${fetchDomains.join(
+          )}; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self' ${fetchDomains.join(
             ' ',
           )}; frame-ancestors 'none'; block-all-mixed-content; upgrade-insecure-requests`,
         },


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

After #624 , we added `default-src`, which then required us to add 2 extra headers: `style-src` and `image-src`

As these were missing, they were causing the following errors:

<img width="595" alt="image" src="https://github.com/user-attachments/assets/4a1b45a4-a5e2-4e12-bcfc-110560fba143">

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #617

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
