### PR TITLE
Change title of the portal to 'Hemi Portal'

### DIFF
--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -7,9 +7,10 @@ import { TunnelHistoryProvider } from 'app/context/tunnelHistoryContext'
 import { locales, type Locale } from 'app/i18n'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { WalletsContext } from 'context/walletsContext'
+import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { NextIntlClientProvider } from 'next-intl'
-import { Suspense } from 'react'
+import { PropsWithChildren, Suspense } from 'react'
 import { SkeletonTheme } from 'react-loading-skeleton'
 
 import { inter } from '../fonts'
@@ -17,6 +18,10 @@ import { inter } from '../fonts'
 import { Analytics } from './_components/analytics'
 import { AppLayout } from './_components/appLayout'
 import { Navbar } from './_components/navbar'
+
+type PageProps = {
+  params: { locale: Locale }
+}
 
 async function getMessages(locale: Locale) {
   try {
@@ -27,16 +32,23 @@ async function getMessages(locale: Locale) {
   return undefined
 }
 
+export async function generateMetadata({
+  params: { locale },
+}: PageProps): Promise<Metadata> {
+  const { metadata } = await getMessages(locale)
+
+  return {
+    title: metadata.title,
+  }
+}
+
 export const generateStaticParams = async () =>
   locales.map(locale => ({ locale }))
 
 export default async function RootLayout({
   children,
   params: { locale },
-}: {
-  children: React.ReactNode
-  params: { locale: Locale }
-}) {
+}: PropsWithChildren<PageProps>) {
   const messages = await getMessages(locale)
 
   return (

--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -7,7 +7,7 @@ type Props = {
 }
 
 export const metadata: Metadata = {
-  title: 'hemi',
+  title: 'Hemi Portal',
 }
 
 export const generateStaticParams = async () =>

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -149,6 +149,9 @@
       "miner": "I'm a Miner"
     }
   },
+  "metadata": {
+    "title": "Hemi Portal"
+  },
   "navbar": {
     "agree-to-terms-and-policy": "By using this application, you agree to the <terms>Terms of Use</terms> and <policy>Privacy Policy</policy>",
     "bitcoinkit": "Hemi Bitcoin Kit",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -149,6 +149,9 @@
       "miner": "Soy Minero"
     }
   },
+  "metadata": {
+    "title": "Portal de Hemi"
+  },
   "navbar": {
     "agree-to-terms-and-policy": "Al usar esta aplicación, usted acepta los <terms>Términos de Uso</terms> y la <policy>Política de Privacidad</policy>",
     "bitcoinkit": "Kit de Hemi Bitcoin",


### PR DESCRIPTION
### Description

Change the page title of the Hemi Portal to "Hemi Portal" (previously "hemi").
Additionally, add i18n for the page title/metadata.

### Screenshots

![image](https://github.com/user-attachments/assets/f9fea5ef-5dde-4cf4-9717-fe9838dd75fd)
![image](https://github.com/user-attachments/assets/c99ad2f1-0aca-4e93-a57e-319d873dbee1)


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #626
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
