### PR TITLE
Consider reconnecting status for check connection

### DIFF
--- a/webapp/hooks/useConnectedToUnsupportedChain.ts
+++ b/webapp/hooks/useConnectedToUnsupportedChain.ts
@@ -4,10 +4,10 @@ import { useAccount as useEvmAccount } from 'wagmi'
 export const useConnectedToUnsupportedEvmChain = function () {
   // if connected to unsupported network, "chain" is undefined
   const { chain, status } = useEvmAccount()
-  return status === 'connected' && chain === undefined
+  return ['connected', 'reconnecting'].includes(status) && chain === undefined
 }
 
 export const useConnectedToUnsupportedBtcChain = function () {
   const { chain, status } = useBtcAccount()
-  return status === 'connected' && chain === undefined
+  return ['connected', 'reconnecting'].includes(status) && chain === undefined
 }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

`chain` is undefined when connected to an unsupported chain. There was a check prior to this, but it wasn't considering the state `reconnecting` to check for supported status or not. `reconnecting` status appears when the user is connected to its wallet and performs a shallow navigation (clicking the Toggle as in the video performs a shallow navigation).

With the appropriate check now working, this no longer breaks

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/2cc33ccd-940c-4be8-b181-1ab20ebdc687

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #629

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
