### PR TITLE
Ignore 'user rejected the request' error on sentry

### DIFF
--- a/webapp/sentry.client.config.ts
+++ b/webapp/sentry.client.config.ts
@@ -1,9 +1,15 @@
 import * as Sentry from '@sentry/nextjs'
 
+const ignoreErrors = [
+  // user rejected a confirmation in the wallet
+  'rejected the request',
+]
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'staging',
+  ignoreErrors,
   integrations: [
     // This overrides the default implementation of the RewriteFrames
     // integration from sentry/nextjs. It adds the decodeURI() to fix a mismatch


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

When a user is prompted to switch chain, and they reject it, a console error is logged.

![image](https://github.com/user-attachments/assets/51d5590a-5940-4128-8288-6e737be08488)

These are valid scenarios that must not be logged to sentry.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #634

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
