### PR TITLE
Adjust Readme for env variables - drop unusued

### DIFF
--- a/webapp/.env
+++ b/webapp/.env
@@ -3,6 +3,3 @@ NEXT_PUBLIC_BTC_OUTPUTS_SIZE=25
 # Once mainnet is published, these values below may go into .env.development as they belong to hemi's testnet
 NEXT_PUBLIC_BITCOIN_NETWORK=testnet
 NEXT_PUBLIC_MEMPOOL_API_URL="https://mempool.space/testnet/api"
-NEXT_PUBLIC_RAINBOW_APP_NAME=Hemi
-NEXT_PUBLIC_RAINBOW_PROJECT_ID=THE_PROJECT_ID
-NEXT_PUBLIC_TESTNET_MODE=true

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -7,9 +7,15 @@
 The environment variables are defined in the `.env` file at the root of the project.
 The prefix `NEXT_PUBLIC_` is required for the variables to be available in the browser. A few variables can be set locally (in a `.env.local`), in addition to the ones already defined in the `.env`
 
-```bash
+```sh
+NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_SEPOLIA=<url> # Optional - Used to override the Hemi Sepolia RPC URL
+NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA=<url> # Optional - Used to override the Sepolia RPC URL
 NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL=<true|false> # Enable the bitcoin tunnel feature
 NEXT_PUBLIC_WORKERS_DEBUG_ENABLE=<true|false> # enable logging on web workers
+# These env variables are required for Enabling Analytics
+NEXT_PUBLIC_ENABLE_ANALYTICS=<true|false> # Enable Analytics with Umami
+NEXT_PUBLIC_ANALYTICS_URL=<url> # Umami analytics URL
+NEXT_PUBLIC_ANALYTICS_WEBSITE_ID=<string> # Umami website ID
 # The following variables could be used to customize the contracts addresses used by Hemi (for example, for testing with a forked blockchain):
 NEXT_PUBLIC_ADDRESS_MANAGER=<address>
 NEXT_PUBLIC_L2_BRIDGE=<address>
@@ -23,15 +29,7 @@ If not defined, the contracts addresses used will be the ones defined in [hemi-v
 
 ## Deployment
 
-Inside the `webapp` folder, create a `.env.production` with the following configuration:
-
-```sh
-NEXT_PUBLIC_TESTNET_MODE=<true|false> # Depending on which network is being deployed
-```
-
-(as well as any other env variable of the list defined above)
-
-and then run the following command:
+Run the following command:
 
 ```sh
 npm run build


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR drops some unused env variables, and adjusts the README for those that were missing.

- `NEXT_PUBLIC_TESTNET_MODE` is no longer needed after https://github.com/hemilabs/ui-monorepo/issues/496
- `NEXT_PUBLIC_RAINBOW_APP_NAME` and `NEXT_PUBLIC_RAINBOW_PROJECT_ID` were never actually in use

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes for the users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
