### PR TITLE
Remove fallback chainIds

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/amount.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/amount.tsx
@@ -3,8 +3,6 @@ import { ChainLogo } from 'components/chainLogo'
 import { InfoIcon } from 'components/icons/infoIcon'
 import { TokenLogo } from 'components/tokenLogo'
 import { Tooltip } from 'components/tooltip'
-import { useHemi } from 'hooks/useHemi'
-import { useNetworks } from 'hooks/useNetworks'
 import smartRound from 'smart-round'
 import { Token } from 'types/token'
 import { TunnelOperation } from 'types/tunnel'
@@ -40,14 +38,11 @@ const formatAmount = function (amount: string, decimals: Token['decimals']) {
 
 export const Amount = function ({ operation }: Props) {
   const { amount, l1Token, l2Token } = operation
-  const hemi = useHemi()
-  const { evmRemoteNetworks } = useNetworks()
 
   const tokenAddress = (isDeposit(operation) ? l1Token : l2Token) as Address
   const chainId = isDeposit(operation)
-    ? // See https://github.com/hemilabs/ui-monorepo/issues/376
-      operation.l1ChainId ?? evmRemoteNetworks[0].id
-    : operation.l2ChainId ?? hemi.id
+    ? operation.l1ChainId
+    : operation.l2ChainId
   const token =
     getTokenByAddress(tokenAddress, chainId) ??
     getL2TokenByBridgedAddress(tokenAddress, chainId) ??

--- a/webapp/hooks/useSyncHistory/reducer.ts
+++ b/webapp/hooks/useSyncHistory/reducer.ts
@@ -1,4 +1,3 @@
-import { hemiTestnet } from 'networks/hemiTestnet'
 import {
   type DepositTunnelOperation,
   type WithdrawTunnelOperation,
@@ -57,26 +56,24 @@ export const historyReducer = function (
           ...state,
           deposits: payload.deposits.map(chainDeposits => ({
             ...chainDeposits,
-            // See https://github.com/hemilabs/ui-monorepo/issues/376
             content: chainDeposits.content.map(
               deposit =>
                 ({
                   ...deposit,
                   l1ChainId: deposit.l1ChainId,
-                  l2ChainId: deposit.l2ChainId ?? hemiTestnet.id,
+                  l2ChainId: deposit.l2ChainId,
                 }) as DepositTunnelOperation,
             ),
             status: 'ready',
           })),
           withdrawals: payload.withdrawals.map(chainWithdrawals => ({
             ...chainWithdrawals,
-            // See https://github.com/hemilabs/ui-monorepo/issues/376
             content: chainWithdrawals.content.map(
               withdrawal =>
                 ({
                   ...withdrawal,
                   l1ChainId: withdrawal.l1ChainId,
-                  l2ChainId: withdrawal.l2ChainId ?? hemiTestnet.id,
+                  l2ChainId: withdrawal.l2ChainId,
                 }) as WithdrawTunnelOperation,
             ),
             status: 'ready',


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

When we implemented bitcoin, the transaction history did not have the l1ChainId nor the l2chainId. These were added so it was easier to query the appropriate RPC URL, but for those cases when these values where missing, a fallback was needed. These have been in prod for a long time (as the values are recorded by syncing, and then the fallback becomes useless), so they can now safely removed.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes for the user

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #376

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
