### PR TITLE
Enable history for mainnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13969,9 +13969,9 @@
       "integrity": "sha512-f1hiPt90QXTPXX9jb8fRuGvzWMkbBpBO/45m3s024Aa0JoSpeVt9AodkxHAnCfK5uTRDdKvbIB8dPU1sbGhOdA=="
     },
     "node_modules/hemi-viem": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-1.5.0.tgz",
-      "integrity": "sha512-mysynUoD75wrZ7fmg5O4bNF016rRvU7NCsqy+rlcY5XoXIX4uRSbw8qz/J5PzpUGBEXghLTkE5EcXRPLZ1JN9w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-1.6.0.tgz",
+      "integrity": "sha512-oyLrtpGJmv8JB33CKuSsAuXNbmYZEdqN66eG6RpZacYiXRUPVr60+pI3CSpj/eeg4R2zx/zMwC6Nv747qrFCTw==",
       "peerDependencies": {
         "viem": "^2.x"
       }
@@ -25271,7 +25271,7 @@
         "debug": "4.3.6",
         "esplora-client": "1.1.0",
         "hemi-socials": "1.0.0",
-        "hemi-viem": "1.5.0",
+        "hemi-viem": "1.6.0",
         "javascript-time-ago": "2.5.10",
         "lodash": "4.17.21",
         "next": "14.2.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -25,7 +25,7 @@
     "debug": "4.3.6",
     "esplora-client": "1.1.0",
     "hemi-socials": "1.0.0",
-    "hemi-viem": "1.5.0",
+    "hemi-viem": "1.6.0",
     "javascript-time-ago": "2.5.10",
     "lodash": "4.17.21",
     "next": "14.2.3",

--- a/webapp/utils/sync-history/chainConfiguration.ts
+++ b/webapp/utils/sync-history/chainConfiguration.ts
@@ -1,5 +1,6 @@
 import { hemiMainnet } from 'networks/hemiMainnet'
 import { hemiTestnet } from 'networks/hemiTestnet'
+import { mainnet } from 'networks/mainnet'
 import { sepolia } from 'networks/sepolia'
 
 // Approximately 1/2 day
@@ -11,6 +12,10 @@ export const chainConfiguration = {
   },
   [hemiTestnet.id]: {
     blockWindowSize: opBasedEvmBlockWindowSize,
+  },
+  [mainnet.id]: {
+    blockWindowSize: 800, // Eth RPC only allows up to 800 blocks per request
+    minBlockToSync: 20_711_548, // Eth block of hemi mainnet birth
   },
   [sepolia.id]: {
     blockWindowSize: opBasedEvmBlockWindowSize,

--- a/webapp/workers/history.ts
+++ b/webapp/workers/history.ts
@@ -5,6 +5,7 @@ import {
   type HistoryActions,
   type TransactionListSyncType,
 } from 'hooks/useSyncHistory/types'
+import { mainnet } from 'networks/mainnet'
 import { sepolia } from 'networks/sepolia'
 import { findChainById } from 'utils/chain'
 import { createBitcoinSync } from 'utils/sync-history/bitcoin'
@@ -66,6 +67,7 @@ const createSyncer = function ({
         withdrawalsSyncInfo:
           withdrawalsSyncInfo as ExtendedSyncInfo<TransactionListSyncType>,
       })
+    case mainnet.id:
     case sepolia.id:
       return createEvmSync({
         address: address as Address,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR updates hemi-viem to its latest version (which adds support for mainnet by setting the L1 contracts), and enables syncing Ethereum mainnet history (for the tx history page)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

It now syncs to Mainnet ETH (though I have no operation done heh)

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/4ee308b6-d2d5-422a-b863-26c755a19caf">

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #647

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
