### PR TITLE
Fix wrong default if mainnet is disabled

### DIFF
--- a/webapp/hooks/useNetworkType.ts
+++ b/webapp/hooks/useNetworkType.ts
@@ -11,5 +11,5 @@ export const useNetworkType = () =>
     'networkType',
     parseAsStringLiteral(
       featureFlags.mainnetEnabled ? networkTypes : (['testnet'] as const),
-    ).withDefault(networkTypes[0]),
+    ).withDefault(featureFlags.mainnetEnabled ? 'mainnet' : 'testnet'),
   )


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

After #651 , the default chain if `mainnet` was disabled was... mainnet 🤦🏽 .  
This PR fixes that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #640

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
