### PR TITLE
Show eth/usdc/usdt first in token list

### DIFF
--- a/webapp/components/tokenSelector/tokenList.tsx
+++ b/webapp/components/tokenSelector/tokenList.tsx
@@ -82,11 +82,22 @@ export const TokenList = function ({
 
   const { width } = useWindowSize()
 
-  const tokensToList = tokens.filter(
-    token =>
-      token.name.toLowerCase().includes(searchText.toLowerCase()) ||
-      token.symbol.toLowerCase().includes(searchText.toLowerCase()),
-  )
+  const tokensToList = tokens
+    .filter(
+      token =>
+        token.name.toLowerCase().includes(searchText.toLowerCase()) ||
+        token.symbol.toLowerCase().includes(searchText.toLowerCase()),
+    )
+    .sort(function (a, b) {
+      if (a.symbol === 'ETH') return -1
+      if (b.symbol === 'ETH') return 1
+      // using startsWith due to .e symbol version in Hemi
+      if (a.symbol.startsWith('USDC')) return -1
+      if (b.symbol.startsWith('USDC')) return 1
+      if (a.symbol.startsWith('USDT')) return -1
+      if (b.symbol.startsWith('USDT')) return 1
+      return a.name.localeCompare(b.name)
+    })
 
   const content = (
     <div className="flex h-[357px] w-full flex-col gap-x-3 bg-white p-6 px-4 md:w-96 md:px-6">


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR pins `ETH`, `USDC` and `USDT` (in that order) first in the token list

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

#### testnet

Hemi Sepolia (L2)

![image](https://github.com/user-attachments/assets/2e6a7aea-6c63-4f98-a50c-8e04b516f95d)

Sepolia (L1)

![image](https://github.com/user-attachments/assets/0512fe39-c591-4bdb-836b-f4b7018821b6)


#### mainnet 

(note `usdc`, and `usdt` are not available in mainnet)

Ethereum (L1)

![image](https://github.com/user-attachments/assets/41e07ec1-042e-4bad-a34d-e365b4dbca7c)

Hemi (L2)

![image](https://github.com/user-attachments/assets/8e630188-31ac-4c04-96ec-40ba8980d837)


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #661 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
