### PR TITLE
Sentry improvements

### DIFF
--- a/.github/actions/deploy-portal/action.yml
+++ b/.github/actions/deploy-portal/action.yml
@@ -48,15 +48,15 @@ inputs:
   NEXT_PUBLIC_SENTRY_DSN:
     required: false
     description: Sentry DSN URL
-  NEXT_PUBLIC_SENTRY_ENVIRONMENT:
-    required: false
-    description: Sentry environment
   NEXT_PUBLIC_TRACES_SAMPLE_RATE:
     required: false
     description: Sentry traces sample rate
   SENTRY_AUTH_TOKEN:
     required: false
     description: Sentry auth token
+  SENTRY_ENVIRONMENT:
+    required: false
+    description: Sentry environment
   SENTRY_ORG:
     required: false
     description: Sentry organization
@@ -84,9 +84,9 @@ runs:
         NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL: ${{ inputs.NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL }}
         NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET: ${{ inputs.NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET }}
         NEXT_PUBLIC_SENTRY_DSN: ${{ inputs.NEXT_PUBLIC_SENTRY_DSN }}
-        NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${{ inputs.NEXT_PUBLIC_SENTRY_ENVIRONMENT }}
         NEXT_PUBLIC_TRACES_SAMPLE_RATE: ${{ inputs.NEXT_PUBLIC_TRACES_SAMPLE_RATE }}
         SENTRY_AUTH_TOKEN: ${{ inputs.SENTRY_AUTH_TOKEN }}
+        SENTRY_ENVIRONMENT: ${{ inputs.SENTRY_ENVIRONMENT }}
         SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
         SENTRY_RELEASE: ${{ inputs.SENTRY_RELEASE }}

--- a/.github/actions/deploy-portal/action.yml
+++ b/.github/actions/deploy-portal/action.yml
@@ -45,9 +45,6 @@ inputs:
   NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET:
     required: true
     description: Feature flag to enable Mainnet
-  NEXT_PUBLIC_RELEASE_VERSION:
-    required: false
-    description: Release version
   NEXT_PUBLIC_SENTRY_DSN:
     required: false
     description: Sentry DSN URL
@@ -66,6 +63,9 @@ inputs:
   SENTRY_PROJECT:
     required: false
     description: Sentry project
+  SENTRY_RELEASE:
+    required: false
+    description: Sentry Release version
 
 runs:
   using: composite
@@ -83,13 +83,13 @@ runs:
         NEXT_PUBLIC_ENABLE_ANALYTICS: ${{ inputs.NEXT_PUBLIC_ENABLE_ANALYTICS }}
         NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL: ${{ inputs.NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL }}
         NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET: ${{ inputs.NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET }}
-        NEXT_PUBLIC_RELEASE_VERSION: ${{ inputs.NEXT_PUBLIC_RELEASE_VERSION }}
         NEXT_PUBLIC_SENTRY_DSN: ${{ inputs.NEXT_PUBLIC_SENTRY_DSN }}
         NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${{ inputs.NEXT_PUBLIC_SENTRY_ENVIRONMENT }}
         NEXT_PUBLIC_TRACES_SAMPLE_RATE: ${{ inputs.NEXT_PUBLIC_TRACES_SAMPLE_RATE }}
         SENTRY_AUTH_TOKEN: ${{ inputs.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
+        SENTRY_RELEASE: ${{ inputs.SENTRY_RELEASE }}
     - name: Check portal build
       id: portal_build
       uses: andstor/file-existence-action@v3

--- a/.github/workflows/hostinger-deployment-prod.yml
+++ b/.github/workflows/hostinger-deployment-prod.yml
@@ -37,9 +37,9 @@ jobs:
           NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL: false
           NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET: false
           NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN_PROD }}
-          NEXT_PUBLIC_SENTRY_ENVIRONMENT: production
           NEXT_PUBLIC_TRACES_SAMPLE_RATE: 1.0
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN_PROD }}
+          SENTRY_ENVIRONMENT: production
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
           SENTRY_RELEASE: ${{ format('{0}@{1}', vars.SENTRY_PROJECT, github.event.release.name) }}

--- a/.github/workflows/hostinger-deployment-prod.yml
+++ b/.github/workflows/hostinger-deployment-prod.yml
@@ -36,19 +36,10 @@ jobs:
           NEXT_PUBLIC_ENABLE_ANALYTICS: true
           NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL: false
           NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET: false
-          NEXT_PUBLIC_RELEASE_VERSION: ${{ github.event.release.name }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN_PROD }}
           NEXT_PUBLIC_SENTRY_ENVIRONMENT: production
           NEXT_PUBLIC_TRACES_SAMPLE_RATE: 1.0
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN_PROD }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-      - name: Create Sentry release
-        uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_INTEGRATION_TOKEN }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-        with:
-          environment: production
-          version: ${{ format('{0}@{1}', vars.SENTRY_PROJECT, github.event.release.name) }}
+          SENTRY_RELEASE: ${{ format('{0}@{1}', vars.SENTRY_PROJECT, github.event.release.name) }}

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -32,6 +32,16 @@ const nextConfig = {
   },
 }
 
+const release =
+  process.env.SENTRY_ENVIRONMENT && process.env.SENTRY_RELEASE
+    ? {
+        deploy: {
+          env: process.env.SENTRY_ENVIRONMENT,
+        },
+        name: process.env.SENTRY_RELEASE,
+      }
+    : { create: false, finalize: false }
+
 /** @type {import('@sentry/nextjs').SentryBuildOptions} */
 const sentryOptions = {
   authToken: process.env.SENTRY_AUTH_TOKEN,
@@ -40,12 +50,7 @@ const sentryOptions = {
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#widen-the-upload-scope
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
-  release: {
-    deploy: {
-      env: process.env.SENTRY_ENVIRONMENT,
-    },
-    name: process.env.SENTRY_RELEASE,
-  },
+  release,
   widenClientFileUpload: true,
 }
 

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -49,16 +49,4 @@ const sentryOptions = {
   widenClientFileUpload: true,
 }
 
-// building with missing flags throws a bunch of warnings, better to conditionally apply sentry config
-// only if everything is set
-if (
-  !!process.env.SENTRY_AUTH_TOKEN &&
-  !!process.env.SENTRY_ORG &&
-  !!process.env.SENTRY_PROJECT &&
-  !!process.env.SENTRY_ENVIRONMENT &&
-  !!process.env.SENTRY_RELEASE
-) {
-  module.exports = withSentryConfig(nextConfig, sentryOptions)
-} else {
-  module.exports = nextConfig
-}
+module.exports = withSentryConfig(nextConfig, sentryOptions)

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -40,6 +40,12 @@ const sentryOptions = {
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#widen-the-upload-scope
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
+  release: {
+    deploy: {
+      env: process.env.SENTRY_ENVIRONMENT,
+    },
+    name: process.env.SENTRY_RELEASE,
+  },
   widenClientFileUpload: true,
 }
 
@@ -48,7 +54,9 @@ const sentryOptions = {
 if (
   !!process.env.SENTRY_AUTH_TOKEN &&
   !!process.env.SENTRY_ORG &&
-  !!process.env.SENTRY_PROJECT
+  !!process.env.SENTRY_PROJECT &&
+  !!process.env.SENTRY_ENVIRONMENT &&
+  !!process.env.SENTRY_RELEASE
 ) {
   module.exports = withSentryConfig(nextConfig, sentryOptions)
 } else {

--- a/webapp/sentry.client.config.ts
+++ b/webapp/sentry.client.config.ts
@@ -26,7 +26,6 @@ function enableSentry() {
         },
       }),
     ],
-    release: `portal@${process.env.NEXT_PUBLIC_RELEASE_VERSION}`,
     tracesSampleRate:
       process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE &&
       !Number.isNaN(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)

--- a/webapp/sentry.client.config.ts
+++ b/webapp/sentry.client.config.ts
@@ -11,7 +11,6 @@ function enableSentry() {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enabled,
-    environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'staging',
     ignoreErrors,
     integrations: [
       // This overrides the default implementation of the RewriteFrames

--- a/webapp/sentry.client.config.ts
+++ b/webapp/sentry.client.config.ts
@@ -1,32 +1,40 @@
 import * as Sentry from '@sentry/nextjs'
 
-const ignoreErrors = [
-  // user rejected a confirmation in the wallet
-  'rejected the request',
-]
+const enabled = !!process.env.NEXT_PUBLIC_SENTRY_DSN
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'staging',
-  ignoreErrors,
-  integrations: [
-    // This overrides the default implementation of the RewriteFrames
-    // integration from sentry/nextjs. It adds the decodeURI() to fix a mismatch
-    // of sourceMaps in reported issues.
-    // ref: https://github.com/getsentry/sentry/issues/19713#issuecomment-696614341
-    Sentry.rewriteFramesIntegration({
-      iteratee(frame) {
-        const { origin } = new URL(frame.filename)
-        frame.filename = decodeURI(frame.filename.replace(origin, 'app://'))
-        return frame
-      },
-    }),
-  ],
-  release: `portal@${process.env.NEXT_PUBLIC_RELEASE_VERSION}`,
-  tracesSampleRate:
-    process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE &&
-    !Number.isNaN(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)
-      ? Number(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)
-      : undefined,
-})
+function enableSentry() {
+  const ignoreErrors = [
+    // user rejected a confirmation in the wallet
+    'rejected the request',
+  ]
+
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    enabled,
+    environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'staging',
+    ignoreErrors,
+    integrations: [
+      // This overrides the default implementation of the RewriteFrames
+      // integration from sentry/nextjs. It adds the decodeURI() to fix a mismatch
+      // of sourceMaps in reported issues.
+      // ref: https://github.com/getsentry/sentry/issues/19713#issuecomment-696614341
+      Sentry.rewriteFramesIntegration({
+        iteratee(frame) {
+          const { origin } = new URL(frame.filename)
+          frame.filename = decodeURI(frame.filename.replace(origin, 'app://'))
+          return frame
+        },
+      }),
+    ],
+    release: `portal@${process.env.NEXT_PUBLIC_RELEASE_VERSION}`,
+    tracesSampleRate:
+      process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE &&
+      !Number.isNaN(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)
+        ? Number(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)
+        : undefined,
+  })
+}
+
+if (enabled) {
+  enableSentry()
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

2 improvements here

- According to [this dev from Sentry's team](https://github.com/getsentry/sentry-javascript/discussions/14139#discussioncomment-11166713), `Sentry.init()` should be called conditionally, but `withSentryConfig` shouldn't. So [956c4d1](https://github.com/hemilabs/ui-monorepo/pull/665/commits/956c4d12744330b63d2ded866424ce5c9a6c8fa1) fixes that, and conditionally calling `Sentry.init` is applied in [c882dd2](https://github.com/hemilabs/ui-monorepo/pull/665/commits/c882dd212347751431e7690b6396682edd109a1e)

- Then, between [527bed9](https://github.com/hemilabs/ui-monorepo/pull/665/commits/527bed99dc1b75a98d78c59eaefff2124d691294) and [c92cdf2](https://github.com/hemilabs/ui-monorepo/pull/665/commits/c92cdf2c7fa5582b075fe20b6e39224235bfb425) fix the duplicated releases. The Github Action was indeed not needed, as Nextjs creates a release upon build. And the proper values needed to be set in `withSentryConfig` instead of `Sentry.init()`. See [the whole discussion thread](https://github.com/getsentry/sentry-javascript/discussions/14139) for further details

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes for the user

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #630

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
