### PR TITLE
Improve estimations for mainnet

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/deposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/deposit.tsx
@@ -458,7 +458,7 @@ const EvmDeposit = function ({ state }: EvmDepositProps) {
   const gas = {
     amount: formatNumber(
       formatUnits(
-        depositGasFees + approvalTokenGasFees,
+        depositGasFees + (needsApproval ? approvalTokenGasFees : BigInt(0)),
         fromChain?.nativeCurrency.decimals,
       ),
       3,

--- a/webapp/app/[locale]/tunnel/_hooks/useApproveToken.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useApproveToken.ts
@@ -26,6 +26,7 @@ export const useApproveToken = function (
     chainId: token.chainId,
     enabled: isConnected && isSupported,
     gasUnits: ApproveErc20TokenGas,
+    overEstimation: 1.5,
   })
 
   const queryClient = useQueryClient()

--- a/webapp/hooks/useEstimateFees.ts
+++ b/webapp/hooks/useEstimateFees.ts
@@ -2,9 +2,7 @@ import Big from 'big.js'
 import { useFeeHistory } from 'wagmi'
 
 const defaultBlockCount = 4
-// Overestimation for L1 gas limit used by OP/SDK
-// See https://github.com/ethereum-optimism/optimism/blob/592daa704a56f5b3df21b41ea7cc294ab63b95ff/packages/sdk/src/cross-chain-messenger.ts#L2060
-const defaultOverEstimation = 1.5
+const defaultOverEstimation = 1
 
 const mean = function (rewards: bigint[] = []) {
   if (rewards.length === 0) {

--- a/webapp/hooks/useL2Bridge.ts
+++ b/webapp/hooks/useL2Bridge.ts
@@ -146,10 +146,6 @@ const useEstimateGasFees = function <T extends GasEstimationOperations>({
     chainId: walletConnectedToChain,
     enabled: status === 'success',
     gasUnits: data,
-    // As the gas limit is hardcoded for some operations, we don't need an overestimation
-    // use 1 to get the exact same value
-    // See https://github.com/hemilabs/ui-monorepo/issues/539
-    overEstimation: hardcodedOps.includes(operation) ? 1 : undefined,
   })
 }
 
@@ -327,6 +323,7 @@ export const useDepositNativeToken = function ({
   ...options
 }: UseDepositNativeToken) {
   const operation = 'depositETH'
+  const { address } = useAccount()
   const hemi = useHemi()
   const { crossChainMessenger, crossChainMessengerStatus } =
     useL1ToL2CrossChainMessenger(l1ChainId)
@@ -334,7 +331,8 @@ export const useDepositNativeToken = function ({
   const overrides = hemi.testnet ? l1OverridesTestnet : tunnelOverrides
 
   const depositNativeTokenGasFees = useEstimateGasFees({
-    args: [toDeposit, overrides],
+    // Need to manually override from address - See https://github.com/ethereum-optimism/optimism/issues/8952
+    args: [toDeposit, merge(overrides, { overrides: { from: address } })],
     crossChainMessenger,
     crossChainMessengerStatus,
     enabled:


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Estimations are a bit off in mainnet. This is due 2 reasons:

- There was an extra `overestimation` when calculating fees; however, this made no sense because the OP SDK already had the overestimation. As in Sepolia, fees are low, this was barely noticeable, but on `mainnet` it is very visible.
- Deposit of native tokens was throwing an error. This' been fixed before, so I applied the same fix.
We must also note that for ERC20 tokens, the estimation can't be retrieved without approving it first, because the simulation of the deposit reverts. This makes sense (as you can't simulate a deposit if the user doesn't have enough allowance), but in testnet it works. It may be that these tokens were simplified. We reviewed this with Max.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Estimations on mainnet are now more accurate (similar to what MM asks)

Native token:

![image](https://github.com/user-attachments/assets/483c47eb-d45e-45be-9c58-7867ef6f4ce9)

![image](https://github.com/user-attachments/assets/3f4645f8-0421-4b5a-9614-cfc6fd2d4ae1)

ERC20 (I had already approved the token at this point)

![image](https://github.com/user-attachments/assets/c16aa2ad-0b51-4616-98bf-405af90ee8b3)

![image](https://github.com/user-attachments/assets/823ef722-9257-43d3-ab67-4c1eb22e46fb)





### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
