### PR TITLE
Custom RPC origins

### DIFF
--- a/webapp/scripts/generateHeaders.js
+++ b/webapp/scripts/generateHeaders.js
@@ -24,22 +24,19 @@ const getDomain = function (url) {
 
 // These are scripts called with fetch()
 const fetchDomains = [
-  // bitcoin APIs from esplora-client
+  // esplora-client - https://github.com/hemilabs/esplora-client/blob/master/src/index.js#L15
   'https://blockstream.info',
   'https://mempool.space',
-  // EVM rpc urls
-  // Hemi Sepolia
-  'https://int02.testnet.rpc.hemi.network',
-  'https://testnet.rpc.hemi.network',
-  // Ethereum Mainnet
+  // Ethereum RPC - https://github.com/wevm/viem/blob/main/src/chains/definitions/mainnet.ts#L9
   'https://cloudflare-eth.com',
-  // Hemi Mainnet
+  'https://eth.drpc.org',
+  // Sepolia RPC - https://github.com/wevm/viem/blob/main/src/chains/definitions/sepolia.ts#L9
+  'https://rpc.sepolia.org',
+  'https://sepolia.drpc.org',
+  // Hemi and Hemi Sepolia RPCs
   'https://*.hemi.network',
   'https://*.rpc.hemi.network',
-  // Sepolia
-  'https://rpc.sepolia.org',
-  'https://rpc2.sepolia.org',
-  // Needed for rainbow kit
+  // RainbowKit
   'wss://relay.walletconnect.com',
   'wss://relay.walletconnect.org',
 ]
@@ -56,7 +53,7 @@ const customRpcOrigins = [
 ]
 customRpcOrigins.forEach(function (url) {
   if (url) {
-    fetchDomains.concat(new URL(url).origin)
+    fetchDomains.push(new URL(url).origin)
   }
 })
 

--- a/webapp/scripts/generateHeaders.js
+++ b/webapp/scripts/generateHeaders.js
@@ -44,6 +44,22 @@ const fetchDomains = [
   'wss://relay.walletconnect.org',
 ]
 
+// If any RPC URL is customized through these env vars, the origin has to be
+// added to the allow list for the client to get the responses. Since the URLs
+// may contain a port or a path, those need to be removed as only the "origin"
+// part is required.
+const customRpcOrigins = [
+  process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_MAINNET,
+  process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_SEPOLIA,
+  process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET,
+  process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA,
+]
+customRpcOrigins.forEach(function (url) {
+  if (url) {
+    fetchDomains.concat(new URL(url).origin)
+  }
+})
+
 // these are domains where we download images from
 const imageSrcUrls = ['https://raw.githubusercontent.com']
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

If custom RPC endpoints are set through environment variables, the CORS headers must be also set during build time.

Environment variables are already set:

<img width="585" alt="image" src="https://github.com/user-attachments/assets/6a42c8bb-0991-4273-9e34-1b3071bf6c2f">

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #697

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
