### PR TITLE
Refactor watch evm withdrawals in web worker

### DIFF
--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -119,7 +119,6 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
       {/* Track updates on bitcoin deposits, in bitcoin or in Hemi */}
       {featureFlags.btcTunnelEnabled && <BitcoinDepositsStatusUpdater />}
       {/* Track updates on withdrawals from Hemi */}
-      {/* Move to web worker https://github.com/hemilabs/ui-monorepo/issues/486 */}
       <WithdrawalsStateUpdater />
       {children}
       {/* Sync the transaction history per chain in the background */}

--- a/webapp/context/tunnelHistoryContext/syncHistoryWorker.tsx
+++ b/webapp/context/tunnelHistoryContext/syncHistoryWorker.tsx
@@ -25,11 +25,16 @@ export const SyncHistoryWorker = function ({
   const workerRef = useRef<AppToWebWorker>(null)
   const [workerLoaded, setWorkerLoaded] = useState(false)
 
+  // This must be done here because there's some weird issue when moving it into a custom hook that prevents
+  // the worker from being loaded. It seems that by loading this component dynamically (Which we do), it doesn't get blocked
+  // as a different origin when running in localhost. When loading statically from a hook, the error
+  // Failed to construct 'Worker': Script at 'cannot be accessed from origin localhost
+  // is logged
   useEffect(
     function initWorker() {
       // load the Worker
       workerRef.current = new Worker(
-        new URL(`../../workers/history.ts`, import.meta.url),
+        new URL('../../workers/history.ts', import.meta.url),
       )
 
       // listen for state updates and forward to our history reducer

--- a/webapp/workers/watchEvmWithdrawals.ts
+++ b/webapp/workers/watchEvmWithdrawals.ts
@@ -1,0 +1,202 @@
+import { MessageStatus } from '@eth-optimism/sdk'
+import debugConstructor from 'debug'
+import PQueue from 'p-queue'
+import pMemoize from 'promise-mem'
+import { RemoteChain } from 'types/chain'
+import {
+  type ToEvmWithdrawOperation,
+  type WithdrawTunnelOperation,
+} from 'types/tunnel'
+import { findChainById } from 'utils/chain'
+import { createQueuedCrossChainMessenger } from 'utils/crossChainMessenger'
+import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
+import { createPublicProvider } from 'utils/providers'
+import { type Chain, type Hash } from 'viem'
+
+const queue = new PQueue({ concurrency: 2 })
+
+const debug = debugConstructor('watch-evm-withdrawals-worker')
+
+export const getUpdateWithdrawalKey = (withdrawal: WithdrawTunnelOperation) =>
+  `update-withdrawal-${withdrawal.l2ChainId}-${withdrawal.transactionHash}` as const
+
+type EnableDebug = { type: 'enable-debug'; payload: string }
+type WatchWithdrawal = {
+  type: 'watch-withdrawal'
+  withdrawal: ToEvmWithdrawOperation
+}
+
+type AppToWebWorkerActions = EnableDebug | WatchWithdrawal
+
+export type AppToWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  postMessage: (message: AppToWebWorkerActions) => void
+}
+
+// Worker is typed with "any", so force type safety for the messages
+// (as in runtime all types are stripped, this will continue to work)
+type WatchEvmWithdrawalsWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  onmessage: (event: MessageEvent<AppToWebWorkerActions>) => void
+  postMessage: (event: {
+    type: `update-withdrawal-${RemoteChain['id']}-${Hash}`
+    updates: Partial<ToEvmWithdrawOperation>
+  }) => void
+}
+
+// See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
+const worker = self as unknown as WatchEvmWithdrawalsWorker
+
+// See https://www.npmjs.com/package/p-queue#priority
+const getPriority = function (withdrawal: ToEvmWithdrawOperation) {
+  // prioritize those with missing vital information
+  if (!withdrawal.timestamp || withdrawal.status === undefined) {
+    return 2
+  }
+  if (
+    [MessageStatus.READY_TO_PROVE, MessageStatus.READY_FOR_RELAY].includes(
+      withdrawal.status,
+    )
+  ) {
+    return 1
+  }
+  return 0
+}
+
+const getBlockTimestamp = (withdrawal: ToEvmWithdrawOperation) =>
+  async function (
+    blockNumber: number | undefined,
+  ): Promise<[number?, number?]> {
+    // Can't return a block if we don't know the number
+    if (blockNumber === undefined) {
+      return []
+    }
+    // Block and timestamp already known - return them
+    if (withdrawal.timestamp) {
+      return [blockNumber, withdrawal.timestamp]
+    }
+    const { timestamp } = await getEvmBlock(blockNumber, withdrawal.l2ChainId)
+    return [blockNumber, Number(timestamp)]
+  }
+
+const getTransactionBlockNumber = function (
+  withdrawal: ToEvmWithdrawOperation,
+) {
+  if (withdrawal.blockNumber) {
+    return Promise.resolve(withdrawal.blockNumber)
+  }
+  return getEvmTransactionReceipt(
+    withdrawal.transactionHash,
+    withdrawal.l2ChainId,
+  ).then(transactionReceipt =>
+    // return undefined if TX is not found - might have not been confirmed yet
+    transactionReceipt ? Number(transactionReceipt.blockNumber) : undefined,
+  )
+}
+
+// Memoized cross chain messenger as this will be created by many withdrawals
+const getCrossChainMessenger = pMemoize(
+  function (l1Chain: Chain, l2Chain: Chain) {
+    const l1Provider = createPublicProvider(
+      l1Chain.rpcUrls.default.http[0],
+      l1Chain,
+    )
+
+    const l2Provider = createPublicProvider(
+      l2Chain.rpcUrls.default.http[0],
+      l2Chain,
+    )
+
+    debug(
+      'Creating cross chain messenger for L1 %s and L2 %s',
+      l1Chain.id,
+      l2Chain.id,
+    )
+
+    return createQueuedCrossChainMessenger({
+      l1ChainId: l1Chain.id,
+      l1Signer: l1Provider,
+      l2Chain,
+      l2Signer: l2Provider,
+    })
+  },
+  { resolver: (l1Chain, l2Chain) => `${l1Chain.id}-${l2Chain.id}` },
+)
+
+const watchWithdrawal = (withdrawal: ToEvmWithdrawOperation) =>
+  // Use a queue to avoid firing lots of requests. Throttling may also not work because it throttles
+  // for a specific period of time and depending on load, requests may take up to 5 seconds to complete
+  // so this let us to query up to <concurrency> checks for status at the same time
+  queue.add(
+    async function checkWithdrawalUpdates() {
+      // as this worker watches withdrawals to EVM chains, l1Chain will be (EVM) Chain
+      const l1Chain = findChainById(withdrawal.l1ChainId) as Chain
+      // L2 are always EVM
+      const l2Chain = findChainById(withdrawal.l2ChainId) as Chain
+
+      const crossChainMessenger = await getCrossChainMessenger(l1Chain, l2Chain)
+      debug('Checking withdrawal %s', withdrawal.transactionHash)
+      const [status, [blockNumber, timestamp]] = await Promise.all([
+        crossChainMessenger.getMessageStatus(
+          withdrawal.transactionHash,
+          // default value, but we want to set direction
+          0,
+          withdrawal.direction,
+        ),
+        getTransactionBlockNumber(withdrawal).then(
+          getBlockTimestamp(withdrawal),
+        ),
+      ])
+      const updates: Partial<ToEvmWithdrawOperation> = {}
+      if (withdrawal.status !== status) {
+        debug(
+          'Withdrawal %s status changed from %s to %s',
+          withdrawal.transactionHash,
+          withdrawal.status ?? 'none',
+          status,
+        )
+        updates.status = status
+      }
+      if (withdrawal.blockNumber !== blockNumber) {
+        debug(
+          'Saving block number %s for withdrawal %s',
+          blockNumber,
+          withdrawal.transactionHash,
+        )
+        updates.blockNumber = blockNumber
+      }
+      if (withdrawal.timestamp !== timestamp) {
+        debug(
+          'Saving timestamp %s for withdrawal %s',
+          timestamp,
+          withdrawal.transactionHash,
+        )
+        updates.timestamp = timestamp
+      }
+
+      if (Object.keys(updates).length > 0) {
+        debug('Sending changes for withdrawal %s', withdrawal.transactionHash)
+        worker.postMessage({
+          type: getUpdateWithdrawalKey(withdrawal),
+          updates,
+        })
+      } else {
+        debug('No changes for withdrawal %s', withdrawal.transactionHash)
+      }
+    },
+    {
+      // Give more priority to those that require polling and are not ready or are missing information
+      // because if ready, after the operation they will change their status automatically and will have
+      // the longest waiting period of all withdrawals, as the others have been waiting for longer
+      priority: getPriority(withdrawal),
+    },
+  )
+
+// wait for the UI to send chain and address once ready
+worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (e.data.type === 'watch-withdrawal') {
+    watchWithdrawal(e.data.withdrawal)
+  }
+  // See https://github.com/debug-js/debug/issues/916#issuecomment-1539231712
+  if (e.data.type === 'enable-debug') {
+    debugConstructor.enable(e.data.payload)
+  }
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR moves the code used to watch EVM withdrawals into a web worker. This way, this code can now run free of the UI.

#### How it worked

A simplified version on how it worked:

`WithdrawalsStateUpdater` was a UI-less component that filters the withdrawals to watch. Per withdrawal, it rendered `WatchEvmWithdrawal`, which inside would run a `useQuery` hook (the key was based on L2ChainId and the transaction hash), in which the `queryFn` (named `pollUpdateWithdrawal`) was added into a [p-queue queue](https://www.npmjs.com/package/p-queue) that was global to the module (the .ts file) to avoid multiple withdrawals firing at the same time. It would rely on `refetchInterval` from `useQuery` for polling. This implementation worked but had 2  downsides:

1. It had side effects in `queryFn` (which shouldn't be run on `useQuery`!!) to save the new states or missing info, if any.
2. It was forced to return _something_ because `useQuery` expects that the `queryFn` returns something (not `undefined`). Which made no sense as we wanted a side effect (getting a state, and saving it if needed) and not querying info. We did it this way to take advantage of the polling feature combined with the queue.

#### New implementation

`WithdrawalsStateUpdater` does the same, but it now only renders one component - `Watcher`. This component creates only one instance of a web worker (loaded from `webapp/workers/watchEvmWithdrawals.ts`), and, then passes this instance to `WatchEvmWithdrawal`, which is rendered per withdrawal.  
`WatchEvmWithdrawal` only sends messages every `N` seconds (Depending on the status of the withdrawal) to the worker, and listens for messages about updating changes.  
The logic to check the state was moved to `watchEvmWithdrawals.ts` and hasn't really changed (it's almost the same as what it was in `pollUpdateWithdrawal`, but we now don't need to return any value). The queue is now part of the worker.
If the user is disconnected or connects to an unsupported chain, the worker unmounts. The logic in `watchEvmWithdrawals` now doesn't depend of the UI (and runs in a different thread)

I had some issues with the worker creation, so that's why I wasn't able to generalize it into something like `useWorker` (Particularly, the effect `initWorker` is almost a duplicate of the one used to sync history). As I still need to move more code into workers (like watching Bitcoin stuff, and deposits), there is room for improvement, once I find the appropriate abstraction.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible change for the user

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #486

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
