### PR TITLE
Improve user input validation

### DIFF
--- a/webapp/utils/notJoi.ts
+++ b/webapp/utils/notJoi.ts
@@ -1,0 +1,35 @@
+// Super lightweight partial re-implementation of joi.
+
+const notJoi = {
+  number() {
+    const positiveFixedPointNumberRx = /^(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))$/
+    return {
+      // This function exists just to match joi's API
+      positive() {
+        // Do nothing as we are matching against `positiveFixedPointNumberRx`
+        return this
+      },
+      // This function exists just to match joi's API
+      unsafe() {
+        // Do nothing as we are coercing the input to `Number` in `validate()`
+        return this
+      },
+      validate(value) {
+        // Coerce from string
+        let _value = value.trim()
+        if (!_value.match(positiveFixedPointNumberRx)) {
+          return { error: 'Must be a positive number', value }
+        }
+        _value = Number.parseFloat(_value)
+        // Validate
+        if (_value === Infinity || isNaN(_value)) {
+          return { error: 'Must be a finite number', value }
+        }
+        // Validated!
+        return { value: _value }
+      },
+    }
+  },
+}
+
+export default notJoi


### PR DESCRIPTION
Addresses the first comment in #702 by improving the validation of the number inputs.

Given that `joi` is a large and complex library, I just extracted the important bits out of it and created `not-joi`, keeping the API so we can swap it for the full library in the future if needed. And yes, doing so was not needed at all, I did that for fun.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #702

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
