### PR TITLE
Detect tunnel op depending on connected wallet

### DIFF
--- a/webapp/app/[locale]/_components/header.tsx
+++ b/webapp/app/[locale]/_components/header.tsx
@@ -2,6 +2,7 @@ import { CloseIcon } from 'components/icons/closeIcon'
 import { HamburgerIcon } from 'components/icons/hamburgerIcon'
 import { Link } from 'components/link'
 import { TunnelTabs } from 'components/tunnelTabs'
+import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
 import dynamic from 'next/dynamic'
 import { HemiSymbol } from 'ui-common/components/hemiLogo'
 
@@ -19,27 +20,30 @@ type Props = {
   toggleMenu: () => void
 }
 
-export const Header = ({ isMenuOpen, toggleMenu }: Props) => (
-  <header
-    className="md:h-17 md:py-4.5 flex h-14 items-center border-b border-solid
+export const Header = function ({ isMenuOpen, toggleMenu }: Props) {
+  const href = useTunnelOperationByConnectedWallet()
+  return (
+    <header
+      className="md:h-17 md:py-4.5 flex h-14 items-center border-b border-solid
      border-neutral-300/55 bg-white px-3 py-3 md:bg-transparent md:px-0"
-  >
-    <div className="h-6 w-6 md:hidden">
-      <Link href="/tunnel">
-        <HemiSymbol />
-      </Link>
-    </div>
-    <div className="hidden pl-6 md:block">
-      <TunnelTabs />
-    </div>
-    <WalletConnection />
-    <button
-      className="flex h-8 w-8 cursor-pointer items-center
-      justify-center rounded-lg border border-neutral-300/55 md:hidden"
-      onClick={toggleMenu}
-      type="button"
     >
-      {isMenuOpen ? <CloseIcon /> : <HamburgerIcon />}
-    </button>
-  </header>
-)
+      <div className="h-6 w-6 md:hidden">
+        <Link href={href}>
+          <HemiSymbol />
+        </Link>
+      </div>
+      <div className="hidden pl-6 md:block">
+        <TunnelTabs />
+      </div>
+      <WalletConnection />
+      <button
+        className="flex h-8 w-8 cursor-pointer items-center
+      justify-center rounded-lg border border-neutral-300/55 md:hidden"
+        onClick={toggleMenu}
+        type="button"
+      >
+        {isMenuOpen ? <CloseIcon /> : <HamburgerIcon />}
+      </button>
+    </header>
+  )
+}

--- a/webapp/app/[locale]/_components/navbar/_components/navItem.tsx
+++ b/webapp/app/[locale]/_components/navbar/_components/navItem.tsx
@@ -98,9 +98,14 @@ const ItemText = ({
   </span>
 )
 
-type ItemLinkProps = Props & Required<Pick<ComponentProps<'a'>, 'href'>>
+type ItemLinkProps = Props & Required<Pick<ComponentProps<typeof Link>, 'href'>>
 
-const ExternalLink = function ({ event, href, icon, text }: ItemLinkProps) {
+const ExternalLink = function ({
+  event,
+  href,
+  icon,
+  text,
+}: Omit<ItemLinkProps, 'href'> & Pick<ComponentProps<'a'>, 'href'>) {
   const [networkType] = useNetworkType()
   const { track } = useUmami()
   const addTracking = () =>
@@ -149,10 +154,11 @@ const PageLink = function ({
 }
 
 export const ItemLink = (props: ItemLinkProps) =>
-  isRelativeUrl(props.href) ? (
-    <PageLink {...props} />
-  ) : (
+  typeof props.href === 'string' && !isRelativeUrl(props.href) ? (
+    // @ts-expect-error Typescript fails to detect that props.href must be a string
     <ExternalLink {...props} />
+  ) : (
+    <PageLink {...props} />
   )
 
 export const ItemWithSubmenu = function ({

--- a/webapp/app/[locale]/_components/navbar/index.tsx
+++ b/webapp/app/[locale]/_components/navbar/index.tsx
@@ -10,6 +10,7 @@ import { PoPMinerIcon } from 'components/icons/popMinerIcon'
 import { ToolsIcon } from 'components/icons/toolsIcon'
 import { TunnelIcon } from 'components/icons/tunnelIcon'
 import { Link } from 'components/link'
+import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import React, { Suspense } from 'react'
@@ -36,11 +37,13 @@ const Separator = () => (
 export const Navbar = function () {
   const t = useTranslations('navbar')
 
+  const href = useTunnelOperationByConnectedWallet()
+
   return (
     <div className="md:h-98vh flex h-[calc(100dvh-56px)] flex-col px-3 pt-3 md:pt-0 [&>*]:md:ml-4 [&>*]:md:pr-4">
       <div className="hidden h-24 items-center justify-center md:flex">
         <div className="flex h-1/3 w-1/3">
-          <Link className="w-full" href="/tunnel">
+          <Link className="w-full" href={href}>
             <HemiLogoFull />
           </Link>
         </div>
@@ -49,7 +52,7 @@ export const Navbar = function () {
         <li className="order-1">
           <ItemLink
             event="nav - tunnel"
-            href="/tunnel"
+            href={href}
             icon={<TunnelIcon />}
             rightSection={
               <div className="ml-auto">

--- a/webapp/app/[locale]/get-started/_components/startUsingHemi.tsx
+++ b/webapp/app/[locale]/get-started/_components/startUsingHemi.tsx
@@ -1,10 +1,11 @@
 import { useUmami } from 'app/analyticsEvents'
 import { Card } from 'components/card'
 import { useNetworkType } from 'hooks/useNetworkType'
+import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
 import Image, { StaticImageData } from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useLocale, useTranslations } from 'next-intl'
-import { isRelativeUrl } from 'utils/url'
+import { isRelativeUrl, queryStringObjectToString } from 'utils/url'
 
 import deployContracts from '../_assets/deployContracts.png'
 import swapTokensMainnet from '../_assets/swapTokens-mainnet.png'
@@ -68,6 +69,7 @@ export const StartUsingHemi = function () {
   const [networkType] = useNetworkType()
   const locale = useLocale()
   const t = useTranslations('get-started')
+  const href = useTunnelOperationByConnectedWallet()
 
   return (
     <Section
@@ -82,7 +84,10 @@ export const StartUsingHemi = function () {
           alt="Tunnel form"
           event="tut - tunnel assets"
           heading={t('tunnel-assets')}
-          href={`/${locale}/tunnel`}
+          href={`/${locale}${href.pathname}${queryStringObjectToString({
+            ...href.query,
+            networkType,
+          })}`}
           image={tunnelAssets}
           subheading={t('learn-about-tunneling')}
         />

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/callToAction.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/callToAction.tsx
@@ -3,20 +3,13 @@ import { NetworkType } from 'hooks/useNetworkType'
 import { usePathname } from 'next/navigation'
 import { useLocale } from 'next-intl'
 import { ComponentProps } from 'react'
+import { queryStringObjectToString } from 'utils/url'
 
 import { useTunnelOperation } from '../../_hooks/useTunnelOperation'
 
 type QueryStringOptions = {
   networkType: NetworkType
   txHash: string
-}
-
-const getCallToActionQueryString = function (options: QueryStringOptions) {
-  const searchParams = new URLSearchParams()
-  Object.entries(options).forEach(([key, value]) =>
-    searchParams.append(key, value),
-  )
-  return `?${searchParams.toString()}`
 }
 
 type Props = QueryStringOptions & { text: string } & Required<
@@ -32,7 +25,7 @@ export const CallToAction = function ({
   const pathname = usePathname().replace(`/${locale}`, '')
   const { updateTxHash } = useTunnelOperation()
 
-  const queryString = getCallToActionQueryString(queryStringOptions)
+  const queryString = queryStringObjectToString(queryStringOptions)
   const href = `${pathname}${queryString}`
   return (
     <ButtonLink

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/noTransactions.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/noTransactions.tsx
@@ -1,4 +1,5 @@
 import { ButtonLink } from 'components/button'
+import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
 import { useTranslations } from 'next-intl'
 
 import { EmptyState } from './emptyState'
@@ -48,9 +49,10 @@ const InboxIcon = () => (
 
 export const NoTransactions = function () {
   const t = useTranslations('tunnel-page.transaction-history')
+  const href = useTunnelOperationByConnectedWallet()
   return (
     <EmptyState
-      action={<ButtonLink href="/tunnel">{t('tunnel-assets')}</ButtonLink>}
+      action={<ButtonLink href={href}>{t('tunnel-assets')}</ButtonLink>}
       icon={<InboxIcon />}
       subtitle={t('no-transactions-get-started')}
       title={t('no-transactions')}

--- a/webapp/components/button.tsx
+++ b/webapp/components/button.tsx
@@ -27,7 +27,7 @@ type Variant = {
 type ButtonProps = ComponentProps<'button'> & Variant & Height
 
 type ButtonLinkProps = Omit<ComponentProps<'a'>, 'href' | 'ref'> &
-  Required<Pick<ComponentProps<'a'>, 'href'>> &
+  Required<Pick<ComponentProps<typeof Link>, 'href'>> &
   Variant
 
 export const Button = ({ height = 'h-8', variant, ...props }: ButtonProps) => (
@@ -40,8 +40,17 @@ export const Button = ({ height = 'h-8', variant, ...props }: ButtonProps) => (
 export const ButtonLink = function ({ variant, ...props }: ButtonLinkProps) {
   const className = `${commonCss} px-2 ${variants[variant ?? 'primary']}`
 
-  if (!props.href || !isRelativeUrl(props.href)) {
-    return <ExternalLink className={className} {...props} />
+  if (
+    !props.href ||
+    (typeof props.href === 'string' && !isRelativeUrl(props.href))
+  ) {
+    return (
+      <ExternalLink
+        className={className}
+        {...props}
+        href={props.href as string | undefined}
+      />
+    )
   }
   return <Link className={className} {...props} />
 }

--- a/webapp/components/tabs.tsx
+++ b/webapp/components/tabs.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { Link } from 'components/link'
-import { MouseEvent, ReactNode } from 'react'
+import { type ComponentProps, type MouseEvent, type ReactNode } from 'react'
 
 type Button = { onClick?: (e: MouseEvent<HTMLButtonElement>) => void }
 type Anchor = {
-  href: string
+  href: ComponentProps<typeof Link>['href']
   onClick?: (e: MouseEvent<HTMLAnchorElement>) => void
 }
 

--- a/webapp/components/tunnelTabs.tsx
+++ b/webapp/components/tunnelTabs.tsx
@@ -3,6 +3,7 @@
 import { type AnalyticsEventsWithChain } from 'app/analyticsEvents'
 import { Tab, Tabs } from 'components/tabs'
 import { useNetworkType } from 'hooks/useNetworkType'
+import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
 import { useUmami } from 'hooks/useUmami'
 import dynamic from 'next/dynamic'
 import { usePathname } from 'next/navigation'
@@ -24,6 +25,8 @@ const TunnelTabsImpl = function () {
   const t = useTranslations('tunnel-page')
   const { track } = useUmami()
 
+  const tunnelHref = useTunnelOperationByConnectedWallet()
+
   if (!pathname.startsWith(`/${locale}/tunnel/`)) {
     return null
   }
@@ -38,7 +41,7 @@ const TunnelTabsImpl = function () {
     <div className="flex items-center justify-center gap-x-4">
       <Tabs>
         <Tab
-          href="/tunnel"
+          href={tunnelHref}
           onClick={addTracking('header - tunnel')}
           selected={pathname === `/${locale}/tunnel/`}
         >

--- a/webapp/hooks/useTunnelOperationByConnectedWallet.ts
+++ b/webapp/hooks/useTunnelOperationByConnectedWallet.ts
@@ -1,0 +1,34 @@
+import { featureFlags } from 'app/featureFlags'
+import { isL2NetworkId } from 'utils/chain'
+
+import { useAccounts } from './useAccounts'
+import { useBitcoin } from './useBitcoin'
+import { useChainIsSupported } from './useChainIsSupported'
+
+/**
+ * Returns the appropriate tunnel operation depending on the wallet the user is
+ * connected to in the query string object.
+ * If the user is connected to an L1, returns "deposit".
+ * If the user is connected to an L2, returns "withdraw", unless it is also connected to bitcoin.
+ * If the user is connected to an unsupported chain, no query string is returned
+ */
+export const useTunnelOperationByConnectedWallet = function () {
+  const bitcoin = useBitcoin()
+  const { btcChainId, evmChainId } = useAccounts()
+
+  const isSupported = useChainIsSupported(evmChainId)
+
+  if (!isSupported) {
+    return { pathname: '/tunnel' }
+  }
+
+  if (!isL2NetworkId(evmChainId)) {
+    return { pathname: '/tunnel', query: { operation: 'deposit' } }
+  }
+  // here we are connected to hemi.
+  // It means that the valid operations are either a withdraw, or a bitcoin deposit (if we're connected to a btc wallet)
+  if (!featureFlags.btcTunnelEnabled || bitcoin.id !== btcChainId) {
+    return { pathname: '/tunnel', query: { operation: 'withdraw' } }
+  }
+  return { pathname: '/tunnel', query: { operation: 'deposit' } }
+}

--- a/webapp/utils/chain.ts
+++ b/webapp/utils/chain.ts
@@ -11,8 +11,10 @@ export const findChainById = (chainId: RemoteChain['id']) =>
 export const isEvmNetwork = (chain: RemoteChain): chain is EvmChain =>
   typeof chain.id === 'number'
 
-export const isL2Network = (chain: Chain) =>
-  [hemiMainnet.id, hemiTestnet.id].includes(chain.id)
+export const isL2NetworkId = (chainId: number) =>
+  [hemiMainnet.id, hemiTestnet.id].includes(chainId)
+
+export const isL2Network = (chain: Chain) => isL2NetworkId(chain.id)
 
 export const overrideRpcUrl = function (chain: Chain, rpcUrl?: string) {
   const isValidCustomSepoliaRpc = !!rpcUrl && rpcUrl.startsWith('https')

--- a/webapp/utils/url.ts
+++ b/webapp/utils/url.ts
@@ -1,1 +1,14 @@
 export const isRelativeUrl = (url: string) => url.startsWith('/')
+
+export const queryStringObjectToString = function (
+  queryString: Record<string, string> = {},
+) {
+  if (Object.keys(queryString).length === 0) {
+    return ''
+  }
+  const searchParams = new URLSearchParams()
+  Object.entries(queryString).forEach(([key, value]) =>
+    searchParams.append(key, value),
+  )
+  return `?${searchParams.toString()}`
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR changes the relative links in the app that target the `/tunnel` page. Now, we will check if the wallet is connected to an L1 or L2 URL. If so, it will set the appropriate operation (deposit or withdrawal, depending on which one is connected).

For unsupported chains, it will resolve to `deposit.`

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/56b4e79d-51b0-4e0c-b96f-dce3719eb758

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #704

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
