### PR TITLE
Fix incorrrect display of btc fees on deposit

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewBtcDeposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewBtcDeposit.tsx
@@ -7,7 +7,7 @@ import { useContext } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { type BtcToken } from 'types/token'
 import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
-import { formatGasFees, getFormattedValue } from 'utils/format'
+import { formatGasFees } from 'utils/format'
 import { useAccount } from 'wagmi'
 
 import {
@@ -96,7 +96,7 @@ const ReviewContent = function ({
           BtcDepositStatus.DEPOSIT_TX_FAILED,
         ].includes(depositStatus) && feePrices?.fastestFee
           ? {
-              amount: getFormattedValue(feePrices?.fastestFee?.toString()),
+              amount: feePrices?.fastestFee?.toString(),
               symbol: 'sat/vB',
             }
           : undefined,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The component where fees are then sent already executed internally `getFormattedValue`. Then, `NaN` was produced by the double call of `getFormattedValue` of the fees string.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

![image](https://github.com/user-attachments/assets/5c0afdff-2362-4fc5-bc13-b836d595ff52)


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #703 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
