### PR TITLE
Add one utility and a few tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,6 +51,10 @@
       }
     },
     {
+      "extends": ["bloq/vitest"],
+      "files": ["*.test.ts"]
+    },
+    {
       "extends": ["bloq/markdown"],
       "files": ["*.md"],
       "rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "chai": "4.4.1",
         "commitlint-config-bloq": "1.1.0",
         "eslint": "8.57.0",
-        "eslint-config-bloq": "4.3.0",
+        "eslint-config-bloq": "4.4.1",
         "husky": "9.1.6",
         "lerna": "8.1.2",
         "lint-staged": "15.2.10",
@@ -1065,6 +1065,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1081,6 +1082,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1097,6 +1099,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1113,6 +1116,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1129,6 +1133,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1145,6 +1150,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1161,6 +1167,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1177,6 +1184,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1193,6 +1201,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1209,6 +1218,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1225,6 +1235,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1241,6 +1252,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1257,6 +1269,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1273,6 +1286,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1289,6 +1303,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1305,6 +1320,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1321,6 +1337,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1337,6 +1354,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1353,6 +1371,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1369,6 +1388,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1385,6 +1405,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1401,6 +1422,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1417,6 +1439,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5348,6 +5371,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -5361,6 +5385,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -5374,6 +5399,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -5387,6 +5413,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -5400,6 +5427,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5413,6 +5441,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5426,6 +5455,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5439,6 +5469,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5452,6 +5483,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5465,6 +5497,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5478,6 +5511,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5491,6 +5525,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5504,6 +5539,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5517,6 +5553,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5530,6 +5567,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5543,6 +5581,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7396,6 +7435,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@vanilla-extract/css": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.18.tgz",
+      "integrity": "sha512-pcnR0hn4KRaWqdEXdZPXLs2wAxzMBD8dKkpVkOuhT+bOOGW1/4BdiUrU3I0LW2loskfVS/XldwcO/lCEoFDyZw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/utils": ">= 8.0",
+        "eslint": ">= 8.57.0",
+        "typescript": ">= 5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -11392,8 +11452,7 @@
     "node_modules/es-module-lexer": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
-      "peer": true
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.0.2",
@@ -11545,13 +11604,15 @@
       }
     },
     "node_modules/eslint-config-bloq": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-bloq/-/eslint-config-bloq-4.3.0.tgz",
-      "integrity": "sha512-2j8fL3BT+29PjTDORz2n0aC4O3Dza1Igy8XNsbaxmSaNvRq9a8oGsJH5fFGXZdESoerFQHGIO2tRTi6o6I9Dpg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-bloq/-/eslint-config-bloq-4.4.1.tgz",
+      "integrity": "sha512-LnNd+2kwkZCZmQVfGXz6pd3K5OGvElRJgWmmno5vNCQ48Ek/h3q90hZHRq/717QjO8tduIJ28ddI4IbaRu0e5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.11.0",
         "@typescript-eslint/parser": "^8.11.0",
+        "@vitest/eslint-plugin": "^1.1.7",
         "eslint-config-next": "^13.0.0",
         "eslint-config-prettier": "^8.0.0",
         "eslint-plugin-import": "^2.0.0",
@@ -12641,6 +12702,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -16768,9 +16839,10 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/magic-string": {
-      "version": "0.30.11",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -22388,9 +22460,10 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg=="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+      "license": "MIT"
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
@@ -22939,10 +23012,11 @@
       "dev": true
     },
     "node_modules/tinypool": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.0.tgz",
-      "integrity": "sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
@@ -22957,10 +23031,11 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.0.tgz",
-      "integrity": "sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25023,7 +25098,8 @@
         "qrcode-terminal": "0.12.0",
         "serve": "14.2.4",
         "tailwindcss": "3.4.14",
-        "typescript": "5.6.3"
+        "typescript": "5.6.3",
+        "vitest": "2.1.8"
       },
       "engines": {
         "node": ">=16"
@@ -25036,6 +25112,102 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "webapp/node_modules/@vitest/expect": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "webapp/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "webapp/node_modules/@vitest/runner": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.8",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "webapp/node_modules/@vitest/snapshot": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "webapp/node_modules/@vitest/spy": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "webapp/node_modules/@vitest/utils": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "webapp/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "webapp/node_modules/camelcase": {
@@ -25066,6 +25238,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "webapp/node_modules/chai": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "webapp/node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "webapp/node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -25081,6 +25280,23 @@
           "optional": true
         }
       }
+    },
+    "webapp/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "webapp/node_modules/loupe": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "webapp/node_modules/map-obj": {
       "version": "5.0.0",
@@ -25122,6 +25338,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "webapp/node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "webapp/node_modules/postcss": {
@@ -25188,6 +25414,122 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "webapp/node_modules/vite-node": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "webapp/node_modules/vitest": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.8",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "webapp/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chai": "4.4.1",
     "commitlint-config-bloq": "1.1.0",
     "eslint": "8.57.0",
-    "eslint-config-bloq": "4.3.0",
+    "eslint-config-bloq": "4.4.1",
     "husky": "9.1.6",
     "lerna": "8.1.2",
     "lint-staged": "15.2.10",

--- a/webapp/hooks/useL2Bridge.ts
+++ b/webapp/hooks/useL2Bridge.ts
@@ -12,6 +12,7 @@ import {
   type CrossChainMessengerProxy,
   createIsolatedCrossChainMessenger,
 } from 'utils/crossChainMessenger'
+import { hasKeys } from 'utils/utilities'
 import { type Chain, type Hash, checksumAddress, isHash } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -122,7 +123,7 @@ const useEstimateGasFees = function <T extends GasEstimationOperations>({
       enabled &&
       isConnectedToExpectedChain &&
       crossChainMessengerStatus === 'success' &&
-      Object.keys(crossChainMessenger.estimateGas).length > 0,
+      hasKeys(crossChainMessenger.estimateGas),
     async queryFn() {
       if (hardcodedOps.includes(operation) && hemi.testnet) {
         // See https://github.com/hemilabs/ui-monorepo/issues/539

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -9,7 +9,8 @@
     "dev:wifi": "WIFI=true LOCAL_IP=$(ipconfig getifaddr en0) PORT=3000 npm run dev",
     "generate:htaccess": "node ./scripts/generateHeaders.js",
     "preserve": "npm run build",
-    "serve": "serve out"
+    "serve": "serve out",
+    "test": "vitest run"
   },
   "dependencies": {
     "@eth-optimism/sdk": "3.2.1",
@@ -65,7 +66,8 @@
     "qrcode-terminal": "0.12.0",
     "serve": "14.2.4",
     "tailwindcss": "3.4.14",
-    "typescript": "5.6.3"
+    "typescript": "5.6.3",
+    "vitest": "2.1.8"
   },
   "engines": {
     "node": ">=16"

--- a/webapp/test/utils/chain.test.ts
+++ b/webapp/test/utils/chain.test.ts
@@ -1,0 +1,27 @@
+import { bitcoinTestnet } from 'btc-wallet/chains'
+import { hemiSepolia } from 'hemi-viem'
+import { isL2Network, isEvmNetwork } from 'utils/chain'
+import { sepolia } from 'viem/chains'
+import { describe, expect, it } from 'vitest'
+
+describe('utils/chain', function () {
+  describe('isL2Network()', function () {
+    it('should return false if the chain is an L1', function () {
+      expect(isL2Network(sepolia)).toBe(false)
+    })
+
+    it('should return true if the chain is hemi', function () {
+      expect(isL2Network(hemiSepolia)).toBe(true)
+    })
+  })
+
+  describe('isEvmNetwork()', function () {
+    it('should return false if the chain is not evm compatible', function () {
+      expect(isEvmNetwork(bitcoinTestnet)).toBe(false)
+    })
+
+    it('should return true if the chain is evm compatible', function () {
+      expect(isEvmNetwork(sepolia)).toBe(true)
+    })
+  })
+})

--- a/webapp/test/utils/format.test.ts
+++ b/webapp/test/utils/format.test.ts
@@ -1,0 +1,30 @@
+import {
+  formatBtcAddress,
+  formatEvmAddress,
+  getFormattedValue,
+} from 'utils/format'
+import { describe, expect, it } from 'vitest'
+
+describe('utils/format', function () {
+  describe('formatBtcAddress', function () {
+    it('should format a btc address correctly', function () {
+      expect(
+        formatBtcAddress('bc1qcup4k9q7j0gsjfcv2nqfeu88wjcs9wv0jfuu56'),
+      ).toBe('bc1qc...fuu56')
+    })
+  })
+
+  describe('formatEvmAddress', function () {
+    it('should format an evm address correctly', function () {
+      expect(
+        formatEvmAddress('0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263'),
+      ).toBe('0x4675...a263')
+    })
+  })
+
+  describe('getFormattedValue', function () {
+    it('should return "< 0.001" if the value is less than that', function () {
+      expect(getFormattedValue('0.00001')).toBe('< 0.001')
+    })
+  })
+})

--- a/webapp/test/utils/url.test.ts
+++ b/webapp/test/utils/url.test.ts
@@ -1,0 +1,30 @@
+import { isRelativeUrl, queryStringObjectToString } from 'utils/url'
+import { describe, expect, it } from 'vitest'
+
+describe('utils/url', function () {
+  describe('isRelativeUrl', function () {
+    it('should return true for relative urls', function () {
+      expect(isRelativeUrl('/test')).toBe(true)
+    })
+
+    it('should return false for full urls', function () {
+      expect(isRelativeUrl('https://google.com.ar/')).toBe(false)
+    })
+  })
+
+  describe('queryStringObjectToString', function () {
+    it('should return an empty string when no value is provided', function () {
+      expect(queryStringObjectToString()).toBe('')
+    })
+
+    it('should return an empty string for an empty object', function () {
+      expect(queryStringObjectToString({})).toBe('')
+    })
+
+    it('should return a query string for an object', function () {
+      expect(queryStringObjectToString({ a: 'b', c: 'd', e: '3' })).toBe(
+        '?a=b&c=d&e=3',
+      )
+    })
+  })
+})

--- a/webapp/test/utils/utilities.test.ts
+++ b/webapp/test/utils/utilities.test.ts
@@ -1,0 +1,14 @@
+import { hasKeys } from 'utils/utilities'
+import { describe, expect, it } from 'vitest'
+
+describe('utils/utilities', function () {
+  describe('hasKeys()', function () {
+    it('returns false for an empty object', function () {
+      expect(hasKeys({})).toBe(false)
+    })
+
+    it('returns true for an object with keys', function () {
+      expect(hasKeys({ a: 1 })).toBe(true)
+    })
+  })
+})

--- a/webapp/utils/url.ts
+++ b/webapp/utils/url.ts
@@ -1,9 +1,11 @@
+import { hasKeys } from './utilities'
+
 export const isRelativeUrl = (url: string) => url.startsWith('/')
 
 export const queryStringObjectToString = function (
   queryString: Record<string, string> = {},
 ) {
-  if (Object.keys(queryString).length === 0) {
+  if (!hasKeys(queryString)) {
     return ''
   }
   const searchParams = new URLSearchParams()

--- a/webapp/utils/utilities.ts
+++ b/webapp/utils/utilities.ts
@@ -1,0 +1,2 @@
+export const hasKeys = (obj: Record<string, unknown>) =>
+  Object.keys(obj).length > 0

--- a/webapp/workers/watchEvmWithdrawals.ts
+++ b/webapp/workers/watchEvmWithdrawals.ts
@@ -11,6 +11,7 @@ import { findChainById } from 'utils/chain'
 import { createQueuedCrossChainMessenger } from 'utils/crossChainMessenger'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import { createPublicProvider } from 'utils/providers'
+import { hasKeys } from 'utils/utilities'
 import { type Chain, type Hash } from 'viem'
 
 const queue = new PQueue({ concurrency: 2 })
@@ -172,7 +173,7 @@ const watchWithdrawal = (withdrawal: ToEvmWithdrawOperation) =>
         updates.timestamp = timestamp
       }
 
-      if (Object.keys(updates).length > 0) {
+      if (hasKeys(updates)) {
         debug('Sending changes for withdrawal %s', withdrawal.transactionHash)
         worker.postMessage({
           type: getUpdateWithdrawalKey(withdrawal),


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

As part of solving https://github.com/hemilabs/ui-monorepo/issues/487, I added a utility and some tests, so I decided to split that into its own PR. This PR adds vitest (no config and just works ⚡ ), updates `eslint-config-bloq` to be able to use `bloq/vitest`) and (finally!) adds a few tests. I hope from here to add more tests to the non-ui parts

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to the user

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to https://github.com/hemilabs/ui-monorepo/issues/487

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
