### PR TITLE
Watch bitcoin deposits worker

### DIFF
--- a/webapp/components/withWorker.tsx
+++ b/webapp/components/withWorker.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { ReactNode, useEffect, useRef } from 'react'
+
+type Props<T> = {
+  children: (workerRef: T) => ReactNode
+  getWorker: () => T
+}
+
+export const WithWorker = function <T extends Worker>({
+  children,
+  getWorker,
+}: Props<T>) {
+  const workerRef = useRef<T>(null)
+
+  useEffect(
+    function initWorker() {
+      // load the Worker
+      workerRef.current = getWorker()
+
+      if (process.env.NEXT_PUBLIC_WORKERS_DEBUG_ENABLE === 'true') {
+        // See https://github.com/debug-js/debug/issues/916#issuecomment-1539231712
+        const debugString = localStorage.getItem('debug') ?? '*'
+        workerRef.current.postMessage({
+          payload: debugString,
+          type: 'enable-debug',
+        })
+      }
+
+      return function terminateWorker() {
+        if (!workerRef.current) {
+          return
+        }
+        workerRef.current.terminate()
+        workerRef.current = null
+      }
+    },
+    [getWorker, workerRef],
+  )
+
+  if (!workerRef.current) {
+    return null
+  }
+
+  return <>{children(workerRef.current)}</>
+}

--- a/webapp/context/tunnelHistoryContext/bitcoinDepositsStatusUpdater.tsx
+++ b/webapp/context/tunnelHistoryContext/bitcoinDepositsStatusUpdater.tsx
@@ -1,89 +1,14 @@
-import { useQuery } from '@tanstack/react-query'
 import { useBtcDeposits } from 'hooks/useBtcDeposits'
-import { useHemiClient } from 'hooks/useHemiClient'
+import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
-import PQueue from 'p-queue'
+import { useEffect, useRef } from 'react'
 import { BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
-import { getTransactionReceipt } from 'utils/btcApi'
-import { getHemiStatusOfBtcDeposit, getVaultAddressByDeposit } from 'utils/hemi'
-import { useAccount } from 'wagmi'
+import { hasKeys } from 'utils/utilities'
+import { useAccount as useEvmAccount } from 'wagmi'
+import { type AppToWorker, getDepositKey } from 'workers/watchBitcoinDeposits'
 
-// concurrently avoid overloading both blockchains
-const bitcoinQueue = new PQueue({ concurrency: 5 })
-const hemiQueue = new PQueue({ concurrency: 5 })
-
-const WatchBitcoinBlockchain = function ({
-  deposit,
-}: {
-  deposit: BtcDepositOperation
-}) {
-  const { updateDeposit } = useTunnelHistory()
-  useQuery({
-    // shouldn't be needed, but let's be safe and avoid extra requests
-    // if somehow deposits that are not pending end up here
-    enabled: deposit.status === BtcDepositStatus.TX_PENDING,
-    queryFn: () =>
-      bitcoinQueue.add(() =>
-        getTransactionReceipt(deposit.transactionHash).then(function (receipt) {
-          if (receipt.status.confirmed) {
-            updateDeposit(deposit, { status: BtcDepositStatus.TX_CONFIRMED })
-          }
-          return receipt.status.confirmed
-        }),
-      ),
-    queryKey: [
-      'btc-deposit-tx-status',
-      deposit.l1ChainId,
-      deposit.transactionHash,
-    ],
-    // every 30 seconds - once status changes, this component won't render anymore
-    // so this hook won't need to "refetch"
-    refetchInterval: 30 * 1000,
-  })
-  return null
-}
-
-const WatchHemiBlockchain = function ({
-  deposit,
-}: {
-  deposit: BtcDepositOperation
-}) {
-  const hemiClient = useHemiClient()
-  const { updateDeposit } = useTunnelHistory()
-
-  useQuery({
-    // shouldn't be needed, but let's be safe and avoid extra requests
-    // if somehow deposits that are not pending end up here
-    enabled: [
-      BtcDepositStatus.TX_CONFIRMED,
-      BtcDepositStatus.BTC_READY_CLAIM,
-    ].includes(deposit.status),
-    queryFn: () =>
-      hemiQueue.add(() =>
-        getVaultAddressByDeposit(hemiClient, deposit)
-          .then(vaultAddress =>
-            getHemiStatusOfBtcDeposit({
-              deposit,
-              hemiClient,
-              vaultAddress,
-            }),
-          )
-          .then(function (newStatus) {
-            if (deposit.status !== newStatus) {
-              updateDeposit(deposit, { status: newStatus })
-            }
-            return newStatus
-          }),
-      ),
-    queryKey: ['btc-deposit-hemi-tx-status', deposit.transactionHash],
-    // every 30 seconds - once status changes, this component won't render anymore
-    // so this hook won't need to "refetch"
-    refetchInterval: 30 * 1000,
-  })
-
-  return null
-}
-
+// put those undefined statuses first
+// but then sorted by timestamp (newest first)
 const byTimestampDesc = function (
   a: BtcDepositOperation,
   b: BtcDepositOperation,
@@ -94,46 +19,155 @@ const byTimestampDesc = function (
   return (a.status ?? -1) - (b.status ?? -1)
 }
 
+const WatchBtcDeposit = function ({
+  deposit,
+  worker,
+}: {
+  deposit: BtcDepositOperation
+  worker: AppToWorker
+}) {
+  const { updateDeposit } = useTunnelHistory()
+
+  useEffect(
+    function watchDepositUpdates() {
+      // Not using useState as 1. this value is local to the effect and
+      // 2. to avoid unsubscribing and resubscribing when the state value changes
+      let hasWorkedPostedBack = false
+      const saveUpdates = function (
+        event: MessageEvent<{
+          updates: Partial<BtcDepositOperation>
+          type: string
+        }>,
+      ) {
+        // This is needed because this component is rendered per-withdrawal, so each component will receive the posted message
+        // for every withdrawal, as there are many withdrawals but only one worker.
+        // Of all components, this "if" clause below will be true for only one rendered component - the one belonging to the withdrawal
+        const { type, updates } = event.data
+        if (type !== getDepositKey(deposit)) {
+          return
+        }
+        // next interval will poll again
+        hasWorkedPostedBack = true
+        if (hasKeys(updates)) {
+          updateDeposit(deposit, updates)
+        }
+      }
+
+      worker.addEventListener('message', saveUpdates)
+
+      // refetch every 30 seconds
+      const interval = 30 * 1000
+
+      let intervalId
+      // skip polling for disabled states (those whose interval is "false")
+      if (typeof interval === 'number') {
+        worker.postMessage({
+          deposit,
+          type: 'watch-btc-deposit',
+        })
+        intervalId = setInterval(function () {
+          if (!hasWorkedPostedBack) {
+            return
+          }
+          worker.postMessage({
+            deposit,
+            type: 'watch-btc-deposit',
+          })
+          // Block posting until a response is received
+          hasWorkedPostedBack = false
+        }, interval)
+      }
+
+      return function cleanup() {
+        worker.removeEventListener('message', saveUpdates)
+        if (intervalId) {
+          clearInterval(intervalId)
+        }
+      }
+    },
+    [deposit, updateDeposit, worker],
+  )
+
+  return null
+}
+
+const Watcher = function ({ deposits }: { deposits: BtcDepositOperation[] }) {
+  const workerRef = useRef<AppToWorker>(null)
+
+  // This must be done here because there's some weird issue when moving it into a custom hook that prevents
+  // the worker from being loaded. It seems that by loading this component dynamically (Which we do), it doesn't get blocked
+  // as a different origin when running in localhost. When loading statically from a hook, the error
+  // "Failed to construct 'Worker': Script at <path> cannot be accessed from origin localhost" is logged
+  useEffect(
+    function initWorker() {
+      // load the Worker
+      workerRef.current = new Worker(
+        new URL('../../workers/watchBitcoinDeposits.ts', import.meta.url),
+      )
+
+      if (process.env.NEXT_PUBLIC_WORKERS_DEBUG_ENABLE === 'true') {
+        // See https://github.com/debug-js/debug/issues/916#issuecomment-1539231712
+        const debugString = localStorage.getItem('debug') ?? '*'
+        workerRef.current.postMessage({
+          payload: debugString,
+          type: 'enable-debug',
+        })
+      }
+
+      return function terminateWorker() {
+        if (!workerRef.current) {
+          return
+        }
+        workerRef.current.terminate()
+        workerRef.current = null
+      }
+    },
+    [workerRef],
+  )
+
+  if (!workerRef.current) {
+    return null
+  }
+
+  // once the only worker is loaded, render these components that will post to the worker
+  // the deposits to watch on intervals
+  return (
+    <>
+      {deposits.map(deposit => (
+        <WatchBtcDeposit
+          deposit={deposit}
+          key={deposit.transactionHash}
+          worker={workerRef.current}
+        />
+      ))}
+    </>
+  )
+}
+
 export const BitcoinDepositsStatusUpdater = function () {
-  // Deposits are checked against Hemi network, but by being connected to any evm wallet
-  // we can retrieve the deposits, as they are made to an EVM address
-  const { isConnected } = useAccount()
+  // Deposits are checked against an hemi address
+  const { isConnected } = useEvmAccount()
   const deposits = useBtcDeposits()
 
-  if (!isConnected) {
+  const unsupportedChain = useConnectedToUnsupportedEvmChain()
+
+  if (!isConnected || unsupportedChain) {
     return null
   }
 
   // Here, btc transactions have not been confirmed, so we must check it
   // in the bitcoin blockchain
-  const depositsToWatchInBitcoin = deposits
-    .filter(deposit => deposit.status === BtcDepositStatus.TX_PENDING)
-    // put those undefined statuses first
-    // but then sorted by timestamp (newest first)
-    .sort(byTimestampDesc)
-
-  // Here, bitcoin transactions have been confirmed, so we must watch
-  // on the Hemi network for its status
-  const depositsToWatchInHemi = deposits
+  const depositsToWatch = deposits
     .filter(deposit =>
       [
+        // Unconfirmed btc transactions, to be watched  in the bitcoin blockchain
+        BtcDepositStatus.TX_PENDING,
+        // Btc transactions confirmed, to be watched in the hemi blockchain
         BtcDepositStatus.TX_CONFIRMED,
         BtcDepositStatus.BTC_READY_CLAIM,
       ].includes(deposit.status),
     )
     .sort(byTimestampDesc)
 
-  return (
-    <>
-      {depositsToWatchInBitcoin.map(deposit => (
-        <WatchBitcoinBlockchain
-          deposit={deposit}
-          key={deposit.transactionHash}
-        />
-      ))}
-      {depositsToWatchInHemi.map(deposit => (
-        <WatchHemiBlockchain deposit={deposit} key={deposit.transactionHash} />
-      ))}
-    </>
-  )
+  return <Watcher deposits={depositsToWatch} />
 }

--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -115,7 +115,6 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
 
   return (
     <TunnelHistoryContext.Provider value={context}>
-      {/* Move to web worker https://github.com/hemilabs/ui-monorepo/issues/487 */}
       {/* Track updates on bitcoin deposits, in bitcoin or in Hemi */}
       {featureFlags.btcTunnelEnabled && <BitcoinDepositsStatusUpdater />}
       {/* Track updates on withdrawals from Hemi */}

--- a/webapp/test/utils/watch/bitcoinDeposit.test.ts
+++ b/webapp/test/utils/watch/bitcoinDeposit.test.ts
@@ -1,0 +1,108 @@
+import { bitcoinTestnet } from 'btc-wallet/chains'
+import { hemiSepolia } from 'hemi-viem'
+import { publicClientToHemiClient } from 'hooks/useHemiClient'
+import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
+import { getTransactionReceipt } from 'utils/btcApi'
+import { getHemiStatusOfBtcDeposit, getVaultAddressByDeposit } from 'utils/hemi'
+import {
+  watchDepositOnBitcoin,
+  watchDepositOnHemi,
+} from 'utils/watch/bitcoinDeposits'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const vaultAddress = '0x0000000000000000000000000000000000000001' as const
+
+const deposit: BtcDepositOperation = {
+  amount: '100000000',
+  l1ChainId: bitcoinTestnet.id,
+  l2ChainId: hemiSepolia.id,
+  status: BtcDepositStatus.TX_PENDING,
+  transactionHash:
+    '4cabca8f8b711c9d6946d737034545879a964c374a193ef9bb15ec966b826a01',
+}
+
+const depositOnHemi = { ...deposit, status: BtcDepositStatus.TX_CONFIRMED }
+
+vi.mock('hooks/useHemiClient', () => ({
+  publicClientToHemiClient: vi.fn(),
+}))
+
+vi.mock('utils/btcApi', () => ({
+  getTransactionReceipt: vi.fn(),
+}))
+
+vi.mock('utils/hemi', () => ({
+  getHemiStatusOfBtcDeposit: vi.fn(),
+  getVaultAddressByDeposit: vi.fn(),
+}))
+
+describe('utils/watch/bitcoinDeposits', function () {
+  beforeEach(function () {
+    vi.clearAllMocks()
+  })
+
+  describe('watchDepositOnBitcoin', function () {
+    it('should not return changes if the receipt show it is still not confirmed', async function () {
+      vi.mocked(getTransactionReceipt).mockResolvedValue({
+        status: { confirmed: false },
+      })
+
+      const updates = await watchDepositOnBitcoin(deposit)
+
+      expect(updates).toEqual({})
+      expect(getTransactionReceipt).toHaveBeenCalledOnce()
+      expect(getTransactionReceipt).toHaveBeenCalledWith(
+        deposit.transactionHash,
+      )
+    })
+
+    it('should return the new status, timestamp and block height if the receipt shows confirmation', async function () {
+      const blockHeight = 123
+      const blockTime = 456
+      vi.mocked(getTransactionReceipt).mockResolvedValue({
+        status: { blockHeight, blockTime, confirmed: true },
+      })
+
+      const updates = await watchDepositOnBitcoin(deposit)
+
+      expect(updates).toEqual({
+        blockNumber: blockHeight,
+        status: BtcDepositStatus.TX_CONFIRMED,
+        timestamp: blockTime,
+      })
+
+      expect(getTransactionReceipt).toHaveBeenCalledOnce()
+      expect(getTransactionReceipt).toHaveBeenCalledWith(
+        deposit.transactionHash,
+      )
+    })
+  })
+
+  describe('watchDepositOnHemi', function () {
+    it('should not return changes if the deposit is confirmed only on bitcoin and is not ready for claiming', async function () {
+      const mock = {}
+      vi.mocked(getHemiStatusOfBtcDeposit).mockResolvedValue(
+        BtcDepositStatus.TX_CONFIRMED,
+      )
+      vi.mocked(getVaultAddressByDeposit).mockResolvedValue(vaultAddress)
+      vi.mocked(publicClientToHemiClient).mockResolvedValue(mock)
+
+      const updates = await watchDepositOnHemi(depositOnHemi)
+
+      expect(updates).toEqual({})
+    })
+
+    it('should return changes if the deposit is confirmed on bitcoin and is ready for claiming', async function () {
+      const mock = {}
+      vi.mocked(getHemiStatusOfBtcDeposit).mockResolvedValue(
+        BtcDepositStatus.BTC_READY_CLAIM,
+      )
+      vi.mocked(getVaultAddressByDeposit).mockResolvedValue(vaultAddress)
+      vi.mocked(publicClientToHemiClient).mockResolvedValue(mock)
+
+      const updates = await watchDepositOnHemi(depositOnHemi)
+
+      expect(updates).toEqual({ status: BtcDepositStatus.BTC_READY_CLAIM })
+    })
+  })
+})

--- a/webapp/utils/watch/bitcoinDeposits.ts
+++ b/webapp/utils/watch/bitcoinDeposits.ts
@@ -1,0 +1,90 @@
+import debugConstructor from 'debug'
+import { publicClientToHemiClient } from 'hooks/useHemiClient'
+import pMemoize from 'promise-mem'
+import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
+import { getTransactionReceipt } from 'utils/btcApi'
+import { findChainById } from 'utils/chain'
+import { getHemiStatusOfBtcDeposit, getVaultAddressByDeposit } from 'utils/hemi'
+import { hasKeys } from 'utils/utilities'
+import { type Chain, createPublicClient, http } from 'viem'
+
+const debug = debugConstructor('watch-btc-deposits-worker')
+
+export const watchDepositOnBitcoin = async function (
+  deposit: BtcDepositOperation,
+) {
+  debug('Watching deposit %s', deposit.transactionHash)
+  const receipt = await getTransactionReceipt(deposit.transactionHash)
+  if (!receipt) {
+    debug('Receipt not found for deposit %s', deposit.transactionHash)
+    return {}
+  }
+
+  const updates: Partial<BtcDepositOperation> = {}
+
+  const newStatus = receipt.status.confirmed
+    ? BtcDepositStatus.TX_CONFIRMED
+    : BtcDepositStatus.TX_PENDING
+
+  if (deposit.status !== newStatus) {
+    debug(
+      'Deposit %s status changed from %s to %s',
+      deposit.transactionHash,
+      deposit.status,
+      newStatus,
+    )
+    updates.status = newStatus
+  }
+  if (deposit.timestamp === undefined && receipt.status.confirmed) {
+    debug(
+      'Timestamp and block number added to deposit %s',
+      deposit.transactionHash,
+    )
+    updates.blockNumber = receipt.status.blockHeight
+    updates.timestamp = receipt.status.blockTime
+  }
+
+  if (!hasKeys(updates)) {
+    debug('No changes for deposit %s on bitcoin chain', deposit.transactionHash)
+  }
+
+  return updates
+}
+
+const getHemiClient = pMemoize(async function (chainId: Chain['id']) {
+  // L2 are always EVM
+  const l2Chain = findChainById(chainId) as Chain
+  const publicClient = createPublicClient({
+    chain: l2Chain,
+    transport: http(),
+  })
+  return publicClientToHemiClient(publicClient)
+})
+
+export const watchDepositOnHemi = async function (
+  deposit: BtcDepositOperation,
+) {
+  const hemiClient = await getHemiClient(deposit.l2ChainId)
+
+  const newStatus = await getVaultAddressByDeposit(hemiClient, deposit).then(
+    vaultAddress =>
+      getHemiStatusOfBtcDeposit({
+        deposit,
+        hemiClient,
+        vaultAddress,
+      }),
+  )
+  if (deposit.status !== newStatus) {
+    debug(
+      'Deposit %s status changed from %s to %s',
+      deposit.transactionHash,
+      deposit.status,
+      newStatus,
+    )
+    return { status: newStatus }
+  }
+
+  debug('No changes for deposit %s on hemi chain', deposit.transactionHash)
+
+  return {}
+}

--- a/webapp/workers/watchBitcoinDeposits.ts
+++ b/webapp/workers/watchBitcoinDeposits.ts
@@ -1,0 +1,70 @@
+import { BtcChain } from 'btc-wallet/chains'
+import { BtcTransaction } from 'btc-wallet/unisat'
+import debugConstructor from 'debug'
+import PQueue from 'p-queue'
+import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
+import {
+  watchDepositOnBitcoin,
+  watchDepositOnHemi,
+} from 'utils/watch/bitcoinDeposits'
+
+type EnableDebug = { type: 'enable-debug'; payload: string }
+type WatchBtcDeposit = {
+  deposit: BtcDepositOperation
+  type: 'watch-btc-deposit'
+}
+
+type AppToWebWorkerActions = EnableDebug | WatchBtcDeposit
+
+export type AppToWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  postMessage: (message: AppToWebWorkerActions) => void
+}
+
+// Worker is typed with "any", so force type safety for the messages
+// (as in runtime all types are stripped, this will continue to work)
+type WatchBtcDepositsWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  onmessage: (event: MessageEvent<AppToWebWorkerActions>) => void
+  postMessage: (event: {
+    type: `update-deposit-${BtcChain['id']}-${BtcTransaction}`
+    updates: Partial<BtcDepositOperation>
+  }) => void
+}
+
+// See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
+const worker = self as unknown as WatchBtcDepositsWorker
+
+// concurrently avoid overloading both blockchains
+const bitcoinQueue = new PQueue({ concurrency: 3 })
+const hemiQueue = new PQueue({ concurrency: 3 })
+
+export const getDepositKey = (deposit: BtcDepositOperation) =>
+  `update-deposit-${deposit.l1ChainId}-${deposit.transactionHash}` as const
+
+const postUpdates =
+  (deposit: BtcDepositOperation) =>
+  (updates: Partial<BtcDepositOperation> = {}) =>
+    worker.postMessage({
+      type: getDepositKey(deposit),
+      updates,
+    })
+
+const watchDeposit = function (deposit: BtcDepositOperation) {
+  if (deposit.status === BtcDepositStatus.TX_PENDING) {
+    bitcoinQueue.add(() =>
+      watchDepositOnBitcoin(deposit).then(postUpdates(deposit)),
+    )
+  } else {
+    hemiQueue.add(() => watchDepositOnHemi(deposit).then(postUpdates(deposit)))
+  }
+}
+
+// wait for the UI to send chain and address once ready
+worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (e.data.type === 'watch-btc-deposit') {
+    watchDeposit(e.data.deposit)
+  }
+  // See https://github.com/debug-js/debug/issues/916#issuecomment-1539231712
+  if (e.data.type === 'enable-debug') {
+    debugConstructor.enable(e.data.payload)
+  }
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Follow up of #710  - This PR refactors the react component `bitcoinDepositsStatusUpdater.tsx` to use a web worker instead of using `react-query` to watch for bitcoin deposits. The worker code now lives in `webapp/workers/watchBitcoinDeposits.ts`. I also created the component `withWorker` that has some logic reusable for the web worker. However, the instantiation of the web worker has to be done manually outside of the component due to how `webpack` parses the code to load web workers in next + typescript. See [this comment](https://github.com/vercel/next.js/issues/31009#issuecomment-1146344161) and [this comment](https://github.com/vercel/next.js/issues/31009#issuecomment-1338645354).  
In the next PR, I will update other web workers to also use `withWorker.tsx`

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes visible to the user

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #487 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
