### PR TITLE
Use with worker withdrawals

### DIFF
--- a/webapp/context/tunnelHistoryContext/withdrawalsStateUpdater.tsx
+++ b/webapp/context/tunnelHistoryContext/withdrawalsStateUpdater.tsx
@@ -7,6 +7,7 @@ import { hemiMainnet } from 'networks/hemiMainnet'
 import { hemiTestnet } from 'networks/hemiTestnet'
 import { useEffect } from 'react'
 import { ToEvmWithdrawOperation } from 'types/tunnel'
+import { hasKeys } from 'utils/utilities'
 import { useAccount } from 'wagmi'
 import {
   type AppToWorker,
@@ -65,9 +66,11 @@ const WatchEvmWithdrawal = function ({
         if (type !== getUpdateWithdrawalKey(withdrawal)) {
           return
         }
-        updateWithdrawal(withdrawal, updates)
         // next interval will poll again
         hasWorkedPostedBack = true
+        if (hasKeys(updates)) {
+          updateWithdrawal(withdrawal, updates)
+        }
       }
 
       worker.addEventListener('message', saveUpdates)

--- a/webapp/workers/watchEvmWithdrawals.ts
+++ b/webapp/workers/watchEvmWithdrawals.ts
@@ -175,13 +175,14 @@ const watchWithdrawal = (withdrawal: ToEvmWithdrawOperation) =>
 
       if (hasKeys(updates)) {
         debug('Sending changes for withdrawal %s', withdrawal.transactionHash)
-        worker.postMessage({
-          type: getUpdateWithdrawalKey(withdrawal),
-          updates,
-        })
       } else {
         debug('No changes for withdrawal %s', withdrawal.transactionHash)
       }
+
+      worker.postMessage({
+        type: getUpdateWithdrawalKey(withdrawal),
+        updates,
+      })
     },
     {
       // Give more priority to those that require polling and are not ready or are missing information


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR consists of 2 commits:

- a46d12bea870d79a9d40e214904b8a7801ec02a0 updates `withdrawalsStateUpdater.tsx` to use the `WithWorker` component created in #714 
- ab3626057df012a05e2b5a16d6731e0c9b8a834d fixes a bug in which, after watching the withdrawals once, it wouldn't iterate again. This was because the worker needs to always post that it has finished watching changes, so the UI tells it again to watch! This was a problem I noticed in the bitcoin updater (PR #714) that I had fixed there, and I am now fixing it for this worker as well.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to the user

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
