### PR TITLE
Cap bitcoin timestamp from block

### DIFF
--- a/webapp/hooks/useBtcTunnel.ts
+++ b/webapp/hooks/useBtcTunnel.ts
@@ -10,6 +10,7 @@ import {
   BtcDepositStatus,
   BtcWithdrawStatus,
 } from 'types/tunnel'
+import { getBitcoinTimestamp } from 'utils/bitcoin'
 import { getEvmBlock } from 'utils/evmApi'
 import {
   claimBtcDeposit,
@@ -225,7 +226,7 @@ export const useDepositBitcoin = function () {
       updateDeposit(deposit, {
         blockNumber: depositReceipt.status.blockHeight,
         status: BtcDepositStatus.TX_CONFIRMED,
-        timestamp: depositReceipt.status.blockTime,
+        timestamp: getBitcoinTimestamp(depositReceipt.status.blockTime),
       })
     },
     [bitcoin, depositReceipt, deposits, updateDeposit],

--- a/webapp/test/utils/bitcoin.test.ts
+++ b/webapp/test/utils/bitcoin.test.ts
@@ -1,0 +1,22 @@
+import { getBitcoinTimestamp } from 'utils/bitcoin'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('utils/bitcoin', function () {
+  describe('getBitcoinTimestamp', function () {
+    it('should return the block time if is prior to the current time', function () {
+      // using 5 minutes ago
+      const blockTime = Math.floor((new Date().getTime() - 5 * 1000) / 1000)
+
+      expect(getBitcoinTimestamp(blockTime)).toBe(blockTime)
+    })
+
+    it('should return the current time if the block time is in the future', function () {
+      const now = new Date(2024, 11, 19).getTime()
+      // using 5 minutes from now
+      const blockTime = Math.floor((now + 5 * 1000) / 1000)
+      vi.setSystemTime(now)
+
+      expect(getBitcoinTimestamp(blockTime)).toBe(Math.floor(now / 1000))
+    })
+  })
+})

--- a/webapp/utils/bitcoin.ts
+++ b/webapp/utils/bitcoin.ts
@@ -31,8 +31,8 @@ export const calculateDepositOutputIndex = (
  * If the user ever resyncs, and the timestamp appeared in the past, then we save that.
  * See https://github.com/hemilabs/ui-monorepo/issues/692
  */
-export const getBitcoinTimestamp = function (timestamp: bigint | number) {
+export const getBitcoinTimestamp = function (timestamp: number) {
   // timestamps from btc are saved in unix format
   const now = Math.floor(new Date().getTime() / 1000)
-  return Math.min(now, Number(timestamp))
+  return Math.min(now, timestamp)
 }

--- a/webapp/utils/bitcoin.ts
+++ b/webapp/utils/bitcoin.ts
@@ -23,3 +23,16 @@ export const calculateDepositOutputIndex = (
   transactionReceipt.vout.findIndex(
     equalsBitcoinCustodyAddress(bitcoinCustodyAddress),
   )
+
+/**
+ * The Bitcoin API we're using (esplora-client) sometimes returns data with +- 1 hour of range.
+ * This means that under certain conditions, the timestamp may be visible to the user as "in X minutes",
+ * meaning the date looks like it is in the future. This function caps the timestamp to "now".
+ * If the user ever resyncs, and the timestamp appeared in the past, then we save that.
+ * See https://github.com/hemilabs/ui-monorepo/issues/692
+ */
+export const getBitcoinTimestamp = function (timestamp: bigint | number) {
+  // timestamps from btc are saved in unix format
+  const now = Math.floor(new Date().getTime() / 1000)
+  return Math.min(now, Number(timestamp))
+}

--- a/webapp/utils/sync-history/bitcoin.ts
+++ b/webapp/utils/sync-history/bitcoin.ts
@@ -8,7 +8,7 @@ import {
 import { TransactionListSyncType } from 'hooks/useSyncHistory/types'
 import pAll from 'p-all'
 import { BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
-import { calculateDepositAmount } from 'utils/bitcoin'
+import { calculateDepositAmount, getBitcoinTimestamp } from 'utils/bitcoin'
 import {
   getAddressTransactions,
   MempoolJsBitcoinTransaction,
@@ -143,7 +143,7 @@ export const createBitcoinSync = function ({
                 l1Token: btc.address,
                 l2ChainId: l2Chain.id,
                 l2Token: btc.extensions.bridgeInfo[l2Chain.id].tokenAddress,
-                timestamp: bitcoinDeposit.status.blockTime,
+                timestamp: getBitcoinTimestamp(bitcoinDeposit.status.blockTime),
                 to: bitcoinCustodyAddress,
                 transactionHash: bitcoinDeposit.txId,
               }

--- a/webapp/utils/watch/bitcoinDeposits.ts
+++ b/webapp/utils/watch/bitcoinDeposits.ts
@@ -2,6 +2,7 @@ import debugConstructor from 'debug'
 import { publicClientToHemiClient } from 'hooks/useHemiClient'
 import pMemoize from 'promise-mem'
 import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
+import { getBitcoinTimestamp } from 'utils/bitcoin'
 import { getTransactionReceipt } from 'utils/btcApi'
 import { findChainById } from 'utils/chain'
 import { getHemiStatusOfBtcDeposit, getVaultAddressByDeposit } from 'utils/hemi'
@@ -41,7 +42,7 @@ export const watchDepositOnBitcoin = async function (
       deposit.transactionHash,
     )
     updates.blockNumber = receipt.status.blockHeight
-    updates.timestamp = receipt.status.blockTime
+    updates.timestamp = getBitcoinTimestamp(receipt.status.blockTime)
   }
 
   if (!hasKeys(updates)) {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

When depositing Bitcoin, the block timestamp may appear sometimes as a future timestamp. This PR caps the time with the current UTC time, so it never appears as a future date in the tx history.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #692

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
