### PR TITLE
Add support for mainnet in BTC Api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12372,9 +12372,10 @@
       }
     },
     "node_modules/esplora-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esplora-client/-/esplora-client-1.1.0.tgz",
-      "integrity": "sha512-b4BAqeh271kfZmILSYac9DMY8pqYP8SgcZHwkJ+oK50JupBXIcCtlzk4rYgnrpYRV1fVafjSy89ct3lJVqu9LA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/esplora-client/-/esplora-client-1.2.0.tgz",
+      "integrity": "sha512-30JPDB4d5Aa8eFeS7IoYFEwSH3kZKCX7BCWABksm0jZ8fF9EDAyjqgInVmzlDtAvecQjBk8JZ7cQNapudCjCtw==",
+      "license": "MIT",
       "dependencies": {
         "fetch-plus-plus": "^1.0.0"
       }
@@ -25057,7 +25058,7 @@
         "camelcase-keys": "9.1.3",
         "crypto-shortener": "1.1.0",
         "debug": "4.3.7",
-        "esplora-client": "1.1.0",
+        "esplora-client": "1.2.0",
         "hemi-socials": "1.0.0",
         "hemi-viem": "2.0.0-alpha.1",
         "javascript-time-ago": "2.5.10",

--- a/webapp/.env
+++ b/webapp/.env
@@ -1,5 +1,2 @@
 NEXT_PUBLIC_BTC_INPUTS_SIZE=105
 NEXT_PUBLIC_BTC_OUTPUTS_SIZE=25
-# Once mainnet is published, these values below may go into .env.development as they belong to hemi's testnet
-NEXT_PUBLIC_BITCOIN_NETWORK=testnet
-NEXT_PUBLIC_MEMPOOL_API_URL="https://mempool.space/testnet/api"

--- a/webapp/hooks/useEstimateBtcFees.ts
+++ b/webapp/hooks/useEstimateBtcFees.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { type Account } from 'btc-wallet/unisat'
-import { getAddressTxsUtxo, getRecommendedFees } from 'utils/btcApi'
+import { createBtcApi } from 'utils/btcApi'
+
+import { useNetworkType } from './useNetworkType'
 
 const btcInputsSize = parseInt(process.env.NEXT_PUBLIC_BTC_INPUTS_SIZE)
 const btcOutputsSize = parseInt(process.env.NEXT_PUBLIC_BTC_OUTPUTS_SIZE)
@@ -8,8 +10,9 @@ const btcOutputsSize = parseInt(process.env.NEXT_PUBLIC_BTC_OUTPUTS_SIZE)
 const expectedOutputs = 2
 
 export const useGetFeePrices = function () {
+  const [networkType] = useNetworkType()
   const { data: feePrices, ...rest } = useQuery({
-    queryFn: getRecommendedFees,
+    queryFn: () => createBtcApi(networkType).getRecommendedFees(),
     queryKey: ['btc-recommended-fees'],
     // refetch every minute
     refetchInterval: 1000 * 60,
@@ -21,10 +24,11 @@ export const useGetFeePrices = function () {
 }
 
 const useGetUtxos = function (account: Account) {
+  const [networkType] = useNetworkType()
   const { data: utxos, ...rest } = useQuery({
     enabled: !!account,
-    queryFn: () => getAddressTxsUtxo(account),
-    queryKey: ['btc-utxos', account],
+    queryFn: () => createBtcApi(networkType).getAddressTxsUtxo(account),
+    queryKey: ['btc-utxos', account, networkType],
   })
   return {
     utxos,

--- a/webapp/hooks/useEstimateBtcFees.ts
+++ b/webapp/hooks/useEstimateBtcFees.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { type Account } from 'btc-wallet/unisat'
-import { getAddressUtxo, getRecommendedFees } from 'utils/btcApi'
+import { getAddressTxsUtxo, getRecommendedFees } from 'utils/btcApi'
 
 const btcInputsSize = parseInt(process.env.NEXT_PUBLIC_BTC_INPUTS_SIZE)
 const btcOutputsSize = parseInt(process.env.NEXT_PUBLIC_BTC_OUTPUTS_SIZE)
@@ -23,7 +23,7 @@ export const useGetFeePrices = function () {
 const useGetUtxos = function (account: Account) {
   const { data: utxos, ...rest } = useQuery({
     enabled: !!account,
-    queryFn: () => getAddressUtxo(account),
+    queryFn: () => getAddressTxsUtxo(account),
     queryKey: ['btc-utxos', account],
   })
   return {

--- a/webapp/hooks/useEstimateBtcFees.ts
+++ b/webapp/hooks/useEstimateBtcFees.ts
@@ -13,7 +13,7 @@ export const useGetFeePrices = function () {
   const [networkType] = useNetworkType()
   const { data: feePrices, ...rest } = useQuery({
     queryFn: () => createBtcApi(networkType).getRecommendedFees(),
-    queryKey: ['btc-recommended-fees'],
+    queryKey: ['btc-recommended-fees', networkType],
     // refetch every minute
     refetchInterval: 1000 * 60,
   })

--- a/webapp/hooks/useWaitForTransactionReceipt.ts
+++ b/webapp/hooks/useWaitForTransactionReceipt.ts
@@ -2,7 +2,9 @@ import { useQuery } from '@tanstack/react-query'
 import { useAccount } from 'btc-wallet/hooks/useAccount'
 import { type BtcTransaction } from 'btc-wallet/unisat'
 import { isChainIdSupported } from 'btc-wallet/utils/chains'
-import { getTransactionReceipt } from 'utils/btcApi'
+import { createBtcApi } from 'utils/btcApi'
+
+import { useNetworkType } from './useNetworkType'
 
 type Args = {
   txId: BtcTransaction
@@ -10,13 +12,14 @@ type Args = {
 
 export const useWaitForTransactionReceipt = function ({ txId }: Args) {
   const { chainId } = useAccount()
+  const [networkType] = useNetworkType()
 
-  const queryKey = ['btc-wallet-wait-tx', chainId, txId]
+  const queryKey = ['btc-wallet-wait-tx', chainId, networkType, txId]
 
   return {
     ...useQuery({
       enabled: !!txId && !!chainId && isChainIdSupported(chainId),
-      queryFn: () => getTransactionReceipt(txId),
+      queryFn: () => createBtcApi(networkType).getTransactionReceipt(txId),
       queryKey,
       refetchInterval(query) {
         // Poll every 30 secs until confirmed

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -25,7 +25,7 @@
     "camelcase-keys": "9.1.3",
     "crypto-shortener": "1.1.0",
     "debug": "4.3.7",
-    "esplora-client": "1.1.0",
+    "esplora-client": "1.2.0",
     "hemi-socials": "1.0.0",
     "hemi-viem": "2.0.0-alpha.1",
     "javascript-time-ago": "2.5.10",

--- a/webapp/utils/btcApi.ts
+++ b/webapp/utils/btcApi.ts
@@ -49,9 +49,9 @@ export const getAddressTransactions = (
     ) as Promise<MempoolJsBitcoinTransaction[]>
 
 // See https://mempool.space/docs/api/rest#get-address-utxo (we are converting to camelCase)
-export const getAddressUtxo = (address: Account) =>
+export const getAddressTxsUtxo = (address: Account) =>
   bitcoin.addresses
-    .getAddressUtxo({ address })
+    .getAddressTxsUtxo({ address })
     .then(utxos =>
       utxos.map(utxo => toCamelCase({ ...utxo, txId: utxo.txid })),
     ) as Promise<Utxo[]>

--- a/webapp/utils/btcApi.ts
+++ b/webapp/utils/btcApi.ts
@@ -1,12 +1,15 @@
-import { Account, BtcTransaction, Satoshis } from 'btc-wallet/unisat'
+import {
+  Account,
+  BtcSupportedNetworks,
+  BtcTransaction,
+  Satoshis,
+} from 'btc-wallet/unisat'
 import camelCaseKeys from 'camelcase-keys'
 import { esploraClient } from 'esplora-client'
+import { NetworkType } from 'hooks/useNetworkType'
 
 const toCamelCase = <T extends Record<string, unknown>>(obj: T) =>
   camelCaseKeys(obj, { deep: true })
-
-const network = process.env.NEXT_PUBLIC_BITCOIN_NETWORK
-const { bitcoin } = esploraClient({ network })
 
 type TransactionStatus = {
   blockTime?: number
@@ -37,36 +40,6 @@ type Utxo = {
   value: Satoshis
 }
 
-// See https://mempool.space/docs/api/rest#get-address-transactions
-export const getAddressTransactions = (
-  address: Account,
-  queryString?: { afterTxId: string },
-) =>
-  bitcoin.addresses
-    .getAddressTxs({ address, after_txid: queryString?.afterTxId })
-    .then(txs =>
-      txs.map(tx => toCamelCase({ ...tx, txId: tx.txid })),
-    ) as Promise<MempoolJsBitcoinTransaction[]>
-
-// See https://mempool.space/docs/api/rest#get-address-utxo (we are converting to camelCase)
-export const getAddressTxsUtxo = (address: Account) =>
-  bitcoin.addresses
-    .getAddressTxsUtxo({ address })
-    .then(utxos =>
-      utxos.map(utxo => toCamelCase({ ...utxo, txId: utxo.txid })),
-    ) as Promise<Utxo[]>
-
-type Fees = {
-  fastestFee: number
-  halfHourFee: number
-  hourFee: number
-  economyFee: number
-  minimumFee: number
-}
-// See https://mempool.space/docs/api/rest#get-recommended-fees
-export const getRecommendedFees = () =>
-  bitcoin.fees.getFeesRecommended() as Promise<Fees>
-
 export type TransactionReceipt = {
   txId: BtcTransaction
   status: {
@@ -77,23 +50,68 @@ export type TransactionReceipt = {
   vout: Vout[]
 }
 
-// See https://mempool.space/testnet/docs/api/rest#get-transaction (we are converting the keys to camelCase)
-export const getTransactionReceipt = (txId: BtcTransaction) =>
-  bitcoin.transactions
-    .getTx({ txid: txId })
-    .catch(function (err) {
-      if (err?.message.includes('not found')) {
-        // It seems it takes a couple of seconds for the Tx for being picked up
-        // react-query doesn't let us to return undefined data, so we must
-        // return an unconfirmed status
-        // Once it appears in the mempool, it will return the full object
-        // with the same confirmation status as false.
-        return { status: { confirmed: false } }
-      }
-      throw err
-    })
-    .then(toCamelCase)
-    .then(({ txid, ...rest }) => ({
-      txId: txid,
-      ...rest,
-    })) as Promise<TransactionReceipt | undefined>
+type Fees = {
+  fastestFee: number
+  halfHourFee: number
+  hourFee: number
+  economyFee: number
+  minimumFee: number
+}
+
+export const mapBitcoinNetwork = (network: BtcSupportedNetworks) =>
+  network === 'livenet' ? 'mainnet' : 'testnet'
+
+export const createBtcApi = function (network: NetworkType) {
+  const { bitcoin } = esploraClient({ network })
+
+  // See https://mempool.space/docs/api/rest#get-address-transactions
+  const getAddressTransactions = (
+    address: Account,
+    queryString?: { afterTxId: string },
+  ) =>
+    bitcoin.addresses
+      .getAddressTxs({ address, after_txid: queryString?.afterTxId })
+      .then(txs =>
+        txs.map(tx => toCamelCase({ ...tx, txId: tx.txid })),
+      ) as Promise<MempoolJsBitcoinTransaction[]>
+
+  // See https://mempool.space/docs/api/rest#get-address-utxo (we are converting to camelCase)
+  const getAddressTxsUtxo = (address: Account) =>
+    bitcoin.addresses
+      .getAddressTxsUtxo({ address })
+      .then(utxos =>
+        utxos.map(utxo => toCamelCase({ ...utxo, txId: utxo.txid })),
+      ) as Promise<Utxo[]>
+
+  // See https://mempool.space/docs/api/rest#get-recommended-fees
+  const getRecommendedFees = () =>
+    bitcoin.fees.getFeesRecommended() as Promise<Fees>
+
+  // See https://mempool.space/testnet/docs/api/rest#get-transaction (we are converting the keys to camelCase)
+  const getTransactionReceipt = (txId: BtcTransaction) =>
+    bitcoin.transactions
+      .getTx({ txid: txId })
+      .catch(function (err) {
+        if (err?.message.includes('not found')) {
+          // It seems it takes a couple of seconds for the Tx for being picked up
+          // react-query doesn't let us to return undefined data, so we must
+          // return an unconfirmed status
+          // Once it appears in the mempool, it will return the full object
+          // with the same confirmation status as false.
+          return { status: { confirmed: false } }
+        }
+        throw err
+      })
+      .then(toCamelCase)
+      .then(({ txid, ...rest }) => ({
+        txId: txid,
+        ...rest,
+      })) as Promise<TransactionReceipt | undefined>
+
+  return {
+    getAddressTransactions,
+    getAddressTxsUtxo,
+    getRecommendedFees,
+    getTransactionReceipt,
+  }
+}

--- a/webapp/utils/hemi.ts
+++ b/webapp/utils/hemi.ts
@@ -6,7 +6,7 @@ import { BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
 import { type Address } from 'viem'
 
 import { calculateDepositOutputIndex } from './bitcoin'
-import { getTransactionReceipt } from './btcApi'
+import { createBtcApi, mapBitcoinNetwork } from './btcApi'
 
 // Max Sanchez note: looks like if we pass in all lower-case hex, Unisat publishes the bytes instead of the string.
 // Tunnel for now is only validating the string representation, but update this in the future using
@@ -141,9 +141,9 @@ export const claimBtcDeposit = ({
     getVaultAddressByDeposit(hemiClient, deposit).then(vaultAddress =>
       getHemiStatusOfBtcDeposit({ deposit, hemiClient, vaultAddress }),
     ),
-    getTransactionReceipt(deposit.transactionHash).then(receipt =>
-      calculateDepositOutputIndex(receipt, deposit.to),
-    ),
+    createBtcApi(mapBitcoinNetwork(deposit.l1ChainId))
+      .getTransactionReceipt(deposit.transactionHash)
+      .then(receipt => calculateDepositOutputIndex(receipt, deposit.to)),
   ]).then(function ([vaultIndex, currentStatus, outputIndex]) {
     if (currentStatus === BtcDepositStatus.BTC_DEPOSITED) {
       throw new Error('Bitcoin Deposit already confirmed')

--- a/webapp/utils/sync-history/bitcoin.ts
+++ b/webapp/utils/sync-history/bitcoin.ts
@@ -10,8 +10,9 @@ import pAll from 'p-all'
 import { BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
 import { calculateDepositAmount, getBitcoinTimestamp } from 'utils/bitcoin'
 import {
-  getAddressTransactions,
-  MempoolJsBitcoinTransaction,
+  createBtcApi,
+  mapBitcoinNetwork,
+  type MempoolJsBitcoinTransaction,
 } from 'utils/btcApi'
 import {
   getBitcoinCustodyAddress,
@@ -101,10 +102,12 @@ export const createBitcoinSync = function ({
       const formattedTxId = afterTxId ?? 'last available transaction'
       debug('Getting transactions batch starting from %s', formattedTxId)
 
-      const transactions = await getAddressTransactions(
-        bitcoinCustodyAddress,
-        afterTxId ? { afterTxId } : undefined,
-      ).then(discardKnownTransactions(localDepositSyncInfo.toKnownTx))
+      const transactions = await createBtcApi(mapBitcoinNetwork(l1Chain.id))
+        .getAddressTransactions(
+          bitcoinCustodyAddress,
+          afterTxId ? { afterTxId } : undefined,
+        )
+        .then(discardKnownTransactions(localDepositSyncInfo.toKnownTx))
 
       debug(
         'Found %s transactions starting from %s',

--- a/webapp/utils/watch/bitcoinDeposits.ts
+++ b/webapp/utils/watch/bitcoinDeposits.ts
@@ -3,7 +3,7 @@ import { publicClientToHemiClient } from 'hooks/useHemiClient'
 import pMemoize from 'promise-mem'
 import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
 import { getBitcoinTimestamp } from 'utils/bitcoin'
-import { getTransactionReceipt } from 'utils/btcApi'
+import { createBtcApi, mapBitcoinNetwork } from 'utils/btcApi'
 import { findChainById } from 'utils/chain'
 import { getHemiStatusOfBtcDeposit, getVaultAddressByDeposit } from 'utils/hemi'
 import { hasKeys } from 'utils/utilities'
@@ -15,7 +15,9 @@ export const watchDepositOnBitcoin = async function (
   deposit: BtcDepositOperation,
 ) {
   debug('Watching deposit %s', deposit.transactionHash)
-  const receipt = await getTransactionReceipt(deposit.transactionHash)
+  const receipt = await createBtcApi(
+    mapBitcoinNetwork(deposit.l1ChainId),
+  ).getTransactionReceipt(deposit.transactionHash)
   if (!receipt) {
     debug('Receipt not found for deposit %s', deposit.transactionHash)
     return {}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps `esplora-client` to the latest version (which uses typescript), and then updates `btcApi` to work with both `testnet` and `mainnet`. As `mainnet` is not enabled, there are no visible changes to the user, but now once the user switches from/to `mainnet`, it will hit the appropriate btc api.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #557

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
