### PR TITLE
Bump token-list, patch USDC name in mainnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2383,9 +2383,9 @@
       }
     },
     "node_modules/@hemilabs/token-list": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@hemilabs/token-list/-/token-list-1.3.0.tgz",
-      "integrity": "sha512-5gcdmF2DElbJkY/FAX+XMDvmv+xY8Aq+jkQLbIwrQQ+FClpU+XeKIJfdrqrlKAfpIAIkBMzUqisiQ8clmYNiQg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@hemilabs/token-list/-/token-list-1.4.2.tgz",
+      "integrity": "sha512-Sr6asbZI7f1Ban7H2h+cJLa8PJQhwZbjhC1u0/XIp2yVjBrIRFuAfWW8Bp2KtT9dq87fCIi7N/UaSMuA77qt2g==",
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -25048,7 +25048,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@eth-optimism/sdk": "3.2.1",
-        "@hemilabs/token-list": "1.3.0",
+        "@hemilabs/token-list": "1.4.2",
         "@rainbow-me/rainbowkit": "2.0.1",
         "@sentry/nextjs": "8.35.0",
         "@tanstack/react-query": "5.24.8",

--- a/patches/@hemilabs+token-list+1.4.2.patch
+++ b/patches/@hemilabs+token-list+1.4.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json b/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
+index c4c6c0f..5ef242b 100644
+--- a/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
++++ b/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
+@@ -339,7 +339,7 @@
+         }
+       },
+       "logoURI": "https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/usdc.svg",
+-      "name": "Bridged USDC (Stargate)",
++      "name": "USDC",
+       "symbol": "USDC.e"
+     }
+   ]

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@eth-optimism/sdk": "3.2.1",
-    "@hemilabs/token-list": "1.3.0",
+    "@hemilabs/token-list": "1.4.2",
     "@rainbow-me/rainbowkit": "2.0.1",
     "@sentry/nextjs": "8.35.0",
     "@tanstack/react-query": "5.24.8",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps the `@hemilabs/token-list` to include `USDC` and `USDT`. `USDC` is patched, as the contract has `stargate` in their name, but we don't want to show this in the list.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="486" alt="image" src="https://github.com/user-attachments/assets/6d18784e-9a69-4d0a-8e19-e4aa13c25973" />

<img width="475" alt="image" src="https://github.com/user-attachments/assets/43d9bd9d-3df7-4640-b90d-68407753a97b" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #719 (it is left open because the stargate URL is TBD)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
