### PR TITLE
Bitcoin withdrawals pt3

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/txStatus.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/txStatus.tsx
@@ -25,7 +25,7 @@ const Failed = function () {
 const InStatus = ({ text }: { text: string }) => (
   <Container>
     <Dot className="border-amber-800/25 bg-amber-400" />
-    <span className="text-[#F59E0B]">{text}</span>
+    <span className="text-amber-600">{text}</span>
   </Container>
 )
 
@@ -39,8 +39,16 @@ const Success = function () {
   )
 }
 
+const Finished = ({ text }: { text: string }) => (
+  <Container>
+    <Dot className="border-neutral-800/25 bg-neutral-500" />
+    <span className="text-neutral-500">{text}</span>
+  </Container>
+)
+
 export const TxStatus = {
   Failed,
+  Finished,
   InStatus,
   Success,
 }

--- a/webapp/context/tunnelHistoryContext/bitcoinWithdrawalsStatusUpdater.tsx
+++ b/webapp/context/tunnelHistoryContext/bitcoinWithdrawalsStatusUpdater.tsx
@@ -6,7 +6,7 @@ import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupport
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useEffect } from 'react'
 import { BtcWithdrawStatus, ToBtcWithdrawOperation } from 'types/tunnel'
-import { isBtcWithdrawalInFinalState } from 'utils/tunnel'
+import { isPendingOperation } from 'utils/tunnel'
 import { hasKeys } from 'utils/utilities'
 import { useAccount as useEvmAccount } from 'wagmi'
 import {
@@ -107,8 +107,7 @@ export function BitcoinWithdrawalsStatusUpdater() {
 
   const withdrawalsToWatch = withdrawals.filter(
     withdrawal =>
-      !isBtcWithdrawalInFinalState(withdrawal) ||
-      missingInformation(withdrawal),
+      isPendingOperation(withdrawal) || missingInformation(withdrawal),
   )
 
   return (

--- a/webapp/context/tunnelHistoryContext/bitcoinWithdrawalsStatusUpdater.tsx
+++ b/webapp/context/tunnelHistoryContext/bitcoinWithdrawalsStatusUpdater.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { WithWorker } from 'components/withWorker'
+import { useBtcWithdrawals } from 'hooks/useBtcWithdrawals'
+import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
+import { useTunnelHistory } from 'hooks/useTunnelHistory'
+import { useEffect } from 'react'
+import { BtcWithdrawStatus, ToBtcWithdrawOperation } from 'types/tunnel'
+import { isBtcWithdrawalInFinalState } from 'utils/tunnel'
+import { hasKeys } from 'utils/utilities'
+import { useAccount as useEvmAccount } from 'wagmi'
+import {
+  type AppToWorker,
+  getWithdrawalKey,
+} from 'workers/watchBitcoinWithdrawals'
+
+function WatchBitcoinWithdrawal({
+  withdrawal,
+  worker,
+}: {
+  withdrawal: ToBtcWithdrawOperation
+  worker: AppToWorker
+}) {
+  const { updateWithdrawal } = useTunnelHistory()
+
+  useEffect(
+    function watchWithdrawalUpdates() {
+      // Not using useState as 1. this value is local to the effect and
+      // 2. to avoid unsubscribing and resubscribing when the state value changes
+      let hasWorkedPostedBack = false
+
+      const saveUpdates = function (
+        event: MessageEvent<{
+          updates: Partial<ToBtcWithdrawOperation>
+          type: string
+        }>,
+      ) {
+        // This is needed because this component is rendered per-withdrawal, so each component will receive the posted message
+        // for every withdrawal, as there are many withdrawals but only one worker.
+        // Of all components, this "if" clause below will be true for only one rendered component - the one belonging to the withdrawal
+        const { type, updates } = event.data
+        if (type !== getWithdrawalKey(withdrawal)) {
+          return
+        }
+        // next interval will poll again
+        hasWorkedPostedBack = true
+        if (hasKeys(updates)) {
+          updateWithdrawal(withdrawal, updates)
+        }
+      }
+
+      worker.addEventListener('message', saveUpdates)
+
+      // refetch every 15 seconds
+      const interval = 15 * 1000
+
+      worker.postMessage({
+        type: 'watch-btc-withdrawal',
+        withdrawal,
+      })
+
+      const intervalId = setInterval(function () {
+        if (!hasWorkedPostedBack) {
+          return
+        }
+        worker.postMessage({
+          type: 'watch-btc-withdrawal',
+          withdrawal,
+        })
+        // Block posting until a response is received
+        hasWorkedPostedBack = false
+      }, interval)
+
+      return function cleanup() {
+        worker.removeEventListener('message', saveUpdates)
+        clearInterval(intervalId)
+      }
+    },
+    [updateWithdrawal, withdrawal, worker],
+  )
+
+  return null
+}
+
+// See https://github.com/vercel/next.js/issues/31009#issuecomment-11463441611
+// and https://github.com/vercel/next.js/issues/31009#issuecomment-1338645354
+const getWorker = () =>
+  new Worker(
+    new URL('../../workers/watchBitcoinWithdrawals.ts', import.meta.url),
+  )
+
+// Unless the "initiateWithdraw" tx is not confirmed, the other 2 fields should be available
+const missingInformation = (withdrawal: ToBtcWithdrawOperation) =>
+  withdrawal.status !== BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING &&
+  (!withdrawal.timestamp || !withdrawal.uuid)
+
+export function BitcoinWithdrawalsStatusUpdater() {
+  const withdrawals = useBtcWithdrawals()
+  // Withdrawals  are checked against an hemi address
+  const { isConnected } = useEvmAccount()
+
+  const unsupportedChain = useConnectedToUnsupportedEvmChain()
+
+  if (!isConnected || unsupportedChain) {
+    return null
+  }
+
+  const withdrawalsToWatch = withdrawals.filter(
+    withdrawal =>
+      !isBtcWithdrawalInFinalState(withdrawal) ||
+      missingInformation(withdrawal),
+  )
+
+  return (
+    <WithWorker getWorker={getWorker}>
+      {(worker: AppToWorker) => (
+        <>
+          {withdrawalsToWatch.map(withdrawal => (
+            <WatchBitcoinWithdrawal
+              key={withdrawal.transactionHash}
+              withdrawal={withdrawal}
+              worker={worker}
+            />
+          ))}
+        </>
+      )}
+    </WithWorker>
+  )
+}

--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -25,6 +25,14 @@ const BitcoinDepositsStatusUpdater = dynamic(
   { ssr: false },
 )
 
+const BitcoinWithdrawalsStatusUpdater = dynamic(
+  () =>
+    import('./bitcoinWithdrawalsStatusUpdater').then(
+      mod => mod.BitcoinWithdrawalsStatusUpdater,
+    ),
+  { ssr: false },
+)
+
 const SyncHistoryWorker = dynamic(
   () => import('./syncHistoryWorker').then(mod => mod.SyncHistoryWorker),
   { ssr: false },
@@ -117,6 +125,8 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
     <TunnelHistoryContext.Provider value={context}>
       {/* Track updates on bitcoin deposits, in bitcoin or in Hemi */}
       {featureFlags.btcTunnelEnabled && <BitcoinDepositsStatusUpdater />}
+      {/* Track updates on bitcoin withdrawals, from Hemi to Bitcoin */}
+      {featureFlags.btcTunnelEnabled && <BitcoinWithdrawalsStatusUpdater />}
       {/* Track updates on withdrawals from Hemi */}
       <WithdrawalsStateUpdater />
       {children}

--- a/webapp/test/utils/tunnel.test.ts
+++ b/webapp/test/utils/tunnel.test.ts
@@ -4,10 +4,28 @@ import {
   BtcWithdrawStatus,
   EvmDepositStatus,
 } from 'types/tunnel'
-import { isPendingOperation } from 'utils/tunnel'
+import { isDeposit, isPendingOperation } from 'utils/tunnel'
 import { describe, it, expect } from 'vitest'
 
 describe('utils/tunnel', function () {
+  describe('isDeposit', function () {
+    it(`should identify deposit operations if the direction is ${MessageDirection.L1_TO_L2}`, function () {
+      const operation = {
+        direction: MessageDirection.L1_TO_L2,
+      }
+      // @ts-expect-error Ignore operation fields not required for this test
+      expect(isDeposit(operation)).toBe(true)
+    })
+
+    it(`should not identify operations as deposit if the direction is not ${MessageDirection.L1_TO_L2}`, function () {
+      const operation = {
+        direction: MessageDirection.L2_TO_L1,
+      }
+      // @ts-expect-error Ignore operation fields not required for this test
+      expect(isDeposit(operation)).toBe(false)
+    })
+  })
+
   describe('isPendingOperation', function () {
     describe('when the operation is a deposit', function () {
       describe('BTC', function () {

--- a/webapp/test/utils/watch/bitcoinWithdrawals.test.ts
+++ b/webapp/test/utils/watch/bitcoinWithdrawals.test.ts
@@ -1,0 +1,152 @@
+import { bitcoinTestnet } from 'btc-wallet/chains'
+import { hemiSepolia } from 'hemi-viem'
+import { type ToBtcWithdrawOperation, BtcWithdrawStatus } from 'types/tunnel'
+import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
+import {
+  getBitcoinWithdrawalUuid,
+  getHemiStatusOfBtcWithdrawal,
+} from 'utils/hemi'
+import { watchBitcoinWithdrawal } from 'utils/watch/bitcoinWithdrawals'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const withdrawal: ToBtcWithdrawOperation = {
+  amount: '100000000',
+  l1ChainId: bitcoinTestnet.id,
+  l2ChainId: hemiSepolia.id,
+  status: BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING,
+  transactionHash: '0x0000000000000000000000000000000000000002',
+}
+
+const withdrawalReceipt = {
+  blockNumber: BigInt(123),
+  transactionHash: withdrawal.transactionHash,
+}
+
+const block = {
+  blockNumber: withdrawalReceipt.blockNumber,
+  timestamp: BigInt(new Date().getTime()),
+}
+
+const uuid = BigInt(1)
+
+vi.mock('utils/evmApi', () => ({
+  getEvmBlock: vi.fn(),
+  getEvmTransactionReceipt: vi.fn(),
+}))
+
+vi.mock('utils/hemi', () => ({
+  getBitcoinWithdrawalUuid: vi.fn(),
+  getHemiStatusOfBtcWithdrawal: vi.fn(),
+}))
+
+describe('utils/watch/bitcoinWithdrawals', function () {
+  beforeEach(function () {
+    vi.clearAllMocks()
+  })
+
+  describe('watchBitcoinWithdrawal', function () {
+    it('should return no changes if the withdrawal is still pending', async function () {
+      vi.mocked(getHemiStatusOfBtcWithdrawal).mockResolvedValue(
+        BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING,
+      )
+
+      const updates = await watchBitcoinWithdrawal(withdrawal)
+
+      expect(updates).toEqual({})
+    })
+
+    it('should update the status and add new fields if status changes to confirmed', async function () {
+      vi.mocked(getHemiStatusOfBtcWithdrawal).mockResolvedValue(
+        BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+      )
+      vi.mocked(getEvmTransactionReceipt).mockResolvedValue(withdrawalReceipt)
+      vi.mocked(getBitcoinWithdrawalUuid).mockReturnValue(uuid)
+      vi.mocked(getEvmBlock).mockResolvedValue(block)
+
+      const updates = await watchBitcoinWithdrawal(withdrawal)
+
+      expect(updates).toEqual({
+        blockNumber: Number(block.blockNumber),
+        status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+        timestamp: Number(block.timestamp),
+        uuid: uuid.toString(),
+      })
+
+      expect(getEvmTransactionReceipt).toHaveBeenCalledOnce()
+      expect(getEvmTransactionReceipt).toHaveBeenCalledWith(
+        withdrawal.transactionHash,
+        withdrawal.l2ChainId,
+      )
+
+      expect(getBitcoinWithdrawalUuid).toHaveBeenCalledOnce()
+
+      expect(getEvmBlock).toHaveBeenCalledOnce()
+      expect(getEvmBlock).toHaveBeenCalledWith(
+        withdrawalReceipt.blockNumber,
+        withdrawal.l2ChainId,
+      )
+    })
+
+    it('should add missing data if the withdrawal was already confirmed', async function () {
+      vi.mocked(getHemiStatusOfBtcWithdrawal).mockResolvedValue(
+        BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+      )
+      vi.mocked(getEvmTransactionReceipt).mockResolvedValue({
+        ...withdrawalReceipt,
+        status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+      })
+      vi.mocked(getBitcoinWithdrawalUuid).mockReturnValue(uuid)
+      vi.mocked(getEvmBlock).mockResolvedValue(block)
+
+      const updates = await watchBitcoinWithdrawal({
+        ...withdrawal,
+        status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+      })
+
+      expect(updates).toEqual({
+        blockNumber: Number(block.blockNumber),
+        timestamp: Number(block.timestamp),
+        uuid: uuid.toString(),
+      })
+
+      expect(getEvmTransactionReceipt).toHaveBeenCalledOnce()
+      expect(getEvmTransactionReceipt).toHaveBeenCalledWith(
+        withdrawal.transactionHash,
+        withdrawal.l2ChainId,
+      )
+
+      expect(getBitcoinWithdrawalUuid).toHaveBeenCalledOnce()
+
+      expect(getEvmBlock).toHaveBeenCalledOnce()
+      expect(getEvmBlock).toHaveBeenCalledWith(
+        withdrawalReceipt.blockNumber,
+        withdrawal.l2ChainId,
+      )
+    })
+
+    it('should not return any changes if there are no changes', async function () {
+      vi.mocked(getHemiStatusOfBtcWithdrawal).mockResolvedValue(
+        BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+      )
+      vi.mocked(getEvmTransactionReceipt).mockResolvedValue({
+        ...withdrawalReceipt,
+        status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+      })
+      vi.mocked(getBitcoinWithdrawalUuid).mockReturnValue(uuid)
+      vi.mocked(getEvmBlock).mockResolvedValue(block)
+
+      const updates = await watchBitcoinWithdrawal({
+        ...withdrawal,
+        blockNumber: Number(block.blockNumber),
+        status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+        timestamp: Number(block.timestamp),
+        uuid: uuid.toString(),
+      })
+
+      expect(updates).toEqual({})
+
+      expect(getBitcoinWithdrawalUuid).not.toHaveBeenCalled()
+      expect(getEvmBlock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/webapp/utils/evmApi.ts
+++ b/webapp/utils/evmApi.ts
@@ -11,6 +11,7 @@ import {
   type Chain,
   type Hash,
   erc20Abi,
+  type TransactionReceipt,
   checksumAddress as toChecksum,
 } from 'viem'
 
@@ -25,10 +26,19 @@ export const getEvmBlock = pMemoize(
   { resolver: (blockNumber, chainId) => `${blockNumber}-${chainId}` },
 )
 
-export const getEvmTransactionReceipt = (hash: Hash, chainId: Chain['id']) =>
+export const getEvmTransactionReceipt = (
+  hash: Hash,
+  chainId: Chain['id'],
+): Promise<TransactionReceipt | null> =>
   wagmiGetTransactionReceipt(allEvmNetworksWalletConfig, {
     chainId,
     hash,
+  }).catch(function (err) {
+    // Do nothing if the TX was not found, as that throws
+    if (err.name === 'TransactionReceiptNotFoundError') {
+      return null
+    }
+    throw err
   })
 
 export const getErc20Token = pMemoize(

--- a/webapp/utils/sync-history/chainConfiguration.ts
+++ b/webapp/utils/sync-history/chainConfiguration.ts
@@ -1,3 +1,4 @@
+import { bitcoinTestnet } from 'btc-wallet/chains'
 import { hemiMainnet } from 'networks/hemiMainnet'
 import { hemiTestnet } from 'networks/hemiTestnet'
 import { mainnet } from 'networks/mainnet'
@@ -7,6 +8,11 @@ import { sepolia } from 'networks/sepolia'
 const opBasedEvmBlockWindowSize = 3500
 
 export const chainConfiguration = {
+  [bitcoinTestnet.id]: {
+    // this block window is on hemi, based on bitcoin testnet.
+    blockWindowSize: opBasedEvmBlockWindowSize,
+    minBlockToSync: 2_165_818, // BitcoinTunnelManager deployment block
+  },
   [hemiMainnet.id]: {
     blockWindowSize: opBasedEvmBlockWindowSize,
   },

--- a/webapp/utils/sync-history/common.ts
+++ b/webapp/utils/sync-history/common.ts
@@ -1,5 +1,17 @@
+import { JsonRpcProvider } from '@ethersproject/providers'
 import { type BlockSyncType } from 'hooks/useSyncHistory/types'
 import { CreateSlidingBlockWindow } from 'sliding-block-window/src'
+
+export const getBlockNumber = async function (
+  toBlock: number | undefined,
+  provider: JsonRpcProvider,
+) {
+  if (toBlock !== undefined) {
+    return toBlock
+  }
+  const blockNumber = Number(await provider.getBlockNumber())
+  return blockNumber
+}
 
 export const getBlockPayload = function ({
   canMove,

--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -21,7 +21,7 @@ import { getEvmBlock } from 'utils/evmApi'
 import { createPublicProvider } from 'utils/providers'
 import { type Chain } from 'viem'
 
-import { getBlockPayload } from './common'
+import { getBlockNumber, getBlockPayload } from './common'
 import { type HistorySyncer } from './types'
 
 const throttlingOptions = { interval: 2000, limit: 1, strict: true }
@@ -53,23 +53,6 @@ export const createEvmSync = function ({
   saveHistory,
   withdrawalsSyncInfo,
 }: HistorySyncer<BlockSyncType>) {
-  const getBlockNumber = async function (
-    toBlock: number | undefined,
-    provider: JsonRpcProvider,
-  ) {
-    if (toBlock !== undefined) {
-      return toBlock
-    }
-    debug('Getting block number for chain %s', provider.network.chainId)
-    const blockNumber = Number(await provider.getBlockNumber())
-    debug(
-      'Last block number for chain %s is %s',
-      provider.network.chainId,
-      blockNumber,
-    )
-    return blockNumber
-  }
-
   const syncDeposits = async function (
     chainProvider: JsonRpcProvider,
     crossChainMessengerPromise: Promise<CrossChainMessengerProxy>,

--- a/webapp/utils/typeUtilities.ts
+++ b/webapp/utils/typeUtilities.ts
@@ -5,6 +5,8 @@ export type DefinedFields<T extends object> = {
   [P in keyof T]-?: Exclude<T[P], null | undefined>
 }
 
+export type EnableWorkersDebug = { type: 'enable-debug'; payload: string }
+
 export type NoPayload = { payload?: never }
 
 export type Payload<T> = { payload: T }

--- a/webapp/utils/watch/bitcoinDeposits.ts
+++ b/webapp/utils/watch/bitcoinDeposits.ts
@@ -1,13 +1,11 @@
 import debugConstructor from 'debug'
-import { publicClientToHemiClient } from 'hooks/useHemiClient'
-import pMemoize from 'promise-mem'
 import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
 import { getBitcoinTimestamp } from 'utils/bitcoin'
 import { createBtcApi, mapBitcoinNetwork } from 'utils/btcApi'
-import { findChainById } from 'utils/chain'
 import { getHemiStatusOfBtcDeposit, getVaultAddressByDeposit } from 'utils/hemi'
 import { hasKeys } from 'utils/utilities'
-import { type Chain, createPublicClient, http } from 'viem'
+
+import { getHemiClient } from './common'
 
 const debug = debugConstructor('watch-btc-deposits-worker')
 
@@ -53,16 +51,6 @@ export const watchDepositOnBitcoin = async function (
 
   return updates
 }
-
-const getHemiClient = pMemoize(async function (chainId: Chain['id']) {
-  // L2 are always EVM
-  const l2Chain = findChainById(chainId) as Chain
-  const publicClient = createPublicClient({
-    chain: l2Chain,
-    transport: http(),
-  })
-  return publicClientToHemiClient(publicClient)
-})
 
 export const watchDepositOnHemi = async function (
   deposit: BtcDepositOperation,

--- a/webapp/utils/watch/bitcoinWithdrawals.ts
+++ b/webapp/utils/watch/bitcoinWithdrawals.ts
@@ -4,7 +4,7 @@ import {
   getBitcoinWithdrawalUuid,
   getHemiStatusOfBtcWithdrawal,
 } from 'utils/hemi'
-import { isBtcWithdrawalInFinalState } from 'utils/tunnel'
+import { isPendingOperation } from 'utils/tunnel'
 
 import { getHemiClient } from './common'
 
@@ -42,12 +42,12 @@ export const watchBitcoinWithdrawal = async function (
   const hemiClient = await getHemiClient(withdrawal.l2ChainId)
 
   // if the withdrawal is on a final state, it won't change, so there's no need to re-check it
-  const newStatus = isBtcWithdrawalInFinalState(withdrawal)
-    ? withdrawal.status
-    : await getHemiStatusOfBtcWithdrawal({
+  const newStatus = isPendingOperation(withdrawal)
+    ? await getHemiStatusOfBtcWithdrawal({
         hemiClient,
         withdrawal,
       })
+    : withdrawal.status
 
   if (withdrawal.status !== newStatus) {
     updates.status = newStatus

--- a/webapp/utils/watch/bitcoinWithdrawals.ts
+++ b/webapp/utils/watch/bitcoinWithdrawals.ts
@@ -1,0 +1,67 @@
+import { type ToBtcWithdrawOperation, BtcWithdrawStatus } from 'types/tunnel'
+import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
+import {
+  getBitcoinWithdrawalUuid,
+  getHemiStatusOfBtcWithdrawal,
+} from 'utils/hemi'
+import { isBtcWithdrawalInFinalState } from 'utils/tunnel'
+
+import { getHemiClient } from './common'
+
+const addMissingInfo = async function (withdrawal: ToBtcWithdrawOperation) {
+  const updates: Partial<ToBtcWithdrawOperation> = {}
+  const receipt = await getEvmTransactionReceipt(
+    withdrawal.transactionHash,
+    withdrawal.l2ChainId,
+  )
+  if (!receipt) {
+    throw new Error(`Receipt not found for tx ${withdrawal.transactionHash}`)
+  }
+  if (withdrawal.uuid === undefined) {
+    // for failed status, uuid may be found depending on which step of the flow failed
+    const uuid = getBitcoinWithdrawalUuid(receipt)
+    if (uuid) {
+      updates.uuid = uuid.toString()
+    }
+  }
+  if (!withdrawal.timestamp) {
+    const block = await getEvmBlock(receipt.blockNumber, withdrawal.l2ChainId)
+    updates.timestamp = Number(block.timestamp)
+  }
+  if (!withdrawal.blockNumber) {
+    updates.blockNumber = Number(receipt.blockNumber)
+  }
+  return updates
+}
+
+export const watchBitcoinWithdrawal = async function (
+  withdrawal: ToBtcWithdrawOperation,
+) {
+  const updates: Partial<ToBtcWithdrawOperation> = {}
+
+  const hemiClient = await getHemiClient(withdrawal.l2ChainId)
+
+  // if the withdrawal is on a final state, it won't change, so there's no need to re-check it
+  const newStatus = isBtcWithdrawalInFinalState(withdrawal)
+    ? withdrawal.status
+    : await getHemiStatusOfBtcWithdrawal({
+        hemiClient,
+        withdrawal,
+      })
+
+  if (withdrawal.status !== newStatus) {
+    updates.status = newStatus
+  }
+
+  // check for values that may be missing
+  if (
+    newStatus !== BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING &&
+    (withdrawal.uuid === undefined || !withdrawal.timestamp)
+  ) {
+    Object.assign(updates, {
+      ...(await addMissingInfo(withdrawal)),
+    })
+  }
+
+  return updates
+}

--- a/webapp/utils/watch/common.ts
+++ b/webapp/utils/watch/common.ts
@@ -1,0 +1,14 @@
+import { publicClientToHemiClient } from 'hooks/useHemiClient'
+import pMemoize from 'promise-mem'
+import { findChainById } from 'utils/chain'
+import { Chain, createPublicClient, http } from 'viem'
+
+export const getHemiClient = pMemoize(async function (chainId: Chain['id']) {
+  // L2 are always EVM
+  const l2Chain = findChainById(chainId) as Chain
+  const publicClient = createPublicClient({
+    chain: l2Chain,
+    transport: http(),
+  })
+  return publicClientToHemiClient(publicClient)
+})

--- a/webapp/workers/history.ts
+++ b/webapp/workers/history.ts
@@ -15,12 +15,12 @@ import {
   type ExtendedSyncInfo,
   type SyncHistoryCombinations,
 } from 'utils/sync-history/types'
+import { type EnableWorkersDebug } from 'utils/typeUtilities'
 import { type Address, type Chain } from 'viem'
 
-type EnableDebug = { type: 'enable-debug'; payload: string }
 type StartSyncing = { type: 'start' } & SyncHistoryCombinations
 
-type AppToWebWorkerActions = EnableDebug | StartSyncing
+type AppToWebWorkerActions = EnableWorkersDebug | StartSyncing
 
 // Worker is typed with "any", so force type safety for the messages
 // (as in runtime all types are stripped, this will continue to work)

--- a/webapp/workers/watchBitcoinDeposits.ts
+++ b/webapp/workers/watchBitcoinDeposits.ts
@@ -3,18 +3,18 @@ import { BtcTransaction } from 'btc-wallet/unisat'
 import debugConstructor from 'debug'
 import PQueue from 'p-queue'
 import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
+import { type EnableWorkersDebug } from 'utils/typeUtilities'
 import {
   watchDepositOnBitcoin,
   watchDepositOnHemi,
 } from 'utils/watch/bitcoinDeposits'
 
-type EnableDebug = { type: 'enable-debug'; payload: string }
 type WatchBtcDeposit = {
   deposit: BtcDepositOperation
   type: 'watch-btc-deposit'
 }
 
-type AppToWebWorkerActions = EnableDebug | WatchBtcDeposit
+type AppToWebWorkerActions = EnableWorkersDebug | WatchBtcDeposit
 
 export type AppToWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
   postMessage: (message: AppToWebWorkerActions) => void

--- a/webapp/workers/watchBitcoinWithdrawals.ts
+++ b/webapp/workers/watchBitcoinWithdrawals.ts
@@ -1,0 +1,77 @@
+import { type BtcChain } from 'btc-wallet/chains'
+import debugConstructor from 'debug'
+import PQueue from 'p-queue'
+import { BtcWithdrawStatus, type ToBtcWithdrawOperation } from 'types/tunnel'
+import { isBtcWithdrawalInFinalState } from 'utils/tunnel'
+import { type EnableWorkersDebug } from 'utils/typeUtilities'
+import { watchBitcoinWithdrawal } from 'utils/watch/bitcoinWithdrawals'
+
+type WatchBtcWithdrawal = {
+  type: 'watch-btc-withdrawal'
+  withdrawal: ToBtcWithdrawOperation
+}
+
+type AppToWebWorkerActions = EnableWorkersDebug | WatchBtcWithdrawal
+
+export type AppToWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  postMessage: (message: AppToWebWorkerActions) => void
+}
+
+// Worker is typed with "any", so force type safety for the messages
+// (as in runtime all types are stripped, this will continue to work)
+type WatchBtcWithdrawalsWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  onmessage: (event: MessageEvent<AppToWebWorkerActions>) => void
+  postMessage: (event: {
+    type: `update-btc-withdrawal-${BtcChain['id']}-${ToBtcWithdrawOperation['transactionHash']}`
+    updates: Partial<ToBtcWithdrawOperation>
+  }) => void
+}
+
+// See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
+const worker = self as unknown as WatchBtcWithdrawalsWorker
+
+const hemiQueue = new PQueue({ concurrency: 3 })
+
+// See https://www.npmjs.com/package/p-queue#priority
+const getPriority = function (withdrawal: ToBtcWithdrawOperation) {
+  // Give priority to running operations
+  if (
+    [
+      BtcWithdrawStatus.CHALLENGE_IN_PROGRESS,
+      BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING,
+    ].includes(withdrawal.status)
+  ) {
+    return 2
+  }
+  // if a final withdrawal reached this point, it is for missing information.
+  // Let's give them priority, so they are removed forever from the queue
+  return isBtcWithdrawalInFinalState(withdrawal) ? 1 : 0
+}
+
+export const getWithdrawalKey = (withdrawal: ToBtcWithdrawOperation) =>
+  `update-btc-withdrawal-${withdrawal.l1ChainId}-${withdrawal.transactionHash}` as const
+
+const postUpdates =
+  (withdrawal: ToBtcWithdrawOperation) =>
+  (updates: Partial<ToBtcWithdrawOperation> = {}) =>
+    worker.postMessage({
+      type: getWithdrawalKey(withdrawal),
+      updates,
+    })
+
+const watchWithdrawal = (withdrawal: ToBtcWithdrawOperation) =>
+  hemiQueue.add(
+    () => watchBitcoinWithdrawal(withdrawal).then(postUpdates(withdrawal)),
+    { priority: getPriority(withdrawal) },
+  )
+
+// wait for the UI to send chain and address once ready
+worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (e.data.type === 'watch-btc-withdrawal') {
+    watchWithdrawal(e.data.withdrawal)
+  }
+  // See https://github.com/debug-js/debug/issues/916#issuecomment-1539231712
+  if (e.data.type === 'enable-debug') {
+    debugConstructor.enable(e.data.payload)
+  }
+}

--- a/webapp/workers/watchBitcoinWithdrawals.ts
+++ b/webapp/workers/watchBitcoinWithdrawals.ts
@@ -2,7 +2,7 @@ import { type BtcChain } from 'btc-wallet/chains'
 import debugConstructor from 'debug'
 import PQueue from 'p-queue'
 import { BtcWithdrawStatus, type ToBtcWithdrawOperation } from 'types/tunnel'
-import { isBtcWithdrawalInFinalState } from 'utils/tunnel'
+import { isPendingOperation } from 'utils/tunnel'
 import { type EnableWorkersDebug } from 'utils/typeUtilities'
 import { watchBitcoinWithdrawal } from 'utils/watch/bitcoinWithdrawals'
 
@@ -45,7 +45,7 @@ const getPriority = function (withdrawal: ToBtcWithdrawOperation) {
   }
   // if a final withdrawal reached this point, it is for missing information.
   // Let's give them priority, so they are removed forever from the queue
-  return isBtcWithdrawalInFinalState(withdrawal) ? 1 : 0
+  return isPendingOperation(withdrawal) ? 0 : 1
 }
 
 export const getWithdrawalKey = (withdrawal: ToBtcWithdrawOperation) =>

--- a/webapp/workers/watchEvmWithdrawals.ts
+++ b/webapp/workers/watchEvmWithdrawals.ts
@@ -11,6 +11,7 @@ import { findChainById } from 'utils/chain'
 import { createQueuedCrossChainMessenger } from 'utils/crossChainMessenger'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import { createPublicProvider } from 'utils/providers'
+import { type EnableWorkersDebug } from 'utils/typeUtilities'
 import { hasKeys } from 'utils/utilities'
 import { type Chain, type Hash } from 'viem'
 
@@ -21,13 +22,12 @@ const debug = debugConstructor('watch-evm-withdrawals-worker')
 export const getUpdateWithdrawalKey = (withdrawal: WithdrawTunnelOperation) =>
   `update-withdrawal-${withdrawal.l2ChainId}-${withdrawal.transactionHash}` as const
 
-type EnableDebug = { type: 'enable-debug'; payload: string }
 type WatchWithdrawal = {
   type: 'watch-withdrawal'
   withdrawal: ToEvmWithdrawOperation
 }
 
-type AppToWebWorkerActions = EnableDebug | WatchWithdrawal
+type AppToWebWorkerActions = EnableWorkersDebug | WatchWithdrawal
 
 export type AppToWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
   postMessage: (message: AppToWebWorkerActions) => void


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

PR Follow up of #740 

This PR focuses on adding the workers who watch the past bitcoin withdrawals for the status change (for example: if a withdrawal wasn't completed, it should after some time specified by the vault, be marked as ready to be challenged to restore the hemi bitcoins). This also includes some UI changes in the Transaction History page

Description per commit

- 4664d63f4908dda011f230061c51e9de2959a7d9 Implements the appropriate status and CTA for bitcoin withdrawals (updatin the prior implementation)
- 92a297051c6627f03233c8f8276161c402c63ece prevents `getEvmTransactionReceipt` to throw if the receipt was not found, returning null instead. There are some scenarios where we need this to be handled like this
- 68d89dded545671a6a3de05428cff8f565dea066 moves a function to a `common` file as it is needed in a few different files (naming is hard)
- 144976f7d46da2a137010875e95c57e8ac3eed71 adds a few small tests for `isDeposit`
- 5412441f49a4a8c1e066719ad0465b9cc209058e Makes a small update to the chain configuration for syncing.
- 8061476d478ecf2ab9e908b32f7da7d2ebc74cdc Adds a minor improvement on the typings for enabling logs for debug in workers
- 1859fce0dd51cba1c8efc6910d8cfb8641602f3f adds a function that, given a withdrawal, gets the state (And any missing information, if any). This is used to watch bitcoin withdrawals by polling. Tests added too.
- 5f194eb27834e59b85c3436994adc6e429220763 Uses the function in the commit above to create a worker whenever there are withdrawals that need to be tracked and tracks them.

- Lastly, cae161e45f5aca1cc74fef45398307705a5bbc8d fixes the conflicts after rebasing with #741 

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

See #740 

<img width="1596" alt="image" src="https://github.com/user-attachments/assets/effe2bf2-9fd8-49bd-8d1c-242ecf6db7d3" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related #738
Related #345 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
