### PR TITLE
Save status when resyncing evm deposits

### DIFF
--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -9,6 +9,7 @@ import {
 } from 'sliding-block-window/src'
 import {
   EvmDepositOperation,
+  EvmDepositStatus,
   ToEvmWithdrawOperation,
   TunnelOperation,
 } from 'types/tunnel'
@@ -36,6 +37,10 @@ const toOperation =
           amount: tunnelOperation.amount.toString(),
           l1ChainId,
           l2ChainId,
+          // If deposits are found, it means they are confirmed. There's no other possible status
+          // This may not be the case if we Get txs from the user's account, instead of checking logs
+          // as failed deposits will also appear https://github.com/hemilabs/ui-monorepo/issues/743
+          status: EvmDepositStatus.DEPOSIT_TX_CONFIRMED,
         }) as T,
     )
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

As part of testing #741 , I noticed deposits where missing the `status` field when resyncing. This PR fixes that.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #744

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
