### PR TITLE
Remove extra character in workflow definition

### DIFF
--- a/.github/workflows/hostinger-deployment.yml
+++ b/.github/workflows/hostinger-deployment.yml
@@ -37,7 +37,7 @@ jobs:
           NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA: ${{ vars.NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA }}
           NEXT_PUBLIC_ENABLE_ANALYTICS: false
           NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL: ${{ vars.NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL || 'false' }}
-          NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET: ${{ vars.NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET || 'false' }}'
+          NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET: ${{ vars.NEXT_PUBLIC_FEATURE_FLAG_ENABLE_MAINNET || 'false' }}
 
   deploy:
     environment: ${{ github.event_name == 'release' && 'production' || 'staging' }}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Removing a character at the end of the workflow, which break the enabling of mainnet in prod (Added as part of #757)

![image](https://github.com/user-attachments/assets/c1c0d1ce-2dec-4f71-9437-7b12286fbb90)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
