### PR TITLE
Removed unsafe-inline and data: from CSP header

### DIFF
--- a/webapp/scripts/generateHeaders.js
+++ b/webapp/scripts/generateHeaders.js
@@ -124,11 +124,11 @@ const serveJson = {
         },
         {
           key: 'Content-Security-Policy',
-          value: `default-src 'self'; script-src 'self' 'unsafe-inline' ${downloadScriptsDomains.join(
+          value: `default-src 'self'; script-src 'self' ${downloadScriptsDomains.join(
             ' ',
-          )}; style-src 'self' 'unsafe-inline'; img-src 'self' ${imageSrcUrls.join(
+          )}; style-src 'self'; img-src 'self' ${imageSrcUrls.join(
             ' ',
-          )} blob: data:; connect-src 'self' ${fetchDomains.join(
+          )} blob:; connect-src 'self' ${fetchDomains.join(
             ' ',
           )}; frame-ancestors 'none'; block-all-mixed-content; upgrade-insecure-requests`,
         },


### PR DESCRIPTION
### Description

This PR removes `unsafe-inline` and `data:` from Content-Security-Policy header as suggested by MDN HTTP Observatory Report (Screenshot)

### Screenshots

![Captura de Tela 2025-01-15 às 16 21 03](https://github.com/user-attachments/assets/10090d78-dad8-4c57-ab52-6021b98ff274)

### Related issue(s)

Related to https://github.com/hemilabs/PM-tracking/issues/10

