### PR TITLE
Fix 'Learn more' link in get-started page

### DIFF
--- a/webapp/app/[locale]/get-started/_components/learnMore.tsx
+++ b/webapp/app/[locale]/get-started/_components/learnMore.tsx
@@ -132,7 +132,7 @@ export const LearnMore = function () {
   const t = useTranslations('get-started')
   const { track } = useUmami()
 
-  const tutorialsUrl = 'https://docs.hemi.xyz/how-to-tutorials/tutorials'
+  const tutorialsUrl = 'https://docs.hemi.xyz/main/start-here'
 
   const addTracking = () =>
     track ? () => track('tut - learn more') : undefined


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The "Learn More" led to the hemi docs page, but inside that hemi docs page resulted in a 404 page (so a broken links automated detector doesn't pick it up).  
This PR updates the link

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #759

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
