### PR TITLE
Improve rpc handling

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -8,10 +8,14 @@ The environment variables are defined in the `.env` file at the root of the proj
 The prefix `NEXT_PUBLIC_` is required for the variables to be available in the browser. A few variables can be set locally (in a `.env.local`), in addition to the ones already defined in the `.env`.
 
 ```sh
-NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_SEPOLIA=<url> # Optional - Used to override the Hemi Sepolia RPC URL
-NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA=<url> # Optional - Used to override the Sepolia RPC URL
-NEXT_PUBLIC_FEATURE_FLAG_ENABLE_BTC_TUNNEL=<true|false> # Enable the bitcoin tunnel feature
-NEXT_PUBLIC_WORKERS_DEBUG_ENABLE=<true|false> # enable logging on web workers
+# Use this variables to override RPC urls per chain. In order to join multiple RPC urls, join them with the "+" character.
+# For example NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA="https://rpc1.testnet.com/rpc+https://rpc2.testnet.com/rpc"
+NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_MAINNET=<urls>
+NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_SEPOLIA=<urls>
+NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET=<urls>
+NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA=<urls>
+# enable logging on web workers
+NEXT_PUBLIC_WORKERS_DEBUG_ENABLE=<true|false>
 # These env variables are required for Enabling Analytics
 NEXT_PUBLIC_ENABLE_ANALYTICS=<true|false> # Enable Analytics with Umami
 NEXT_PUBLIC_ANALYTICS_URL=<url> # Umami analytics URL

--- a/webapp/context/evmWalletContext.tsx
+++ b/webapp/context/evmWalletContext.tsx
@@ -9,7 +9,7 @@ import {
 import { metaMaskWallet } from '@rainbow-me/rainbowkit/wallets'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { allEvmNetworks } from 'networks'
-import { http } from 'viem'
+import { buildTransports } from 'utils/transport'
 import { WagmiProvider, createConfig } from 'wagmi'
 
 type Props = {
@@ -36,14 +36,7 @@ const connectors = connectorsForWallets(
 export const allEvmNetworksWalletConfig = createConfig({
   chains: allEvmNetworks,
   connectors,
-  transports: Object.fromEntries(
-    allEvmNetworks.map(n => [
-      n.id,
-      http(n.rpcUrls.default.http[0], {
-        batch: { wait: 1000 },
-      }),
-    ]),
-  ),
+  transports: buildTransports(allEvmNetworks),
 })
 
 export const EvmWalletContext = ({ children, locale }: Props) => (

--- a/webapp/hooks/useEthersSigner.ts
+++ b/webapp/hooks/useEthersSigner.ts
@@ -1,23 +1,10 @@
 // See https://wagmi.sh/react/guides/ethers#connector-client-%E2%86%92-signer
 import { useMemo } from 'react'
-import {
-  createFallbackProvider,
-  createPublicProvider,
-  createSignerProvider,
-} from 'utils/providers'
-import type { Chain, PublicClient } from 'viem'
+import { createSignerProvider, createProvider } from 'utils/providers'
+import type { Chain } from 'viem'
 import { Config, useConnectorClient, usePublicClient } from 'wagmi'
 
 import { useChainIsSupported } from './useChainIsSupported'
-
-// See https://wagmi.sh/react/guides/ethers#client-%E2%86%92-provider
-function publicClientToProvider(publicClient: PublicClient) {
-  const { chain, transport } = publicClient
-  if (transport.type === 'fallback') {
-    return createFallbackProvider(chain, transport.transports)
-  }
-  return createPublicProvider(transport.url, chain)
-}
 
 // https://wagmi.sh/react/guides/ethers#connector-client-%E2%86%92-signer
 // Types provided by docs do not work, unless [strict](https://www.typescriptlang.org/tsconfig#strict) is enabled.
@@ -43,13 +30,8 @@ export function useJsonRpcProvider(chainId: Chain['id']) {
   return useMemo(
     () =>
       publicClient && isSupported
-        ? publicClientToProvider(publicClient)
+        ? createProvider(publicClient.chain)
         : undefined,
     [isSupported, publicClient],
   )
 }
-
-export type Provider =
-  | ReturnType<typeof useWeb3Provider>
-  | ReturnType<typeof useJsonRpcProvider>
-  | undefined

--- a/webapp/networks/hemiMainnet.ts
+++ b/webapp/networks/hemiMainnet.ts
@@ -1,7 +1,7 @@
 import { hemi } from 'hemi-viem'
-import { overrideRpcUrl } from 'networks/utils'
+import { updateRpcUrls } from 'networks/utils'
 
-export const hemiMainnet = overrideRpcUrl(
+export const hemiMainnet = updateRpcUrls(
   hemi,
   process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_MAINNET,
 )

--- a/webapp/networks/hemiTestnet.ts
+++ b/webapp/networks/hemiTestnet.ts
@@ -1,7 +1,7 @@
 import { hemiSepolia } from 'hemi-viem'
-import { overrideRpcUrl } from 'networks/utils'
+import { updateRpcUrls } from 'networks/utils'
 
-export const hemiTestnet = overrideRpcUrl(
+export const hemiTestnet = updateRpcUrls(
   hemiSepolia,
   process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_SEPOLIA,
 )

--- a/webapp/networks/mainnet.ts
+++ b/webapp/networks/mainnet.ts
@@ -1,7 +1,7 @@
-import { overrideRpcUrl } from 'networks/utils'
+import { updateRpcUrls } from 'networks/utils'
 import { mainnet as mainnetDefinition } from 'viem/chains'
 
-export const mainnet = overrideRpcUrl(
+export const mainnet = updateRpcUrls(
   mainnetDefinition,
   process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET,
 )

--- a/webapp/networks/sepolia.ts
+++ b/webapp/networks/sepolia.ts
@@ -1,7 +1,7 @@
-import { overrideRpcUrl } from 'networks/utils'
+import { updateRpcUrls } from 'networks/utils'
 import { sepolia as sepoliaDefinition } from 'viem/chains'
 
-export const sepolia = overrideRpcUrl(
+export const sepolia = updateRpcUrls(
   sepoliaDefinition,
   process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA,
 )

--- a/webapp/networks/utils.ts
+++ b/webapp/networks/utils.ts
@@ -1,14 +1,18 @@
+import { isValidUrl } from 'utils/url'
 import { type Chain } from 'viem'
 import { defineChain } from 'viem/utils'
 
-export const overrideRpcUrl = function (chain: Chain, rpcUrl?: string) {
-  const isValidCustomSepoliaRpc = !!rpcUrl && rpcUrl.startsWith('https')
-  if (isValidCustomSepoliaRpc) {
+export const updateRpcUrls = function (chain: Chain, rpcUrlEnv?: string) {
+  if (typeof rpcUrlEnv !== 'string') {
+    return chain
+  }
+  const urls = rpcUrlEnv.split('+').filter(isValidUrl)
+  if (urls.length > 0) {
     return defineChain({
       ...chain,
       rpcUrls: {
         default: {
-          http: [rpcUrl],
+          http: urls,
         },
       },
     })

--- a/webapp/scripts/generateHeaders.js
+++ b/webapp/scripts/generateHeaders.js
@@ -50,7 +50,7 @@ const customRpcOrigins = [
   process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_SEPOLIA,
   process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET,
   process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA,
-]
+].flatMap((p = '') => p.split('+'))
 customRpcOrigins.forEach(function (url) {
   if (url) {
     fetchDomains.push(new URL(url).origin)

--- a/webapp/test/utils/url.test.ts
+++ b/webapp/test/utils/url.test.ts
@@ -1,4 +1,4 @@
-import { isRelativeUrl, queryStringObjectToString } from 'utils/url'
+import { isRelativeUrl, isValidUrl, queryStringObjectToString } from 'utils/url'
 import { describe, expect, it } from 'vitest'
 
 describe('utils/url', function () {
@@ -9,6 +9,22 @@ describe('utils/url', function () {
 
     it('should return false for full urls', function () {
       expect(isRelativeUrl('https://google.com.ar/')).toBe(false)
+    })
+  })
+
+  describe('isValidUrl', function () {
+    describe('isValidUrl', function () {
+      it('should return true for a valid URL', function () {
+        expect(isValidUrl('https://example.com/path?name=value')).toBe(true)
+      })
+
+      it('should return false for an invalid URL', function () {
+        expect(isValidUrl('invalid-url')).toBe(false)
+      })
+
+      it('should return false for an empty string', function () {
+        expect(isValidUrl('')).toBe(false)
+      })
     })
   })
 

--- a/webapp/test/utils/watch/evmWithdrawals.test.ts
+++ b/webapp/test/utils/watch/evmWithdrawals.test.ts
@@ -3,7 +3,7 @@ import { hemiSepolia } from 'hemi-viem'
 import { ToEvmWithdrawOperation } from 'types/tunnel'
 import { createQueuedCrossChainMessenger } from 'utils/crossChainMessenger'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
-import { createPublicProvider } from 'utils/providers'
+import { createProvider } from 'utils/providers'
 // import { watchEvmWithdrawal } from 'utils/watch/evmWithdrawals'
 import { sepolia } from 'viem/chains'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -26,7 +26,7 @@ vi.mock('utils/evmApi', () => ({
 }))
 
 vi.mock('utils/providers', () => ({
-  createPublicProvider: vi.fn(),
+  createProvider: vi.fn(),
 }))
 
 describe('utils/watch/evmWithdrawals', function () {
@@ -40,7 +40,7 @@ describe('utils/watch/evmWithdrawals', function () {
     it('should return no changes if the withdrawal is pending', async function () {
       const { watchEvmWithdrawal } = await import('utils/watch/evmWithdrawals')
       vi.mocked(createQueuedCrossChainMessenger).mockResolvedValue({})
-      vi.mocked(createPublicProvider).mockResolvedValue({})
+      vi.mocked(createProvider).mockResolvedValue({})
       vi.mocked(getEvmTransactionReceipt).mockResolvedValue(null)
 
       const updates = await watchEvmWithdrawal(withdrawal)

--- a/webapp/utils/chain.ts
+++ b/webapp/utils/chain.ts
@@ -3,7 +3,6 @@ import { hemiMainnet } from 'networks/hemiMainnet'
 import { hemiTestnet } from 'networks/hemiTestnet'
 import { type EvmChain, type RemoteChain } from 'types/chain'
 import { type Chain } from 'viem'
-import { defineChain } from 'viem/utils'
 
 export const findChainById = (chainId: RemoteChain['id']) =>
   allNetworks.find(n => n.id === chainId)
@@ -21,18 +20,3 @@ export const isL2NetworkId = (chainId: number) =>
   [hemiMainnet.id, hemiTestnet.id].includes(chainId)
 
 export const isL2Network = (chain: Chain) => isL2NetworkId(chain.id)
-
-export const overrideRpcUrl = function (chain: Chain, rpcUrl?: string) {
-  const isValidCustomRpc = !!rpcUrl && rpcUrl.startsWith('https')
-  if (isValidCustomRpc) {
-    return defineChain({
-      ...chain,
-      rpcUrls: {
-        default: {
-          http: [rpcUrl],
-        },
-      },
-    })
-  }
-  return chain
-}

--- a/webapp/utils/chainClients.ts
+++ b/webapp/utils/chainClients.ts
@@ -1,9 +1,8 @@
 import { publicClientToHemiClient } from 'hooks/useHemiClient'
-import pMemoize from 'promise-mem'
 import { findChainById } from 'utils/chain'
 import { Chain, createPublicClient, http } from 'viem'
 
-export const getHemiClient = pMemoize(async function (chainId: Chain['id']) {
+export const getHemiClient = function (chainId: Chain['id']) {
   // L2 are always EVM
   const l2Chain = findChainById(chainId) as Chain
   const publicClient = createPublicClient({
@@ -11,4 +10,4 @@ export const getHemiClient = pMemoize(async function (chainId: Chain['id']) {
     transport: http(),
   })
   return publicClientToHemiClient(publicClient)
-})
+}

--- a/webapp/utils/chainClients.ts
+++ b/webapp/utils/chainClients.ts
@@ -1,13 +1,14 @@
 import { publicClientToHemiClient } from 'hooks/useHemiClient'
 import { findChainById } from 'utils/chain'
-import { Chain, createPublicClient, http } from 'viem'
+import { buildTransport } from 'utils/transport'
+import { Chain, createPublicClient } from 'viem'
 
 export const getHemiClient = function (chainId: Chain['id']) {
   // L2 are always EVM
   const l2Chain = findChainById(chainId) as Chain
   const publicClient = createPublicClient({
     chain: l2Chain,
-    transport: http(),
+    transport: buildTransport(l2Chain),
   })
   return publicClientToHemiClient(publicClient)
 }

--- a/webapp/utils/sync-history/bitcoin.ts
+++ b/webapp/utils/sync-history/bitcoin.ts
@@ -2,7 +2,7 @@ import { MessageDirection } from '@eth-optimism/sdk'
 import { BtcChain } from 'btc-wallet/chains'
 import { Account, BtcTransaction } from 'btc-wallet/unisat'
 import { bitcoinTunnelManagerAbi } from 'hemi-viem/contracts'
-import { HemiPublicClient, publicClientToHemiClient } from 'hooks/useHemiClient'
+import { type HemiPublicClient } from 'hooks/useHemiClient'
 import {
   type BlockSyncType,
   type TransactionListSyncType,
@@ -26,6 +26,7 @@ import {
   mapBitcoinNetwork,
   type MempoolJsBitcoinTransaction,
 } from 'utils/btcApi'
+import { getHemiClient } from 'utils/chainClients'
 import { getEvmBlock } from 'utils/evmApi'
 import {
   getHemiStatusOfBtcDeposit,
@@ -40,10 +41,8 @@ import { createPublicProvider } from 'utils/providers'
 import { getNativeToken } from 'utils/token'
 import {
   type Address,
-  createPublicClient,
   decodeFunctionData,
   type Hash,
-  http,
   type Log,
   parseAbiItem,
   toHex,
@@ -228,12 +227,7 @@ export const createBitcoinSync = function ({
 > & {
   l1Chain: BtcChain
 } & Pick<HistorySyncer<BlockSyncType>, 'withdrawalsSyncInfo'>) {
-  const l2PublicClient = createPublicClient({
-    chain: l2Chain,
-    transport: http(),
-  })
-
-  const hemiClient = publicClientToHemiClient(l2PublicClient)
+  const hemiClient = getHemiClient(l2Chain.id)
 
   const getBitcoinWithdrawals = ({
     fromBlock,

--- a/webapp/utils/sync-history/bitcoin.ts
+++ b/webapp/utils/sync-history/bitcoin.ts
@@ -37,7 +37,7 @@ import {
   getBitcoinCustodyAddress,
   getVaultAddressByIndex,
 } from 'utils/hemiMemoized'
-import { createPublicProvider } from 'utils/providers'
+import { createProvider } from 'utils/providers'
 import { getNativeToken } from 'utils/token'
 import {
   type Address,
@@ -365,7 +365,7 @@ export const createBitcoinSync = function ({
   const syncWithdrawals = async function () {
     const lastBlock = await getBlockNumber(
       withdrawalsSyncInfo.toBlock,
-      createPublicProvider(l2Chain.rpcUrls.default.http[0], l2Chain),
+      createProvider(l2Chain),
     )
 
     const initialBlock =

--- a/webapp/utils/sync-history/common.ts
+++ b/webapp/utils/sync-history/common.ts
@@ -1,10 +1,10 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
+import { type BaseProvider } from '@ethersproject/providers'
 import { type BlockSyncType } from 'hooks/useSyncHistory/types'
 import { CreateSlidingBlockWindow } from 'sliding-block-window/src'
 
 export const getBlockNumber = async function (
   toBlock: number | undefined,
-  provider: JsonRpcProvider,
+  provider: BaseProvider,
 ) {
   if (toBlock !== undefined) {
     return toBlock

--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -1,5 +1,5 @@
 import { type TokenBridgeMessage } from '@eth-optimism/sdk'
-import { JsonRpcProvider } from '@ethersproject/providers'
+import { type BaseProvider } from '@ethersproject/providers'
 import { BlockSyncType } from 'hooks/useSyncHistory/types'
 import pAll from 'p-all'
 import pThrottle from 'p-throttle'
@@ -18,7 +18,7 @@ import {
   type CrossChainMessengerProxy,
 } from 'utils/crossChainMessenger'
 import { getEvmBlock } from 'utils/evmApi'
-import { createPublicProvider } from 'utils/providers'
+import { createProvider } from 'utils/providers'
 import { type Chain } from 'viem'
 
 import { getBlockNumber, getBlockPayload } from './common'
@@ -54,7 +54,7 @@ export const createEvmSync = function ({
   withdrawalsSyncInfo,
 }: HistorySyncer<BlockSyncType>) {
   const syncDeposits = async function (
-    chainProvider: JsonRpcProvider,
+    chainProvider: BaseProvider,
     crossChainMessengerPromise: Promise<CrossChainMessengerProxy>,
   ) {
     debug('Starting process to sync deposits')
@@ -143,7 +143,7 @@ export const createEvmSync = function ({
   }
 
   const syncWithdrawals = async function (
-    chainProvider: JsonRpcProvider,
+    chainProvider: BaseProvider,
     crossChainMessengerPromise: Promise<CrossChainMessengerProxy>,
   ) {
     debug('Starting process to sync withdrawals')
@@ -247,15 +247,9 @@ export const createEvmSync = function ({
     // EVM chains use Ethers providers because that's what
     // the cross-chain messenger expects
     debug('Creating providers')
-    const l1Provider = createPublicProvider(
-      l1Chain.rpcUrls.default.http[0],
-      l1Chain,
-    )
+    const l1Provider = createProvider(l1Chain)
 
-    const l2Provider = createPublicProvider(
-      l2Chain.rpcUrls.default.http[0],
-      l2Chain,
-    )
+    const l2Provider = createProvider(l2Chain)
 
     const crossChainMessengerPromise = createQueuedCrossChainMessenger({
       l1ChainId: l1Chain.id,

--- a/webapp/utils/transport.ts
+++ b/webapp/utils/transport.ts
@@ -1,0 +1,18 @@
+import { OrderedChains } from 'types/chain'
+import { type Chain, fallback, http } from 'viem'
+
+export const buildTransport = function (network: Chain) {
+  const httpConfig = {
+    batch: { wait: 1000 },
+  }
+  const rpcUrls = network.rpcUrls.default.http
+  if (rpcUrls.length > 1) {
+    return fallback(
+      rpcUrls.map(rpcUrl => http(rpcUrl, httpConfig), { rank: true }),
+    )
+  }
+  return http(rpcUrls[0], httpConfig)
+}
+
+export const buildTransports = (networks: Chain[] | OrderedChains) =>
+  Object.fromEntries(networks.map(n => [n.id, buildTransport(n)]))

--- a/webapp/utils/transport.ts
+++ b/webapp/utils/transport.ts
@@ -4,11 +4,16 @@ import { type Chain, fallback, http } from 'viem'
 export const buildTransport = function (network: Chain) {
   const httpConfig = {
     batch: { wait: 1000 },
+    retryCount: 2,
   }
   const rpcUrls = network.rpcUrls.default.http
   if (rpcUrls.length > 1) {
     return fallback(
-      rpcUrls.map(rpcUrl => http(rpcUrl, httpConfig), { rank: true }),
+      rpcUrls.map(rpcUrl => http(rpcUrl, httpConfig), {
+        // rank every 10 seconds
+        rank: { interval: 10_000 },
+        retryCount: 2,
+      }),
     )
   }
   return http(rpcUrls[0], httpConfig)

--- a/webapp/utils/url.ts
+++ b/webapp/utils/url.ts
@@ -2,6 +2,15 @@ import { hasKeys } from './utilities'
 
 export const isRelativeUrl = (url: string) => url.startsWith('/')
 
+export const isValidUrl = function (url: string) {
+  try {
+    new URL(url)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export const queryStringObjectToString = function (
   queryString: Record<string, string> = {},
 ) {

--- a/webapp/utils/watch/bitcoinDeposits.ts
+++ b/webapp/utils/watch/bitcoinDeposits.ts
@@ -2,10 +2,9 @@ import debugConstructor from 'debug'
 import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
 import { getBitcoinTimestamp } from 'utils/bitcoin'
 import { createBtcApi, mapBitcoinNetwork } from 'utils/btcApi'
+import { getHemiClient } from 'utils/chainClients'
 import { getHemiStatusOfBtcDeposit, getVaultAddressByDeposit } from 'utils/hemi'
 import { hasKeys } from 'utils/utilities'
-
-import { getHemiClient } from './common'
 
 const debug = debugConstructor('watch-btc-deposits-worker')
 
@@ -55,7 +54,7 @@ export const watchDepositOnBitcoin = async function (
 export const watchDepositOnHemi = async function (
   deposit: BtcDepositOperation,
 ) {
-  const hemiClient = await getHemiClient(deposit.l2ChainId)
+  const hemiClient = getHemiClient(deposit.l2ChainId)
 
   const newStatus = await getVaultAddressByDeposit(hemiClient, deposit).then(
     vaultAddress =>

--- a/webapp/utils/watch/bitcoinWithdrawals.ts
+++ b/webapp/utils/watch/bitcoinWithdrawals.ts
@@ -1,12 +1,11 @@
 import { type ToBtcWithdrawOperation, BtcWithdrawStatus } from 'types/tunnel'
+import { getHemiClient } from 'utils/chainClients'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import {
   getBitcoinWithdrawalUuid,
   getHemiStatusOfBtcWithdrawal,
 } from 'utils/hemi'
 import { isPendingOperation } from 'utils/tunnel'
-
-import { getHemiClient } from './common'
 
 const addMissingInfo = async function (withdrawal: ToBtcWithdrawOperation) {
   const updates: Partial<ToBtcWithdrawOperation> = {}
@@ -39,7 +38,7 @@ export const watchBitcoinWithdrawal = async function (
 ) {
   const updates: Partial<ToBtcWithdrawOperation> = {}
 
-  const hemiClient = await getHemiClient(withdrawal.l2ChainId)
+  const hemiClient = getHemiClient(withdrawal.l2ChainId)
 
   // if the withdrawal is on a final state, it won't change, so there's no need to re-check it
   const newStatus = isPendingOperation(withdrawal)

--- a/webapp/utils/watch/evmWithdrawals.ts
+++ b/webapp/utils/watch/evmWithdrawals.ts
@@ -3,21 +3,15 @@ import { ToEvmWithdrawOperation } from 'types/tunnel'
 import { findChainById } from 'utils/chain'
 import { createQueuedCrossChainMessenger } from 'utils/crossChainMessenger'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
-import { createPublicProvider } from 'utils/providers'
+import { createProvider } from 'utils/providers'
 import { Chain } from 'viem'
 
 // Memoized cross chain messenger as this will be created by many withdrawals
 const getCrossChainMessenger = pMemoize(
   function (l1Chain: Chain, l2Chain: Chain) {
-    const l1Provider = createPublicProvider(
-      l1Chain.rpcUrls.default.http[0],
-      l1Chain,
-    )
+    const l1Provider = createProvider(l1Chain)
 
-    const l2Provider = createPublicProvider(
-      l2Chain.rpcUrls.default.http[0],
-      l2Chain,
-    )
+    const l2Provider = createProvider(l2Chain)
 
     return createQueuedCrossChainMessenger({
       l1ChainId: l1Chain.id,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds support for multiple RPC URLs by leveraging [viem's Fallback transport](https://viem.sh/docs/clients/transports/fallback.html) and [ether's fallback provider](https://docs.ethers.org/v6/api/providers/fallback-provider/).  
Remember that we use viem everywhere in the app, except when using the OP SDK, which requires a ethers provider (hence the double usage redundant until we get rid of the already deprecated OP SDK).

Now multiple URLs can be configured in each env variable, as long as they are split with `+`. For example:

```sh
NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA="https://sepolia.drpc.org+https://eth-sepolia-public.unifra.io"
```

The recommendation to this is to place the URL we want to be added to the wallet first. The rest can be used as fallbacks. Ethers in particular distribute the requests along all the URLs, so it's not a fallback mechanism.

I also simplified a bit the transformation from viem's client to ethers' providers, and the creating of public client as well.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes are visible to the users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #658
Closes #773
Related to #383

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
