### PR TITLE
Add watcher for EVM deposits

### DIFF
--- a/webapp/context/tunnelHistoryContext/evmDepositsStatusUpdater.tsx
+++ b/webapp/context/tunnelHistoryContext/evmDepositsStatusUpdater.tsx
@@ -1,0 +1,117 @@
+import { WithWorker } from 'components/withWorker'
+import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
+import { useEvmDeposits } from 'hooks/useEvmDeposits'
+import { useTunnelHistory } from 'hooks/useTunnelHistory'
+import { useEffect } from 'react'
+import { EvmDepositOperation } from 'types/tunnel'
+import { isPendingOperation } from 'utils/tunnel'
+import { hasKeys } from 'utils/utilities'
+import { useAccount } from 'wagmi'
+import { type AppToWorker, getDepositKey } from 'workers/watchEvmDeposits'
+
+const WatchEvmDeposit = function ({
+  deposit,
+  worker,
+}: {
+  deposit: EvmDepositOperation
+  worker: AppToWorker
+}) {
+  const { updateDeposit } = useTunnelHistory()
+
+  useEffect(
+    function watchDepositUpdates() {
+      // Not using useState as 1. this value is local to the effect and
+      // 2. to avoid unsubscribing and resubscribing when the state value changes
+      let hasWorkedPostedBack = false
+      const saveUpdates = function (
+        event: MessageEvent<{
+          updates: Partial<EvmDepositOperation>
+          type: string
+        }>,
+      ) {
+        // This is needed because this component is rendered per-withdrawal, so each component will receive the posted message
+        // for every withdrawal, as there are many withdrawals but only one worker.
+        // Of all components, this "if" clause below will be true for only one rendered component - the one belonging to the withdrawal
+        const { type, updates } = event.data
+        if (type !== getDepositKey(deposit)) {
+          return
+        }
+        // next interval will poll again
+        hasWorkedPostedBack = true
+        if (hasKeys(updates)) {
+          updateDeposit(deposit, updates)
+        }
+      }
+
+      worker.addEventListener('message', saveUpdates)
+
+      // refetch every 15 seconds
+      const interval = 15 * 1000
+
+      worker.postMessage({
+        deposit,
+        type: 'watch-evm-deposit',
+      })
+
+      const intervalId = setInterval(function () {
+        if (!hasWorkedPostedBack) {
+          return
+        }
+        worker.postMessage({
+          deposit,
+          type: 'watch-evm-deposit',
+        })
+        // Block posting until a response is received
+        hasWorkedPostedBack = false
+      }, interval)
+
+      return function cleanup() {
+        worker.removeEventListener('message', saveUpdates)
+        clearInterval(intervalId)
+      }
+    },
+    [deposit, updateDeposit, worker],
+  )
+
+  return null
+}
+
+const missingInformation = (deposit: EvmDepositOperation) =>
+  !deposit.blockNumber || !deposit.timestamp
+
+// See https://github.com/vercel/next.js/issues/31009#issuecomment-11463441611
+// and https://github.com/vercel/next.js/issues/31009#issuecomment-1338645354
+const getWorker = () =>
+  new Worker(new URL('../../workers/watchEvmDeposits.ts', import.meta.url))
+
+export const EvmDepositsStatusUpdater = function () {
+  const { isConnected } = useAccount()
+
+  const deposits = useEvmDeposits()
+
+  const unsupportedChain = useConnectedToUnsupportedEvmChain()
+
+  if (!isConnected || unsupportedChain) {
+    return null
+  }
+
+  const depositsToWatch = deposits.filter(
+    deposit => isPendingOperation(deposit) || missingInformation(deposit),
+  )
+
+  return (
+    <WithWorker getWorker={getWorker}>
+      {(worker: AppToWorker) => (
+        <>
+          {depositsToWatch.map(deposit => (
+            <WatchEvmDeposit
+              deposit={deposit}
+              key={deposit.transactionHash}
+              worker={worker}
+            />
+          ))}
+        </>
+      )}
+    </WithWorker>
+  )
+}

--- a/webapp/context/tunnelHistoryContext/index.tsx
+++ b/webapp/context/tunnelHistoryContext/index.tsx
@@ -33,6 +33,14 @@ const BitcoinWithdrawalsStatusUpdater = dynamic(
   { ssr: false },
 )
 
+const EvmDepositsStatusUpdater = dynamic(
+  () =>
+    import('./evmDepositsStatusUpdater').then(
+      mod => mod.EvmDepositsStatusUpdater,
+    ),
+  { ssr: false },
+)
+
 const SyncHistoryWorker = dynamic(
   () => import('./syncHistoryWorker').then(mod => mod.SyncHistoryWorker),
   { ssr: false },
@@ -129,6 +137,8 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
       {featureFlags.btcTunnelEnabled && <BitcoinWithdrawalsStatusUpdater />}
       {/* Track updates on withdrawals from Hemi */}
       <WithdrawalsStateUpdater />
+      {/* Track updates on deposits to Hemi, tracking any missing info */}
+      <EvmDepositsStatusUpdater />
       {children}
       {/* Sync the transaction history per chain in the background */}
       {historyChainSync}

--- a/webapp/test/utils/watch/evmDeposits.test.ts
+++ b/webapp/test/utils/watch/evmDeposits.test.ts
@@ -1,0 +1,72 @@
+import { EvmDepositStatus, type EvmDepositOperation } from 'types/tunnel'
+import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
+import { watchEvmDeposit } from 'utils/watch/evmDeposits'
+import { sepolia } from 'viem/chains'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('utils/evmApi', () => ({
+  getEvmBlock: vi.fn(),
+  getEvmTransactionReceipt: vi.fn(),
+}))
+
+// @ts-expect-error only use the minimum required properties
+const deposit: EvmDepositOperation = {
+  l1ChainId: sepolia.id,
+  status: EvmDepositStatus.DEPOSIT_TX_PENDING,
+  transactionHash: '0x0000000000000000000000000000000000000005',
+}
+
+const receipt = { blockNumber: BigInt(100), status: 'success' }
+const block = { timestamp: BigInt(1630000000) }
+
+describe('watchEvmDeposit', function () {
+  it('should not return any update if the transaction is still pending', async function () {
+    vi.mocked(getEvmTransactionReceipt).mockResolvedValue(null)
+
+    const updates = await watchEvmDeposit(deposit)
+
+    expect(updates).toEqual({})
+    expect(getEvmBlock).not.toHaveBeenCalled()
+  })
+
+  it(`should return the new status set to ${EvmDepositStatus.DEPOSIT_TX_CONFIRMED} if the transaction was confirmed`, async function () {
+    vi.mocked(getEvmTransactionReceipt).mockResolvedValue(receipt)
+    vi.mocked(getEvmBlock).mockResolvedValue(block)
+
+    const updates = await watchEvmDeposit(deposit)
+
+    expect(updates.status).toBe(EvmDepositStatus.DEPOSIT_TX_CONFIRMED)
+    expect(updates.blockNumber).toBe(Number(receipt.blockNumber))
+    expect(updates.timestamp).toBe(Number(block.timestamp))
+    expect(getEvmTransactionReceipt).toHaveBeenCalledWith(
+      deposit.transactionHash,
+      deposit.l1ChainId,
+    )
+    expect(getEvmBlock).toHaveBeenCalledWith(
+      receipt.blockNumber,
+      deposit.l1ChainId,
+    )
+  })
+
+  it(`should update status to ${EvmDepositStatus.DEPOSIT_TX_FAILED} if the transaction reverted`, async function () {
+    vi.mocked(getEvmTransactionReceipt).mockResolvedValue({
+      ...receipt,
+      status: 'reverted',
+    })
+    vi.mocked(getEvmBlock).mockResolvedValue(block)
+
+    const updates = await watchEvmDeposit(deposit)
+
+    expect(updates.status).toBe(EvmDepositStatus.DEPOSIT_TX_FAILED)
+    expect(updates.blockNumber).toBe(Number(receipt.blockNumber))
+    expect(updates.timestamp).toBe(Number(block.timestamp))
+    expect(getEvmTransactionReceipt).toHaveBeenCalledWith(
+      deposit.transactionHash,
+      deposit.l1ChainId,
+    )
+    expect(getEvmBlock).toHaveBeenCalledWith(
+      receipt.blockNumber,
+      deposit.l1ChainId,
+    )
+  })
+})

--- a/webapp/test/utils/watch/evmWithdrawals.test.ts
+++ b/webapp/test/utils/watch/evmWithdrawals.test.ts
@@ -4,7 +4,6 @@ import { ToEvmWithdrawOperation } from 'types/tunnel'
 import { createQueuedCrossChainMessenger } from 'utils/crossChainMessenger'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import { createProvider } from 'utils/providers'
-// import { watchEvmWithdrawal } from 'utils/watch/evmWithdrawals'
 import { sepolia } from 'viem/chains'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/webapp/utils/watch/evmDeposits.ts
+++ b/webapp/utils/watch/evmDeposits.ts
@@ -1,0 +1,36 @@
+import { EvmDepositStatus, type EvmDepositOperation } from 'types/tunnel'
+import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
+
+export const watchEvmDeposit = async function (deposit: EvmDepositOperation) {
+  const updates: Partial<EvmDepositOperation> = {}
+
+  // check if it has completed on the background
+  const receipt = await getEvmTransactionReceipt(
+    deposit.transactionHash,
+    deposit.l1ChainId,
+  )
+  // if receipt was not found, it means the transaction is still pending - return here
+  if (!receipt) {
+    return updates
+  }
+  const newStatus =
+    receipt.status === 'success'
+      ? EvmDepositStatus.DEPOSIT_TX_CONFIRMED
+      : EvmDepositStatus.DEPOSIT_TX_FAILED
+  // if the status has changed, save the update
+  if (deposit.status !== newStatus) {
+    updates.status = newStatus
+  }
+
+  if (!updates.blockNumber) {
+    updates.blockNumber = Number(receipt.blockNumber)
+  }
+  if (!updates.timestamp) {
+    updates.timestamp = await getEvmBlock(
+      receipt.blockNumber,
+      deposit.l1ChainId,
+    ).then(block => Number(block.timestamp))
+  }
+
+  return updates
+}

--- a/webapp/utils/workers.ts
+++ b/webapp/utils/workers.ts
@@ -1,0 +1,3 @@
+// See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
+export const typeWorker = <T>(worker: Window & typeof globalThis) =>
+  worker as unknown as T

--- a/webapp/workers/history.ts
+++ b/webapp/workers/history.ts
@@ -16,6 +16,7 @@ import {
   type SyncHistoryCombinations,
 } from 'utils/sync-history/types'
 import { type EnableWorkersDebug } from 'utils/typeUtilities'
+import { typeWorker } from 'utils/workers'
 import { type Address, type Chain } from 'viem'
 
 type StartSyncing = { type: 'start' } & SyncHistoryCombinations
@@ -33,8 +34,7 @@ type SyncWebWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
   postMessage: (event: HistoryActions) => void
 }
 
-// See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
-const worker = self as unknown as SyncWebWorker
+const worker = typeWorker<SyncWebWorker>(self)
 
 const saveHistory = (action: HistoryActions) => worker.postMessage(action)
 

--- a/webapp/workers/watchBitcoinDeposits.ts
+++ b/webapp/workers/watchBitcoinDeposits.ts
@@ -8,6 +8,7 @@ import {
   watchDepositOnBitcoin,
   watchDepositOnHemi,
 } from 'utils/watch/bitcoinDeposits'
+import { typeWorker } from 'utils/workers'
 
 type WatchBtcDeposit = {
   deposit: BtcDepositOperation
@@ -30,8 +31,7 @@ type WatchBtcDepositsWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
   }) => void
 }
 
-// See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
-const worker = self as unknown as WatchBtcDepositsWorker
+const worker = typeWorker<WatchBtcDepositsWorker>(self)
 
 // concurrently avoid overloading both blockchains
 const bitcoinQueue = new PQueue({ concurrency: 3 })

--- a/webapp/workers/watchBitcoinWithdrawals.ts
+++ b/webapp/workers/watchBitcoinWithdrawals.ts
@@ -5,6 +5,7 @@ import { BtcWithdrawStatus, type ToBtcWithdrawOperation } from 'types/tunnel'
 import { isPendingOperation } from 'utils/tunnel'
 import { type EnableWorkersDebug } from 'utils/typeUtilities'
 import { watchBitcoinWithdrawal } from 'utils/watch/bitcoinWithdrawals'
+import { typeWorker } from 'utils/workers'
 
 type WatchBtcWithdrawal = {
   type: 'watch-btc-withdrawal'
@@ -27,8 +28,7 @@ type WatchBtcWithdrawalsWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
   }) => void
 }
 
-// See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
-const worker = self as unknown as WatchBtcWithdrawalsWorker
+const worker = typeWorker<WatchBtcWithdrawalsWorker>(self)
 
 const hemiQueue = new PQueue({ concurrency: 3 })
 

--- a/webapp/workers/watchEvmDeposits.ts
+++ b/webapp/workers/watchEvmDeposits.ts
@@ -1,0 +1,65 @@
+import debugConstructor from 'debug'
+import PQueue from 'p-queue'
+import { type EvmDepositOperation } from 'types/tunnel'
+import { type EnableWorkersDebug } from 'utils/typeUtilities'
+import { hasKeys } from 'utils/utilities'
+import { watchEvmDeposit } from 'utils/watch/evmDeposits'
+import { typeWorker } from 'utils/workers'
+import { Chain } from 'viem'
+
+const debug = debugConstructor('watch-evm-deposits-worker')
+
+const hemiQueue = new PQueue({ concurrency: 5 })
+
+type WatchEvmDeposit = {
+  deposit: EvmDepositOperation
+  type: 'watch-evm-deposit'
+}
+
+type AppToWebWorkerActions = EnableWorkersDebug | WatchEvmDeposit
+
+export type AppToWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  postMessage: (message: AppToWebWorkerActions) => void
+}
+
+// Worker is typed with "any", so force type safety for the messages
+// (as in runtime all types are stripped, this will continue to work)
+type WatchEvmDepositsWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
+  onmessage: (event: MessageEvent<AppToWebWorkerActions>) => void
+  postMessage: (event: {
+    type: `update-evm-deposit-${Chain['id']}-${EvmDepositOperation['transactionHash']}`
+    updates: Partial<EvmDepositOperation>
+  }) => void
+}
+
+const worker = typeWorker<WatchEvmDepositsWorker>(self)
+
+export const getDepositKey = (withdrawal: EvmDepositOperation) =>
+  `update-evm-deposit-${withdrawal.l1ChainId}-${withdrawal.transactionHash}` as const
+
+const postUpdates = (deposit: EvmDepositOperation) =>
+  function (updates: Partial<EvmDepositOperation> = {}) {
+    if (hasKeys(updates)) {
+      debug('Sending changes for deposit %s', deposit.transactionHash)
+    } else {
+      debug('No changes for deposit %s', deposit.transactionHash)
+    }
+    worker.postMessage({
+      type: getDepositKey(deposit),
+      updates,
+    })
+  }
+
+const watchDeposit = (deposit: EvmDepositOperation) =>
+  hemiQueue.add(() => watchEvmDeposit(deposit).then(postUpdates(deposit)))
+
+// wait for the UI to send chain and address once ready
+worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (e.data.type === 'watch-evm-deposit') {
+    watchDeposit(e.data.deposit)
+  }
+  // See https://github.com/debug-js/debug/issues/916#issuecomment-1539231712
+  if (e.data.type === 'enable-debug') {
+    debugConstructor.enable(e.data.payload)
+  }
+}

--- a/webapp/workers/watchEvmWithdrawals.ts
+++ b/webapp/workers/watchEvmWithdrawals.ts
@@ -9,6 +9,7 @@ import {
 import { type EnableWorkersDebug } from 'utils/typeUtilities'
 import { hasKeys } from 'utils/utilities'
 import { watchEvmWithdrawal } from 'utils/watch/evmWithdrawals'
+import { typeWorker } from 'utils/workers'
 import { type Hash } from 'viem'
 
 const queue = new PQueue({ concurrency: 2 })
@@ -39,8 +40,7 @@ type WatchEvmWithdrawalsWorker = Omit<Worker, 'onmessage' | 'postMessage'> & {
   }) => void
 }
 
-// See https://github.com/Microsoft/TypeScript/issues/20595#issuecomment-587297818
-const worker = self as unknown as WatchEvmWithdrawalsWorker
+const worker = typeWorker<WatchEvmWithdrawalsWorker>(self)
 
 // See https://www.npmjs.com/package/p-queue#priority
 const getPriority = function (withdrawal: ToEvmWithdrawOperation) {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the last [watcher](https://cdn.marvel.com/content/1x/102_cba0100_comp_005_v901_f89ebdcc.jpeg) for operations so if any information is missing that is already part of the history, it will be updated.

This was implemented previously for withdrawals and bitcoin, but it was pending for EVM deposits.

If you want to review this commit by commit:

- 9704782c97d68dd8225ffa18a31724ab828aeee8 adds `typeWorker` as a small reusable utility for typing workers properly
- 8baee8b10c6ab8953f66cd19e0539a0e74719493 adds the watcher component, worker, and tests
- a2c5b0e5c2a97dd56b9cc6e410d3e4f3891af7eb Removes a commented line from a previous PR which should've been deleted

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Closing the drawer

https://github.com/user-attachments/assets/523cbb96-0168-4bcb-811f-f39ddce5ec7f

Closing the app

https://github.com/user-attachments/assets/9130dda1-4ae3-408e-8eb7-546e2ade3f8d

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes https://github.com/hemilabs/ui-monorepo/issues/549

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
