### PR TITLE
Filter 'Talisman not configured' error from Sentry

### DIFF
--- a/webapp/sentry.client.config.ts
+++ b/webapp/sentry.client.config.ts
@@ -4,8 +4,13 @@ const enabled = !!process.env.NEXT_PUBLIC_SENTRY_DSN
 
 function enableSentry() {
   const ignoreErrors = [
+    // Disable until WalletConnect is enabled, as it will fail for all users
+    // See https://github.com/hemilabs/ui-monorepo/issues/633
+    'connection failed for host: wss://relay.walletconnect.org',
     // user rejected a confirmation in the wallet
     'rejected the request',
+    // Unsupported wallet + user error
+    'Talisman extension has not been configured yet',
     // React internal error thrown when something outside react modifies the DOM
     // This is usually because of a browser extension or Chrome's built-in translate. There's no action to do.
     // See https://blog.sentry.io/making-your-javascript-projects-less-noisy/#ignore-un-actionable-errors
@@ -13,9 +18,6 @@ function enableSentry() {
     'The node before which the new node is to be inserted is not a child of this node.',
     // Thrown when firefox prevents an add-on from referencing a DOM element that has been removed.
     `TypeError: can't access dead object`,
-    // Disable until WalletConnect is enabled, as it will fail for all users
-    // See https://github.com/hemilabs/ui-monorepo/issues/633
-    'connection failed for host: wss://relay.walletconnect.org',
   ]
 
   Sentry.init({


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR filters out the following error from Sentry:

> Error: Talisman extension has not been configured yet. Please continue with onboarding.

As

1. Talisman is not supported by the portal
2. This is an error on user land, as it seems they haven't configured the wallet properly.

See [docs](https://docs.sentry.io/platforms/javascript/configuration/filtering/#filtering-error-events) for filtering events on sentry config.

I will archive this error on Sentry UI.


I also re-ordered the error messages so they are sorted alphabetically

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to https://github.com/hemilabs/ui-monorepo/issues/715

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
