### PR TITLE
Add stake drawer

### DIFF
--- a/webapp/app/[locale]/stake/_components/manageStake/fees.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/fees.tsx
@@ -1,0 +1,30 @@
+import { EvmFeesSummary } from 'components/evmFeesSummary'
+import { useHemi } from 'hooks/useHemi'
+import { useTranslations } from 'next-intl'
+import { formatUnits } from 'viem'
+
+import { useEstimateStakeFees } from '../../_hooks/useEstimateStakeFees'
+import { useEstimateUnstakeFees } from '../../_hooks/useEstimateUnstakeFees'
+
+const Fees = function ({ estimatedFees }: { estimatedFees: bigint }) {
+  const hemi = useHemi()
+  const t = useTranslations('common')
+
+  const gas = {
+    amount: formatUnits(estimatedFees, hemi.nativeCurrency.decimals),
+    label: t('network-gas-fee', { network: hemi.name }),
+    symbol: hemi.nativeCurrency.symbol,
+  }
+
+  return (
+    <div className="px-4">
+      <EvmFeesSummary gas={gas} operationSymbol={hemi.nativeCurrency.symbol} />
+    </div>
+  )
+}
+
+export const StakeFees = () => <Fees estimatedFees={useEstimateStakeFees()} />
+
+export const UnstakeFees = () => (
+  <Fees estimatedFees={useEstimateUnstakeFees()} />
+)

--- a/webapp/app/[locale]/stake/_components/manageStake/index.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/index.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import {
+  Drawer,
+  DrawerParagraph,
+  DrawerSection,
+  DrawerTitle,
+} from 'components/drawer'
+import { TokenInput } from 'components/tokenInput'
+import { TokenSelectorReadOnly } from 'components/tokenSelector/readonly'
+import { useTokenBalance } from 'hooks/useBalance'
+import { useTranslations } from 'next-intl'
+import { FormEvent, useState } from 'react'
+import { StakeToken } from 'types/stake'
+import { CloseIcon } from 'ui-common/components/closeIcon'
+import { canSubmit } from 'utils/stake'
+import { parseUnits } from 'viem'
+import { useAccount } from 'wagmi'
+
+import { useAmount } from '../../_hooks/useAmount'
+import { type DrawerModes } from '../../_hooks/useDrawerStakeQueryString'
+import { DiamondTag, HemiTag, PointsTag } from '../rewardTag'
+
+import { StakeFees, UnstakeFees } from './fees'
+import { StakeMaxBalance, UnstakeMaxBalance } from './maxBalance'
+import { StrategyDetails } from './strategyDetails'
+import { SubmitButton } from './submitButton'
+import { Tabs } from './tabs'
+import { StakeOperations } from './types'
+
+type Props = {
+  closeDrawer: () => void
+  initialOperation: StakeOperations
+  mode: DrawerModes
+  token: StakeToken
+}
+
+export const ManageStake = function ({
+  closeDrawer,
+  mode,
+  token,
+  ...props
+}: Props) {
+  const isManaging = mode === 'manage' && 'initialOperation' in props
+
+  const { chainId } = useAccount()
+  const [amount, setAmount] = useAmount()
+  const [operation, setOperation] = useState<StakeOperations>(() =>
+    isManaging ? props.initialOperation : 'stake',
+  )
+  const { balance } = useTokenBalance(token)
+
+  const t = useTranslations('stake-page.drawer')
+  const tCommon = useTranslations('common')
+
+  const { heading, subheading } = {
+    manage: {
+      heading: t('manage-your-stake'),
+      subheading: t('description-manage-stake'),
+    },
+    stake: {
+      heading: t('stake-token', { symbol: token.symbol }),
+      subheading: t('stake-and-earn-rewards', { symbol: token.symbol }),
+    },
+  }[mode]
+
+  const handleSubmit = function (e: FormEvent) {
+    e.preventDefault()
+    // TODO implement submit https://github.com/hemilabs/ui-monorepo/issues/774
+  }
+
+  const isStaking = mode === 'stake' || operation === 'stake'
+
+  // TODO define how to get these https://github.com/hemilabs/ui-monorepo/issues/794
+  const strategyDetails = {
+    rewards: [
+      <DiamondTag key="diamond" />,
+      <HemiTag key="hemi" />,
+      <PointsTag key="points" />,
+    ],
+    token,
+    tvl: ' $ 129M',
+  }
+
+  const submitDisabled = !!canSubmit({
+    amount: parseUnits(amount, token.decimals),
+    balance,
+    connectedChainId: chainId,
+    token,
+  }).error
+
+  return (
+    <Drawer onClose={closeDrawer}>
+      <form className="drawer-content h-[95dvh] md:h-full">
+        <div className="flex items-center justify-between">
+          <DrawerTitle>{heading}</DrawerTitle>
+          <button
+            className="cursor-pointer"
+            onClick={closeDrawer}
+            type="button"
+          >
+            <CloseIcon className="[&>path]:hover:stroke-black" />
+          </button>
+        </div>
+        <div className="mb-5">
+          <DrawerParagraph>{subheading}</DrawerParagraph>
+        </div>
+        <div className="skip-parent-padding-x">
+          {isManaging && (
+            <div className="relative translate-y-px">
+              <Tabs onSelect={setOperation} selected={operation} />
+            </div>
+          )}
+          <DrawerSection>
+            <div className="flex flex-col gap-y-4">
+              <div className="[&>*]:hover:shadow-large [&>*]:border-neutral-300/55 [&>*]:bg-white">
+                <TokenInput
+                  // TODO disable when submitting https://github.com/hemilabs/ui-monorepo/issues/774
+                  disabled={false}
+                  label={tCommon('amount')}
+                  maxBalanceButton={
+                    isStaking ? (
+                      <StakeMaxBalance
+                        disabled={submitDisabled || balance === BigInt(0)}
+                        onSetMaxBalance={setAmount}
+                        token={token}
+                      />
+                    ) : (
+                      <UnstakeMaxBalance
+                        disabled={submitDisabled || balance === BigInt(0)}
+                        onSetMaxBalance={setAmount}
+                        token={token}
+                      />
+                    )
+                  }
+                  onChange={setAmount}
+                  token={token}
+                  tokenSelector={<TokenSelectorReadOnly token={token} />}
+                  value={amount}
+                />
+              </div>
+              {isStaking ? <StakeFees /> : <UnstakeFees />}
+            </div>
+          </DrawerSection>
+        </div>
+        {isStaking && (
+          <div className="mt-1">
+            <StrategyDetails {...strategyDetails} />
+          </div>
+        )}
+        <div className="mt-auto flex flex-col gap-y-3 text-center">
+          {isStaking && (
+            <DrawerParagraph>{t('you-can-stake-anytime')}</DrawerParagraph>
+          )}
+          <SubmitButton
+            // TODO disable when submitting https://github.com/hemilabs/ui-monorepo/issues/774
+            disabled={!canSubmit}
+            onSubmit={handleSubmit}
+            text={tCommon(operation)}
+          />
+        </div>
+      </form>
+    </Drawer>
+  )
+}

--- a/webapp/app/[locale]/stake/_components/manageStake/index.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/index.tsx
@@ -154,7 +154,7 @@ export const ManageStake = function ({
           )}
           <SubmitButton
             // TODO disable when submitting https://github.com/hemilabs/ui-monorepo/issues/774
-            disabled={!canSubmit}
+            disabled={submitDisabled}
             onSubmit={handleSubmit}
             text={tCommon(operation)}
           />

--- a/webapp/app/[locale]/stake/_components/manageStake/maxBalance.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/maxBalance.tsx
@@ -1,0 +1,15 @@
+import { SetMaxEvmBalance } from 'components/setMaxBalance'
+import { ComponentProps } from 'react'
+
+import { useEstimateStakeFees } from '../../_hooks/useEstimateStakeFees'
+import { useEstimateUnstakeFees } from '../../_hooks/useEstimateUnstakeFees'
+
+type Props = Omit<ComponentProps<typeof SetMaxEvmBalance>, 'gas'>
+
+export const StakeMaxBalance = (props: Props) => (
+  <SetMaxEvmBalance {...props} gas={useEstimateStakeFees()} />
+)
+
+export const UnstakeMaxBalance = (props: Props) => (
+  <SetMaxEvmBalance {...props} gas={useEstimateUnstakeFees()} />
+)

--- a/webapp/app/[locale]/stake/_components/manageStake/strategyDetails.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/strategyDetails.tsx
@@ -1,0 +1,48 @@
+import { useTranslations } from 'next-intl'
+import { ReactNode } from 'react'
+import { StakeToken } from 'types/stake'
+
+import { Website } from './website'
+
+type Props = {
+  rewards: ReactNode[]
+  token: StakeToken
+  tvl: string
+}
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div className="flex items-center justify-between border-b border-solid border-neutral-300/55 py-4">
+    {children}
+  </div>
+)
+
+const Subtitle = ({ text }: { text: string }) => (
+  <h6 className="text-sm font-medium text-neutral-500">{text}</h6>
+)
+
+export const StrategyDetails = function ({ rewards, tvl, token }: Props) {
+  const t = useTranslations('stake-page.drawer.strategy-details')
+  return (
+    <div className="flex flex-col">
+      <Container>
+        <h5>{t('heading')}</h5>
+      </Container>
+      <Container>
+        <Subtitle text={t('rewards')} />
+        <div className="flex h-6 flex-wrap gap-x-1">
+          {rewards.map((reward, index) => (
+            <div key={index}>{reward}</div>
+          ))}
+        </div>
+      </Container>
+      <Container>
+        <Subtitle text={t('tvl')} />
+        <span className="text-base font-semibold text-neutral-950">{tvl}</span>
+      </Container>
+      <Container>
+        <Subtitle text={t('website')} />
+        <Website token={token} />
+      </Container>
+    </div>
+  )
+}

--- a/webapp/app/[locale]/stake/_components/manageStake/submitButton.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/submitButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from 'components/button'
+import { SubmitWhenConnectedToChain } from 'components/submitWhenConnectedToChain'
+import { useHemi } from 'hooks/useHemi'
+import { FormEvent } from 'react'
+
+type Props = {
+  disabled: boolean
+  onSubmit: (e: FormEvent) => void
+  text: string
+}
+
+export const SubmitButton = function ({ disabled, onSubmit, text }: Props) {
+  const hemi = useHemi()
+  return (
+    <div className="flex [&>button]:w-full">
+      <SubmitWhenConnectedToChain
+        chainId={hemi.id}
+        submitButton={
+          <Button disabled={disabled} onSubmit={onSubmit} type="submit">
+            {text}
+          </Button>
+        }
+      />
+    </div>
+  )
+}

--- a/webapp/app/[locale]/stake/_components/manageStake/tabs.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/tabs.tsx
@@ -1,0 +1,54 @@
+import { useTranslations } from 'next-intl'
+
+import { type StakeOperations } from './types'
+
+const Tab = ({
+  onSelect,
+  selected,
+  text,
+}: {
+  onSelect: () => void
+  selected: boolean
+  text: string
+}) => (
+  <li
+    className={`group/tab flex w-full items-center justify-center py-3 ${
+      selected ? 'border-b border-solid border-b-orange-500' : ''
+    }`}
+  >
+    <button
+      className={`${
+        selected
+          ? 'cursor-auto text-neutral-950'
+          : 'cursor-pointer text-neutral-500'
+      } w-full text-xl font-medium group-hover/tab:text-neutral-950`}
+      onClick={onSelect}
+      type="button"
+    >
+      {text}
+    </button>
+  </li>
+)
+
+type Props = {
+  onSelect: (operation: StakeOperations) => void
+  selected: StakeOperations
+}
+
+export const Tabs = function ({ onSelect, selected }: Props) {
+  const t = useTranslations('common')
+  return (
+    <ul className="flex w-full">
+      <Tab
+        onSelect={() => onSelect('stake')}
+        selected={selected === 'stake'}
+        text={t('stake')}
+      />
+      <Tab
+        onSelect={() => onSelect('unstake')}
+        selected={selected === 'unstake'}
+        text={t('unstake')}
+      />
+    </ul>
+  )
+}

--- a/webapp/app/[locale]/stake/_components/manageStake/types.ts
+++ b/webapp/app/[locale]/stake/_components/manageStake/types.ts
@@ -1,0 +1,1 @@
+export type StakeOperations = 'stake' | 'unstake'

--- a/webapp/app/[locale]/stake/_components/manageStake/website.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/website.tsx
@@ -1,0 +1,42 @@
+import { ExternalLink } from 'components/externalLink'
+import { ArrowDownLeftIcon } from 'components/icons/arrowDownLeftIcon'
+import { useTranslations } from 'next-intl'
+import { StakeToken } from 'types/stake'
+
+const websitesMap: Partial<
+  Record<StakeToken['extensions']['protocol'], string>
+> = {
+  bedRock: 'https://www.bedrock.technology',
+  bitFi: 'https://www.bitfi.one/#waitlist',
+  exSat: 'https://exsat.network/app/bridge',
+  lorenzo: 'https://app.lorenzo-protocol.xyz/staking',
+  merlinChain: 'https://merlinchain.io/bridge',
+  // TODO add nodeDao website https://github.com/hemilabs/ui-monorepo/issues/794
+  pumpBtc: 'https://mainnet.pumpbtc.xyz',
+  solv: 'https://app.solv.finance/solvbtc?network=bitcoin-mainnet',
+  stakeStone: 'https://app.stakestone.io/u/sbtc/stake',
+  uniRouter: 'https://app.unirouter.io',
+}
+
+type Props = {
+  token: StakeToken
+}
+
+export const Website = function ({ token }: Props) {
+  const t = useTranslations('common')
+  return (
+    <>
+      {websitesMap[token.extensions.protocol] ? (
+        <ExternalLink
+          className="group/link flex cursor-pointer items-center gap-x-1 text-sm font-medium text-neutral-500"
+          href={websitesMap[token.extensions.protocol]}
+        >
+          <span className="group-hover/link:text-neutral-700">{t('open')}</span>
+          <ArrowDownLeftIcon className="[&>path]:fill-neutral-500 [&>path]:group-hover/link:fill-neutral-700" />
+        </ExternalLink>
+      ) : (
+        <span className="text-neutral-500">-</span>
+      )}
+    </>
+  )
+}

--- a/webapp/app/[locale]/stake/_components/manageStake/website.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/website.tsx
@@ -7,15 +7,15 @@ const websitesMap: Partial<
   Record<StakeToken['extensions']['protocol'], string>
 > = {
   bedRock: 'https://www.bedrock.technology',
-  bitFi: 'https://www.bitfi.one/#waitlist',
-  exSat: 'https://exsat.network/app/bridge',
-  lorenzo: 'https://app.lorenzo-protocol.xyz/staking',
-  merlinChain: 'https://merlinchain.io/bridge',
-  // TODO add nodeDao website https://github.com/hemilabs/ui-monorepo/issues/794
+  bitFi: 'https://www.bitfi.one',
+  exSat: 'https://exsat.network',
+  lorenzo: 'https://lorenzo-protocol.xyz',
+  merlinChain: 'https://merlinchain.io',
+  nodeDao: 'https://www.nodedao.com',
   pumpBtc: 'https://mainnet.pumpbtc.xyz',
-  solv: 'https://app.solv.finance/solvbtc?network=bitcoin-mainnet',
-  stakeStone: 'https://app.stakestone.io/u/sbtc/stake',
-  uniRouter: 'https://app.unirouter.io',
+  solv: 'https://solv.finance',
+  stakeStone: 'https://stakestone.io/#/home',
+  uniRouter: 'https://www.unirouter.io/#',
 }
 
 type Props = {

--- a/webapp/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/webapp/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -4,7 +4,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { Button } from 'components/button'
+import { ButtonLink } from 'components/button'
 import { Card } from 'components/card'
 import { Link } from 'components/link'
 import { TokenLogo } from 'components/tokenLogo'
@@ -15,6 +15,7 @@ import Skeleton from 'react-loading-skeleton'
 import { StakeToken } from 'types/stake'
 import { useWindowSize } from 'ui-common/hooks/useWindowSize'
 
+import { useDrawerStakeQueryString } from '../../_hooks/useDrawerStakeQueryString'
 import { protocolImages } from '../../protocols/protocolImages'
 import { Column, ColumnHeader, Header } from '../table'
 import { TokenRewards } from '../tokenRewards'
@@ -83,13 +84,30 @@ const columnsBuilder = (
     meta: { width: '350px' },
   },
   {
-    cell: () => (
-      <div className="max-w-24">
-        <Button height="h-4" type="button">
-          <p>{t('stake.title')}</p>
-        </Button>
-      </div>
-    ),
+    cell: function CallToAction({ row }) {
+      const { setDrawerQueryString } = useDrawerStakeQueryString()
+
+      return (
+        <div className="max-w-24">
+          <ButtonLink
+            href={{
+              pathname: '/stake',
+              query: {
+                address: row.original.token.address,
+                mode: 'stake',
+              },
+            }}
+            onClick={function (e) {
+              e.preventDefault()
+              e.stopPropagation()
+              setDrawerQueryString('stake', row.original.token.address)
+            }}
+          >
+            {t('stake.title')}
+          </ButtonLink>
+        </div>
+      )
+    },
     header: () => <Header text={t('stake.action')} />,
     id: 'action',
     meta: { width: '80px' },

--- a/webapp/app/[locale]/stake/_hooks/useAmount.ts
+++ b/webapp/app/[locale]/stake/_hooks/useAmount.ts
@@ -1,0 +1,15 @@
+import { useCallback, useState } from 'react'
+import { sanitizeAmount } from 'utils/form'
+
+export const useAmount = function () {
+  const [amount, setAmount] = useState('0')
+
+  const onChange = useCallback(function (input: string) {
+    const { error, value } = sanitizeAmount(input)
+    if (!error) {
+      setAmount(value)
+    }
+  }, [])
+
+  return [amount, onChange] as const
+}

--- a/webapp/app/[locale]/stake/_hooks/useDrawerStakeQueryString.ts
+++ b/webapp/app/[locale]/stake/_hooks/useDrawerStakeQueryString.ts
@@ -1,0 +1,32 @@
+import { parseAsStringLiteral, useQueryState } from 'nuqs'
+import { parseAsEvmAddress } from 'utils/url'
+import { Address } from 'viem'
+
+const drawerModes = ['manage', 'stake'] as const
+export type DrawerModes = (typeof drawerModes)[number]
+
+export const useDrawerStakeQueryString = function () {
+  const [tokenAddress, setTokenAddress] = useQueryState(
+    'tokenAddress',
+    parseAsEvmAddress.withOptions({ clearOnDefault: true }),
+  )
+
+  const [drawerMode, setDrawerMode] = useQueryState(
+    'drawerMode',
+    parseAsStringLiteral(drawerModes).withOptions({ clearOnDefault: true }),
+  )
+
+  const setDrawerQueryString = function (
+    mode: DrawerModes | null,
+    address: Address | null,
+  ) {
+    setDrawerMode(mode)
+    setTokenAddress(address)
+  }
+
+  return {
+    drawerMode,
+    setDrawerQueryString,
+    tokenAddress,
+  }
+}

--- a/webapp/app/[locale]/stake/_hooks/useEstimateStakeFees.ts
+++ b/webapp/app/[locale]/stake/_hooks/useEstimateStakeFees.ts
@@ -1,0 +1,18 @@
+import { useEstimateFees } from 'hooks/useEstimateFees'
+import { useHemi } from 'hooks/useHemi'
+import { useAccount } from 'wagmi'
+
+// TODO review estimation of gas units is correct https://github.com/hemilabs/ui-monorepo/issues/774
+const StakeGasUnits = BigInt(300_000)
+
+export const useEstimateStakeFees = function () {
+  const { status } = useAccount()
+  const hemi = useHemi()
+
+  return useEstimateFees({
+    chainId: hemi.id,
+    enabled: status === 'connected',
+    gasUnits: StakeGasUnits,
+    overEstimation: 1.5,
+  })
+}

--- a/webapp/app/[locale]/stake/_hooks/useEstimateUnstakeFees.ts
+++ b/webapp/app/[locale]/stake/_hooks/useEstimateUnstakeFees.ts
@@ -1,0 +1,18 @@
+import { useEstimateFees } from 'hooks/useEstimateFees'
+import { useHemi } from 'hooks/useHemi'
+import { useAccount } from 'wagmi'
+
+// TODO review estimation of gas units is correct https://github.com/hemilabs/ui-monorepo/issues/774
+const UnstakeGasUnits = BigInt(300_000)
+
+export const useEstimateUnstakeFees = function () {
+  const { status } = useAccount()
+  const hemi = useHemi()
+
+  return useEstimateFees({
+    chainId: hemi.id,
+    enabled: status === 'connected',
+    gasUnits: UnstakeGasUnits,
+    overEstimation: 1.5,
+  })
+}

--- a/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -8,7 +8,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { Button, ButtonLink } from 'components/button'
+import { ButtonLink } from 'components/button'
 import { Card } from 'components/card'
 import { TokenLogo } from 'components/tokenLogo'
 import Image from 'next/image'
@@ -299,12 +299,11 @@ export const StakeAssetsTable = function ({
         <h5 className="flex-shrink-0 flex-grow basis-2/5 md:flex-grow-0 md:basis-auto">
           {t('dashboard.staking-assets')}
         </h5>
-        <Button height="h-4" onClick={stakeMore} type="button">
-          <p>
-            <span className="mr-1">+</span>
-            {t('dashboard.stake-more')}
-          </p>
-        </Button>
+        <div className="[&>a]:py-1">
+          <ButtonLink href="/stake">
+            <span className="mr-1">+{t('dashboard.stake-more')}</span>
+          </ButtonLink>
+        </div>
       </div>
       <Card>
         <div className="max-h-[50dvh] overflow-x-auto p-2" ref={containerRef}>

--- a/webapp/app/[locale]/stake/layout.tsx
+++ b/webapp/app/[locale]/stake/layout.tsx
@@ -1,4 +1,43 @@
+'use client'
+
 import { StakeTabs } from 'components/stakeTabs'
+import { useStakeTokens } from 'hooks/useStakeTokens'
+import dynamic from 'next/dynamic'
+import { Suspense } from 'react'
+
+import { useDrawerStakeQueryString } from './_hooks/useDrawerStakeQueryString'
+
+const ManageStake = dynamic(
+  () => import('./_components/manageStake').then(mod => mod.ManageStake),
+  {
+    ssr: false,
+  },
+)
+
+const SideDrawer = function () {
+  const { drawerMode, setDrawerQueryString, tokenAddress } =
+    useDrawerStakeQueryString()
+  const stakeTokens = useStakeTokens()
+
+  if (!tokenAddress || !drawerMode) {
+    return null
+  }
+
+  const token = stakeTokens.find(t => t.address === tokenAddress)
+
+  if (!token) {
+    return null
+  }
+
+  return (
+    <ManageStake
+      closeDrawer={() => setDrawerQueryString(null, null)}
+      initialOperation={drawerMode === 'manage' ? 'unstake' : 'stake'}
+      mode={drawerMode}
+      token={token}
+    />
+  )
+}
 
 type Props = {
   children: React.ReactNode
@@ -10,6 +49,9 @@ const Layout = ({ children }: Props) => (
       <StakeTabs />
     </div>
     {children}
+    <Suspense>
+      <SideDrawer />
+    </Suspense>
   </>
 )
 

--- a/webapp/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -138,7 +138,7 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
             })}
             setMaxBalanceButton={
               <SetMaxBtcBalance
-                isRunningOperation={isDepositing}
+                disabled={isDepositing}
                 onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
                 token={fromToken}
               />

--- a/webapp/app/[locale]/tunnel/_components/evmDeposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/evmDeposit.tsx
@@ -288,8 +288,8 @@ export const EvmDeposit = function ({ state }: EvmDepositProps) {
             isRunningOperation={isRunningOperation}
             setMaxBalanceButton={
               <SetMaxEvmBalance
+                disabled={isRunningOperation}
                 gas={depositGasFees}
-                isRunningOperation={isRunningOperation}
                 onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
                 token={fromToken}
               />

--- a/webapp/app/[locale]/tunnel/_components/evmDeposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/evmDeposit.tsx
@@ -6,6 +6,7 @@ import {
   CustomTunnelsThroughPartner,
   tunnelsThroughPartner,
 } from 'components/customTunnelsThroughPartner'
+import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import { useChain } from 'hooks/useChain'
 import { useNetworkType } from 'hooks/useNetworkType'
@@ -24,7 +25,7 @@ import { canSubmit, getTotal } from '../_utils'
 
 import { ConnectEvmWallet } from './connectEvmWallet'
 import { Erc20TokenApproval } from './erc20TokenApproval'
-import { EvmSummary } from './evmSummary'
+import { FeesContainer } from './feesContainer'
 import { FormContent, TunnelForm } from './form'
 
 const SetMaxEvmBalance = dynamic(
@@ -273,11 +274,13 @@ export const EvmDeposit = function ({ state }: EvmDepositProps) {
       <TunnelForm
         belowForm={
           canDeposit ? (
-            <EvmSummary
-              gas={gas}
-              operationSymbol={fromToken.symbol}
-              total={totalDeposit}
-            />
+            <FeesContainer>
+              <EvmFeesSummary
+                gas={gas}
+                operationSymbol={fromToken.symbol}
+                total={totalDeposit}
+              />
+            </FeesContainer>
           ) : null
         }
         formContent={

--- a/webapp/app/[locale]/tunnel/_components/feesContainer.tsx
+++ b/webapp/app/[locale]/tunnel/_components/feesContainer.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react'
+
+export const FeesContainer = ({ children }: { children: ReactNode }) => (
+  <div className="px-8 py-4 md:px-10">{children}</div>
+)

--- a/webapp/app/[locale]/tunnel/_components/form.tsx
+++ b/webapp/app/[locale]/tunnel/_components/form.tsx
@@ -1,6 +1,8 @@
 import { Card } from 'components/card'
 import { SwitchToNetworkToast } from 'components/switchToNetworkToast'
 import { TokenInput } from 'components/tokenInput'
+import { TokenSelector } from 'components/tokenSelector'
+import { TokenSelectorReadOnly } from 'components/tokenSelector/readonly'
 import { useCustomTokenAddress } from 'hooks/useCustomTokenAddress'
 import { useHemi } from 'hooks/useHemi'
 import { useTunnelTokens } from 'hooks/useTunnelTokens'
@@ -86,23 +88,29 @@ export const FormContent = function ({
         updateToNetwork={updateToNetwork}
       />
       <TokenInput
-        chainId={fromNetworkId}
         disabled={isRunningOperation}
         label={t('form.send')}
         maxBalanceButton={setMaxBalanceButton}
         minInputMsg={minInputMsg}
         onChange={updateFromInput}
-        onSelectToken={updateFromToken}
         token={fromToken}
-        tokens={fromTokens}
+        tokenSelector={
+          <TokenSelector
+            chainId={fromNetworkId}
+            disabled={isRunningOperation}
+            onSelectToken={updateFromToken}
+            selectedToken={fromToken}
+            tokens={fromTokens}
+          />
+        }
         value={fromInput}
       />
       <TokenInput
         disabled={isRunningOperation}
         label={t('form.receive')}
         onChange={updateFromInput}
-        readOnly
         token={toToken}
+        tokenSelector={<TokenSelectorReadOnly token={toToken} />}
         // Tunnelling goes 1:1, so output equals input
         value={fromInput}
       />

--- a/webapp/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/webapp/app/[locale]/tunnel/_components/withdraw.tsx
@@ -180,8 +180,8 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
           })}
           setMaxBalanceButton={
             <SetMaxEvmBalance
+              disabled={isWithdrawing}
               gas={estimatedFees}
-              isRunningOperation={isWithdrawing}
               onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
               token={fromToken}
             />
@@ -345,8 +345,8 @@ const EvmWithdraw = function ({ state }: EvmWithdrawProps) {
             isRunningOperation={isWithdrawing}
             setMaxBalanceButton={
               <SetMaxEvmBalance
+                disabled={isWithdrawing}
                 gas={withdrawGasFees}
-                isRunningOperation={isWithdrawing}
                 onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
                 token={fromToken}
               />

--- a/webapp/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/webapp/app/[locale]/tunnel/_components/withdraw.tsx
@@ -6,6 +6,7 @@ import {
   CustomTunnelsThroughPartner,
   tunnelsThroughPartner,
 } from 'components/customTunnelsThroughPartner'
+import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { useAccounts } from 'hooks/useAccounts'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import { useWithdrawBitcoin } from 'hooks/useBtcTunnel'
@@ -35,7 +36,7 @@ import { useWithdraw } from '../_hooks/useWithdraw'
 import { canSubmit, getTotal } from '../_utils'
 
 import { ConnectEvmWallet } from './connectEvmWallet'
-import { EvmSummary } from './evmSummary'
+import { FeesContainer } from './feesContainer'
 import { FormContent, TunnelForm } from './form'
 import { ReceivingAddress } from './receivingAddress'
 import { SubmitWithTwoWallets } from './submitWithTwoWallets'
@@ -156,14 +157,16 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
             )}
           />
           {canWithdraw ? (
-            <EvmSummary
-              gas={gas}
-              operationSymbol={fromToken.symbol}
-              total={getTotal({
-                fromInput,
-                fromToken,
-              })}
-            />
+            <FeesContainer>
+              <EvmFeesSummary
+                gas={gas}
+                operationSymbol={fromToken.symbol}
+                total={getTotal({
+                  fromInput,
+                  fromToken,
+                })}
+              />
+            </FeesContainer>
           ) : null}
         </div>
       }
@@ -328,11 +331,13 @@ const EvmWithdraw = function ({ state }: EvmWithdrawProps) {
       <TunnelForm
         belowForm={
           canWithdraw ? (
-            <EvmSummary
-              gas={gas}
-              operationSymbol={fromToken.symbol}
-              total={fromInput}
-            />
+            <FeesContainer>
+              <EvmFeesSummary
+                gas={gas}
+                operationSymbol={fromToken.symbol}
+                total={fromInput}
+              />
+            </FeesContainer>
           ) : null
         }
         formContent={

--- a/webapp/components/evmFeesSummary.tsx
+++ b/webapp/components/evmFeesSummary.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from 'next-intl'
 import { getFormattedValue } from 'utils/format'
 
-export const EvmSummary = function ({
+export const EvmFeesSummary = function ({
   gas,
   operationSymbol,
   total,
@@ -12,23 +12,25 @@ export const EvmSummary = function ({
     symbol: string
   }
   operationSymbol: string
-  total: string
+  total?: string
 }) {
   const t = useTranslations()
   return (
-    <div className="flex flex-col gap-y-1 px-8 py-4 text-sm md:px-10">
+    <div className="flex flex-col gap-y-1 text-sm">
       <div className="flex items-center justify-between">
         <span className="text-neutral-500">{gas.label}</span>
         <span className="text-neutral-950">{`${getFormattedValue(gas.amount)} ${
           gas.symbol
         }`}</span>
       </div>
-      <div className="flex items-center justify-between">
-        <span className="text-neutral-500">{t('common.total')}</span>
-        <span className="text-neutral-950">{`${getFormattedValue(
-          total,
-        )} ${operationSymbol}`}</span>
-      </div>
+      {total !== undefined && (
+        <div className="flex items-center justify-between">
+          <span className="text-neutral-500">{t('common.total')}</span>
+          <span className="text-neutral-950">{`${getFormattedValue(
+            total,
+          )} ${operationSymbol}`}</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/webapp/components/setMaxBalance.tsx
+++ b/webapp/components/setMaxBalance.tsx
@@ -31,16 +31,16 @@ const MaxButton = function ({
 }
 
 type Props<T extends Token = Token> = {
-  token: T
-  isRunningOperation: boolean
+  disabled: boolean
   onSetMaxBalance: (maxBalance: string) => void
+  token: T
 }
 
 export const SetMaxEvmBalance = function ({
-  token,
+  disabled,
   gas,
-  isRunningOperation,
   onSetMaxBalance,
+  token,
 }: Props<EvmToken> & { gas: bigint }) {
   const {
     balance: walletNativeTokenBalance,
@@ -61,15 +61,15 @@ export const SetMaxEvmBalance = function ({
 
   const handleClick = () => onSetMaxBalance(maxBalance)
 
-  const disabled =
-    isLoadingNativeTokenBalance || isRunningOperation || Big(maxBalance).lte(0)
+  const maxButtonDisabled =
+    disabled || isLoadingNativeTokenBalance || Big(maxBalance).lte(0)
 
-  return <MaxButton disabled={disabled} onClick={handleClick} />
+  return <MaxButton disabled={maxButtonDisabled} onClick={handleClick} />
 }
 
 export const SetMaxBtcBalance = function ({
   token,
-  isRunningOperation,
+  disabled,
   onSetMaxBalance,
 }: Props<BtcToken>) {
   const { address } = useBtcAccount()
@@ -78,8 +78,8 @@ export const SetMaxBtcBalance = function ({
 
   const { fees, isLoading: isLoadingFees } = useEstimateBtcFees(address)
 
-  const disabled =
-    isRunningOperation ||
+  const maxButtonDisabled =
+    disabled ||
     isLoadingBalance ||
     isLoadingFees ||
     btcBalance === 0 ||
@@ -88,5 +88,5 @@ export const SetMaxBtcBalance = function ({
   const handleClick = () =>
     onSetMaxBalance(formatUnits(BigInt(btcBalance - fees), token.decimals))
 
-  return <MaxButton disabled={disabled} onClick={handleClick} />
+  return <MaxButton disabled={maxButtonDisabled} onClick={handleClick} />
 }

--- a/webapp/components/tokenInput.tsx
+++ b/webapp/components/tokenInput.tsx
@@ -1,11 +1,8 @@
 import Big from 'big.js'
-import { TokenLogo } from 'components/tokenLogo'
-import { TokenSelector } from 'components/tokenSelector'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
-import { RemoteChain } from 'types/chain'
 import { Token } from 'types/token'
 
 const Balance = dynamic(
@@ -24,26 +21,19 @@ type Props = {
   maxBalanceButton?: ReactNode
   minInputMsg?: string
   onChange: (value: string) => void
-  onSelectToken?: (token: Token) => void
-  readOnly?: boolean
   token: Token
+  tokenSelector: ReactNode
   value: string
-} & ( // only set chainId and list of tokens if the input is not read only
-  | { chainId: RemoteChain['id']; readOnly?: false; tokens: Token[] }
-  | { chainId?: never; readOnly: true; tokens?: never }
-)
+}
 
 export const TokenInput = function ({
-  chainId,
   disabled,
   label,
   maxBalanceButton,
   minInputMsg,
   onChange,
-  onSelectToken,
-  readOnly = false,
   token,
-  tokens,
+  tokenSelector,
   value,
 }: Props) {
   const t = useTranslations('tunnel-page')
@@ -73,22 +63,7 @@ export const TokenInput = function ({
           )}
         </div>
         <div className="flex h-full flex-col items-end justify-end gap-y-3 text-sm">
-          {readOnly ? (
-            <div className="flex items-center justify-between gap-x-2">
-              <TokenLogo size="small" token={token} />
-              <span className="font-medium text-neutral-950">
-                {token.symbol}
-              </span>
-            </div>
-          ) : (
-            <TokenSelector
-              chainId={chainId}
-              disabled={disabled}
-              onSelectToken={onSelectToken}
-              selectedToken={token}
-              tokens={tokens}
-            />
-          )}
+          {tokenSelector}
           <div className="flex items-center justify-end gap-x-2 text-sm">
             <span className="text-neutral-500">{t('form.balance')}:</span>
             <span className="text-neutral-950">

--- a/webapp/components/tokenSelector/readonly.tsx
+++ b/webapp/components/tokenSelector/readonly.tsx
@@ -1,0 +1,13 @@
+import { TokenLogo } from 'components/tokenLogo'
+import { Token } from 'types/token'
+
+type Props = {
+  token: Token
+}
+
+export const TokenSelectorReadOnly = ({ token }: Props) => (
+  <div className="flex items-center justify-between gap-x-2">
+    <TokenLogo size="small" token={token} />
+    <span className="font-medium text-neutral-950">{token.symbol}</span>
+  </div>
+)

--- a/webapp/hooks/useCustomTokenAddress.ts
+++ b/webapp/hooks/useCustomTokenAddress.ts
@@ -1,10 +1,5 @@
-import { createParser, useQueryState } from 'nuqs'
-import { isAddress } from 'viem'
-
-const parseAsEvmAddress = createParser({
-  parse: (queryValue: string) => (isAddress(queryValue) ? queryValue : null),
-  serialize: value => value,
-})
+import { useQueryState } from 'nuqs'
+import { parseAsEvmAddress } from 'utils/url'
 
 export const useCustomTokenAddress = () =>
   useQueryState('customTokenAddress', parseAsEvmAddress.withDefault(null))

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -3,6 +3,7 @@
     "add": "Add",
     "add-hemi-to-wallet": "Add Hemi Network to your wallet",
     "added": "Added",
+    "amount": "Amount",
     "connect-to-network": "Connect to {network}",
     "connect-to-supported-network": "Connect to supported network",
     "connect-wallet": "Connect Wallet",
@@ -18,7 +19,9 @@
     "learn-more": "Learn more",
     "network-does-not-match": "This network doesn’t match the one selected in your wallet.",
     "network-gas-fee": "{network} gas fee",
+    "open": "Open",
     "select-network": "Select Network",
+    "stake": "Stake",
     "success": "Success",
     "swap": "Swap",
     "switch-to-network": "Switch to {network}",
@@ -31,6 +34,7 @@
       "rejected": "Tx rejected"
     },
     "unexpected-error": "An unexpected error has ocurred. Please try again.",
+    "unstake": "Unstake",
     "unsupported-chain-heading": "You're not connected to a supported chain",
     "view": "View",
     "wait-complete": "Wait complete",
@@ -194,6 +198,19 @@
       "total-earned-points": "Total Hemi points earned",
       "total-staked": "Total Staked",
       "your-stake": "Your Stake"
+    },
+    "drawer": {
+      "description-manage-stake": "Top up your stake, or withdraw anytime—you're in full control!",
+      "manage-your-stake": "Manage your stake",
+      "stake-and-earn-rewards": "Stake {symbol} and earn rewards!",
+      "stake-token": "Stake {symbol}",
+      "strategy-details": {
+        "heading": "Strategy Details",
+        "rewards": "Rewards",
+        "tvl": "TVL (on Hemi)",
+        "website": "Website"
+      },
+      "you-can-stake-anytime": "You can withdraw any time and keep the points already earned."
     },
     "protocol": "Protocol",
     "rewards": "Rewards",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -3,6 +3,7 @@
     "add": "Agregar",
     "add-hemi-to-wallet": "Añadir la red Hemi a su billetera",
     "added": "Agregada",
+    "amount": "Monto",
     "connect-to-network": "Conectarse a {network}",
     "connect-to-supported-network": "Conectarse a una red soportada",
     "connect-wallet": "Conectar Billetera",
@@ -18,7 +19,9 @@
     "learn-more": "Aprenda más",
     "network-does-not-match": "Esta red no coincide con la seleccionada en su billetera.",
     "network-gas-fee": "Tarifa de gas de {network}",
+    "open": "Abrir",
     "select-network": "Seleccione Red",
+    "stake": "Apostar",
     "success": "Exitoso",
     "swap": "Intercambiar",
     "switch-to-network": "Cambiar a {network}",
@@ -31,6 +34,7 @@
       "rejected": "Tx rechazada"
     },
     "unexpected-error": "Ocurrió un error inesperado. Por favor inténtelo de nuevo.",
+    "unstake": "Desbloquear",
     "unsupported-chain-heading": "Usted no se encuentra conectado a una red soportada",
     "view": "Ver",
     "wait-complete": "Espera completada",
@@ -194,6 +198,19 @@
       "total-earned-points": "Total de puntos Hemi ganados",
       "total-staked": "Total Apostado",
       "your-stake": "Su Apuesta"
+    },
+    "drawer": {
+      "description-manage-stake": "Recargue su apuesta o retire en cualquier momento— ¡Usted tiene el control total!",
+      "manage-your-stake": "Gestione su apuesta",
+      "stake-and-earn-rewards": "¡Apueste {symbol} y gane recompensas!",
+      "stake-token": "Apostar {symbol}",
+      "strategy-details": {
+        "heading": "Detalles de la Estrategia",
+        "rewards": "Recompensas",
+        "tvl": "TVL (en Hemi)",
+        "website": "Sitio web"
+      },
+      "you-can-stake-anytime": "Puede retirar en cualquier momento y conservar los puntos ya ganados."
     },
     "protocol": "Protocolo",
     "rewards": "Recompensas",

--- a/webapp/test/utils/form.test.ts
+++ b/webapp/test/utils/form.test.ts
@@ -1,0 +1,49 @@
+import { sanitizeAmount } from 'utils/form'
+import { describe, expect, it } from 'vitest'
+
+describe('sanitizeAmount', function () {
+  it('should return "0" if input is empty', function () {
+    const result = sanitizeAmount('')
+    expect(result).toEqual({ value: '0' })
+  })
+
+  it('should return error if input is not a valid number', function () {
+    const result = sanitizeAmount('abc')
+    expect(result).toHaveProperty('error')
+  })
+
+  it('should remove leading zeroes from input', function () {
+    const result = sanitizeAmount('0123')
+    expect(result).toEqual({ value: '123' })
+  })
+
+  it('should add a zero if input starts with a dot', function () {
+    const result = sanitizeAmount('.5')
+    expect(result).toEqual({ value: '0.5' })
+  })
+
+  it('should return the same value if input is a valid number', function () {
+    const result = sanitizeAmount('123.45')
+    expect(result).toEqual({ value: '123.45' })
+  })
+
+  it('should return error if input is a negative number', function () {
+    const result = sanitizeAmount('-123')
+    expect(result).toHaveProperty('error')
+  })
+
+  it('should return zero if input is "0"', function () {
+    const result = sanitizeAmount('0')
+    expect(result).toEqual({ value: '0' })
+  })
+
+  it('should return zero if input is "00"', function () {
+    const result = sanitizeAmount('00')
+    expect(result).toEqual({ value: '0' })
+  })
+
+  it('should return 0.123 if input is "00.123"', function () {
+    const result = sanitizeAmount('00.123')
+    expect(result).toEqual({ value: '0.123' })
+  })
+})

--- a/webapp/test/utils/url.test.ts
+++ b/webapp/test/utils/url.test.ts
@@ -13,18 +13,16 @@ describe('utils/url', function () {
   })
 
   describe('isValidUrl', function () {
-    describe('isValidUrl', function () {
-      it('should return true for a valid URL', function () {
-        expect(isValidUrl('https://example.com/path?name=value')).toBe(true)
-      })
+    it('should return true for a valid URL', function () {
+      expect(isValidUrl('https://example.com/path?name=value')).toBe(true)
+    })
 
-      it('should return false for an invalid URL', function () {
-        expect(isValidUrl('invalid-url')).toBe(false)
-      })
+    it('should return false for an invalid URL', function () {
+      expect(isValidUrl('invalid-url')).toBe(false)
+    })
 
-      it('should return false for an empty string', function () {
-        expect(isValidUrl('')).toBe(false)
-      })
+    it('should return false for an empty string', function () {
+      expect(isValidUrl('')).toBe(false)
     })
   })
 

--- a/webapp/types/stake.ts
+++ b/webapp/types/stake.ts
@@ -1,3 +1,5 @@
+import { Address } from 'viem'
+
 import { type EvmToken, type Extensions } from './token'
 
 export const stakeProtocols = [
@@ -18,7 +20,10 @@ export type StakeProtocols = (typeof stakeProtocols)[number]
 
 export type Reward = 'hemi' | 'points'
 
-export type StakeToken = EvmToken & {
+export type StakeToken = Omit<EvmToken, 'address'> & {
+  // we can override Address because we only stake erc20 (native tokens excluded), so we know for sure
+  // that address is of Address type
+  address: Address
   // EvmToken has a broad definition of "protocol", but for StakeToken let's make a
   // defined list of protocols that make a token a Stake one.
   extensions: Omit<Extensions, 'protocol'> & {

--- a/webapp/utils/form.ts
+++ b/webapp/utils/form.ts
@@ -1,0 +1,29 @@
+import joi from 'utils/notJoi'
+
+const schema = joi.number().positive().unsafe()
+
+export const sanitizeAmount = function (input: string) {
+  // If the user cleared the input, just set it to "0".
+  if (!input) {
+    return { value: '0' }
+  }
+  // Verify the input can be parsed as a valid number.
+  const { error, value } = schema.validate(input)
+  if (error) {
+    return { error }
+  }
+
+  // Remove any leading zeroes to address cases like "01", that must be
+  // converted to "1".
+  const _value = input.replace(/^0+/, '')
+  // if input ends with a dot, add a zero so it is a valid number.
+  if (_value.startsWith('.')) {
+    return { value: `0${_value}` }
+  }
+  // Input may be "0", "00", "000..." or any combination, but all are equal to 0.
+  // So just return "0" in that case
+  if (value === 0) {
+    return { value: '0' }
+  }
+  return { value: _value }
+}

--- a/webapp/utils/url.ts
+++ b/webapp/utils/url.ts
@@ -1,3 +1,6 @@
+import { createParser } from 'nuqs'
+import { isAddress } from 'viem'
+
 import { hasKeys } from './utilities'
 
 export const isRelativeUrl = (url: string) => url.startsWith('/')
@@ -10,6 +13,11 @@ export const isValidUrl = function (url: string) {
     return false
   }
 }
+
+export const parseAsEvmAddress = createParser({
+  parse: (queryValue: string) => (isAddress(queryValue) ? queryValue : null),
+  serialize: value => value,
+})
 
 export const queryStringObjectToString = function (
   queryString: Record<string, string> = {},


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the UI for the Stake drawer. Note that the submission code is not done yet, so that's why the issues are left open

#### Description by commit

- 5951639b125a92254fa0d9c203b97814c77acaed Creates `sanitizeAmount ` with the logic used in the tunnel for the input, and moves it into the `utils` folder, so it can be reused here. Tests added
- c04dc3f3c0420a932631730ee14d54f9689b491a Improves even further the `TokenInput`. As many props were part of the `TokenSelector`, I did some component composition and updated it so now `TokenSelector` is a prop. Now the interface of `TokenInput` is more clean and simple
- 5d1ea99ea35a2dd2efee46517cd7d58e602dad22 Moves the fees component that's rendered below the tunnel form, so I Can reuse it in the stake drawer. Now it is part of the `components` folder
- 7c5201d9aab081beb215bcec572212412529e76a The `MaxBalance` button component has a `isRunningOperation` prop to disable it. Its naming was confusing , so I updated it into using a more standard `disabled`.
- 6698d2f0a38a10a4875dcd6410aabc80f88ca885 Moves the `nuqs` parser `parseAsEvmAddress` into a common folder, so I can reuse it for opening the drawer. This parser is used to validate a query string is a valid EVM Address
- ab119a1598de1d1c2ad509ec825ab1c6e64e8bec based in all the previous changes, this is the one that actually creates the Drawer.
- cb5d1e31399b931a541f33df0b25619a44f0f05c Updates the `/stake` layout to allow the drawer to be opened from anywhere under the routes of this layout (which are `/stake` and `/stake/dashboard`). Depending the token selected, the query string `tokenAddress` is set (which uses the parser from the commit above), and the `drawerMode` query string value is used to give some context to the drawer, and show (or not) the "Stake/Unstake" tabs.  
With this commit, users clicking a row in the dashboard will open the Drawer with the "Unstake" tab active (See video)
- 55247e0b258d72eac55b6f652ed8bd0db0675eed updates the "Stake" in the "/stake" page to open the drawer, and the "+Stake more" to redirect to the Stake page

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<details>
  <summary>Mobile</summary>

<img width="479" alt="image" src="https://github.com/user-attachments/assets/680017b8-164f-4d82-8930-08d0352482d6" />

<img width="514" alt="image" src="https://github.com/user-attachments/assets/2ecf8a08-9768-4cae-a028-6d1fd7b04cf3" />

<img width="497" alt="image" src="https://github.com/user-attachments/assets/9289f559-1453-4d17-8a81-a4a905509ca8" />

</details>

<details>
  <summary>Desktop</summary>

<img width="1690" alt="image" src="https://github.com/user-attachments/assets/ced19690-41d7-45d3-8e57-501cc72f08c8" />

<img width="1660" alt="image" src="https://github.com/user-attachments/assets/0ca4582b-5e2c-4a79-9565-ebe11b58ed0e" />

<img width="1667" alt="image" src="https://github.com/user-attachments/assets/871312e7-540b-423f-a991-3a36a9fc9d3e" />

</details>



https://github.com/user-attachments/assets/78ebebf9-8247-426d-b0aa-228563fbea15

(Note that the drawer without "tabs" is opened from the "Stake" tab)

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #754 and #755

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
