### PR TITLE
Challenge bitcoin wording update

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/challengeBtcWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/challengeBtcWithdrawal.tsx
@@ -72,8 +72,8 @@ export const ChallengeBtcWithdrawal = function ({ withdrawal }: Props) {
   return (
     <div className="flex h-full flex-col justify-between gap-y-24">
       <WarningBox
-        heading={t('review-withdraw.we-could-not-process-this-withdraw')}
-        subheading={t('review-withdraw.challenge-to-get-bitcoins-back')}
+        heading={t('review-withdrawal.we-could-not-process-this-withdraw')}
+        subheading={t('review-withdrawal.challenge-to-get-bitcoins-back')}
       />
       <DrawerCallToAction
         expectedChainId={withdrawal.l2ChainId}

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewBtcWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewBtcWithdrawal.tsx
@@ -49,7 +49,7 @@ const ReviewContent = function ({
   )
   const challengeWithdrawalEstimatedFees =
     useEstimateChallengeBtcWithdrawalFees(withdrawal.l2ChainId)
-  const t = useTranslations('tunnel-page.review-withdraw')
+  const t = useTranslations('tunnel-page.review-withdrawal')
   const tCommon = useTranslations('common')
 
   const shouldAddChallengeStep = () =>

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -60,7 +60,7 @@ const ReviewContent = function ({
   const toChain = useChain(withdrawal.l1ChainId)
   const [operationStatus] = useContext(ToEvmWithdrawalContext)
   const [networkType] = useNetworkType()
-  const t = useTranslations('tunnel-page.review-withdraw')
+  const t = useTranslations('tunnel-page.review-withdrawal')
   const tCommon = useTranslations('common')
 
   const { claimWithdrawalTokenGasFees } = useClaimTransaction(withdrawal)

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -265,11 +265,11 @@
       "you-are-depositing": "You are depositing",
       "your-deposit-is-complete": "Your deposit is complete."
     },
-    "review-withdraw": {
+    "review-withdrawal": {
       "challenge-to-get-bitcoins-back": "Click 'Challenge withdrawal' yo reclaim your BTC and send it back to your Hemi address.",
       "challenge-withdrawal": "Challenge Withdrawal",
       "claim-withdrawal": "Claim withdrawal",
-      "heading": "Review Withdraw",
+      "heading": "Review Withdrawal",
       "initiate-withdrawal": "Initiate withdrawal",
       "prove-withdrawal": "Prove withdrawal",
       "total-to-withdraw": "Total to withdraw",

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -266,7 +266,7 @@
       "your-deposit-is-complete": "Your deposit is complete."
     },
     "review-withdraw": {
-      "challenge-to-get-bitcoins-back": "Click on the 'Challenge withdraw' to receive your bitcoins back in Hemi",
+      "challenge-to-get-bitcoins-back": "Click 'Challenge withdrawal' yo reclaim your BTC and send it back to your Hemi address.",
       "challenge-withdrawal": "Challenge Withdrawal",
       "claim-withdrawal": "Claim withdrawal",
       "heading": "Review Withdraw",
@@ -274,7 +274,7 @@
       "prove-withdrawal": "Prove withdrawal",
       "total-to-withdraw": "Total to withdraw",
       "view-tx": "View",
-      "we-could-not-process-this-withdraw": "We couldn't process this withdraw automatically",
+      "we-could-not-process-this-withdraw": "We couldn't process this withdrawal",
       "withdraw-completed": "Withdrawal completed",
       "withdraw-on-its-way": "You're almost there! Complete the remaining steps to claim your withdrawal.",
       "your-withdraw-is-completed": "Your withdrawal is complete."

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -180,19 +180,19 @@
   },
   "stake-page": {
     "dashboard": {
+      "asset": "Asset",
+      "protocol": "Protocol",
+      "rewards": "Rewards",
+      "stake": "Stake",
+      "staked": "Staked",
+      "stake-more": "Stake more",
+      "stake-earn-points-label": "Stake and|earn po|ints",
+      "staking-assets": "Staking assets",
       "subtitle": "Stake your assets to earn rewards and boost your points.",
       "title": "Dashboard",
       "total-earned-points": "Total Hemi points earned",
       "total-staked": "Total Staked",
-      "your-stake": "Your Stake",
-      "staking-assets": "Staking assets",
-      "protocol": "Protocol",
-      "asset": "Asset",
-      "staked": "Staked",
-      "rewards": "Rewards",
-      "stake-more": "Stake more",
-      "stake": "Stake",
-      "stake-earn-points-label": "Stake and|earn po|ints"
+      "your-stake": "Your Stake"
     },
     "stake": {
       "subtitle": "Stake assets to earn points and rewards.",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -265,7 +265,7 @@
       "your-deposit-is-complete": "Su depósito ha sido completado"
     },
     "review-withdraw": {
-      "challenge-to-get-bitcoins-back": "Haga clic en 'Disputar Retiro' para recibir sus bitcoins de vuelta en Hemi",
+      "challenge-to-get-bitcoins-back": "Haga clic en 'Disputar Retiro' para reclamar su BTC y enviarlo de vuelta a su dirección de Hemi.",
       "challenge-withdrawal": "Disputar Retiro",
       "claim-withdrawal": "Reclamar retiro",
       "heading": "Revisar Retiro",
@@ -273,7 +273,7 @@
       "prove-withdrawal": "Probar retiro",
       "total-to-withdraw": "Total a retirar",
       "view-tx": "Ver",
-      "we-could-not-process-this-withdraw": "No pudimos procesar este retiro automáticamente",
+      "we-could-not-process-this-withdraw": "No pudimos procesar este retiro",
       "withdraw-completed": "Retiro completado",
       "withdraw-on-its-way": "¡Ya falta poco! Complete el resto de los pasos para reclamar su retiro.",
       "your-withdraw-is-completed": "Su retiro ha sido completado."

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -264,7 +264,7 @@
       "you-are-depositing": "Usted está depositando",
       "your-deposit-is-complete": "Su depósito ha sido completado"
     },
-    "review-withdraw": {
+    "review-withdrawal": {
       "challenge-to-get-bitcoins-back": "Haga clic en 'Disputar Retiro' para reclamar su BTC y enviarlo de vuelta a su dirección de Hemi.",
       "challenge-withdrawal": "Disputar Retiro",
       "claim-withdrawal": "Reclamar retiro",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -180,18 +180,19 @@
   },
   "stake-page": {
     "dashboard": {
+      "asset": "Activo",
+      "protocol": "Protocolo",
+      "rewards": "Recompensas",
+      "stake": "Apuesta",
+      "staked": "Apostado",
+      "stake-more": "Apuesta más",
+      "stake-earn-points-label": "Apuesta y|ganar p|untos",
+      "staking-assets": "Activos en apuesta",
       "subtitle": "Apueste sus activos para ganar recompensas y aumentar tus puntos.",
       "title": "Panel",
       "total-earned-points": "Total de puntos Hemi ganados",
       "total-staked": "Total Apostado",
-      "your-stake": "Su Apuesta",
-      "protocol": "Protocolo",
-      "asset": "Activo",
-      "staked": "Apostado",
-      "rewards": "Recompensas",
-      "stake-more": "Apuesta más",
-      "stake": "Apuesta",
-      "stake-earn-points-label": "Apuesta y|ganar p|untos"
+      "your-stake": "Su Apuesta"
     },
     "stake": {
       "subtitle": "Apueste activos para ganar puntos y recompensas.",

--- a/webapp/test/locale.test.ts
+++ b/webapp/test/locale.test.ts
@@ -1,0 +1,33 @@
+import { readdir, readFile } from 'fs/promises'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+const getFullKeys = (obj: Record<string, string> | string, prefix?: string) =>
+  Object.keys(obj).flatMap(function (key) {
+    const fullKey = prefix ? `${prefix}.${key}` : key
+    return typeof obj[key] === 'object' && obj[key] !== null
+      ? getFullKeys(obj[key], fullKey)
+      : fullKey
+  })
+
+describe('locale messages', function () {
+  describe('All locale resource files should have the same keys in the same order', function () {
+    it('should have the same keys in the same order', async function () {
+      // get the directory file names
+      const messagesDir = path.resolve(__dirname, '../messages')
+      const files = await readdir(messagesDir)
+
+      // read the file, and get its keys into an array
+      const keysArrays = await Promise.all(
+        files.map(async function (file) {
+          const filePath = path.join(messagesDir, file)
+          const content = JSON.parse(await readFile(filePath, 'utf-8'))
+          return getFullKeys(content)
+        }),
+      )
+
+      // compare all keys arrays with the first one - by transitivity, all should be equal
+      keysArrays.forEach(keysArray => expect(keysArray).toEqual(keysArrays[0]))
+    })
+  })
+})


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR does some wording updates and adds a test to ensure the locale files (English and Spanish) are in sync.

- 2e818bd7d901176343f7ed8c1bf77a5a75ae782f updates the "Warning" message when challenging a Bitcoin Withdrawal
- c71b2b2983652f960a9456bfe1c9b00e70067f6b Updates the title from "Review Withdraw" to "Review withdrawal". Keys were updated in the resource file to match this
- 3bef37858e1292cf688ac4f25b125227a5acf74c Adds a test that ensures `en.json` and `es.json` have the same keys and within the same order. Typescript already checks that keys used in the code are present in `en.json` (See that [here](https://github.com/hemilabs/ui-monorepo/blob/22c1ce401fc1ef755afd4ad58a8fe58e4aae8202/webapp/global.d.ts#L4)) - this will allow us to have the 2 files (And future added) to be consistent. The only step I would add is an eslint extension to allow `.json` files to have their keys consistently sorted (alphabetically). TBD for the future.  
As part of this commit, I found 1 key missing (`stake-page.staking-assets`) in the Spanish file. I also sorted the keys where I did that update

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

![image](https://github.com/user-attachments/assets/82d1c18b-a28e-4958-892a-92214ccf5740)

![image](https://github.com/user-attachments/assets/e71e87db-34e2-4493-81d2-58dfa03773ce)


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #803

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
