### PR TITLE
Misc changes stake

### DIFF
--- a/webapp/app/[locale]/stake/_components/manageStake/index.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/index.tsx
@@ -9,6 +9,7 @@ import {
 import { TokenInput } from 'components/tokenInput'
 import { TokenSelectorReadOnly } from 'components/tokenSelector/readonly'
 import { useTokenBalance } from 'hooks/useBalance'
+import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
 import { useTranslations } from 'next-intl'
 import { FormEvent, useState } from 'react'
 import { StakeToken } from 'types/stake'
@@ -45,6 +46,9 @@ export const ManageStake = function ({
 
   const { chainId } = useAccount()
   const [amount, setAmount] = useAmount()
+  const connectedToExpectedChain = useIsConnectedToExpectedNetwork(
+    token.chainId,
+  )
   const [operation, setOperation] = useState<StakeOperations>(() =>
     isManaging ? props.initialOperation : 'stake',
   )
@@ -121,13 +125,17 @@ export const ManageStake = function ({
                   maxBalanceButton={
                     isStaking ? (
                       <StakeMaxBalance
-                        disabled={submitDisabled || balance === BigInt(0)}
+                        disabled={
+                          !connectedToExpectedChain || balance === BigInt(0)
+                        }
                         onSetMaxBalance={setAmount}
                         token={token}
                       />
                     ) : (
                       <UnstakeMaxBalance
-                        disabled={submitDisabled || balance === BigInt(0)}
+                        disabled={
+                          !connectedToExpectedChain || balance === BigInt(0)
+                        }
                         onSetMaxBalance={setAmount}
                         token={token}
                       />

--- a/webapp/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/webapp/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -4,6 +4,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
+import { Balance } from 'components/balance'
 import { ButtonLink } from 'components/button'
 import { Card } from 'components/card'
 import { Link } from 'components/link'
@@ -18,9 +19,8 @@ import { useWindowSize } from 'ui-common/hooks/useWindowSize'
 import { useDrawerStakeQueryString } from '../../_hooks/useDrawerStakeQueryString'
 import { protocolImages } from '../../protocols/protocolImages'
 import { Column, ColumnHeader, Header } from '../table'
+import { TokenBalance } from '../tokenBalance'
 import { TokenRewards } from '../tokenRewards'
-
-import { WalletBalance } from './walletBalance'
 
 const columnsBuilder = (
   t: ReturnType<typeof useTranslations<'stake-page'>>,
@@ -50,7 +50,9 @@ const columnsBuilder = (
     meta: { width: '120px' },
   },
   {
-    cell: ({ row }) => <WalletBalance token={row.original} />,
+    cell: ({ row }) => (
+      <TokenBalance balance={<Balance token={row.original} />} />
+    ),
     header: () => <Header text={t('wallet-balance')} />,
     id: 'wallet-balance',
     meta: { width: '100px' },

--- a/webapp/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/webapp/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -20,25 +20,17 @@ import { protocolImages } from '../../protocols/protocolImages'
 import { Column, ColumnHeader, Header } from '../table'
 import { TokenRewards } from '../tokenRewards'
 
-type WalletBalanceValues = {
-  quantity: string
-  monetaryValue: string
-}
-
-export type StakeStrategyColumns = {
-  token: StakeToken
-  walletBalance: WalletBalanceValues
-}
+import { WalletBalance } from './walletBalance'
 
 const columnsBuilder = (
   t: ReturnType<typeof useTranslations<'stake-page'>>,
-): ColumnDef<StakeStrategyColumns>[] => [
+): ColumnDef<StakeToken>[] => [
   {
     cell: ({ row }) => (
       <div className="flex items-center space-x-2">
         <Image
-          alt={row.original.token.extensions.protocol}
-          src={protocolImages[row.original.token.extensions.protocol]}
+          alt={row.original.extensions.protocol}
+          src={protocolImages[row.original.extensions.protocol]}
         />
       </div>
     ),
@@ -49,8 +41,8 @@ const columnsBuilder = (
   {
     cell: ({ row }) => (
       <div className="flex items-center justify-center space-x-2">
-        <TokenLogo size="small" token={row.original.token} />
-        <span className="text-neutral-950">{row.original.token.symbol}</span>
+        <TokenLogo size="small" token={row.original} />
+        <span className="text-neutral-950">{row.original.symbol}</span>
       </div>
     ),
     header: () => <Header text={t('asset')} />,
@@ -58,17 +50,7 @@ const columnsBuilder = (
     meta: { width: '120px' },
   },
   {
-    cell: ({ row }) => (
-      <div className="flex flex-col justify-end">
-        <span className="text-neutral-950">
-          {row.original.walletBalance.quantity}
-        </span>
-        <p className="text-neutral-500">
-          <span className="mr-1">$</span>
-          {row.original.walletBalance.monetaryValue}
-        </p>
-      </div>
-    ),
+    cell: ({ row }) => <WalletBalance token={row.original} />,
     header: () => <Header text={t('wallet-balance')} />,
     id: 'wallet-balance',
     meta: { width: '100px' },
@@ -76,7 +58,7 @@ const columnsBuilder = (
   {
     cell: ({ row }) => (
       <div className="flex flex-wrap items-center gap-2 overflow-hidden">
-        <TokenRewards rewards={row.original.token.extensions.rewards} />
+        <TokenRewards rewards={row.original.extensions.rewards} />
       </div>
     ),
     header: () => <Header text={t('rewards')} />,
@@ -93,14 +75,14 @@ const columnsBuilder = (
             href={{
               pathname: '/stake',
               query: {
-                address: row.original.token.address,
+                address: row.original.address,
                 mode: 'stake',
               },
             }}
             onClick={function (e) {
               e.preventDefault()
               e.stopPropagation()
-              setDrawerQueryString('stake', row.original.token.address)
+              setDrawerQueryString('stake', row.original.address)
             }}
           >
             {t('stake.title')}
@@ -115,7 +97,7 @@ const columnsBuilder = (
 ]
 
 type StakeStrategyTableImpProps = {
-  data: StakeStrategyColumns[]
+  data: StakeToken[]
   loading: boolean
 }
 
@@ -202,17 +184,6 @@ type Props = {
 export const StakeStrategyTable = function ({ data, loading }: Props) {
   const t = useTranslations('stake-page.stake')
 
-  // TODO - We need to define quantity and monetaryValue for the walletBalance
-  // Related to the issue #796 - https://github.com/hemilabs/ui-monorepo/issues/796
-  const mapStakeTokensToColumns = (tokens): StakeStrategyColumns[] =>
-    tokens.map(token => ({
-      token,
-      walletBalance: {
-        monetaryValue: '125',
-        quantity: '0.08',
-      },
-    }))
-
   // TODO - The learn how to stake on hemi link is TBD
   return (
     <div className="rounded-2.5xl relative z-20 -translate-y-32 bg-neutral-100 p-1 text-sm font-medium md:-translate-y-24">
@@ -231,10 +202,7 @@ export const StakeStrategyTable = function ({ data, loading }: Props) {
       </div>
       <Card>
         <div className="max-h-[48dvh] overflow-x-auto p-2">
-          <StakeStrategyTableImp
-            data={mapStakeTokensToColumns(data)}
-            loading={loading}
-          />
+          <StakeStrategyTableImp data={data} loading={loading} />
         </div>
       </Card>
     </div>

--- a/webapp/app/[locale]/stake/_components/stakeStrategyTable/walletBalance.tsx
+++ b/webapp/app/[locale]/stake/_components/stakeStrategyTable/walletBalance.tsx
@@ -1,0 +1,19 @@
+import { Balance } from 'components/balance'
+import { StakeToken } from 'types/stake'
+
+type Props = {
+  token: StakeToken
+}
+
+export const WalletBalance = ({ token }: Props) => (
+  <div className="flex flex-col justify-end">
+    <span className="text-neutral-950">
+      <Balance token={token} />
+    </span>
+    <p className="text-neutral-500">
+      <span className="mr-1">$</span>
+      {/* TODO - TBD how to calculate monetaryValue - https://github.com/hemilabs/ui-monorepo/issues/796 */}
+      125
+    </p>
+  </div>
+)

--- a/webapp/app/[locale]/stake/_components/tokenBalance.tsx
+++ b/webapp/app/[locale]/stake/_components/tokenBalance.tsx
@@ -1,15 +1,12 @@
-import { Balance } from 'components/balance'
-import { StakeToken } from 'types/stake'
+import { ReactNode } from 'react'
 
 type Props = {
-  token: StakeToken
+  balance: ReactNode
 }
 
-export const WalletBalance = ({ token }: Props) => (
+export const TokenBalance = ({ balance }: Props) => (
   <div className="flex flex-col justify-end">
-    <span className="text-neutral-950">
-      <Balance token={token} />
-    </span>
+    <span className="text-neutral-950">{balance}</span>
     <p className="text-neutral-500">
       <span className="mr-1">$</span>
       {/* TODO - TBD how to calculate monetaryValue - https://github.com/hemilabs/ui-monorepo/issues/796 */}

--- a/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
+++ b/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+import { useNetworkType } from 'hooks/useNetworkType'
+import { StakeToken } from 'types/stake'
+import { useAccount } from 'wagmi'
+
+export const useStakedBalance = function (token: StakeToken) {
+  const { address, isConnected } = useAccount()
+  const [networkType] = useNetworkType()
+
+  const { data: balance, ...rest } = useQuery({
+    enabled: isConnected,
+    // TODO call hemiClient.stakedBalance(tokenAddress, address) once defined
+    // See https://github.com/hemilabs/ui-monorepo/issues/774
+    queryFn: () => Promise.resolve(BigInt(0)),
+    queryKey: [
+      'staked-token-balance',
+      address,
+      networkType,
+      token.chainId,
+      token.address,
+    ],
+  })
+  return {
+    balance,
+    ...rest,
+  }
+}

--- a/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -20,29 +20,17 @@ import { StakeToken } from 'types/stake'
 import { useWindowSize } from 'ui-common/hooks/useWindowSize'
 import { queryStringObjectToString } from 'utils/url'
 
-import {
-  Column,
-  ColumnHeader,
-  Header,
-} from '../../../../stake/_components/table'
-import { TokenRewards } from '../../../../stake/_components/tokenRewards'
+import { Column, ColumnHeader, Header } from '../../../_components/table'
+import { TokenBalance } from '../../../_components/tokenBalance'
+import { TokenRewards } from '../../../_components/tokenRewards'
 import { useDrawerStakeQueryString } from '../../../_hooks/useDrawerStakeQueryString'
 import { protocolImages } from '../../../protocols/protocolImages'
 
+import { StakedBalance } from './stakedBalance'
 import { WelcomeStake } from './welcomeStake'
 
-type StakedValues = {
-  quantity: string
-  monetaryValue: string
-}
-
-type StakeAssetsColumns = {
-  token: StakeToken
-  staked: StakedValues
-}
-
 type ActionProps = {
-  stake: StakeAssetsColumns
+  stake: StakeToken
 }
 
 const Body = function ({
@@ -51,10 +39,10 @@ const Body = function ({
   loading,
   rows,
 }: {
-  columns: ColumnDef<StakeAssetsColumns>[]
+  columns: ColumnDef<StakeToken>[]
   containerRef: MutableRefObject<HTMLDivElement>
   loading: boolean
-  rows: Row<StakeAssetsColumns>[]
+  rows: Row<StakeToken>[]
 }) {
   const { setDrawerQueryString } = useDrawerStakeQueryString()
   const rowVirtualizer = useVirtualizer({
@@ -65,7 +53,7 @@ const Body = function ({
   })
 
   // TODO add analytics for this event https://github.com/hemilabs/ui-monorepo/issues/765
-  const openDrawer = ({ token }: StakeAssetsColumns) =>
+  const openDrawer = (token: StakeToken) =>
     setDrawerQueryString('manage', token.address)
 
   return (
@@ -88,7 +76,7 @@ const Body = function ({
       {(!loading || rows.length > 0) && (
         <>
           {rowVirtualizer.getVirtualItems().map(function (virtualRow) {
-            const row = rows[virtualRow.index] as Row<StakeAssetsColumns>
+            const row = rows[virtualRow.index] as Row<StakeToken>
             return (
               <tr
                 className="group/stake-row absolute flex w-full items-center"
@@ -123,7 +111,7 @@ const CallToAction = function ({ stake }: ActionProps) {
 
   const queryString = queryStringObjectToString({
     mode: 'manage',
-    tokenAddress: stake.token.address,
+    tokenAddress: stake.address,
   })
 
   return (
@@ -146,13 +134,13 @@ const CallToAction = function ({ stake }: ActionProps) {
 
 const columnsBuilder = (
   t: ReturnType<typeof useTranslations<'stake-page'>>,
-): ColumnDef<StakeAssetsColumns>[] => [
+): ColumnDef<StakeToken>[] => [
   {
     cell: ({ row }) => (
       <div className="flex items-center space-x-2">
         <Image
-          alt={row.original.token.extensions.protocol}
-          src={protocolImages[row.original.token.extensions.protocol]}
+          alt={row.original.extensions.protocol}
+          src={protocolImages[row.original.extensions.protocol]}
         />
       </div>
     ),
@@ -163,8 +151,8 @@ const columnsBuilder = (
   {
     cell: ({ row }) => (
       <div className="flex items-center justify-center space-x-2">
-        <TokenLogo size="small" token={row.original.token} />
-        <span className="text-neutral-950">{row.original.token.symbol}</span>
+        <TokenLogo size="small" token={row.original} />
+        <span className="text-neutral-950">{row.original.symbol}</span>
       </div>
     ),
     header: () => <Header text={t('asset')} />,
@@ -173,13 +161,7 @@ const columnsBuilder = (
   },
   {
     cell: ({ row }) => (
-      <div className="flex flex-col justify-end">
-        <span className="text-neutral-950">{row.original.staked.quantity}</span>
-        <p className="text-neutral-500">
-          <span className="mr-1">$</span>
-          {row.original.staked.monetaryValue}
-        </p>
-      </div>
+      <TokenBalance balance={<StakedBalance token={row.original} />} />
     ),
     header: () => <Header text={t('dashboard.staked')} />,
     id: 'staked',
@@ -188,7 +170,7 @@ const columnsBuilder = (
   {
     cell: ({ row }) => (
       <div className="flex flex-wrap items-center gap-2 overflow-hidden">
-        <TokenRewards rewards={row.original.token.extensions.rewards} />
+        <TokenRewards rewards={row.original.extensions.rewards} />
       </div>
     ),
     header: () => <Header text={t('rewards')} />,
@@ -208,7 +190,7 @@ const columnsBuilder = (
 
 type Props = {
   containerRef: MutableRefObject<HTMLDivElement>
-  data: StakeAssetsColumns[]
+  data: StakeToken[]
   loading: boolean
 }
 

--- a/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/stakedBalance.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/stakedBalance.tsx
@@ -1,0 +1,12 @@
+import { RenderBalance } from 'components/balance'
+import { StakeToken } from 'types/stake'
+
+import { useStakedBalance } from '../../../_hooks/useStakedBalance'
+
+type Props = {
+  token: StakeToken
+}
+
+export const StakedBalance = ({ token }: Props) => (
+  <RenderBalance {...useStakedBalance(token)} token={token} />
+)

--- a/webapp/app/[locale]/stake/dashboard/page.tsx
+++ b/webapp/app/[locale]/stake/dashboard/page.tsx
@@ -28,15 +28,7 @@ const Page = function () {
         <EarnedPoints />
       </div>
       <div className="mt-6 md:mt-8">
-        <StakeAssetsTable
-          // TODO - This is a mock data, replace it with the real data
-          // Related to the issue #774 - https://github.com/hemilabs/ui-monorepo/issues/774
-          data={stakeTokens.map(token => ({
-            staked: { monetaryValue: '112', quantity: '0.24' },
-            token,
-          }))}
-          loading={false}
-        />
+        <StakeAssetsTable data={stakeTokens} loading={false} />
       </div>
     </div>
   )

--- a/webapp/components/balance.tsx
+++ b/webapp/components/balance.tsx
@@ -12,7 +12,7 @@ type Props<T extends Token = Token> = {
   token: T
 }
 
-const RenderBalance = ({
+export const RenderBalance = ({
   balance,
   fetchStatus,
   status,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds 3 misc changes for stake:

- c0e1c4b5fc7c45146922939aea2cfa4e015bc3af Loads the ERC20 token balances for the user in the "Stake" table
- 116df762d1bac02f0bc3b24ccf7d977a7f289d69 Fixes the "Max" button on the Stake drawer
- c81a7f2b3f19c076f2e3fb5b6d819a7177bb9667 adds the code to load the Staked Balance. Note that this depends on the contract calls being implemented (cc @ArturDolzan )

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Balances loaded for Mainnet

<img width="1135" alt="image" src="https://github.com/user-attachments/assets/c5a50e2d-826e-478e-a4a8-552d4a01b10c" />

Balances loaded for testnet

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/7557bda7-e53e-4d59-9afb-ba6b874bc4b3" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #774

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
