### PR TITLE
Add hemi-viem-stake-actions pkg and public client calls

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
       ],
       "files": [
         "btc-wallet/**/*.{js,ts,tsx}",
+        "hemi-viem-stake-actions/**/*.{js,ts}",
         "sliding-block-window/**/*.{js,ts}",
         "subgraphs/**/*.{js,ts}",
         "ui-common/**/*.{js,ts,tsx}",

--- a/hemi-viem-stake-actions/actions/public/stakeManager.ts
+++ b/hemi-viem-stake-actions/actions/public/stakeManager.ts
@@ -1,0 +1,52 @@
+import { type Address, type Client } from 'viem'
+import { readContract } from 'viem/actions'
+
+import {
+  stakeManagerAbi,
+  stakeManagerAddresses,
+} from '../../contracts/stakeManager'
+
+/**
+ * Retrieves the balance of a specific token for a given address.
+ *
+ * @param {Client} client - The Viem client used to read from the contract.
+ * @param {Object} parameters - Query parameters.
+ * @param {Address} parameters.tokenAddress - The address of the token to check.
+ * @param {Address} parameters.address - The user address for which the balance will be returned.
+ * @returns {Promise<bigint>} The token balance for the specified address.
+ */
+export function stakedBalance(
+  client: Client,
+  parameters: { tokenAddress: Address; address: Address },
+) {
+  const { tokenAddress, address } = parameters
+  return readContract(client, {
+    abi: stakeManagerAbi,
+    // @ts-expect-error: TS is complaining about client.chain!.id definition, but this works
+    address: stakeManagerAddresses[client.chain!.id],
+    args: [tokenAddress, address],
+    functionName: 'balance',
+  })
+}
+
+/**
+ * Checks whether a given token address is in the allowlist.
+ *
+ * @param {Client} client - The Viem client used to read from the contract.
+ * @param {Object} parameters - Query parameters.
+ * @param {Address} parameters.address - The token address to verify in the allowlist.
+ * @returns {Promise<boolean>} True if the token is in the allowlist, otherwise false.
+ */
+export function stakeTokenAllowlist(
+  client: Client,
+  parameters: { address: Address },
+) {
+  const { address } = parameters
+  return readContract(client, {
+    abi: stakeManagerAbi,
+    // @ts-expect-error: TS is complaining about client.chain!.id definition, but this works
+    address: stakeManagerAddresses[client.chain!.id],
+    args: [address],
+    functionName: 'tokenAllowlist',
+  })
+}

--- a/hemi-viem-stake-actions/contracts/stakeManager.ts
+++ b/hemi-viem-stake-actions/contracts/stakeManager.ts
@@ -1,0 +1,812 @@
+import { hemiSepolia } from 'hemi-viem'
+import { type Address, type Chain } from 'viem'
+
+export const stakeManagerAddresses: Record<Chain['id'], Address> = {
+  [hemiSepolia.id]: '0x935CC431313C52427ccf45385138a136580bf59f',
+}
+
+export const stakeManagerAbi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_signer',
+        type: 'address',
+      },
+      {
+        internalType: 'address[]',
+        name: '_tokensAllowed',
+        type: 'address[]',
+      },
+      {
+        internalType: 'address',
+        name: '_weth',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [],
+    name: 'CannotDepositForZeroAddress',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'CannotRenounceOwnership',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'DepositAmountCannotBeZero',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'DuplicateToken',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'EnforcedPause',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ExpectedPause',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'currentNonce',
+        type: 'uint256',
+      },
+    ],
+    name: 'InvalidAccountNonce',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidShortString',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'MigratorAlreadyAllowedOrBlocked',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'MigratorBlocked',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'MigratorCannotBeZeroAddress',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnableInvalidOwner',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'OwnableUnauthorizedAccount',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'SafeERC20FailedOperation',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'SignatureExpired',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'SignatureInvalid',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'SignerAlreadySetToAddress',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'SignerCannotBeZeroAddress',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'str',
+        type: 'string',
+      },
+    ],
+    name: 'StringTooLong',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'TokenAlreadyConfiguredWithState',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'TokenArrayCannotBeEmpty',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'TokenCannotBeZeroAddress',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'TokenNotAllowedForStaking',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UserDoesNotHaveStake',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'WETHCannotBeZeroAddress',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'WithdrawAmountCannotBeZero',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'migrator',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bool',
+        name: 'blocked',
+        type: 'bool',
+      },
+    ],
+    name: 'BlocklistChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'eventId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'depositor',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Deposit',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: 'EIP712DomainChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'eventId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'user',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address[]',
+        name: 'tokens',
+        type: 'address[]',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'destination',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'migrator',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256[]',
+        name: 'amounts',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'Migrate',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferStarted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'Paused',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'newSigner',
+        type: 'address',
+      },
+    ],
+    name: 'SignerChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bool',
+        name: 'enabled',
+        type: 'bool',
+      },
+    ],
+    name: 'TokenStakabilityChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'Unpaused',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'eventId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'withdrawer',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Withdraw',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'acceptOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'balance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_migrator',
+        type: 'address',
+      },
+      {
+        internalType: 'bool',
+        name: '_blocklisted',
+        type: 'bool',
+      },
+    ],
+    name: 'blockMigrator',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_for',
+        type: 'address',
+      },
+    ],
+    name: 'depositETHFor',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_token',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_for',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'depositFor',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'eip712Domain',
+    outputs: [
+      {
+        internalType: 'bytes1',
+        name: 'fields',
+        type: 'bytes1',
+      },
+      {
+        internalType: 'string',
+        name: 'name',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'version',
+        type: 'string',
+      },
+      {
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'verifyingContract',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'salt',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'extensions',
+        type: 'uint256[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address[]',
+        name: '_tokens',
+        type: 'address[]',
+      },
+      {
+        internalType: 'address',
+        name: '_migratorContract',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_destination',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_signatureExpiry',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: '_authorizationSignatureFromZircuit',
+        type: 'bytes',
+      },
+    ],
+    name: 'migrate',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_user',
+        type: 'address',
+      },
+      {
+        internalType: 'address[]',
+        name: '_tokens',
+        type: 'address[]',
+      },
+      {
+        internalType: 'address',
+        name: '_migratorContract',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_destination',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_signatureExpiry',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: '_stakerSignature',
+        type: 'bytes',
+      },
+    ],
+    name: 'migrateWithSig',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'migratorBlocklist',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+    ],
+    name: 'nonces',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'pause',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'paused',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'pendingOwner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_token',
+        type: 'address',
+      },
+      {
+        internalType: 'bool',
+        name: '_canStake',
+        type: 'bool',
+      },
+    ],
+    name: 'setStakable',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_signer',
+        type: 'address',
+      },
+    ],
+    name: 'setZircuitSigner',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'tokenAllowlist',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'unpause',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'zircuitSigner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const

--- a/hemi-viem-stake-actions/index.ts
+++ b/hemi-viem-stake-actions/index.ts
@@ -1,0 +1,19 @@
+import { type Client } from 'viem'
+
+import {
+  stakedBalance,
+  stakeTokenAllowlist,
+} from './actions/public/stakeManager'
+
+/**
+ * Extends a Viem `Client` with staking-related actions.
+ *
+ * @param {Object} options - Additional configuration options.
+ * @returns {Function} A function that extends the Viem `Client`.
+ */
+export const hemiPublicStakeActions = () => (client: Client) => ({
+  stakedBalance: (params: Parameters<typeof stakedBalance>[1]) =>
+    stakedBalance(client, params),
+  stakeTokenAllowlist: (params: Parameters<typeof stakeTokenAllowlist>[1]) =>
+    stakeTokenAllowlist(client, params),
+})

--- a/hemi-viem-stake-actions/package.json
+++ b/hemi-viem-stake-actions/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "hemi-viem-stake-actions",
+  "version": "1.0.0",
+  "description": "Hemi Viem Stake Actions",
+  "keywords": [
+    "eth",
+    "ethereum",
+    "hemi",
+    "stake",
+    "viem",
+    "wagmi"
+  ],
+  "license": "MIT",
+  "author": {
+    "email": "artur@bloq.com",
+    "name": "Artur Dolzan Neto"
+  },
+  "scripts": {
+    "tsc:check": "tsc"
+  },
+  "devDependencies": {
+    "viem": "2.22.10"
+  },
+  "peerDependencies": {
+    "viem": "^2.x"
+  },
+  "exports": {
+    ".": "./index.ts"
+  }
+}

--- a/hemi-viem-stake-actions/tsconfig.json
+++ b/hemi-viem-stake-actions/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "strictNullChecks": true
+  },
+  "extends": "../tsconfig.base.json",
+  "exclude": ["node_modules"],
+  "include": ["**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "workspaces": [
         "btc-wallet",
+        "hemi-viem-stake-actions",
         "sliding-block-window",
         "subgraphs/*",
         "ui-common",
@@ -47,6 +48,28 @@
         "@tanstack/react-query": ">=5.24.0",
         "react": "18.2.0",
         "react-dom": "18.2.0"
+      }
+    },
+    "hemi-stake": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "viem": "2.22.10"
+      },
+      "peerDependencies": {
+        "viem": "^2.x",
+        "wagmi": "^2.x"
+      }
+    },
+    "hemi-viem-stake-actions": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "viem": "2.22.10"
+      },
+      "peerDependencies": {
+        "viem": "^2.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -15770,6 +15793,10 @@
         "viem": "^2.x"
       }
     },
+    "node_modules/hemi-viem-stake-actions": {
+      "resolved": "hemi-viem-stake-actions",
+      "link": true
+    },
     "node_modules/hey-listen": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
@@ -27226,6 +27253,7 @@
         "fetch-plus-plus": "1.0.0",
         "hemi-socials": "1.0.0",
         "hemi-viem": "2.0.0",
+        "hemi-viem-stake-actions": "1.0.0",
         "javascript-time-ago": "2.5.10",
         "lodash": "4.17.21",
         "next": "14.2.16",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "private": true,
   "workspaces": [
     "btc-wallet",
+    "hemi-viem-stake-actions",
     "sliding-block-window",
     "subgraphs/*",
     "ui-common",

--- a/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
+++ b/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { useHemiClient } from 'hooks/useHemiClient'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { StakeToken } from 'types/stake'
 import { useAccount } from 'wagmi'
@@ -6,12 +7,16 @@ import { useAccount } from 'wagmi'
 export const useStakedBalance = function (token: StakeToken) {
   const { address, isConnected } = useAccount()
   const [networkType] = useNetworkType()
+  const hemiClient = useHemiClient()
+
+  function getStakedBalance() {
+    if (!hemiClient || !address) return Promise.resolve(BigInt(0))
+    return hemiClient.stakedBalance({ address, tokenAddress: token.address })
+  }
 
   const { data: balance, ...rest } = useQuery({
     enabled: isConnected,
-    // TODO call hemiClient.stakedBalance(tokenAddress, address) once defined
-    // See https://github.com/hemilabs/ui-monorepo/issues/774
-    queryFn: () => Promise.resolve(BigInt(0)),
+    queryFn: getStakedBalance,
     queryKey: [
       'staked-token-balance',
       address,

--- a/webapp/hooks/useHemiClient.ts
+++ b/webapp/hooks/useHemiClient.ts
@@ -7,6 +7,7 @@ import {
   hemi as hemiMainnet,
   hemiSepolia,
 } from 'hemi-viem'
+import { hemiPublicStakeActions } from 'hemi-viem-stake-actions'
 import { useMemo } from 'react'
 import {
   hemiPublicExtraActions,
@@ -32,6 +33,7 @@ export const publicClientToHemiClient = (publicClient: PublicClient) =>
     .extend(hemiPublicSimpleBitcoinVaultActions())
     .extend(hemiPublicSimpleBitcoinVaultStateActions())
     .extend(hemiPublicBitcoinTunnelManagerActions())
+    .extend(hemiPublicStakeActions())
     .extend(hemiPublicExtraActions({ defaultBitcoinVaults }))
 
 export const useHemiClient = function () {

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -28,6 +28,7 @@ const nextConfig = {
   trailingSlash: true,
   transpilePackages: [
     'btc-wallet',
+    'hemi-viem-stake-actions',
     'sliding-block-window',
     'ui-common',
     'wagmi-erc20-hooks',

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -30,6 +30,7 @@
     "fetch-plus-plus": "1.0.0",
     "hemi-socials": "1.0.0",
     "hemi-viem": "2.0.0",
+    "hemi-viem-stake-actions": "1.0.0",
     "javascript-time-ago": "2.5.10",
     "lodash": "4.17.21",
     "next": "14.2.16",


### PR DESCRIPTION
### Description

This PR introduces the new package `hemi-viem-stake-actions` and also two public methods, `stakedBalance` and `stakeTokenAllowlist`, extending publicClientToHemiClient.

### Related issue(s)
Related to #774 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
