### PR TITLE
Load staked positions in dashboard

### DIFF
--- a/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -12,6 +12,7 @@ import { useUmami } from 'app/analyticsEvents'
 import { ButtonLink } from 'components/button'
 import { Card } from 'components/card'
 import { TokenLogo } from 'components/tokenLogo'
+import { useStakeTokens } from 'hooks/useStakeTokens'
 import Image from 'next/image'
 import { usePathname, useRouter } from 'next/navigation'
 import { useLocale, useTranslations } from 'next-intl'
@@ -25,6 +26,7 @@ import { Column, ColumnHeader, Header } from '../../../_components/table'
 import { TokenBalance } from '../../../_components/tokenBalance'
 import { TokenRewards } from '../../../_components/tokenRewards'
 import { useDrawerStakeQueryString } from '../../../_hooks/useDrawerStakeQueryString'
+import { useUserHasPositions } from '../../../_hooks/useStakedBalance'
 import { protocolImages } from '../../../protocols/protocolImages'
 
 import { StakedBalance } from './stakedBalance'
@@ -264,17 +266,18 @@ function stakeMore() {
   // Related to the issue #774 - https://github.com/hemilabs/ui-monorepo/issues/774
 }
 
-export const StakeAssetsTable = function ({
-  data,
-  loading,
-}: Omit<Props, 'containerRef'>) {
+export const StakeAssetsTable = function () {
   const locale = useLocale()
   const containerRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
+  const stakeTokens = useStakeTokens()
   const t = useTranslations('stake-page')
   const { track } = useUmami()
+  const result = useUserHasPositions()
 
-  if (data.length === 0 && !loading) {
+  const { hasPositions, loading } = result
+
+  if (!hasPositions) {
     return <WelcomeStake onClick={stakeMore} />
   }
 
@@ -303,7 +306,7 @@ export const StakeAssetsTable = function ({
         <div className="max-h-[50dvh] overflow-x-auto p-2" ref={containerRef}>
           <StakeAssetsTableImp
             containerRef={containerRef}
-            data={data}
+            data={stakeTokens}
             loading={loading}
           />
         </div>

--- a/webapp/app/[locale]/stake/dashboard/page.tsx
+++ b/webapp/app/[locale]/stake/dashboard/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { PageTitle } from 'components/pageTitle'
-import { useStakeTokens } from 'hooks/useStakeTokens'
 import { useTranslations } from 'next-intl'
 
 import { StakeAssetsTable } from './_components/stakeAssetsTable'
@@ -13,8 +12,6 @@ import {
 
 const Page = function () {
   const t = useTranslations('stake-page')
-
-  const stakeTokens = useStakeTokens()
 
   return (
     <div className="h-fit-rest-screen w-full">
@@ -28,7 +25,7 @@ const Page = function () {
         <EarnedPoints />
       </div>
       <div className="mt-6 md:mt-8">
-        <StakeAssetsTable data={stakeTokens} loading={false} />
+        <StakeAssetsTable />
       </div>
     </div>
   )


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR loads the staked positions of users. As discussed with Nahuel, the "Stake and Earn Points" are shown in the dashboard until any position > 0 is loaded

I also created this issue https://github.com/hemilabs/ui-monorepo/issues/823 which I noticed it happens many times locally  https://github.com/hemilabs/ui-monorepo/issues/823

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/6453a302-fe50-4ccc-9680-d10917887d9e

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to https://github.com/hemilabs/ui-monorepo/issues/774

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
