### PR TITLE
Implement stakeToken and unstakeToken Functions

### DIFF
--- a/hemi-viem-stake-actions/actions/wallet/stakeManager.ts
+++ b/hemi-viem-stake-actions/actions/wallet/stakeManager.ts
@@ -1,0 +1,102 @@
+import { type Address, type Client } from 'viem'
+import { writeContract } from 'viem/actions'
+
+import {
+  stakeManagerAbi,
+  stakeManagerAddresses,
+} from '../../contracts/stakeManager'
+
+/**
+ * Performs staking of an ERC-20 token by calling the `depositFor` function on the contract.
+ *
+ * @param {Client} client - The Viem client configured to interact with the blockchain.
+ * @param {Object} parameters - The transaction parameters for staking.
+ * @param {bigint} parameters.amount - The amount of tokens to be staked.
+ * @param {Address} parameters.forAccount - The user's address initiating the staking.
+ * @param {Address} parameters.tokenAddress - The ERC-20 token address being staked.
+ *
+ * @returns {Promise<Address>} - The transaction sent to the blockchain.
+ */
+export function stakeERC20Token(
+  client: Client,
+  parameters: {
+    amount: bigint
+    forAccount: Address
+    tokenAddress: Address
+  },
+) {
+  const { amount, forAccount, tokenAddress } = parameters
+  return writeContract(client, {
+    abi: stakeManagerAbi,
+    account: forAccount,
+    // @ts-expect-error: TS is complaining about client.chain!.id definition, but this works
+    address: stakeManagerAddresses[client.chain!.id],
+    args: [tokenAddress, forAccount, amount],
+    // @ts-expect-error: TS is complaining about client.chain definition, but this works
+    chain: client.chain,
+    functionName: 'depositFor',
+  })
+}
+
+/**
+ * Performs staking of native ETH by calling the `depositETHFor` function on the contract.
+ *
+ * @param {Client} client - The Viem client configured to interact with the blockchain.
+ * @param {Object} parameters - The transaction parameters for staking.
+ * @param {bigint} parameters.amount - The amount of tokens to be staked.
+ * @param {Address} parameters.forAccount - The user's address initiating the staking.
+ *
+ * @returns {Promise<Address>} - The transaction sent to the blockchain.
+ */
+export function stakeETHToken(
+  client: Client,
+  parameters: {
+    amount: bigint
+    forAccount: Address
+  },
+) {
+  const { amount, forAccount } = parameters
+  return writeContract(client, {
+    abi: stakeManagerAbi,
+    account: forAccount,
+    // @ts-expect-error: TS is complaining about client.chain!.id definition, but this works
+    address: stakeManagerAddresses[client.chain!.id],
+    args: [forAccount],
+    // @ts-expect-error: TS is complaining about client.chain definition, but this works
+    chain: client.chain,
+    functionName: 'depositETHFor',
+    value: amount,
+  })
+}
+
+/**
+ * Unstakes a previously staked token by calling the `withdraw` function on the contract.
+ *
+ * @param {Client} client - The Viem client configured to interact with the blockchain.
+ * @param {Object} parameters - The transaction parameters for unstaking.
+ * @param {bigint} parameters.amount - The amount of tokens to be unstaked.
+ * @param {Address} parameters.forAccount - The user's address initiating the unstaking.
+ * @param {Address} parameters.tokenAddress - The token address to be unstaked.
+ *
+ * @returns {Promise<Address>} - The transaction sent to the blockchain.
+ */
+export function unstakeToken(
+  client: Client,
+  parameters: {
+    amount: bigint
+    forAccount: Address
+    tokenAddress: Address
+  },
+) {
+  const { amount, forAccount, tokenAddress } = parameters
+  return writeContract(client, {
+    abi: stakeManagerAbi,
+    account: forAccount,
+    // @ts-expect-error: TS is complaining about client.chain!.id definition, but this works
+    address: stakeManagerAddresses[client.chain!.id],
+    args: [tokenAddress, amount],
+    // @ts-expect-error: TS is complaining about client.chain definition, but this works
+    chain: client.chain,
+    functionName: 'withdraw',
+  })
+}

--- a/hemi-viem-stake-actions/index.ts
+++ b/hemi-viem-stake-actions/index.ts
@@ -4,9 +4,14 @@ import {
   stakedBalance,
   stakeTokenAllowlist,
 } from './actions/public/stakeManager'
+import {
+  stakeERC20Token,
+  stakeETHToken,
+  unstakeToken,
+} from './actions/wallet/stakeManager'
 
 /**
- * Extends a Viem `Client` with staking-related actions.
+ * Extends a Viem `Client` with staking-related public actions.
  *
  * @param {Object} options - Additional configuration options.
  * @returns {Function} A function that extends the Viem `Client`.
@@ -16,4 +21,19 @@ export const hemiPublicStakeActions = () => (client: Client) => ({
     stakedBalance(client, params),
   stakeTokenAllowlist: (params: Parameters<typeof stakeTokenAllowlist>[1]) =>
     stakeTokenAllowlist(client, params),
+})
+
+/**
+ * Extends a Viem `Client` with staking-related wallet actions.
+ *
+ * @param {Object} options - Additional configuration options.
+ * @returns {Function} A function that extends the Viem `Client`.
+ */
+export const hemiWalletStakeActions = () => (client: Client) => ({
+  stakeERC20Token: (params: Parameters<typeof stakeERC20Token>[1]) =>
+    stakeERC20Token(client, params),
+  stakeETHToken: (params: Parameters<typeof stakeETHToken>[1]) =>
+    stakeETHToken(client, params),
+  unstakeToken: (params: Parameters<typeof unstakeToken>[1]) =>
+    unstakeToken(client, params),
 })

--- a/webapp/hooks/useHemiClient.ts
+++ b/webapp/hooks/useHemiClient.ts
@@ -7,12 +7,12 @@ import {
   hemi as hemiMainnet,
   hemiSepolia,
 } from 'hemi-viem'
-import { hemiPublicStakeActions } from 'hemi-viem-stake-actions'
-import { useMemo } from 'react'
 import {
-  hemiPublicExtraActions,
-  hemiWalletExtraActions,
-} from 'utils/hemiClientExtraActions'
+  hemiPublicStakeActions,
+  hemiWalletStakeActions,
+} from 'hemi-viem-stake-actions'
+import { useMemo } from 'react'
+import { hemiPublicExtraActions } from 'utils/hemiClientExtraActions'
 import { type WalletClient, type PublicClient } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
 
@@ -45,7 +45,7 @@ export const useHemiClient = function () {
 const walletClientToHemiClient = (walletClient: WalletClient) =>
   walletClient
     .extend(hemiWalletBitcoinTunnelManagerActions())
-    .extend(hemiWalletExtraActions())
+    .extend(hemiWalletStakeActions())
 
 export const useHemiWalletClient = function () {
   const hemi = useHemi()

--- a/webapp/test/utils/stake.test.ts
+++ b/webapp/test/utils/stake.test.ts
@@ -8,10 +8,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('utils/token', () => ({
   getErc20TokenBalance: vi.fn(),
+  isNativeToken: vi.fn(token => token.symbol === 'ETH'),
 }))
 
 // @ts-expect-error Adding minimal properties needed
 const token: EvmToken = {
+  address: zeroAddress,
   chainId: hemiSepolia.id,
   decimals: 18,
   symbol: 'fakeToken',
@@ -89,7 +91,8 @@ describe('utils/stake', function () {
     const hemiPublicClient: HemiPublicClient = { chain: hemiSepolia }
     // @ts-expect-error only add the minimum values required
     const hemiWalletClient: HemiWalletClient = {
-      stakeToken: vi.fn(),
+      stakeERC20Token: vi.fn(),
+      stakeETHToken: vi.fn(),
     }
 
     it('should throw error if the consumer can not stake', async function () {
@@ -97,7 +100,7 @@ describe('utils/stake', function () {
       await expect(
         stake({
           amount: '1',
-          from: zeroAddress,
+          forAccount: zeroAddress,
           hemiPublicClient,
           hemiWalletClient,
           token,
@@ -109,15 +112,15 @@ describe('utils/stake', function () {
       getErc20TokenBalance.mockResolvedValue(parseUnits('10', token.decimals))
       await stake({
         amount: '1',
-        from: zeroAddress,
+        forAccount: zeroAddress,
         hemiPublicClient,
         hemiWalletClient,
         token,
       })
-      expect(hemiWalletClient.stakeToken).toHaveBeenCalledWith({
+      expect(hemiWalletClient.stakeERC20Token).toHaveBeenCalledWith({
         amount: parseUnits('1', token.decimals),
-        from: zeroAddress,
-        token,
+        forAccount: zeroAddress,
+        tokenAddress: token.address,
       })
     })
   })

--- a/webapp/utils/hemiClientExtraActions.ts
+++ b/webapp/utils/hemiClientExtraActions.ts
@@ -1,14 +1,4 @@
-import { EvmToken } from 'types/token'
-import { Address, type Client, Hash } from 'viem'
-
-// Fake resolving to a hash address so typings are defined. Here, a TX hash from the blockchain would be returned
-// Note that this won't be in checksum format
-const generateFakeTxHashAddress = () =>
-  '0x'.concat(
-    [...Array(64)]
-      .map(() => Math.floor(Math.random() * 16).toString(16))
-      .join('') as Hash,
-  )
+import { type Client } from 'viem'
 
 export const hemiPublicExtraActions =
   ({ defaultBitcoinVaults }) =>
@@ -21,15 +11,3 @@ export const hemiPublicExtraActions =
       // @ts-expect-error can't use PublicClient in parameter as fails to compile.
       Promise.resolve(defaultBitcoinVaults[client.chain.id]),
   })
-
-// This will eventually be removed. See issue below
-export const hemiWalletExtraActions = () => () => ({
-  // TODO TBD real implementation. See https://github.com/hemilabs/ui-monorepo/issues/774
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  stakeToken: (_: { amount: bigint; from: Address; token: EvmToken }) =>
-    Promise.resolve(generateFakeTxHashAddress()),
-  // TODO TBD real implementation. See https://github.com/hemilabs/ui-monorepo/issues/774
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  unstakeToken: (_: { amount: bigint; from: Address; token: EvmToken }) =>
-    Promise.resolve(generateFakeTxHashAddress()),
-})


### PR DESCRIPTION
### Description

This PR implements three functions for staking and unstaking tokens in the staking contract.

- **stakeERC20Token**, which allows users to stake ERC-20 tokens by calling depositFor.
- **stakeETHToken**, which enables staking of native ETH via depositETHFor.
- **unstakeToken**, which handles unstaking for both ERC-20 and native ETH

### Related issue(s)

Related to #774 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
