### PR TITLE
Fix intellisense for useTranslations

### DIFF
--- a/webapp/intl.d.ts
+++ b/webapp/intl.d.ts
@@ -1,13 +1,4 @@
-import '@tanstack/react-table'
-
 // Use type safe message keys with `next-intl`
 type Messages = typeof import('./messages/en.json')
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 declare interface IntlMessages extends Messages {}
-
-declare module '@tanstack/react-table' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface ColumnMeta<TData, TValue> {
-    width?: string
-  }
-}

--- a/webapp/react-table.d.ts
+++ b/webapp/react-table.d.ts
@@ -1,0 +1,8 @@
+import '@tanstack/react-table'
+
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData, TValue> {
+    width?: string
+  }
+}

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -6,8 +6,9 @@
   },
   "extends": "../tsconfig.base.json",
   "include": [
-    "global.d.ts",
+    "intl.d.ts",
     "next-env.d.ts",
+    "react-table.d.ts",
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

A small issue I just came across: Intellisense only works if module declarations are one per file. Unsure why it happens, but it seems to have been introduced in https://github.com/hemilabs/ui-monorepo/pull/781 after adding a second `declare module` to the file `global.d.ts`.

To fix it, I moved the `declare module` added in that PR to a new file `react-table.d.ts`. And I renamed `global.d.ts` to `intl.d.ts` (As now will only include the declaration for typing `useTranslations`). I updated `tsconfig.json` to include both files

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Before the fix, this is how Intellisense looks on `useTranslations()`

![image](https://github.com/user-attachments/assets/cfd280b7-5883-4be8-b84d-3d16970f1f46)

After the fix, it offers proper autocompletion

![image](https://github.com/user-attachments/assets/f3a16fef-f73f-4f0d-b655-9e940bc68b66)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
