### PR TITLE
Keep network type when clicking 'Stake More'

### DIFF
--- a/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -12,6 +12,7 @@ import { useUmami } from 'app/analyticsEvents'
 import { ButtonLink } from 'components/button'
 import { Card } from 'components/card'
 import { TokenLogo } from 'components/tokenLogo'
+import { useNetworkType } from 'hooks/useNetworkType'
 import { usePathnameWithoutLocale } from 'hooks/usePathnameWithoutLocale'
 import { useStakeTokens } from 'hooks/useStakeTokens'
 import { useRouter } from 'next/navigation'
@@ -259,6 +260,7 @@ const StakeAssetsTableImp = function ({ containerRef, data, loading }: Props) {
 
 export const StakeAssetsTable = function () {
   const locale = useLocale()
+  const [networkType] = useNetworkType()
   const containerRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
   const stakeTokens = useStakeTokens()
@@ -278,7 +280,8 @@ export const StakeAssetsTable = function () {
     e.preventDefault()
     e.stopPropagation()
     track?.('stake - stake more')
-    router.push(`/${locale}${stakeMoreUrl}`)
+    const queryString = queryStringObjectToString({ networkType })
+    router.push(`/${locale}${stakeMoreUrl}${queryString}`)
   }
 
   return (


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

When clicking "Stake More" and the user was in testnet, the user was redirected to mainnet. This PR fixes that.  
Note that, besides showing the link, we are using `router.push` to be able to track the button click. That's why there was a mismatch between the visible link (Correct) and the route the user was pushed to (Wrong)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/b44d8c61-7b53-4793-8189-36921438af70

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
