### PR TITLE
Fix minor spelling mistake

### DIFF
--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -297,7 +297,7 @@
       "your-deposit-is-complete": "Your deposit is complete."
     },
     "review-withdrawal": {
-      "challenge-to-get-bitcoins-back": "Click 'Challenge withdrawal' yo reclaim your BTC and send it back to your Hemi address.",
+      "challenge-to-get-bitcoins-back": "Click 'Challenge withdrawal' to reclaim your BTC and send it back to your Hemi address.",
       "challenge-withdrawal": "Challenge Withdrawal",
       "claim-withdrawal": "Claim withdrawal",
       "heading": "Review Withdrawal",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR fixes a spelling mistake, replacing `yo replace` with `to replace`. We're dropping the [Breaking Bad's Jesse](https://i.pinimg.com/564x/38/f0/28/38f0285ab331ecf4aa955560fd73c6e5.jpg) style of writing for a more formal writing.

Spanish translation was already correct.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #861

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
