### PR TITLE
Check confirmations before allowing manual confirm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15785,9 +15785,9 @@
       "integrity": "sha512-f1hiPt90QXTPXX9jb8fRuGvzWMkbBpBO/45m3s024Aa0JoSpeVt9AodkxHAnCfK5uTRDdKvbIB8dPU1sbGhOdA=="
     },
     "node_modules/hemi-viem": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.2.0.tgz",
-      "integrity": "sha512-OhUyQmpR95fOcxD/2IkjAUTHZ+eEH5vf6JljcS//3uGDixkauUw44XgGBGsqCQGPerZB2/HRFMEx9OOkHKZMRQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.3.0.tgz",
+      "integrity": "sha512-ohBB2vpgDsJd/APKejZUjwSSWDytYd6Wa88a/Pfc16ZibBTnA7ZFdzF8nUOYF6CI37lycdetkZEBxm5E+7Ozag==",
       "license": "MIT",
       "peerDependencies": {
         "viem": "^2.x"
@@ -27252,7 +27252,7 @@
         "eth-rpc-cache": "2.0.0",
         "fetch-plus-plus": "1.0.0",
         "hemi-socials": "1.0.0",
-        "hemi-viem": "2.2.0",
+        "hemi-viem": "2.3.0",
         "hemi-viem-stake-actions": "1.0.0",
         "javascript-time-ago": "2.5.10",
         "lodash": "4.17.21",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,7 @@
     "eth-rpc-cache": "2.0.0",
     "fetch-plus-plus": "1.0.0",
     "hemi-socials": "1.0.0",
-    "hemi-viem": "2.2.0",
+    "hemi-viem": "2.3.0",
     "hemi-viem-stake-actions": "1.0.0",
     "javascript-time-ago": "2.5.10",
     "lodash": "4.17.21",

--- a/webapp/utils/hemiMemoized.ts
+++ b/webapp/utils/hemiMemoized.ts
@@ -50,3 +50,10 @@ export const getVaultIndexByBTCAddress = pMemoize(
     hemiClient.getVaultChildIndex(),
   { resolver: (_, deposit) => `${deposit.l1ChainId}_${deposit.to}` },
 )
+
+// Memoizing it as it is unlikely to change
+export const getBitcoinKitAddress = pMemoize(
+  // @ts-expect-error needs to be fixed https://github.com/hemilabs/hemi-viem/issues/30
+  (hemiClient: HemiPublicClient) => hemiClient.getBitcoinKitAddress(),
+  { resolver: hemiClient => hemiClient.chain.id },
+)


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR considers the Transaction Confirmations on Bitcoin that Hemi sees on Bitcoin deposits, before converting them to deposits that could be manually confirmed by the user. Some tests were added.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to the user.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes https://github.com/hemilabs/ui-monorepo/issues/859

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
