### PR TITLE
Fixed minor UI issues on stake page

### DIFF
--- a/webapp/app/[locale]/stake/_components/manageStake/strategyDetails.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/strategyDetails.tsx
@@ -26,7 +26,7 @@ export const StrategyDetails = function ({ tvl, token }: Props) {
   return (
     <div className="flex flex-col">
       <Container>
-        <h5>{t('heading')}</h5>
+        <h5 className="font-medium">{t('heading')}</h5>
       </Container>
       <Container>
         <Subtitle text={t('rewards')} />

--- a/webapp/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/webapp/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -161,7 +161,7 @@ const StakeStrategyTableImp = function ({
       </thead>
       <tbody className="relative">
         {rows.map(row => (
-          <tr className="flex items-center" key={row.id}>
+          <tr className="group/stake-row flex items-center" key={row.id}>
             {row.getVisibleCells().map(cell => (
               <Column
                 key={cell.id}
@@ -206,7 +206,7 @@ export const StakeStrategyTable = function ({ data, loading }: Props) {
         <p className="flex text-sm font-normal text-neutral-600">
           {t('new-here')}
           <ExternalLink href={learnHowToStakeLink} onClick={trackLinkClick}>
-            <span className="ml-1 text-orange-500">
+            <span className="ml-1 text-orange-500 hover:text-orange-700">
               {t('learn-how-to-stake-on-hemi')}
             </span>
           </ExternalLink>


### PR DESCRIPTION
### Description

Fixed the following UI issues on the stake page:
- The "Learn how to stake" was missing a hover action (Added hover:text-orange-700)

<img width="275" alt="Captura de Tela 2025-02-18 às 15 14 19" src="https://github.com/user-attachments/assets/46fdcab8-ee29-4efe-984b-61f67d932ea2" />

- The "Strategy Details" section title is now with font-weight medium 
<img width="443" alt="Captura de Tela 2025-02-18 às 15 14 43" src="https://github.com/user-attachments/assets/fed8630b-3648-4849-a166-a90ca549bdf8" />

- When hovering the rows in the "Stake" table, there should be a background hover, similar to the Transaction History table. Added bg-neutral-50.

<img width="1115" alt="Captura de Tela 2025-02-18 às 15 14 30" src="https://github.com/user-attachments/assets/4f38fe92-9e6e-46bc-983a-50e9bba582bf" />



### Related issue(s)

Closes #847

### Checklist

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
