### PR TITLE
Set batchSize for json rpc calls to 3

### DIFF
--- a/webapp/utils/transport.ts
+++ b/webapp/utils/transport.ts
@@ -3,7 +3,7 @@ import { type Chain, fallback, http } from 'viem'
 
 export const buildTransport = function (network: Chain) {
   const httpConfig = {
-    batch: { wait: 1000 },
+    batch: { batchSize: 3, wait: 1000 },
     retryCount: 2,
   }
   const rpcUrls = network.rpcUrls.default.http


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Gabriel noticed that some calls to our public RPCs failed because requests are batched in groups of 5 or more together, some RPCs forbid more than 3 requests. 

![image](https://github.com/user-attachments/assets/9ba91caa-fc7b-4f04-ad35-f4c017659161)

These were causing 500 errors. This PR attempts to set the batch size to 3 - Default was set to [1000](https://viem.sh/docs/clients/transports/http#batchbatchsize-optional) according to viem's docs.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
