### PR TITLE
Fixed minor UI issues on stake welcome page

### DIFF
--- a/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/welcomeStake.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/welcomeStake.tsx
@@ -5,8 +5,8 @@ import { StakeLink } from './stakeLink'
 
 export const WelcomeStake = () => (
   <div
-    className="shadow-large flex flex-col items-center rounded-2xl border border-solid border-neutral-300/55 px-5
-    pt-12 lg:mt-12 lg:h-[50dvh] lg:flex-row lg:justify-between lg:gap-x-12 lg:py-12 2xl:justify-evenly 2xl:gap-x-24"
+    className="shadow-large mb-12 flex flex-col items-center rounded-2xl border border-solid border-neutral-300/55
+    px-5 pt-12 lg:mt-12 lg:h-[50dvh] lg:flex-row lg:justify-evenly lg:gap-x-44 lg:py-12 xl:gap-x-16"
     style={{
       background:
         'radial-gradient(100% 100% at 50% 0%, rgba(253, 239, 232, 0.16) 14.12%, rgba(255, 108, 21, 0.16) 32.29%, rgba(255, 24, 20, 0.03) 98.87%), #FFF',

--- a/webapp/app/[locale]/stake/dashboard/page.tsx
+++ b/webapp/app/[locale]/stake/dashboard/page.tsx
@@ -14,7 +14,7 @@ const Page = function () {
   const t = useTranslations('stake-page')
 
   return (
-    <div className="h-fit-rest-screen w-full">
+    <div className="h-fit-rest-screen w-full pb-4">
       <PageTitle
         subtitle={t('dashboard.subtitle')}
         title={t('dashboard.title')}

--- a/webapp/app/[locale]/stake/dashboard/page.tsx
+++ b/webapp/app/[locale]/stake/dashboard/page.tsx
@@ -14,7 +14,7 @@ const Page = function () {
   const t = useTranslations('stake-page')
 
   return (
-    <div className="h-fit-rest-screen w-full pb-4">
+    <div className="h-fit-rest-screen w-full pb-4 md:pb-0">
       <PageTitle
         subtitle={t('dashboard.subtitle')}
         title={t('dashboard.title')}


### PR DESCRIPTION
### Description

Fixed the following UI issues on the stake welcome page:
1. On Desktop, the images are way too close to the margins

<img width="1438" alt="Captura de Tela 2025-02-20 às 15 33 01" src="https://github.com/user-attachments/assets/61b17def-b31b-4774-b995-f2e00ce815b2" />

2. On mobile, we need to add some margin from the dashboard container to the end of the viewport

<img width="425" alt="Captura de Tela 2025-02-20 às 15 31 00" src="https://github.com/user-attachments/assets/e5f5bf5d-8f5f-4409-80da-0aa980532209" />


### Related issue(s)

Closes #846

### Checklist

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
