### PR TITLE
Fixed Learn more tabs UI on Get Started page

### DIFF
--- a/webapp/app/[locale]/get-started/_components/learnMore.tsx
+++ b/webapp/app/[locale]/get-started/_components/learnMore.tsx
@@ -161,35 +161,37 @@ export const LearnMore = function () {
               </div>
             </div>
             <div className="flex basis-full flex-col gap-y-4 xl:basis-1/2">
-              <Tabs>
-                <Tab
-                  onClick={function () {
-                    setSelectedTab('wallet')
-                    track?.('tut - wallet setup')
-                  }}
-                  selected={selectedTab === 'wallet'}
-                >
-                  {t('learn-more-tutorials.wallet-setup')}
-                </Tab>
-                <Tab
-                  onClick={function () {
-                    setSelectedTab('dev-tooling')
-                    track?.('tut - dev tooling')
-                  }}
-                  selected={selectedTab === 'dev-tooling'}
-                >
-                  {t('learn-more-tutorials.developer-tooling')}
-                </Tab>
-                <Tab
-                  onClick={function () {
-                    setSelectedTab('PoP-miner')
-                    track?.('tut - pop miner')
-                  }}
-                  selected={selectedTab === 'PoP-miner'}
-                >
-                  {t('learn-more-tutorials.pop-miner')}
-                </Tab>
-              </Tabs>
+              <div className="md:self-start">
+                <Tabs>
+                  <Tab
+                    onClick={function () {
+                      setSelectedTab('wallet')
+                      track?.('tut - wallet setup')
+                    }}
+                    selected={selectedTab === 'wallet'}
+                  >
+                    {t('learn-more-tutorials.wallet-setup')}
+                  </Tab>
+                  <Tab
+                    onClick={function () {
+                      setSelectedTab('dev-tooling')
+                      track?.('tut - dev tooling')
+                    }}
+                    selected={selectedTab === 'dev-tooling'}
+                  >
+                    {t('learn-more-tutorials.developer-tooling')}
+                  </Tab>
+                  <Tab
+                    onClick={function () {
+                      setSelectedTab('PoP-miner')
+                      track?.('tut - pop miner')
+                    }}
+                    selected={selectedTab === 'PoP-miner'}
+                  >
+                    {t('learn-more-tutorials.pop-miner')}
+                  </Tab>
+                </Tabs>
+              </div>
               {selectedTab === 'dev-tooling' && <DeveloperTooling />}
               {selectedTab === 'PoP-miner' && <PoPMiner />}
               {selectedTab === 'wallet' && <WalletSetup />}


### PR DESCRIPTION
### Description

Fixed the following UI issues on the Get Started page:
1. The tabs container is not displaying at the correct width. Currently, they are spanning the full width of the parent container instead of matching the size of the internal content.

<img width="1020" alt="Captura de Tela 2025-02-20 às 15 48 53" src="https://github.com/user-attachments/assets/c04e4105-e310-434a-9e3a-531402b65ec0" />

### Related issue(s)

Closes #840

### Checklist

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.