### PR TITLE
Fixed spacing between TX hash and arrow icon

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/txLink.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/txLink.tsx
@@ -14,7 +14,7 @@ export const TxLink = function ({ chainId, txHash }: Props) {
   const hash = `${txHash.slice(0, 6)}...${txHash.slice(-4)}`
   const href = `${chain?.blockExplorers?.default.url}/tx/${txHash}`
   return (
-    <div className="group/txhash-link flex w-full items-center justify-between gap-x-2">
+    <div className="group/txhash-link flex w-full items-center gap-x-2">
       <ExternalLink
         className="cursor-pointer text-neutral-600 hover:text-neutral-950"
         href={href}


### PR DESCRIPTION
### Description

Fixed spacing between transaction hash link and arrow icon

### Screenshots

![Captura de Tela 2025-02-20 às 16 37 17](https://github.com/user-attachments/assets/24b6c269-b288-44e0-a39a-0e35aaa08850)

### Related issue(s)

Closes #839

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
