### PR TITLE
Fixed tabs padding left that was doubled

### DIFF
--- a/webapp/app/[locale]/_components/header.tsx
+++ b/webapp/app/[locale]/_components/header.tsx
@@ -35,8 +35,6 @@ export const Header = function ({ isMenuOpen, toggleMenu }: Props) {
       </div>
       <div className="hidden pl-6 md:block">
         <StakeTabs />
-      </div>
-      <div className="hidden pl-6 md:block">
         <TunnelTabs />
       </div>
       <WalletConnection />


### PR DESCRIPTION
### Description

The Tunnel tabs padding left was doubled after adding the Stake Tabs, because it was adding the padding left when it was invisible.

### Screenshots

![Captura de Tela 2025-02-24 às 16 46 43](https://github.com/user-attachments/assets/efa4d168-c856-4cdb-8c10-818f916ae728)

### Related issue(s)

Closes #871

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
