### PR TITLE
Added CoinMarketCap attribution on stake pages

### DIFF
--- a/webapp/app/[locale]/stake/_components/cmcAttribution.tsx
+++ b/webapp/app/[locale]/stake/_components/cmcAttribution.tsx
@@ -1,0 +1,19 @@
+import { ExternalLink } from 'components/externalLink'
+import { useTranslations } from 'next-intl'
+
+export const CmcAttribution = function () {
+  const t = useTranslations('common')
+
+  return (
+    <div className="flex flex-col justify-end">
+      <p className="flex text-sm font-normal text-neutral-600">
+        {t('data-attribution')}
+        <ExternalLink href="https://coinmarketcap.com/">
+          <span className="ml-1 text-orange-500 hover:text-orange-700">
+            CoinMarketCap.com
+          </span>
+        </ExternalLink>
+      </p>
+    </div>
+  )
+}

--- a/webapp/app/[locale]/stake/dashboard/page.tsx
+++ b/webapp/app/[locale]/stake/dashboard/page.tsx
@@ -3,6 +3,8 @@
 import { PageTitle } from 'components/pageTitle'
 import { useTranslations } from 'next-intl'
 
+import { CmcAttribution } from '../_components/cmcAttribution'
+
 import { StakeAssetsTable } from './_components/stakeAssetsTable'
 import {
   EarnedPoints,
@@ -26,6 +28,9 @@ const Page = function () {
       </div>
       <div className="mt-6 md:mt-8">
         <StakeAssetsTable />
+      </div>
+      <div className="mt-6">
+        <CmcAttribution />
       </div>
     </div>
   )

--- a/webapp/app/[locale]/stake/page.tsx
+++ b/webapp/app/[locale]/stake/page.tsx
@@ -2,6 +2,7 @@
 
 import { useStakeTokens } from 'hooks/useStakeTokens'
 
+import { CmcAttribution } from './_components/cmcAttribution'
 import { StakeGraph } from './_components/icons/stakeGraph'
 import { StakeAndEarn } from './_components/stakeAndEarn'
 import { StakeStrategyTable } from './_components/stakeStrategyTable'
@@ -35,6 +36,9 @@ export default function Page() {
       <PageBackground />
       <div className="relative z-20 -translate-y-60 md:-translate-y-48">
         <StakeStrategyTable data={stakeTokens} loading={false} />
+        <div className="mt-6">
+          <CmcAttribution />
+        </div>
       </div>
     </div>
   )

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -13,6 +13,7 @@
     "connect-your-wallet": "Connect your Wallet",
     "copied": "Copied",
     "copy": "Copy",
+    "data-attribution": "Data provided by",
     "erc20-approve-10x-deposits": "Approve 10x the amount of this deposit",
     "erc20-approve-10x-detailed-description": "By activating 10x approval we automatically add 10x the amount of this transaction as allowance for future ones, saving you money on gas fees and time.",
     "erc20-extra-approval": "Approve 10x deposits",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -13,6 +13,7 @@
     "connect-your-wallet": "Conecte su Billetera",
     "copied": "Copiado",
     "copy": "Copiar",
+    "data-attribution": "Datos proporcionados por",
     "erc20-approve-10x-deposits": "Aprobar 10x el monto de este depósito",
     "erc20-approve-10x-detailed-description": "Al activar la aprobación 10x, automáticamente agregamos 10 veces el monto de esta transacción como monto autorizado para otras futuras, lo que le permite ahorrar dinero en tarifas de gas y tiempo.",
     "erc20-extra-approval": "Aprobar 10x este depósito",


### PR DESCRIPTION
### Description

Added CoinMarketCap attribution on stake pages

### Screenshots

Dashboard tab:
<img width="1439" alt="Captura de Tela 2025-02-24 às 17 22 45" src="https://github.com/user-attachments/assets/7a3c07d0-92cc-413c-b46b-63782c8f4e00" />

Stake tab:
<img width="1439" alt="Captura de Tela 2025-02-24 às 17 23 15" src="https://github.com/user-attachments/assets/fb31e53a-4a16-4bf3-bba5-e3500302494a" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #854

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
