### PR TITLE
Add Success Toast for stake

### DIFF
--- a/webapp/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -15,6 +15,7 @@ import { useAllowance } from 'wagmi-erc20-hooks'
 
 import { useAmount } from '../../_hooks/useAmount'
 import { useStake } from '../../_hooks/useStake'
+import { StakeToast } from '../stakeToast'
 
 import { StakeFees } from './fees'
 import { StakeMaxBalance } from './maxBalance'
@@ -159,56 +160,67 @@ export const StakeOperation = function ({
   }
 
   return (
-    <Operation
-      amount={amount}
-      callToAction={
-        <StakeCallToAction
-          isSubmitting={isSubmitting}
-          stakeStatus={stakeStatus}
+    <>
+      {stakeStatus === StakeStatusEnum.STAKE_TX_CONFIRMED && (
+        <StakeToast
+          chainId={token.chainId}
+          txHash={stakeTransactionHash}
+          type="stake"
         />
-      }
-      closeDrawer={closeDrawer}
-      heading={heading}
-      isOperating={isOperating}
-      onSubmit={handleStake}
-      preview={
-        <Preview
-          amount={amount}
-          fees={<StakeFees />}
-          isOperating={isOperating}
-          maxBalance={
-            <StakeMaxBalance
-              disabled={isSubmitting}
-              onSetMaxBalance={setAmount}
-              token={token}
-            />
-          }
-          operation="stake"
-          setAmount={setAmount}
-          setOperation={() => onOperationChange('unstake')}
-          showTabs={showTabs}
-          strategyDetails={<StrategyDetails token={token} />}
-          submitButton={
-            <>
-              <DrawerParagraph>{t('you-can-unstake-anytime')}</DrawerParagraph>
-              <SubmitButton
-                disabled={!canStake}
-                text={
-                  isPending || isSubmitting
-                    ? '...'
-                    : requiresApproval
-                      ? t('approve-and-stake')
-                      : tCommon('stake')
-                }
+      )}
+      <Operation
+        amount={amount}
+        callToAction={
+          <StakeCallToAction
+            isSubmitting={isSubmitting}
+            stakeStatus={stakeStatus}
+          />
+        }
+        closeDrawer={closeDrawer}
+        heading={heading}
+        isOperating={isOperating}
+        onSubmit={handleStake}
+        preview={
+          <Preview
+            amount={amount}
+            fees={<StakeFees />}
+            isOperating={isOperating}
+            maxBalance={
+              <StakeMaxBalance
+                disabled={isSubmitting}
+                onSetMaxBalance={setAmount}
+                token={token}
               />
-            </>
-          }
-          token={token}
-        />
-      }
-      steps={steps}
-      subheading={subheading}
-      token={token}
-    />
+            }
+            operation="stake"
+            setAmount={setAmount}
+            setOperation={() => onOperationChange('unstake')}
+            showTabs={showTabs}
+            strategyDetails={<StrategyDetails token={token} />}
+            submitButton={
+              <>
+                <DrawerParagraph>
+                  {t('you-can-unstake-anytime')}
+                </DrawerParagraph>
+                <SubmitButton
+                  disabled={!canStake}
+                  text={
+                    isPending || isSubmitting
+                      ? '...'
+                      : requiresApproval
+                        ? t('approve-and-stake')
+                        : tCommon('stake')
+                  }
+                />
+              </>
+            }
+            token={token}
+          />
+        }
+        steps={steps}
+        subheading={subheading}
+        token={token}
+      />
+    </>
   )
 }

--- a/webapp/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
@@ -17,6 +17,7 @@ import { formatUnits, parseUnits } from 'viem'
 import { useAmount } from '../../_hooks/useAmount'
 import { useStakedBalance } from '../../_hooks/useStakedBalance'
 import { useUnstake } from '../../_hooks/useUnstake'
+import { StakeToast } from '../stakeToast'
 
 import { UnstakeFees } from './fees'
 import { UnstakeMaxBalance } from './maxBalance'
@@ -101,51 +102,60 @@ export const UnstakeOperation = function ({
   const isOperating = unstakeStatus !== undefined
 
   return (
-    <Operation
-      amount={amount}
-      callToAction={
-        <UnstakeCallToAction
-          isSubmitting={isSubmitting}
-          unstakeStatus={unstakeStatus}
+    <>
+      {unstakeStatus === UnstakeStatusEnum.UNSTAKE_TX_CONFIRMED && (
+        <StakeToast
+          chainId={token.chainId}
+          txHash={unStakeTransactionHash}
+          type="unstake"
         />
-      }
-      closeDrawer={closeDrawer}
-      heading={heading}
-      isOperating={isOperating}
-      onSubmit={handleUnstake}
-      preview={
-        <Preview
-          amount={amount}
-          balanceComponent={StakedBalance}
-          fees={<UnstakeFees />}
-          isOperating={isOperating}
-          maxBalance={
-            <UnstakeMaxBalance
-              disabled={isSubmitting}
-              onSetMaxBalance={setAmount}
-              token={token}
-            />
-          }
-          operation="unstake"
-          setAmount={setAmount}
-          setOperation={() => onOperationChange('stake')}
-          showTabs
-          submitButton={
-            <SubmitButton
-              disabled={!canUnstake}
-              text={
-                isStakedPositionPending || isSubmitting
-                  ? '...'
-                  : tCommon('unstake')
-              }
-            />
-          }
-          token={token}
-        />
-      }
-      steps={[unstakeStep]}
-      subheading={subheading}
-      token={token}
-    />
+      )}
+      <Operation
+        amount={amount}
+        callToAction={
+          <UnstakeCallToAction
+            isSubmitting={isSubmitting}
+            unstakeStatus={unstakeStatus}
+          />
+        }
+        closeDrawer={closeDrawer}
+        heading={heading}
+        isOperating={isOperating}
+        onSubmit={handleUnstake}
+        preview={
+          <Preview
+            amount={amount}
+            balanceComponent={StakedBalance}
+            fees={<UnstakeFees />}
+            isOperating={isOperating}
+            maxBalance={
+              <UnstakeMaxBalance
+                disabled={isSubmitting}
+                onSetMaxBalance={setAmount}
+                token={token}
+              />
+            }
+            operation="unstake"
+            setAmount={setAmount}
+            setOperation={() => onOperationChange('stake')}
+            showTabs
+            submitButton={
+              <SubmitButton
+                disabled={!canUnstake}
+                text={
+                  isStakedPositionPending || isSubmitting
+                    ? '...'
+                    : tCommon('unstake')
+                }
+              />
+            }
+            token={token}
+          />
+        }
+        steps={[unstakeStep]}
+        subheading={subheading}
+        token={token}
+      />
+    </>
   )
 }

--- a/webapp/app/[locale]/stake/_components/stakeToast.tsx
+++ b/webapp/app/[locale]/stake/_components/stakeToast.tsx
@@ -1,0 +1,89 @@
+import { ExternalLink } from 'components/externalLink'
+import { CheckMark } from 'components/icons/checkMark'
+import { Link } from 'components/link'
+import { useChain } from 'hooks/useChain'
+import { useTranslations } from 'next-intl'
+import { useEffect, useState } from 'react'
+import { RemoteChain } from 'types/chain'
+import { CloseIcon } from 'ui-common/components/closeIcon'
+import { formatEvmHash } from 'utils/format'
+import { type Hash } from 'viem'
+
+type ToastType = 'stake' | 'unstake'
+
+type Props = {
+  autoCloseMs?: number
+  chainId: RemoteChain['id']
+  txHash: Hash
+  type: ToastType
+}
+
+export const StakeToast = function ({
+  autoCloseMs = 5000,
+  chainId,
+  txHash,
+  type,
+}: Props) {
+  const [closedToast, setClosedToast] = useState(false)
+  const blockExplorer = useChain(chainId).blockExplorers.default
+
+  const t = useTranslations('stake-page.toast')
+
+  useEffect(
+    function autoCloseToast() {
+      if (autoCloseMs) {
+        const timer = setTimeout(function closeToastAfterDelay() {
+          setClosedToast(true)
+        }, autoCloseMs)
+
+        return () => clearTimeout(timer)
+      }
+      return undefined
+    },
+    [autoCloseMs],
+  )
+
+  if (closedToast) {
+    return null
+  }
+
+  return (
+    <div
+      className="shadow-soft fixed bottom-20 left-4 right-4 z-40 flex justify-between
+      gap-x-3 rounded-xl border border-solid border-black/85 bg-neutral-800 p-3.5
+    text-sm font-medium text-white md:bottom-auto md:left-auto md:right-8 md:top-20"
+    >
+      <div className="mt-1.5">
+        <CheckMark className="[&>path]:stroke-emerald-500" />
+      </div>
+      <div className="flex flex-col items-start gap-y-1.5">
+        <h5 className="text-base">
+          {type === 'stake'
+            ? t('staking-successful')
+            : t('unstaking-successful')}
+        </h5>
+        <p className="text-neutral-400 md:max-w-96">
+          {t('here-your-stake-tx', {
+            type: t(type === 'stake' ? 'staking' : 'unstaking'),
+          })}
+          <ExternalLink href={`${blockExplorer.url}/tx/${txHash}`}>
+            <span className="ml-1 text-orange-500 hover:text-orange-700">
+              {formatEvmHash(txHash)}
+            </span>
+          </ExternalLink>
+        </p>
+        {type === 'stake' && (
+          <Link
+            className="mt-1.5 cursor-pointer underline hover:text-neutral-200 hover:opacity-80"
+            href="/stake/dashboard"
+          >
+            {t('go-staking-dashboard')}
+          </Link>
+        )}
+      </div>
+      <button className="h-fit" onClick={() => setClosedToast(true)}>
+        <CloseIcon className="[&>path]:hover:stroke-white" />
+      </button>
+    </div>
+  )
+}

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -234,6 +234,14 @@
       "subtitle": "Stake assets to earn points and rewards.",
       "title": "Stake"
     },
+    "toast": {
+      "go-staking-dashboard": "View your staking dashboard",
+      "here-your-stake-tx": "Here’s your {type} transaction:",
+      "staking": "staking",
+      "staking-successful": "Staking successful",
+      "unstaking": "unstaking",
+      "unstaking-successful": "Unstaking successful"
+    },
     "wallet-balance": "Wallet balance"
   },
   "token-custom-drawer": {

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -234,6 +234,14 @@
       "subtitle": "Apueste activos para ganar puntos y recompensas.",
       "title": "Apostar"
     },
+    "toast": {
+      "go-staking-dashboard": "Vea su panel de control de sus apuestas",
+      "here-your-stake-tx": "Aquí está su transacción de {type}:",
+      "staking": "apuesta",
+      "staking-successful": "Apuesta exitosa",
+      "unstaking": "retiro",
+      "unstaking-successful": "Retiro exitoso"
+    },
     "wallet-balance": "Saldo de la billetera"
   },
   "token-custom-drawer": {

--- a/webapp/test/utils/format.test.ts
+++ b/webapp/test/utils/format.test.ts
@@ -1,4 +1,4 @@
-import { formatBtcAddress, formatEvmAddress } from 'utils/format'
+import { formatBtcAddress, formatEvmAddress, formatEvmHash } from 'utils/format'
 import { describe, expect, it } from 'vitest'
 
 describe('utils/format', function () {
@@ -15,6 +15,16 @@ describe('utils/format', function () {
       expect(
         formatEvmAddress('0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263'),
       ).toBe('0x4675...a263')
+    })
+  })
+
+  describe('formatTxHash', function () {
+    it('should format an tx hash correctly', function () {
+      expect(
+        formatEvmHash(
+          '0x5a3f5c2b87c9e4d1e3e0e5c27691d3a04e94f08b3f6a1d4b4d6b96e20b91c8e6',
+        ),
+      ).toBe('0x5a3f...c8e6')
     })
   })
 })

--- a/webapp/utils/format.ts
+++ b/webapp/utils/format.ts
@@ -1,7 +1,7 @@
 import { type Account } from 'btc-wallet/unisat'
 import { shorten } from 'crypto-shortener'
 import { smartRound } from 'smart-round'
-import { type Address } from 'viem'
+import { type Address, type Hash } from 'viem'
 
 export const formatBtcAddress = (account: Account) =>
   shorten(account, { length: 5 })
@@ -11,6 +11,9 @@ export const formatEvmAddress = (address: Address) =>
 
 const cryptoRounder = smartRound(6, 0, 6)
 const fiatRounder = smartRound(6, 2, 2)
+
+export const formatEvmHash = (txHash: Hash) =>
+  shorten(txHash, { length: 4, prefixes: ['0x'] })
 
 export const formatNumber = (value: number | string) =>
   cryptoRounder(value, { roundingMode: 'round-down', shouldFormat: true })


### PR DESCRIPTION
### Description

This PR implements a success toast to notify users when a stake/unstake transaction is successfully completed. The toast includes:

- A success message
- A formatted transaction hash
- An auto-close feature (default: 5 seconds)
- A manual close button

### Screenshots

Desktop

https://github.com/user-attachments/assets/fbf0fdaf-75a2-4636-9251-d3cbb4b0fec7

Mobile

https://github.com/user-attachments/assets/20a64c29-6643-4320-b5ad-7aff56e8b8ec

Unstake operations

![Captura de Tela 2025-02-26 às 13 04 27](https://github.com/user-attachments/assets/387b0fdd-9085-463c-9ee8-dccee43aea16)


### Related issue(s)

Closes #880 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
