### PR TITLE
Fix api cors headers

### DIFF
--- a/token-prices/README.md
+++ b/token-prices/README.md
@@ -28,7 +28,7 @@ These control the `api` server:
 
 | Variable  | Description                                                     | Default                 |
 | --------- | --------------------------------------------------------------- | ----------------------- |
-| ORIGINS   | Comma-separated list of allowed origins. '\*' is not supported. | `http://localhos:3001`  |
+| ORIGINS   | Comma-separated list of allowed origins. '\*' is not supported. | `http://localhos:3000`  |
 | PORT      | The HTTP port the server listens for requests.                  | 3001                    |
 | REDIS_URL | The URL of the Redis database.                                  | `http://localhost:6379` |
 
@@ -54,6 +54,6 @@ docker compose --env-file=.env.local up
 Then the prices can be obtained as follows:
 
 ```console
-$ curl http://localhost:3000
+$ curl http://localhost:3001
 {"prices":{"BTC":"94514.79193898945","M-BTC":"95894.52612269788","PUMPBTC":"95990.74415080296","WBTC":"95797.80677773379"},"time":"2025-02-17T23:12:35.803Z"}
 ```

--- a/token-prices/README.md
+++ b/token-prices/README.md
@@ -26,10 +26,11 @@ These environment variables control how the `cron` job behaves:
 
 These control the `api` server:
 
-| Variable  | Description                                    | Default                 |
-| --------- | ---------------------------------------------- | ----------------------- |
-| PORT      | The HTTP port the server listens for requests. | 3000                    |
-| REDIS_URL | The URL of the Redis database.                 | `http://localhost:6379` |
+| Variable  | Description                                                     | Default                 |
+| --------- | --------------------------------------------------------------- | ----------------------- |
+| ORIGINS   | Comma-separated list of allowed origins. '\*' is not supported. | `http://localhos:3001`  |
+| PORT      | The HTTP port the server listens for requests.                  | 3001                    |
+| REDIS_URL | The URL of the Redis database.                                  | `http://localhost:6379` |
 
 ### Stored data
 

--- a/token-prices/api/Dockerfile
+++ b/token-prices/api/Dockerfile
@@ -11,6 +11,6 @@ USER node
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 3001
 
 CMD npm start

--- a/token-prices/api/server.js
+++ b/token-prices/api/server.js
@@ -5,9 +5,9 @@ const pLimitOne = require('promise-limit-one')
 const redis = require('redis')
 
 const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379'
-const portStr = process.env.PORT || '3000'
+const portStr = process.env.PORT || '3001'
 const port = parseInt(portStr)
-const originsStr = process.env.ORIGINS || `http://localhost:${portStr}`
+const originsStr = process.env.ORIGINS || 'http://localhost:3000'
 const origins = originsStr.split(',')
 
 const client = redis.createClient({ url: redisUrl })

--- a/token-prices/api/server.js
+++ b/token-prices/api/server.js
@@ -7,7 +7,8 @@ const redis = require('redis')
 const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379'
 const portStr = process.env.PORT || '3000'
 const port = parseInt(portStr)
-const origin = process.env.ORIGIN || '*.hemi.xyz'
+const originsStr = process.env.ORIGINS || `http://localhost:${portStr}`
+const origins = originsStr.split(',')
 
 const client = redis.createClient({ url: redisUrl })
 client.connect()
@@ -32,10 +33,14 @@ const getPricesFromCache = pLimitOne(async function () {
   return data
 })
 
-async function requestHandler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', origin)
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+async function handleRequest(req, res) {
+  const { 'access-control-request-headers': headers, origin } = req.headers
+  if (headers) {
+    res.setHeader('Access-Control-Allow-Headers', headers)
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET')
+  const allowOrigin = origins.includes(origin) ? origin : false
+  res.setHeader('Access-Control-Allow-Origin', allowOrigin)
 
   if (req.method === 'OPTIONS') {
     res.writeHead(204)
@@ -64,4 +69,4 @@ async function requestHandler(req, res) {
   res.end(JSON.stringify(data))
 }
 
-http.createServer(requestHandler).listen(port)
+http.createServer(handleRequest).listen(port)

--- a/token-prices/docker-compose.yml
+++ b/token-prices/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       context: api
     environment:
       NODE_ENV: production
-      ORIGIN: ${ORIGIN}
+      ORIGINS: ${ORIGINS}
       PORT: ${PORT}
       REDIS_URL: redis://cache:6379
     depends_on:

--- a/token-prices/docker-compose.yml
+++ b/token-prices/docker-compose.yml
@@ -24,4 +24,4 @@ services:
     depends_on:
       - cache
     ports:
-      - 3000:3000
+      - 3001:3001


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The changes in #911 to respond CORS headers were incomplete and incorrect.

- Given this API may be used for multiple apps (staging, prod), the ORIGIN variable was changed to ORIGINS and it is now a comma-separated list of origins.
- The `Access-Control-Allow-Origin` header must contain a scheme (i.e. `http`). Asterisks, as was set in the prior default value, are not allowed. It is either `*` or an [origin](https://nodejs.org/docs/latest/api/url.html#url-strings-and-url-objects). See the [RFC 6454](https://www.rfc-editor.org/rfc/rfc6454.html) for more information.
- The `Access-Control-Allow-Methods` header only has a `GET` method now as responding `OPTIONS` is not strictly required for "simple" `GET` requests.
- The `Access-Control-Allow-Headers` header just reflects the request headers following [what `cors` does](https://github.com/expressjs/cors/blob/v2.8.5/lib/index.js#L99).

Additionally, the default port was changed to 3001 to prevent using the same port as the portal app.