### PR TITLE
Add TVL in "Strategy Details"

### DIFF
--- a/webapp/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -187,12 +187,7 @@ export const StakeOperation = function ({
           setAmount={setAmount}
           setOperation={() => onOperationChange('unstake')}
           showTabs={showTabs}
-          strategyDetails={
-            <>
-              {/* TODO define how to get TVL https://github.com/hemilabs/ui-monorepo/issues/794 */}
-              <StrategyDetails token={token} tvl=" $ 129M" />
-            </>
-          }
+          strategyDetails={<StrategyDetails token={token} />}
           submitButton={
             <>
               <DrawerParagraph>{t('you-can-unstake-anytime')}</DrawerParagraph>

--- a/webapp/app/[locale]/stake/_components/manageStake/strategyDetails.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/strategyDetails.tsx
@@ -4,11 +4,11 @@ import { StakeToken } from 'types/stake'
 
 import { TokenRewards } from '../tokenRewards'
 
+import { Tvl } from './tvl'
 import { Website } from './website'
 
 type Props = {
   token: StakeToken
-  tvl: string
 }
 
 const Container = ({ children }: { children: ReactNode }) => (
@@ -21,7 +21,7 @@ const Subtitle = ({ text }: { text: string }) => (
   <h6 className="text-sm font-medium text-neutral-500">{text}</h6>
 )
 
-export const StrategyDetails = function ({ tvl, token }: Props) {
+export const StrategyDetails = function ({ token }: Props) {
   const t = useTranslations('stake-page.drawer.strategy-details')
   return (
     <div className="flex flex-col">
@@ -36,7 +36,12 @@ export const StrategyDetails = function ({ tvl, token }: Props) {
       </Container>
       <Container>
         <Subtitle text={t('tvl')} />
-        <span className="text-base font-semibold text-neutral-950">{tvl}</span>
+        <div className="flex items-center gap-x-1 text-base font-semibold text-neutral-950">
+          <span>$</span>
+          <span className="min-w-8">
+            <Tvl token={token} />
+          </span>
+        </div>
       </Container>
       <Container>
         <Subtitle text={t('website')} />

--- a/webapp/app/[locale]/stake/_components/manageStake/tvl.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/tvl.tsx
@@ -1,6 +1,8 @@
+import Big from 'big.js'
 import { RenderFiatBalance } from 'components/fiatBalance'
 import { useTotalSupply } from 'hooks/useTotalSupply'
 import { StakeToken } from 'types/stake'
+import { formatFiatNumber } from 'utils/format'
 
 export const Tvl = function ({ token }: { token: StakeToken }) {
   const {
@@ -11,6 +13,17 @@ export const Tvl = function ({ token }: { token: StakeToken }) {
   return (
     <RenderFiatBalance
       balance={supply}
+      customFormatter={function (amount) {
+        // for less than one million, use the regular format.
+        if (Big(amount).lt(1_000_000)) {
+          return formatFiatNumber(amount)
+        }
+        // for larger than that, use the million format.
+        return new Intl.NumberFormat('en-US', { notation: 'compact' }).format(
+          // @ts-expect-error NumberFormat.format accept strings, typings are wrong. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#parameters
+          amount,
+        )
+      }}
       fetchStatus={fetchStatus}
       queryStatus={status}
       token={token}

--- a/webapp/app/[locale]/stake/_components/manageStake/tvl.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/tvl.tsx
@@ -1,0 +1,19 @@
+import { RenderFiatBalance } from 'components/fiatBalance'
+import { useTotalSupply } from 'hooks/useTotalSupply'
+import { StakeToken } from 'types/stake'
+
+export const Tvl = function ({ token }: { token: StakeToken }) {
+  const {
+    data: supply,
+    fetchStatus,
+    status,
+  } = useTotalSupply(token.address, token.chainId)
+  return (
+    <RenderFiatBalance
+      balance={supply}
+      fetchStatus={fetchStatus}
+      queryStatus={status}
+      token={token}
+    />
+  )
+}

--- a/webapp/components/fiatBalance.tsx
+++ b/webapp/components/fiatBalance.tsx
@@ -5,8 +5,8 @@ import { useTokenBalance, useNativeTokenBalance } from 'hooks/useBalance'
 import { useTokenPrices } from 'hooks/useTokenPrices'
 import { ComponentProps } from 'react'
 import Skeleton from 'react-loading-skeleton'
-import { smartRound } from 'smart-round'
 import { type BtcToken, type EvmToken, type Token } from 'types/token'
+import { formatFiatNumber } from 'utils/format'
 import { isNativeToken } from 'utils/nativeToken'
 import { isEvmToken } from 'utils/token'
 import { formatUnits } from 'viem'
@@ -17,15 +17,15 @@ type Props<T extends Token = Token> = {
   token: T
 }
 
-const fiatRounder = smartRound(6, 2, 2)
-
 const RenderFiatBalanceUnsafe = function ({
   balance = BigInt(0),
+  customFormatter = formatFiatNumber,
   fetchStatus,
   queryStatus,
   token,
 }: Props & {
   balance: bigint | undefined
+  customFormatter?: (amount: string) => string
   fetchStatus: FetchStatus
   queryStatus: QueryStatus
 }) {
@@ -77,9 +77,9 @@ const RenderFiatBalanceUnsafe = function ({
           '-'}
         {status === 'success' && (
           <>
-            {fiatRounder(Big(stringBalance).times(price).toFixed(2), {
-              shouldFormat: true,
-            })}
+            {customFormatter(
+              Big(stringBalance).times(price).toFixed(token.decimals),
+            )}
           </>
         )}
       </>

--- a/webapp/components/fiatBalance.tsx
+++ b/webapp/components/fiatBalance.tsx
@@ -37,8 +37,10 @@ const RenderFiatBalanceUnsafe = function ({
 
   const stringBalance = formatUnits(balance, token.decimals)
 
-  const price =
-    data?.[(token.extensions?.priceSymbol ?? token.symbol).toUpperCase()] ?? '0'
+  const priceSymbol = (
+    token.extensions?.priceSymbol ?? token.symbol
+  ).toUpperCase()
+  const price = data?.[priceSymbol] ?? '0'
 
   const mergedFetchStatuses = function () {
     const fetchStatuses = [fetchStatus, tokenPricesFetchStatus]

--- a/webapp/components/fiatBalance.tsx
+++ b/webapp/components/fiatBalance.tsx
@@ -37,7 +37,8 @@ const RenderFiatBalanceUnsafe = function ({
 
   const stringBalance = formatUnits(balance, token.decimals)
 
-  const price = data?.[token.symbol.toUpperCase()] ?? '0'
+  const price =
+    data?.[(token.extensions?.priceSymbol ?? token.symbol).toUpperCase()] ?? '0'
 
   const mergedFetchStatuses = function () {
     const fetchStatuses = [fetchStatus, tokenPricesFetchStatus]

--- a/webapp/hooks/useTotalSupply.ts
+++ b/webapp/hooks/useTotalSupply.ts
@@ -1,0 +1,15 @@
+import { Token } from 'types/token'
+import { type Address, type Chain, erc20Abi } from 'viem'
+import { useReadContract } from 'wagmi'
+
+export const useTotalSupply = (
+  address: Token['address'],
+  chainId?: Chain['id'],
+) =>
+  useReadContract({
+    abi: erc20Abi,
+    address: address as Address,
+    args: [],
+    chainId,
+    functionName: 'totalSupply',
+  })

--- a/webapp/tokenList/stakeTokens.ts
+++ b/webapp/tokenList/stakeTokens.ts
@@ -29,18 +29,21 @@ export const stakeWhiteList: Partial<
     // hemiBTC
     '0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28': {
       protocol: 'hemi',
+      priceSymbol: 'btc',
       rewards: ['hemi'],
       website: websitesMap.hemi,
     },
     // enzoBTC
     '0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a': {
       protocol: 'lorenzo',
+      priceSymbol: 'btc',
       rewards: ['hemi', 'lorenzo'],
       website: websitesMap.lorenzo,
     },
     // iBTC
     '0x8154Aaf094c2f03Ad550B6890E1d4264B5DdaD9A': {
       protocol: 'exSat',
+      priceSymbol: 'btc',
       rewards: ['hemi'],
       website: websitesMap.exSat,
     },
@@ -53,6 +56,7 @@ export const stakeWhiteList: Partial<
     // oBTC
     '0xe3C0FF176eF92FC225096C6d1788cCB818808b35': {
       protocol: 'obeliskNodeDao',
+      priceSymbol: 'btc',
       rewards: ['hemi'],
       website: websitesMap.obeliskNodeDao,
     },
@@ -65,12 +69,14 @@ export const stakeWhiteList: Partial<
     // stBTC
     '0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3': {
       protocol: 'lorenzo',
+      priceSymbol: 'btc',
       rewards: ['hemi', 'lorenzo'],
       website: websitesMap.lorenzo,
     },
     // uBTC
     '0x78E26E8b953C7c78A58d69d8B9A91745C2BbB258': {
       protocol: 'uniRouter',
+      priceSymbol: 'btc',
       rewards: ['hemi', 'unirouter', 'bsquared'],
       website: websitesMap.uniRouter,
     },

--- a/webapp/types/token.ts
+++ b/webapp/types/token.ts
@@ -9,6 +9,8 @@ export type Extensions = {
     }
   }
   protocol?: string
+  // Use this to map which symbol should be used to map prices
+  priceSymbol?: string
   tunnel?: boolean
   tunnelPartner?: string
 }

--- a/webapp/utils/format.ts
+++ b/webapp/utils/format.ts
@@ -9,6 +9,11 @@ export const formatBtcAddress = (account: Account) =>
 export const formatEvmAddress = (address: Address) =>
   shorten(address, { length: 4, prefixes: ['0x'] })
 
-const rounder = smartRound(6, 0, 6)
+const cryptoRounder = smartRound(6, 0, 6)
+const fiatRounder = smartRound(6, 2, 2)
+
 export const formatNumber = (value: number | string) =>
-  rounder(value, { roundingMode: 'round-down', shouldFormat: true })
+  cryptoRounder(value, { roundingMode: 'round-down', shouldFormat: true })
+
+export const formatFiatNumber = (value: number | string) =>
+  fiatRounder(value, { shouldFormat: true })


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the TVL in the "Strategy Details" section. As discussed with Nahuel, we use the "compact" notation for TVL larger than 1 million. TVL is calculated as the price of the token times the supply of emitted tokens.
It also updates the `extensions` for some tokens to add the symbol they should consider for the pricing - for example, some of the BTC tokens use the BTC price.

If the token prices API is not enabled, a `-` is shown

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/dfdd2bd8-836f-46b9-a248-338d8924dccf

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes https://github.com/hemilabs/ui-monorepo/issues/794

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
