### PR TITLE
Add Hemi Withdrawals subgraph

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,8 +3,7 @@
   "overrides": [
     {
       "excludedFiles": [
-        "subgraphs/*/build/**/*.ts",
-        "subgraphs/*/generated/**/*.ts",
+        "subgraphs/**/*.ts",
         "webapp/scripts/*.js",
         "webapp/*.config.js"
       ],
@@ -18,7 +17,6 @@
         "btc-wallet/**/*.{js,ts,tsx}",
         "hemi-viem-stake-actions/**/*.{js,ts}",
         "sliding-block-window/**/*.{js,ts}",
-        "subgraphs/**/*.{js,ts}",
         "ui-common/**/*.{js,ts,tsx}",
         "wagmi-erc20-hooks/**/*.{js,ts,tsx}",
         "webapp/**/*.{js,ts,tsx}"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ subgraphs/data
 # Graph CLI generated artifacts
 subgraphs/tunnel-deposits-subgraph/build
 subgraphs/tunnel-deposits-subgraph/generated
+subgraphs/hemi-tunnel-withdrawals-subgraph/build
+subgraphs/hemi-tunnel-withdrawals-subgraph/generated

--- a/package-lock.json
+++ b/package-lock.json
@@ -15906,6 +15906,10 @@
       "resolved": "https://registry.npmjs.org/hemi-socials/-/hemi-socials-1.0.0.tgz",
       "integrity": "sha512-f1hiPt90QXTPXX9jb8fRuGvzWMkbBpBO/45m3s024Aa0JoSpeVt9AodkxHAnCfK5uTRDdKvbIB8dPU1sbGhOdA=="
     },
+    "node_modules/hemi-tunnel-withdrawals-subgraph": {
+      "resolved": "subgraphs/hemi-tunnel-withdrawals-subgraph",
+      "link": true
+    },
     "node_modules/hemi-viem": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.3.0.tgz",
@@ -27339,6 +27343,13 @@
         "@types/sinon": "17.0.3",
         "sinon": "18.0.0",
         "vitest": "2.0.5"
+      }
+    },
+    "subgraphs/hemi-tunnel-withdrawals-subgraph": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@graphprotocol/graph-cli": "0.95.0",
+        "@graphprotocol/graph-ts": "0.36.0"
       }
     },
     "subgraphs/tunnel-deposits": {

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/abis/BitcoinTunnelManager.json
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/abis/BitcoinTunnelManager.json
@@ -1,0 +1,301 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "initialAdmin", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "initialVaultFactoryUpgradeDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minimumVaultFactoryUpgradeDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "initialBitcoinKitUpgradeDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "initialGlobalConfigAdminUpgradeDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IBitcoinKit",
+        "name": "bitcoinKitAddr",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "depositTxId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositSats",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netSatsAfterFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositConfirmed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "setupAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operatorAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vaultAddress",
+        "type": "address"
+      }
+    ],
+    "name": "VaultCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "withdrawer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "uuid",
+        "type": "uint64"
+      }
+    ],
+    "name": "WithdrawalChallengeSuccess",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "withdrawer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "btcAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawalSats",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netSatsAfterFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "uuid",
+        "type": "uint64"
+      }
+    ],
+    "name": "WithdrawalInitiated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "btcTokenContract",
+    "outputs": [
+      { "internalType": "contract BTCToken", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burnLiquidatedBTC",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint64", "name": "uuid", "type": "uint64" },
+      { "internalType": "bytes", "name": "extraInfo", "type": "bytes" }
+    ],
+    "name": "challengeWithdrawal",
+    "outputs": [{ "internalType": "bool", "name": "success", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "vaultIndex", "type": "uint32" },
+      { "internalType": "bytes32", "name": "txid", "type": "bytes32" },
+      { "internalType": "uint256", "name": "outputIndex", "type": "uint256" },
+      { "internalType": "bytes", "name": "extraInfo", "type": "bytes" }
+    ],
+    "name": "confirmDeposit",
+    "outputs": [
+      { "internalType": "bool", "name": "successful", "type": "bool" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "setupAdmin", "type": "address" },
+      { "internalType": "address", "name": "operatorAdmin", "type": "address" },
+      { "internalType": "uint256", "name": "vaultType", "type": "uint256" },
+      { "internalType": "bytes", "name": "extraInfo", "type": "bytes" }
+    ],
+    "name": "createVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "globalConfig",
+    "outputs": [
+      { "internalType": "contract GlobalConfig", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "vaultIndex", "type": "uint32" },
+      { "internalType": "string", "name": "btcAddress", "type": "string" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "initiateWithdrawal",
+    "outputs": [
+      { "internalType": "uint256", "name": "feeSats", "type": "uint256" },
+      { "internalType": "uint64", "name": "uuid", "type": "uint64" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "vaultIndex", "type": "uint32" },
+      { "internalType": "uint256", "name": "amountToMint", "type": "uint256" }
+    ],
+    "name": "mintOperatorFees",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountMinted", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "originalBitcoinKitContract",
+    "outputs": [
+      { "internalType": "contract IBitcoinKit", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "vaultIndex", "type": "uint32" },
+      { "internalType": "bytes32", "name": "txid", "type": "bytes32" },
+      { "internalType": "uint256", "name": "outputIndex", "type": "uint256" },
+      { "internalType": "bytes", "name": "extraInfo", "type": "bytes" }
+    ],
+    "name": "preconfirmDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vaultCounter",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "vaultList",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "name": "vaults",
+    "outputs": [
+      {
+        "internalType": "contract IBitcoinVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/abis/L2Bridge.json
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/abis/L2Bridge.json
@@ -1,0 +1,424 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "addresspayable",
+        "name": "_otherBridge",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2Token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "DepositFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "localToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "remoteToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "ERC20BridgeFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "localToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "remoteToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "ERC20BridgeInitiated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "ETHBridgeFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "ETHBridgeInitiated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2Token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "WithdrawalInitiated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MESSENGER",
+    "outputs": [
+      {
+        "internalType": "contractCrossDomainMessenger",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "OTHER_BRIDGE",
+    "outputs": [
+      {
+        "internalType": "contractStandardBridge",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_localToken", "type": "address" },
+      { "internalType": "address", "name": "_remoteToken", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "uint32", "name": "_minGasLimit", "type": "uint32" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "bridgeERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_localToken", "type": "address" },
+      { "internalType": "address", "name": "_remoteToken", "type": "address" },
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "uint32", "name": "_minGasLimit", "type": "uint32" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "bridgeERC20To",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "_minGasLimit", "type": "uint32" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "bridgeETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint32", "name": "_minGasLimit", "type": "uint32" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "bridgeETHTo",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "deposits",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_localToken", "type": "address" },
+      { "internalType": "address", "name": "_remoteToken", "type": "address" },
+      { "internalType": "address", "name": "_from", "type": "address" },
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "finalizeBridgeERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_from", "type": "address" },
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "finalizeBridgeETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_l1Token", "type": "address" },
+      { "internalType": "address", "name": "_l2Token", "type": "address" },
+      { "internalType": "address", "name": "_from", "type": "address" },
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "finalizeDeposit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l1TokenBridge",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "messenger",
+    "outputs": [
+      {
+        "internalType": "contractCrossDomainMessenger",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_l2Token", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "uint32", "name": "_minGasLimit", "type": "uint32" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_l2Token", "type": "address" },
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "uint32", "name": "_minGasLimit", "type": "uint32" },
+      { "internalType": "bytes", "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "withdrawTo",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/networks.json
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/networks.json
@@ -1,0 +1,22 @@
+{
+  "hemi": {
+    "BitcoinTunnelManager": {
+      "address": "0xEAcA824F46c000fB89403846Bb57e6b913321081",
+      "startBlock": 1125154
+    },
+    "L2Bridge": {
+      "address": "0x4200000000000000000000000000000000000010",
+      "startBlock": 0
+    }
+  },
+  "hemi-sepolia": {
+    "BitcoinTunnelManager": {
+      "address": "0x8221CFD3Eca3c5F9FA27b2AE774151642f1C449e",
+      "startBlock": 2165818
+    },
+    "L2Bridge": {
+      "address": "0x4200000000000000000000000000000000000010",
+      "startBlock": 0
+    }
+  }
+}

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hemi-tunnel-withdrawals-subgraph",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "graph build",
+    "build:hemi": "npm run build -- --network hemi",
+    "build:hemi-sepolia": "npm run build -- --network hemi-sepolia",
+    "codegen": "graph codegen",
+    "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
+    "deploy-local:hemi": "npm run deploy-local -- --network hemi",
+    "deploy-local:hemi-sepolia": "npm run deploy-local -- --network hemi-sepolia",
+    "deploy-studio:hemi": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-hemi  --version-label $(jq -r .version package.json) --network hemi",
+    "deploy-studio:hemi-sepolia": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-hemi-sepolia  --version-label $(jq -r .version package.json) --network hemi-sepolia",
+    "graph:auth": "graph auth",
+    "prepare": "npm run codegen",
+    "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
+  },
+  "dependencies": {
+    "@graphprotocol/graph-cli": "0.95.0",
+    "@graphprotocol/graph-ts": "0.36.0"
+  }
+}

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/schema.graphql
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/schema.graphql
@@ -24,7 +24,7 @@ type BtcWithdrawal @entity(immutable: true) {
   l2Token: Bytes! # address
   id: Bytes!
   timestamp: BigInt!
-  to: String! # address
+  to: String # btc address, optional
   transactionHash: Bytes!
   uuid: BigInt!
 }

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/schema.graphql
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/schema.graphql
@@ -1,0 +1,30 @@
+type EvmWithdrawal @entity(immutable: true) {
+  amount: BigInt! # uint256
+  blockNumber: BigInt!
+  direction: Int! #  number
+  from: Bytes! # address
+  l1ChainId: Int! # number
+  l1Token: Bytes! # address
+  l2ChainId: Int! # number
+  l2Token: Bytes! # address
+  id: Bytes!
+  timestamp: BigInt!
+  to: Bytes! # address
+  transactionHash: Bytes!
+}
+
+type BtcWithdrawal @entity(immutable: true) {
+  amount: BigInt! # uint256
+  blockNumber: BigInt!
+  direction: Int! #  number
+  from: Bytes! # address
+  l1ChainId: String! # number
+  l1Token: Bytes! # address
+  l2ChainId: Int! # number
+  l2Token: Bytes! # address
+  id: Bytes!
+  timestamp: BigInt!
+  to: String! # address
+  transactionHash: Bytes!
+  uuid: BigInt!
+}

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/src/entities/baseWithdrawal.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/src/entities/baseWithdrawal.ts
@@ -1,0 +1,144 @@
+import {
+  Entity,
+  Value,
+  ValueKind,
+  Bytes,
+  BigInt,
+} from '@graphprotocol/graph-ts'
+
+export class BaseWithdrawal extends Entity {
+  constructor(id: Bytes) {
+    super()
+    this.set('id', Value.fromBytes(id))
+  }
+
+  get amount(): BigInt {
+    const value = this.get('amount')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBigInt()
+    }
+  }
+
+  set amount(value: BigInt) {
+    this.set('amount', Value.fromBigInt(value))
+  }
+
+  get blockNumber(): BigInt {
+    const value = this.get('blockNumber')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBigInt()
+    }
+  }
+
+  set blockNumber(value: BigInt) {
+    this.set('blockNumber', Value.fromBigInt(value))
+  }
+
+  get direction(): i32 {
+    const value = this.get('direction')
+    if (!value || value.kind == ValueKind.NULL) {
+      return 0
+    } else {
+      return value.toI32()
+    }
+  }
+
+  set direction(value: i32) {
+    this.set('direction', Value.fromI32(value))
+  }
+
+  get from(): Bytes {
+    const value = this.get('from')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set from(value: Bytes) {
+    this.set('from', Value.fromBytes(value))
+  }
+
+  get l2ChainId(): i32 {
+    const value = this.get('l2ChainId')
+    if (!value || value.kind == ValueKind.NULL) {
+      return 0
+    } else {
+      return value.toI32()
+    }
+  }
+
+  set l2ChainId(value: i32) {
+    this.set('l2ChainId', Value.fromI32(value))
+  }
+
+  get l1Token(): Bytes {
+    const value = this.get('l1Token')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set l1Token(value: Bytes) {
+    this.set('l1Token', Value.fromBytes(value))
+  }
+
+  get l2Token(): Bytes {
+    const value = this.get('l2Token')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set l2Token(value: Bytes) {
+    this.set('l2Token', Value.fromBytes(value))
+  }
+
+  get id(): Bytes {
+    const value = this.get('id')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set id(value: Bytes) {
+    this.set('id', Value.fromBytes(value))
+  }
+
+  get timestamp(): BigInt {
+    const value = this.get('timestamp')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBigInt()
+    }
+  }
+
+  set timestamp(value: BigInt) {
+    this.set('timestamp', Value.fromBigInt(value))
+  }
+
+  get transactionHash(): Bytes {
+    const value = this.get('transactionHash')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set transactionHash(value: Bytes) {
+    this.set('transactionHash', Value.fromBytes(value))
+  }
+}

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/src/entities/btcWithdrawal.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/src/entities/btcWithdrawal.ts
@@ -1,0 +1,71 @@
+import { Value, ValueKind, store, Bytes, BigInt } from '@graphprotocol/graph-ts'
+import { BaseWithdrawal } from './baseWithdrawal'
+
+export class BtcWithdrawal extends BaseWithdrawal {
+  constructor(id: Bytes) {
+    super(id)
+  }
+
+  save(): void {
+    let id = this.get('id')
+    assert(id != null, 'Cannot save BtcWithdrawal entity without an ID')
+    if (id) {
+      assert(
+        id.kind == ValueKind.BYTES,
+        `Entities of type BtcWithdrawal must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+      )
+      store.set('BtcWithdrawal', id.toBytes().toHexString(), this)
+    }
+  }
+
+  static loadInBlock(id: Bytes): BtcWithdrawal | null {
+    return changetype<BtcWithdrawal | null>(
+      store.get_in_block('BtcWithdrawal', id.toHexString()),
+    )
+  }
+
+  static load(id: Bytes): BtcWithdrawal | null {
+    return changetype<BtcWithdrawal | null>(
+      store.get('BtcWithdrawal', id.toHexString()),
+    )
+  }
+
+  get to(): string {
+    const value = this.get('to')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toString()
+    }
+  }
+
+  set to(value: string) {
+    this.set('to', Value.fromString(value))
+  }
+
+  get uuid(): BigInt {
+    let value = this.get('uuid')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBigInt()
+    }
+  }
+
+  set uuid(value: BigInt) {
+    this.set('uuid', Value.fromBigInt(value))
+  }
+
+  get l1ChainId(): string {
+    const value = this.get('l1ChainId')
+    if (!value || value.kind == ValueKind.NULL) {
+      return ''
+    } else {
+      return value.toString()
+    }
+  }
+
+  set l1ChainId(value: string) {
+    this.set('l1ChainId', Value.fromString(value))
+  }
+}

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/src/entities/evmWithdrawal.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/src/entities/evmWithdrawal.ts
@@ -1,0 +1,59 @@
+import { Value, ValueKind, store, Bytes } from '@graphprotocol/graph-ts'
+
+import { BaseWithdrawal } from './baseWithdrawal'
+
+export class EvmWithdrawal extends BaseWithdrawal {
+  constructor(id: Bytes) {
+    super(id)
+  }
+
+  save(): void {
+    const id = this.get('id')
+    assert(id != null, 'Cannot save EvmWithdrawal entity without an ID')
+    if (id) {
+      assert(
+        id.kind == ValueKind.BYTES,
+        `Entities of type EvmWithdrawal must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+      )
+      store.set('EvmWithdrawal', id.toBytes().toHexString(), this)
+    }
+  }
+
+  static loadInBlock(id: Bytes): EvmWithdrawal | null {
+    return changetype<EvmWithdrawal | null>(
+      store.get_in_block('EvmWithdrawal', id.toHexString()),
+    )
+  }
+
+  static load(id: Bytes): EvmWithdrawal | null {
+    return changetype<EvmWithdrawal | null>(
+      store.get('EvmWithdrawal', id.toHexString()),
+    )
+  }
+
+  get l1ChainId(): i32 {
+    const value = this.get('l1ChainId')
+    if (!value || value.kind == ValueKind.NULL) {
+      return 0
+    } else {
+      return value.toI32()
+    }
+  }
+
+  set l1ChainId(value: i32) {
+    this.set('l1ChainId', Value.fromI32(value))
+  }
+
+  get to(): Bytes {
+    const value = this.get('to')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set to(value: Bytes) {
+    this.set('to', Value.fromBytes(value))
+  }
+}

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/src/mappings/bitcoin-tunnel-manager.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/src/mappings/bitcoin-tunnel-manager.ts
@@ -1,0 +1,74 @@
+import {
+  Address,
+  Bytes,
+  dataSource,
+  log,
+  ethereum,
+} from '@graphprotocol/graph-ts'
+
+import { getBitcoinChainId, getEvmChainId, zeroAddress } from '../../../utils'
+import { WithdrawalInitiated as BtcWithdrawalInitiatedEvent } from '../../generated/BitcoinTunnelManager/BitcoinTunnelManager'
+import { BtcWithdrawal } from '../entities/btcWithdrawal'
+
+const bitcoinTokenMap = new Map<string, Address>()
+// See https://github.com/hemilabs/token-list/blob/45d5e76798173b896773203482b723235f05d0b5/src/hemi.tokenlist.json#L258
+bitcoinTokenMap.set(
+  'livenet',
+  Address.fromString('0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28'),
+)
+// See https://github.com/hemilabs/token-list/blob/45d5e76798173b896773203482b723235f05d0b5/src/hemi.tokenlist.json#L404
+bitcoinTokenMap.set(
+  'testnet',
+  Address.fromString('0x36Ab5Dba83d5d470F670BC4c06d7Da685d9afAe7'),
+)
+
+const initiateWithdrawalFn = '(uint32,string,uint256)'
+
+export function handleWithdrawalInitiated(
+  event: BtcWithdrawalInitiatedEvent,
+): void {
+  log.debug('BtcWithdrawal {} found', [event.transaction.hash.toHexString()])
+
+  const entity = new BtcWithdrawal(
+    event.transaction.hash.concatI32(event.logIndex.toI32()),
+  )
+  entity.amount = event.params.withdrawalSats
+  entity.blockNumber = event.block.number
+  // 1 is direction from L2 to L1
+  entity.direction = 1
+  entity.from = event.params.withdrawer
+
+  entity.l2ChainId = getEvmChainId(dataSource.network())
+  entity.l1ChainId = getBitcoinChainId(entity.l2ChainId)
+
+  entity.l1Token = zeroAddress
+  entity.l2Token = bitcoinTokenMap.get(entity.l1ChainId)
+
+  entity.timestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+
+  entity.uuid = event.params.uuid
+
+  // This is the only way I managed to decode the input, by excluding the signature hash.
+  // See https://github.com/graphprotocol/graph-tooling/issues/1088
+  const dec = ethereum.decode(
+    initiateWithdrawalFn,
+    Bytes.fromHexString('0x' + event.transaction.input.toHexString().slice(10)),
+  )
+
+  if (!dec) {
+    log.error('Failed to decode BtcWithdrawal input {} for {}', [
+      event.transaction.input.toHexString(),
+      entity.transactionHash.toHexString(),
+    ])
+    return
+  }
+  const decodedTuple = dec.toTuple()
+
+  // Here this parameter is the bitcoin address that the vault operator owns
+  entity.to = decodedTuple[1].toString()
+
+  log.debug('Saving BtcWithdrawal', [])
+  entity.save()
+  log.info('BtcWithdrawal {} saved', [entity.transactionHash.toHexString()])
+}

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/src/mappings/l-2-bridge.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/src/mappings/l-2-bridge.ts
@@ -1,0 +1,44 @@
+// Note: This file is written in AssemblyScript. It is required like this to run in the Graph nodes.
+// See docs https://www.assemblyscript.org/ - don't let the .ts extension confuse you. It's fairly limited
+// and many js/ts operations are not supported
+import { dataSource, log } from '@graphprotocol/graph-ts'
+
+import { WithdrawalInitiated as WithdrawalInitiatedEvent } from '../../generated/L2Bridge/L2Bridge'
+import { EvmWithdrawal } from '../entities/evmWithdrawal'
+
+const ethereumMainnetId = 1
+const hemiMainnetId = 43111
+const hemiSepoliaId = 743111
+const sepoliaId = 11155111
+
+const chainMap = new Map<string, i32>()
+chainMap.set('hemi', hemiMainnetId)
+chainMap.set('hemi-sepolia', hemiSepoliaId)
+
+export function handleWithdrawalInitiated(
+  event: WithdrawalInitiatedEvent,
+): void {
+  log.debug('EvmWithdrawal {} found', [event.transaction.hash.toHexString()])
+  const entity = new EvmWithdrawal(
+    event.transaction.hash.concatI32(event.logIndex.toI32()),
+  )
+  entity.amount = event.params.amount
+  entity.blockNumber = event.block.number
+  // 1 is direction from L2 to L1
+  entity.direction = 1
+  entity.from = event.params.from
+  entity.l1Token = event.params.l1Token
+  entity.l2Token = event.params.l2Token
+
+  entity.l2ChainId = chainMap.get(dataSource.network())
+  entity.l1ChainId =
+    entity.l2ChainId == hemiMainnetId ? ethereumMainnetId : sepoliaId
+
+  entity.to = event.params.to
+  entity.timestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+
+  log.debug('Saving EvmWithdrawal', [])
+  entity.save()
+  log.info('EvmWithdrawal {} saved', [entity.transactionHash.toHexString()])
+}

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/src/mappings/l-2-bridge.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/src/mappings/l-2-bridge.ts
@@ -3,17 +3,9 @@
 // and many js/ts operations are not supported
 import { dataSource, log } from '@graphprotocol/graph-ts'
 
+import { getEthereumChainId, getEvmChainId } from '../../../utils'
 import { WithdrawalInitiated as WithdrawalInitiatedEvent } from '../../generated/L2Bridge/L2Bridge'
 import { EvmWithdrawal } from '../entities/evmWithdrawal'
-
-const ethereumMainnetId = 1
-const hemiMainnetId = 43111
-const hemiSepoliaId = 743111
-const sepoliaId = 11155111
-
-const chainMap = new Map<string, i32>()
-chainMap.set('hemi', hemiMainnetId)
-chainMap.set('hemi-sepolia', hemiSepoliaId)
 
 export function handleWithdrawalInitiated(
   event: WithdrawalInitiatedEvent,
@@ -30,9 +22,8 @@ export function handleWithdrawalInitiated(
   entity.l1Token = event.params.l1Token
   entity.l2Token = event.params.l2Token
 
-  entity.l2ChainId = chainMap.get(dataSource.network())
-  entity.l1ChainId =
-    entity.l2ChainId == hemiMainnetId ? ethereumMainnetId : sepoliaId
+  entity.l2ChainId = getEvmChainId(dataSource.network())
+  entity.l1ChainId = getEthereumChainId(entity.l2ChainId)
 
   entity.to = event.params.to
   entity.timestamp = event.block.timestamp

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/subgraph.yaml
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/subgraph.yaml
@@ -1,0 +1,49 @@
+specVersion: 1.0.0
+indexerHints:
+  prune: auto
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum
+    name: L2Bridge
+    network: hemi-sepolia
+    source:
+      abi: L2Bridge
+      address: '0x4200000000000000000000000000000000000010'
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - EvmWithdrawal
+        - WithdrawalInitiated
+      abis:
+        - name: L2Bridge
+          file: ./abis/L2Bridge.json
+      eventHandlers:
+        - event: WithdrawalInitiated(indexed address,indexed address,indexed
+            address,address,uint256,bytes)
+          handler: handleWithdrawalInitiated
+      file: ./src/mappings/l-2-bridge.ts
+  - kind: ethereum
+    name: BitcoinTunnelManager
+    network: hemi-sepolia
+    source:
+      abi: BitcoinTunnelManager
+      address: '0x8221CFD3Eca3c5F9FA27b2AE774151642f1C449e'
+      startBlock: 2165818
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - WithdrawalInitiated
+      abis:
+        - name: BitcoinTunnelManager
+          file: ./abis/BitcoinTunnelManager.json
+      eventHandlers:
+        - event: WithdrawalInitiated(indexed address,indexed address,indexed
+            string,uint256,uint256,uint64)
+          handler: handleWithdrawalInitiated
+      file: ./src/mappings/bitcoin-tunnel-manager.ts

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/subgraph.yaml
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/subgraph.yaml
@@ -16,7 +16,6 @@ dataSources:
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
-        - EvmWithdrawal
         - WithdrawalInitiated
       abis:
         - name: L2Bridge

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/tsconfig.json
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json",
+  "include": ["src"]
+}

--- a/subgraphs/tunnel-deposits-subgraph/package.json
+++ b/subgraphs/tunnel-deposits-subgraph/package.json
@@ -14,7 +14,7 @@
     "deploy-studio:sepolia": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-sepolia  --version-label $(jq -r .version package.json) --network sepolia",
     "graph:auth": "graph auth",
     "prepare": "npm run codegen",
-    "remove-local": "graph remove --node http://localhost:8020/ tunnel-deposits-subgraph"
+    "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.95.0",

--- a/subgraphs/tunnel-deposits-subgraph/src/mappings/l1-standard-bridge.ts
+++ b/subgraphs/tunnel-deposits-subgraph/src/mappings/l1-standard-bridge.ts
@@ -1,22 +1,14 @@
 // Note: This file is written in AssemblyScript. It is required like this to run in the Graph nodes.
 // See docs https://www.assemblyscript.org/ - don't let the .ts extension confuse you. It's fairly limited
 // and many js/ts operations are not supported
-import { Address, Bytes, dataSource, log } from '@graphprotocol/graph-ts'
+import { Bytes, dataSource, log } from '@graphprotocol/graph-ts'
 
+import { getEvmChainId, getHemiChainId, zeroAddress } from '../../../utils'
 import {
   ERC20DepositInitiated,
   ETHDepositInitiated as ETHDepositInitiatedEvent,
 } from '../../generated/L1StandardBridge/L1StandardBridge'
 import { Deposit } from '../entities/deposit'
-
-const ethereumMainnetId = 1
-const hemiMainnetId = 43111
-const hemiSepoliaId = 743111
-const sepoliaId = 11155111
-
-const chainMap = new Map<string, i32>()
-chainMap.set('mainnet', ethereumMainnetId)
-chainMap.set('sepolia', sepoliaId)
 
 export function handleERC20Deposit(event: ERC20DepositInitiated): void {
   log.debug('ERC20 deposit {} found', [event.transaction.hash.toHexString()])
@@ -29,11 +21,10 @@ export function handleERC20Deposit(event: ERC20DepositInitiated): void {
   // 0 is direction from L1 to L2
   entity.direction = 0
   entity.from = event.params.from
-  entity.l1ChainId = chainMap.get(dataSource.network())
+  entity.l1ChainId = getEvmChainId(dataSource.network())
   entity.l1Token = event.params.l1Token
   entity.l2Token = event.params.l2Token
-  entity.l2ChainId =
-    entity.l1ChainId == ethereumMainnetId ? hemiMainnetId : hemiSepoliaId
+  entity.l2ChainId = getHemiChainId(entity.l1ChainId)
   entity.to = event.params.to
   entity.timestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
@@ -51,16 +42,15 @@ export function handleETHDeposit(event: ETHDepositInitiatedEvent): void {
   entity.blockNumber = event.block.number
   entity.direction = 0
   entity.from = event.params.from
-  entity.l1ChainId = chainMap.get(dataSource.network())
-  entity.l1Token = Bytes.fromHexString(Address.zero().toHexString())
+  entity.l1ChainId = getEvmChainId(dataSource.network())
+  entity.l1Token = zeroAddress
   // Special address used by OP to store bridged eth
   // See https://github.com/ethereum-optimism/optimism/blob/fa19f9aa250c0f548e0fdd226114aebf2c4c3fed/packages/contracts-bedrock/src/libraries/Predeploys.sol#L51
   // While it is legacy, it is still being used on ETH deposits
   entity.l2Token = Bytes.fromHexString(
     '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000',
   )
-  entity.l2ChainId =
-    entity.l1ChainId == ethereumMainnetId ? hemiMainnetId : hemiSepoliaId
+  entity.l2ChainId = getHemiChainId(entity.l1ChainId)
   entity.to = event.params.to
   entity.timestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash

--- a/subgraphs/tunnel-deposits-subgraph/src/mappings/l1-standard-bridge.ts
+++ b/subgraphs/tunnel-deposits-subgraph/src/mappings/l1-standard-bridge.ts
@@ -26,6 +26,7 @@ export function handleERC20Deposit(event: ERC20DepositInitiated): void {
 
   entity.amount = event.params.amount
   entity.blockNumber = event.block.number
+  // 0 is direction from L1 to L2
   entity.direction = 0
   entity.from = event.params.from
   entity.l1ChainId = chainMap.get(dataSource.network())

--- a/subgraphs/utils/index.ts
+++ b/subgraphs/utils/index.ts
@@ -16,6 +16,9 @@ chainMap.set('hemi-sepolia', hemiSepoliaId)
 export const getBitcoinChainId = (chainId: i32): string =>
   chainId === hemiSepoliaId ? 'testnet' : 'livenet'
 
+export const getEthereumChainId = (l2ChainId: i32): i32 =>
+  l2ChainId === hemiMainnetId ? ethereumMainnetId : sepoliaId
+
 export const getEvmChainId = (chain: string): i32 => chainMap.get(chain)
 
 export const getHemiChainId = (l1ChainId: i32): i32 =>

--- a/subgraphs/utils/index.ts
+++ b/subgraphs/utils/index.ts
@@ -1,0 +1,22 @@
+import { Address, Bytes } from '@graphprotocol/graph-ts'
+
+export const zeroAddress = Bytes.fromHexString(Address.zero().toHexString())
+
+const ethereumMainnetId = 1
+const hemiMainnetId = 43111
+const hemiSepoliaId = 743111
+const sepoliaId = 11155111
+
+const chainMap = new Map<string, i32>()
+chainMap.set('mainnet', ethereumMainnetId)
+chainMap.set('sepolia', sepoliaId)
+chainMap.set('hemi', hemiMainnetId)
+chainMap.set('hemi-sepolia', hemiSepoliaId)
+
+export const getBitcoinChainId = (chainId: i32): string =>
+  chainId === hemiSepoliaId ? 'testnet' : 'livenet'
+
+export const getEvmChainId = (chain: string): i32 => chainMap.get(chain)
+
+export const getHemiChainId = (l1ChainId: i32): i32 =>
+  l1ChainId === ethereumMainnetId ? hemiMainnetId : hemiSepoliaId


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR Adds the withdrawals subgraph. This will be deployed on Hemi (Sepolia), and will index withdrawals to Ethereum (mainnet|sepolia) and initiated to Bitcoin (testnet|mainnet).

#### Some notes

- This PR only adds the subgraph. The code that uses it in the sync-history process will go in a different PR (Still on development/test)
- I had to disable `eslint` for `subgraphs/*`. After all, the code is AssemblyScript and not Typescript, so many warnings make no sense (For example, there's no string interpolation in AssemblyScript). I couldn't find a maintained AssemblyScript linter, so my only option was to disable it
- There is an issue when parsing the input of transactions in The Graph, so the field `to` in Btc Withdrawals (which is used to know where the user is withdrawing their Bitcoins in Bitcoin Blockchain) had to be set as optional. If you look at the subgraph, it is being parsed for some, but not for others :/ This will need to be solved on the consumer side of the subgraph
- Remember some of the classes are auto-generated - _This is AssemblyScript, not Typescript!_ 

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to https://github.com/hemilabs/ui-monorepo/issues/743

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
