### PR TITLE
Add estimated height for virtualized table

### DIFF
--- a/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -36,7 +36,7 @@ import { WelcomeStake } from './welcomeStake'
 type ActionProps = {
   stake: StakeToken
 }
-
+const rowSize = 52
 const Body = function ({
   columns,
   containerRef,
@@ -51,8 +51,14 @@ const Body = function ({
   const { setDrawerQueryString } = useDrawerStakeQueryString()
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
-    estimateSize: () => 52,
+    estimateSize: () => rowSize,
     getScrollElement: () => containerRef.current,
+    initialRect: {
+      // Estimation to fix the initial render that's broken. See https://github.com/TanStack/virtual/issues/871
+      height: rows.length * rowSize,
+      // Not relevant, but type mandatory
+      width: 0,
+    },
     overscan: 10,
   })
 

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/table.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/table.tsx
@@ -55,7 +55,7 @@ const Column = (props: ComponentProps<'td'>) => (
 const Header = ({ text }: { text?: string }) => (
   <span className="block py-2 text-left text-neutral-600">{text}</span>
 )
-
+const rowSize = 52
 const Body = function ({
   columns,
   containerRef,
@@ -70,8 +70,14 @@ const Body = function ({
   const t = useTranslations('tunnel-page.transaction-history')
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
-    estimateSize: () => 52,
+    estimateSize: () => rowSize,
     getScrollElement: () => containerRef.current,
+    initialRect: {
+      // Estimation to fix the initial render that's broken. See https://github.com/TanStack/virtual/issues/871
+      height: rows.length * rowSize,
+      // Not relevant, but type mandatory
+      width: 0,
+    },
     overscan: 10,
   })
   const { updateTxHash } = useTunnelOperation()


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR fixes a bug in the Virtualized tables in which the tables render empty, and if a re-render was triggered, they render ok.

The issue, as [pointed out by Thomas in this comment](https://github.com/hemilabs/ui-monorepo/issues/823#issuecomment-2688193508), is that there's some inconsistency between the initial data returned by the hook. Even though the rows to render are sent to the hook, it returns `getVirtualItems` as 0. 
This function tries to return the number of visible items, calculated by `height` and `witdh` of the table container. This miscalculation seems to be a bug in the library, See https://github.com/TanStack/virtual/issues/871

After debugging a little bit inside `@tanstack/react-virtual` I found an option for estimating the size of tables in `SSR`, named [initialRect](https://tanstack.com/virtual/latest/docs/api/virtualizer#initialrect).  This option lets you give an estimation of `width` and `height` in `SSR` environment, where the `window` object is not defined.
We're not using SSR, but I figured this option would work for us as the amount of `rows` is defined when creating the virtualization. As the row height is also known, I gave it a try, and it worked.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/024f9a19-1139-43c3-9d9f-487c54cc21f3

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #823

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
