### PR TITLE
Bump hemi-viem to v2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15907,9 +15907,9 @@
       "integrity": "sha512-f1hiPt90QXTPXX9jb8fRuGvzWMkbBpBO/45m3s024Aa0JoSpeVt9AodkxHAnCfK5uTRDdKvbIB8dPU1sbGhOdA=="
     },
     "node_modules/hemi-viem": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.3.0.tgz",
-      "integrity": "sha512-ohBB2vpgDsJd/APKejZUjwSSWDytYd6Wa88a/Pfc16ZibBTnA7ZFdzF8nUOYF6CI37lycdetkZEBxm5E+7Ozag==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.3.1.tgz",
+      "integrity": "sha512-A4yLRsUkhIshU88jmM7JKojefTZmxKeswLQL/p6JfKRdB5Xw/w5UrpLLWrD2U6KprzweQSYcyB5KcAeHD0uOEA==",
       "license": "MIT",
       "peerDependencies": {
         "viem": "^2.x"
@@ -27418,7 +27418,7 @@
         "eth-rpc-cache": "2.0.0",
         "fetch-plus-plus": "1.0.0",
         "hemi-socials": "1.0.0",
-        "hemi-viem": "2.3.0",
+        "hemi-viem": "2.3.1",
         "hemi-viem-stake-actions": "1.0.0",
         "javascript-time-ago": "2.5.10",
         "lodash": "4.17.21",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,7 @@
     "eth-rpc-cache": "2.0.0",
     "fetch-plus-plus": "1.0.0",
     "hemi-socials": "1.0.0",
-    "hemi-viem": "2.3.0",
+    "hemi-viem": "2.3.1",
     "hemi-viem-stake-actions": "1.0.0",
     "javascript-time-ago": "2.5.10",
     "lodash": "4.17.21",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps `hemi-viem` to use the `v2.3.1`, which should fix a bug when calling Bitcoin Kit. This should solve https://github.com/hemilabs/ui-monorepo/issues/924 

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes https://github.com/hemilabs/ui-monorepo/issues/924

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
