### PR TITLE
Remove "networkType" query string on default network

### DIFF
--- a/webapp/components/link.tsx
+++ b/webapp/components/link.tsx
@@ -1,5 +1,4 @@
-import { featureFlags } from 'app/featureFlags'
-import { useNetworkType } from 'hooks/useNetworkType'
+import { defaultNetworkType, useNetworkType } from 'hooks/useNetworkType'
 import BaseLink from 'next-intl/link'
 import { ComponentProps } from 'react'
 import { type UrlObject } from 'url'
@@ -29,7 +28,6 @@ const getQuery = function (q: UrlObject['query']): Record<string, string> {
 // between mainnet and testnet when explicitly selected.
 export const Link = function (props: ComponentProps<typeof BaseLink>) {
   const [networkType] = useNetworkType()
-  const defaultNetworkType = featureFlags.mainnetEnabled ? 'mainnet' : 'testnet'
 
   let href = props.href
 

--- a/webapp/components/link.tsx
+++ b/webapp/components/link.tsx
@@ -1,3 +1,4 @@
+import { featureFlags } from 'app/featureFlags'
 import { useNetworkType } from 'hooks/useNetworkType'
 import BaseLink from 'next-intl/link'
 import { ComponentProps } from 'react'
@@ -22,14 +23,31 @@ const getQuery = function (q: UrlObject['query']): Record<string, string> {
   return query
 }
 
-// When using link to navigate between pages, we need to persist the query string
-// for network type; otherwise, when navigating, users would switch between mainnet and testnet
-// due to the loss of this value
+// When using link to navigate between pages, we only persist the networkType
+// query parameter when it differs from the default network type. This keeps
+// the URL clean for the default network while still allowing navigation
+// between mainnet and testnet when explicitly selected.
 export const Link = function (props: ComponentProps<typeof BaseLink>) {
   const [networkType] = useNetworkType()
-  const href =
-    typeof props.href === 'string'
-      ? { pathname: props.href, query: { networkType } }
-      : { ...props.href, query: { ...getQuery(props.href.query), networkType } }
+  const defaultNetworkType = featureFlags.mainnetEnabled ? 'mainnet' : 'testnet'
+
+  let href = props.href
+
+  if (networkType !== defaultNetworkType) {
+    if (typeof href === 'string') {
+      href = { pathname: href, query: { networkType } }
+    } else {
+      href = {
+        ...href,
+        query: { ...getQuery(href.query), networkType },
+      }
+    }
+  } else if (typeof href !== 'string') {
+    href = {
+      ...href,
+      query: getQuery(href.query),
+    }
+  }
+
   return <BaseLink {...props} href={href} />
 }

--- a/webapp/hooks/useNetworkType.ts
+++ b/webapp/hooks/useNetworkType.ts
@@ -6,10 +6,14 @@ import { useQueryState, parseAsStringLiteral } from 'nuqs'
 export const networkTypes = ['mainnet', 'testnet'] as const
 export type NetworkType = (typeof networkTypes)[number]
 
+export const defaultNetworkType = featureFlags.mainnetEnabled
+  ? 'mainnet'
+  : 'testnet'
+
 export const useNetworkType = () =>
   useQueryState(
     'networkType',
     parseAsStringLiteral(
       featureFlags.mainnetEnabled ? networkTypes : (['testnet'] as const),
-    ).withDefault(featureFlags.mainnetEnabled ? 'mainnet' : 'testnet'),
+    ).withDefault(defaultNetworkType),
   )


### PR DESCRIPTION
### Description
Improve URL handling for network type query parameter by only adding it when not on the default network. 

This change prevents unnecessary query parameters from cluttering URLs when navigating between pages on the default network (testnet or mainnet). The `Link` component now conditionally adds the `networkType` parameter, keeping URLs clean while preserving network type selection when explicitly changed.

### Screenshots
https://www.loom.com/share/23cdda7652654eb99f9f0488be4414cc?sid=1e744592-66b1-4efb-a7cc-295679738a9f

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #920
Fixes #920 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
