### PR TITLE
Add usd value on 'Your Stake' card

### DIFF
--- a/webapp/components/fiatBalance.tsx
+++ b/webapp/components/fiatBalance.tsx
@@ -8,7 +8,7 @@ import Skeleton from 'react-loading-skeleton'
 import { type BtcToken, type EvmToken, type Token } from 'types/token'
 import { formatFiatNumber } from 'utils/format'
 import { isNativeToken } from 'utils/nativeToken'
-import { isEvmToken } from 'utils/token'
+import { getTokenPrice, isEvmToken } from 'utils/token'
 import { formatUnits } from 'viem'
 
 import { ErrorBoundary } from './errorBoundary'
@@ -37,10 +37,7 @@ const RenderFiatBalanceUnsafe = function ({
 
   const stringBalance = formatUnits(balance, token.decimals)
 
-  const priceSymbol = (
-    token.extensions?.priceSymbol ?? token.symbol
-  ).toUpperCase()
-  const price = data?.[priceSymbol] ?? '0'
+  const price = getTokenPrice(token, data)
 
   const mergedFetchStatuses = function () {
     const fetchStatuses = [fetchStatus, tokenPricesFetchStatus]

--- a/webapp/test/utils/token.test.ts
+++ b/webapp/test/utils/token.test.ts
@@ -1,4 +1,5 @@
 import {
+  getTokenPrice,
   isStakeToken,
   isTunnelToken,
   isEvmToken,
@@ -7,6 +8,20 @@ import {
 import { describe, expect, it } from 'vitest'
 
 describe('utils/token', function () {
+  describe('getTokenPrice', function () {
+    it('should return the price based in the token symbol', function () {
+      const token = { symbol: 'usdt' }
+      const prices = { USDT: '0.99' }
+      expect(getTokenPrice(token, prices)).toBe('0.99')
+    })
+
+    it('should return the price based in the token priceSymbol if defined', function () {
+      const token = { extensions: { priceSymbol: 'usdt' }, symbol: 'usdt.e' }
+      const prices = { USDT: '0.99' }
+      expect(getTokenPrice(token, prices)).toBe('0.99')
+    })
+  })
+
   describe('isEvmToken', function () {
     it('should return true if token is an EVM token', function () {
       const token = {

--- a/webapp/utils/token.ts
+++ b/webapp/utils/token.ts
@@ -95,3 +95,14 @@ export const isTunnelToken = (token: Token) => token.extensions?.tunnel === true
 
 export const tunnelsThroughPartner = (token: Token) =>
   token.extensions?.tunnelPartner !== undefined
+
+export const getTokenPrice = function (
+  token: Token,
+  prices: Record<string, string>,
+) {
+  const priceSymbol = (
+    token.extensions?.priceSymbol ?? token.symbol
+  ).toUpperCase()
+  const price = prices?.[priceSymbol] ?? '0'
+  return price
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR updates the `Your Stake` card to show the amount of USD staked for the user. 

If the Prices API is not set up, it will just show `-`

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

See how the Section updates after unstaking

https://github.com/user-attachments/assets/a1364cff-6f6c-4311-9206-c7000d2dd983

Price API not set

<img width="1645" alt="image" src="https://github.com/user-attachments/assets/57d90f64-ec3b-42b5-9660-9a3d0416b3d7" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #929

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
