### PR TITLE
Token price docker images

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -13,12 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        context:
-          - token-prices/api
-          - token-prices/cron
-        image:
-          - hemilabs/token-prices-api
-          - hemilabs/token-prices-cron
+        include:
+          - context: token-prices/api
+            image: hemilabs/token-prices-api
+          - context: token-prices/cron
+            image: hemilabs/token-prices-cron
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/docker-build-push

--- a/token-prices/api/Dockerfile
+++ b/token-prices/api/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.18.3-alpine
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 WORKDIR /app
 
@@ -13,4 +13,4 @@ COPY . .
 
 EXPOSE 3001
 
-CMD npm start
+CMD ["npm", "start"]

--- a/token-prices/cron/Dockerfile
+++ b/token-prices/cron/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.18.3-alpine
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 WORKDIR /app
 
@@ -11,4 +11,4 @@ USER node
 
 COPY . .
 
-CMD npm run refresh-prices
+CMD ["npm", "run", "refresh-prices"]


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

While #945 fixed the build, it introduced another error in the strategy matrix being too wide (generating 4 builds instead of 2). This PR fixes that and fixes a few [warning seen in the build logs](https://github.com/hemilabs/ui-monorepo/actions/runs/13642771104/job/38135948138#step:3:694).

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #796