### PR TITLE
Total staked subgraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,9 @@ tsconfig.tsbuildinfo
 # information from docker-compose
 subgraphs/data
 # Graph CLI generated artifacts
-subgraphs/tunnel-deposits-subgraph/build
-subgraphs/tunnel-deposits-subgraph/generated
+subgraphs/hemi-stake-operations-subgraph/build
+subgraphs/hemi-stake-operations-subgraph/generated
 subgraphs/hemi-tunnel-withdrawals-subgraph/build
 subgraphs/hemi-tunnel-withdrawals-subgraph/generated
+subgraphs/tunnel-deposits-subgraph/build
+subgraphs/tunnel-deposits-subgraph/generated

--- a/package-lock.json
+++ b/package-lock.json
@@ -15906,6 +15906,10 @@
       "resolved": "https://registry.npmjs.org/hemi-socials/-/hemi-socials-1.0.0.tgz",
       "integrity": "sha512-f1hiPt90QXTPXX9jb8fRuGvzWMkbBpBO/45m3s024Aa0JoSpeVt9AodkxHAnCfK5uTRDdKvbIB8dPU1sbGhOdA=="
     },
+    "node_modules/hemi-stake-operations-subgraph": {
+      "resolved": "subgraphs/hemi-stake-operations-subgraph",
+      "link": true
+    },
     "node_modules/hemi-tunnel-withdrawals-subgraph": {
       "resolved": "subgraphs/hemi-tunnel-withdrawals-subgraph",
       "link": true
@@ -27343,6 +27347,13 @@
         "@types/sinon": "17.0.3",
         "sinon": "18.0.0",
         "vitest": "2.0.5"
+      }
+    },
+    "subgraphs/hemi-stake-operations-subgraph": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@graphprotocol/graph-cli": "0.95.0",
+        "@graphprotocol/graph-ts": "0.36.0"
       }
     },
     "subgraphs/hemi-tunnel-withdrawals-subgraph": {

--- a/subgraphs/hemi-stake-operations-subgraph/abis/ZtakingPool.json
+++ b/subgraphs/hemi-stake-operations-subgraph/abis/ZtakingPool.json
@@ -1,0 +1,519 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_signer", "type": "address" },
+      {
+        "internalType": "address[]",
+        "name": "_tokensAllowed",
+        "type": "address[]"
+      },
+      { "internalType": "address", "name": "_weth", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "CannotDepositForZeroAddress", "type": "error" },
+  { "inputs": [], "name": "CannotRenounceOwnership", "type": "error" },
+  { "inputs": [], "name": "DepositAmountCannotBeZero", "type": "error" },
+  { "inputs": [], "name": "DuplicateToken", "type": "error" },
+  { "inputs": [], "name": "EnforcedPause", "type": "error" },
+  { "inputs": [], "name": "ExpectedPause", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "currentNonce", "type": "uint256" }
+    ],
+    "name": "InvalidAccountNonce",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InvalidShortString", "type": "error" },
+  { "inputs": [], "name": "MigratorAlreadyAllowedOrBlocked", "type": "error" },
+  { "inputs": [], "name": "MigratorBlocked", "type": "error" },
+  { "inputs": [], "name": "MigratorCannotBeZeroAddress", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  { "inputs": [], "name": "SignatureExpired", "type": "error" },
+  { "inputs": [], "name": "SignatureInvalid", "type": "error" },
+  { "inputs": [], "name": "SignerAlreadySetToAddress", "type": "error" },
+  { "inputs": [], "name": "SignerCannotBeZeroAddress", "type": "error" },
+  {
+    "inputs": [{ "internalType": "string", "name": "str", "type": "string" }],
+    "name": "StringTooLong",
+    "type": "error"
+  },
+  { "inputs": [], "name": "TokenAlreadyConfiguredWithState", "type": "error" },
+  { "inputs": [], "name": "TokenArrayCannotBeEmpty", "type": "error" },
+  { "inputs": [], "name": "TokenCannotBeZeroAddress", "type": "error" },
+  { "inputs": [], "name": "TokenNotAllowedForStaking", "type": "error" },
+  { "inputs": [], "name": "UserDoesNotHaveStake", "type": "error" },
+  { "inputs": [], "name": "WETHCannotBeZeroAddress", "type": "error" },
+  { "inputs": [], "name": "WithdrawAmountCannotBeZero", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "migrator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "blocked",
+        "type": "bool"
+      }
+    ],
+    "name": "BlocklistChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "depositor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "EIP712DomainChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "destination",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "migrator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "Migrate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newSigner",
+        "type": "address"
+      }
+    ],
+    "name": "SignerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "TokenStakabilityChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "withdrawer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "balance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_migrator", "type": "address" },
+      { "internalType": "bool", "name": "_blocklisted", "type": "bool" }
+    ],
+    "name": "blockMigrator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_for", "type": "address" }
+    ],
+    "name": "depositETHFor",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "address", "name": "_for", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+    ],
+    "name": "depositFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      { "internalType": "bytes1", "name": "fields", "type": "bytes1" },
+      { "internalType": "string", "name": "name", "type": "string" },
+      { "internalType": "string", "name": "version", "type": "string" },
+      { "internalType": "uint256", "name": "chainId", "type": "uint256" },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      { "internalType": "bytes32", "name": "salt", "type": "bytes32" },
+      { "internalType": "uint256[]", "name": "extensions", "type": "uint256[]" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address[]", "name": "_tokens", "type": "address[]" },
+      {
+        "internalType": "address",
+        "name": "_migratorContract",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "_destination", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "_signatureExpiry",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_authorizationSignatureFromZircuit",
+        "type": "bytes"
+      }
+    ],
+    "name": "migrate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_user", "type": "address" },
+      { "internalType": "address[]", "name": "_tokens", "type": "address[]" },
+      {
+        "internalType": "address",
+        "name": "_migratorContract",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "_destination", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "_signatureExpiry",
+        "type": "uint256"
+      },
+      { "internalType": "bytes", "name": "_stakerSignature", "type": "bytes" }
+    ],
+    "name": "migrateWithSig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "migratorBlocklist",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "nonces",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "bool", "name": "_canStake", "type": "bool" }
+    ],
+    "name": "setStakable",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_signer", "type": "address" }
+    ],
+    "name": "setZircuitSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "tokenAllowlist",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "zircuitSigner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/hemi-stake-operations-subgraph/networks.json
+++ b/subgraphs/hemi-stake-operations-subgraph/networks.json
@@ -1,0 +1,14 @@
+{
+  "hemi": {
+    "ZtakingPool": {
+      "address": "0x4F5E928763CBFaF5fFD8907ebbB0DAbd5f78bA83",
+      "startBlock": 1220463
+    }
+  },
+  "hemi-sepolia": {
+    "ZtakingPool": {
+      "address": "0x935CC431313C52427ccf45385138a136580bf59f",
+      "startBlock": 2511452
+    }
+  }
+}

--- a/subgraphs/hemi-stake-operations-subgraph/package.json
+++ b/subgraphs/hemi-stake-operations-subgraph/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hemi-stake-operations-subgraph",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "graph build",
+    "build:hemi": "npm run build -- --network hemi",
+    "build:hemi-sepolia": "npm run build -- --network hemi-sepolia",
+    "codegen": "graph codegen",
+    "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
+    "deploy-local:hemi": "npm run deploy-local -- --network hemi",
+    "deploy-local:hemi-sepolia": "npm run deploy-local -- --network hemi-sepolia",
+    "deploy-studio:hemi": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-hemi  --version-label $(jq -r .version package.json) --network hemi",
+    "deploy-studio:hemi-sepolia": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-hemi-sepolia  --version-label $(jq -r .version package.json) --network hemi-sepolia",
+    "graph:auth": "graph auth",
+    "prepare": "npm run codegen",
+    "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
+  },
+  "dependencies": {
+    "@graphprotocol/graph-cli": "0.95.0",
+    "@graphprotocol/graph-ts": "0.36.0"
+  }
+}

--- a/subgraphs/hemi-stake-operations-subgraph/schema.graphql
+++ b/subgraphs/hemi-stake-operations-subgraph/schema.graphql
@@ -1,0 +1,26 @@
+type Deposit @entity(immutable: true) {
+  id: Bytes!
+  eventId: BigInt! # uint256
+  depositor: Bytes! # address
+  token: Bytes! # address
+  amount: BigInt! # uint256
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type Withdraw @entity(immutable: true) {
+  id: Bytes!
+  eventId: BigInt! # uint256
+  withdrawer: Bytes! # address
+  token: Bytes! # address
+  amount: BigInt! # uint256
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type TokenStakeBalance @entity {
+  id: Bytes! # token address
+  totalStaked: BigInt!
+}

--- a/subgraphs/hemi-stake-operations-subgraph/src/mappings/ztaking-pool.ts
+++ b/subgraphs/hemi-stake-operations-subgraph/src/mappings/ztaking-pool.ts
@@ -1,0 +1,84 @@
+// Note: This file is written in AssemblyScript. It is required like this to run in the Graph nodes.
+// See docs https://www.assemblyscript.org/ - don't let the .ts extension confuse you. It's fairly limited
+// and many js/ts operations are not supported
+import { BigInt, Bytes, log } from '@graphprotocol/graph-ts'
+
+import {
+  Deposit as DepositEvent,
+  Withdraw as WithdrawEvent,
+} from '../../generated/ZtakingPool/ZtakingPool'
+import { Deposit, TokenStakeBalance, Withdraw } from '../../generated/schema'
+
+const getTokenStakeBalance = function (tokenAddress: Bytes): TokenStakeBalance {
+  let tokenStakeBalance = TokenStakeBalance.load(tokenAddress)
+  if (tokenStakeBalance == null) {
+    tokenStakeBalance = new TokenStakeBalance(tokenAddress)
+    tokenStakeBalance.totalStaked = BigInt.fromI32(0)
+  }
+  return tokenStakeBalance
+}
+
+export function handleDeposit(event: DepositEvent): void {
+  log.debug('Found stake operation {}', [event.transaction.hash.toHexString()])
+  let entity = new Deposit(
+    event.transaction.hash.concatI32(event.logIndex.toI32()),
+  )
+  entity.eventId = event.params.eventId
+  entity.depositor = event.params.depositor
+  entity.token = event.params.token
+  entity.amount = event.params.amount
+
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+
+  const tokenStake = getTokenStakeBalance(event.params.token)
+
+  tokenStake.totalStaked = tokenStake.totalStaked.plus(event.params.amount)
+
+  log.debug('Saving stake operation {}', [event.transaction.hash.toHexString()])
+  entity.save()
+  log.debug('Saving updated total staked for token {}', [
+    event.params.token.toHexString(),
+  ])
+  tokenStake.save()
+  log.info('Stake operation {} saved', [event.transaction.hash.toHexString()])
+}
+
+export function handleWithdraw(event: WithdrawEvent): void {
+  log.debug('Found unstake operation {}', [
+    event.transaction.hash.toHexString(),
+  ])
+  let entity = new Withdraw(
+    event.transaction.hash.concatI32(event.logIndex.toI32()),
+  )
+  entity.eventId = event.params.eventId
+  entity.withdrawer = event.params.withdrawer
+  entity.token = event.params.token
+  entity.amount = event.params.amount
+
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+
+  const tokenStake = getTokenStakeBalance(event.params.token)
+
+  tokenStake.totalStaked = tokenStake.totalStaked.minus(event.params.amount)
+
+  if (tokenStake.totalStaked.lt(BigInt.fromI32(0))) {
+    // should never happen, but...
+    log.error('Total staked for token {} is negative', [
+      event.params.token.toHexString(),
+    ])
+  }
+
+  log.debug('Saving unstake operation {}', [
+    event.transaction.hash.toHexString(),
+  ])
+  entity.save()
+  log.debug('Saving updated total staked for token {}', [
+    event.params.token.toHexString(),
+  ])
+  tokenStake.save()
+  log.info('Unstake operation {} saved', [event.transaction.hash.toHexString()])
+}

--- a/subgraphs/hemi-stake-operations-subgraph/subgraph.yaml
+++ b/subgraphs/hemi-stake-operations-subgraph/subgraph.yaml
@@ -1,0 +1,30 @@
+specVersion: 1.0.0
+indexerHints:
+  prune: auto
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum
+    name: ZtakingPool
+    network: hemi-sepolia
+    source:
+      address: '0x935CC431313C52427ccf45385138a136580bf59f'
+      abi: ZtakingPool
+      startBlock: 2511452
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Deposit
+        - TokenStakeBalance
+        - Withdraw
+      abis:
+        - name: ZtakingPool
+          file: ./abis/ZtakingPool.json
+      eventHandlers:
+        - event: Deposit(indexed uint256,indexed address,indexed address,uint256)
+          handler: handleDeposit
+        - event: Withdraw(indexed uint256,indexed address,indexed address,uint256)
+          handler: handleWithdraw
+      file: ./src/mappings/ztaking-pool.ts

--- a/subgraphs/hemi-stake-operations-subgraph/tsconfig.json
+++ b/subgraphs/hemi-stake-operations-subgraph/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json",
+  "include": ["src", "tests"]
+}

--- a/webapp/utils/subgraph.ts
+++ b/webapp/utils/subgraph.ts
@@ -25,30 +25,30 @@ const request = <TResponse, TSchema extends Schema = Schema>(
     method: 'POST',
   }) satisfies Promise<TResponse>
 
-/**
- * Use this to override the full url - for example, when using subgraph studio
- * or a local subgraph
- */
-const subgraphUrls = {
-  [hemi.id]: process.env.NEXT_PUBLIC_SUBGRAPH_HEMI_URL,
-  [hemiSepolia.id]: process.env.NEXT_PUBLIC_SUBGRAPH_HEMI_SEPOLIA_URL,
-  [mainnet.id]: process.env.NEXT_PUBLIC_SUBGRAPH_MAINNET_URL,
-  [sepolia.id]: process.env.NEXT_PUBLIC_SUBGRAPH_SEPOLIA_URL,
-}
-
-/**
- * Subgraph Ids from the subgraphs published in Arbitrum
- */
-const subgraphIds = {
-  [hemi.id]: process.env.NEXT_PUBLIC_SUBGRAPH_HEMI_ID,
-  [hemiSepolia.id]: process.env.NEXT_PUBLIC_SUBGRAPH_HEMI_SEPOLIA_ID,
-  [mainnet.id]: process.env.NEXT_PUBLIC_SUBGRAPH_MAINNET_ID,
-  [sepolia.id]: process.env.NEXT_PUBLIC_SUBGRAPH_SEPOLIA_ID,
-}
-
 type GraphResponse<T> = { data: T }
 
-const getGraphUrl = function (chainId: Chain['id']) {
+const getTunnelSubgraphUrl = function (chainId: Chain['id']) {
+  /**
+   * Use this to override the full url - for example, when using subgraph studio
+   * or a local subgraph
+   */
+  const subgraphUrls = {
+    [hemi.id]: process.env.NEXT_PUBLIC_SUBGRAPH_HEMI_URL,
+    [hemiSepolia.id]: process.env.NEXT_PUBLIC_SUBGRAPH_HEMI_SEPOLIA_URL,
+    [mainnet.id]: process.env.NEXT_PUBLIC_SUBGRAPH_MAINNET_URL,
+    [sepolia.id]: process.env.NEXT_PUBLIC_SUBGRAPH_SEPOLIA_URL,
+  }
+
+  /**
+   * Subgraph Ids from the subgraphs published in Arbitrum
+   */
+  const subgraphIds = {
+    [hemi.id]: process.env.NEXT_PUBLIC_SUBGRAPH_HEMI_ID,
+    [hemiSepolia.id]: process.env.NEXT_PUBLIC_SUBGRAPH_HEMI_SEPOLIA_ID,
+    [mainnet.id]: process.env.NEXT_PUBLIC_SUBGRAPH_MAINNET_ID,
+    [sepolia.id]: process.env.NEXT_PUBLIC_SUBGRAPH_SEPOLIA_ID,
+  }
+
   const url = subgraphUrls[chainId]
   if (url) {
     return url
@@ -71,7 +71,7 @@ const getGraphUrl = function (chainId: Chain['id']) {
  * @returns A Promise that resolves into the last indexed block.
  */
 export const getLastIndexedBlock = function (chainId: Chain['id']) {
-  const url = getGraphUrl(chainId)
+  const url = getTunnelSubgraphUrl(chainId)
   const schema = {
     query: `{
       _meta {
@@ -135,7 +135,7 @@ export const getBtcWithdrawals = function ({
   orderDirection?: 'asc' | 'desc'
   skip?: number
 }) {
-  const url = getGraphUrl(chainId)
+  const url = getTunnelSubgraphUrl(chainId)
   // By default, graphql is capped to 100 elements. See https://github.com/directus/directus/issues/3667#issuecomment-758854070
   // Bring everything - either way, for most cases, the blockNumber will filter and only a few handful withdrawals will be brought
   const schema = {
@@ -212,7 +212,7 @@ export const getEvmDeposits = function ({
   orderDirection?: 'asc' | 'desc'
   skip?: number
 }) {
-  const url = getGraphUrl(chainId)
+  const url = getTunnelSubgraphUrl(chainId)
   // By default, graphql is capped to 100 elements. See https://github.com/directus/directus/issues/3667#issuecomment-758854070
   // Bring everything - either way, for most cases, the blockNumber will filter and only a few handful deposits will be brought
   const schema = {
@@ -290,7 +290,7 @@ export const getEvmWithdrawals = function ({
   orderDirection?: 'asc' | 'desc'
   skip?: number
 }) {
-  const url = getGraphUrl(chainId)
+  const url = getTunnelSubgraphUrl(chainId)
   // By default, graphql is capped to 100 elements. See https://github.com/directus/directus/issues/3667#issuecomment-758854070
   // Bring everything - either way, for most cases, the blockNumber will filter and only a few handful deposits will be brought
   const schema = {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the `hemi-stake-operations-subgraph` which is used to track Stake totals.

The subgraph, besides saving each stake and unstake operation, saves a summary view of the total staked position. It looks like this


```json
{
  "data": {
    "tokenStakeBalances": [
      {
        "id": "0x0c8afd1b58aa2a5bad2414b861d8a7ff898edc3a",
        "totalStaked": "1406000000000000000"
      },
      {
        "id": "0x3adf21a6cbc9ce6d5a3ea401e7bae9499d391298",
        "totalStaked": "1399000000"
      },
      {
        "id": "0xd47971c7f5b1067d25cd45d30b2c9eb60de96443",
        "totalStaked": "3140500000"
      },
      {
        "id": "0xec46e0efb2ea8152da0327a5eb3ff9a43956f13e",
        "totalStaked": "1610000000011300000000"
      }
    ]
  }
}
```

In addition to that, it also renames a function in 5351232f44225eff79c2f80679c2379c502aa082 that will be used in the next PR. In this incoming PR, this new subgraph data will be consumed to fill the "Total Stake" card

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #930

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
