### PR TITLE
Add ETH TVL

### DIFF
--- a/webapp/app/[locale]/stake/_components/manageStake/tvl.tsx
+++ b/webapp/app/[locale]/stake/_components/manageStake/tvl.tsx
@@ -1,9 +1,12 @@
 import { RenderFiatBalance } from 'components/fiatBalance'
 import { useTotalSupply } from 'hooks/useTotalSupply'
-import { StakeToken } from 'types/stake'
+import { type StakeToken } from 'types/stake'
+import { type EvmToken } from 'types/token'
 import { formatLargeFiatNumber } from 'utils/format'
+import { isNativeAddress } from 'utils/nativeToken'
+import { getWrappedEther } from 'utils/token'
 
-export const Tvl = function ({ token }: { token: StakeToken }) {
+const TokenTvl = function ({ token }: { token: EvmToken }) {
   const {
     data: supply,
     fetchStatus,
@@ -19,3 +22,17 @@ export const Tvl = function ({ token }: { token: StakeToken }) {
     />
   )
 }
+
+const EthTvl = function ({ token }: { token: EvmToken }) {
+  // For ETH, we use the WETH supply instead
+  const wrappedToken = getWrappedEther(token.chainId)
+
+  return <TokenTvl token={wrappedToken} />
+}
+
+export const Tvl = ({ token }: { token: StakeToken }) =>
+  isNativeAddress(token.address) ? (
+    <EthTvl token={token} />
+  ) : (
+    <TokenTvl token={token} />
+  )

--- a/webapp/app/[locale]/stake/_hooks/useDrawerStakeQueryString.ts
+++ b/webapp/app/[locale]/stake/_hooks/useDrawerStakeQueryString.ts
@@ -1,5 +1,4 @@
 import { parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs'
-import { Address } from 'viem'
 
 const drawerModes = ['manage', 'stake'] as const
 export type DrawerModes = (typeof drawerModes)[number]
@@ -17,7 +16,7 @@ export const useDrawerStakeQueryString = function () {
 
   const setDrawerQueryString = function (
     mode: DrawerModes | null,
-    address: Address | null,
+    address: string | null,
   ) {
     setDrawerMode(mode)
     setTokenAddress(address)

--- a/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
+++ b/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
@@ -3,6 +3,8 @@ import { HemiPublicClient, useHemiClient } from 'hooks/useHemiClient'
 import { NetworkType, useNetworkType } from 'hooks/useNetworkType'
 import { useStakeTokens } from 'hooks/useStakeTokens'
 import { StakeToken } from 'types/stake'
+import { isNativeToken } from 'utils/nativeToken'
+import { getWrappedEther } from 'utils/token'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -37,7 +39,10 @@ const getStakedBalance = ({
     }
     return hemiClient.stakedBalance({
       address,
-      tokenAddress: token.address,
+      // @ts-expect-error tokenAddress is a string Address
+      tokenAddress: isNativeToken(token)
+        ? getWrappedEther(token.chainId).address
+        : token.address,
     })
   }
 

--- a/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
+++ b/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
@@ -98,6 +98,8 @@ export const useStakePositions = function () {
           ({ data, status }) =>
             status === 'success' && data.balance > BigInt(0),
         )
+        // Exclude ETH, as WETH will appear already
+        .filter(({ data }) => !isNativeToken(data))
         .map(({ data }) => data),
     }),
     queries: stakeTokens.map(token => ({

--- a/webapp/types/stake.ts
+++ b/webapp/types/stake.ts
@@ -1,5 +1,3 @@
-import { Address } from 'viem'
-
 import { type EvmToken, type Extensions } from './token'
 
 export const stakeProtocols = [
@@ -40,10 +38,7 @@ export type StakeExtensions = Omit<Extensions, 'protocol'> & {
   website: string
 }
 
-export type StakeToken = Omit<EvmToken, 'address'> & {
-  // we can override Address because we only stake erc20 (native tokens excluded), so we know for sure
-  // that address is of Address type
-  address: Address
+export type StakeToken = EvmToken & {
   balance?: bigint
   // EvmToken has a broad definition of "protocol", but for StakeToken let's make a
   // defined list of protocols that make a token a Stake one.

--- a/webapp/utils/token.ts
+++ b/webapp/utils/token.ts
@@ -3,6 +3,7 @@ import { stakeProtocols, type StakeProtocols, StakeToken } from 'types/stake'
 import { EvmToken, Token } from 'types/token'
 import {
   type Address,
+  type Chain,
   type Client,
   erc20Abi,
   isAddress,
@@ -106,3 +107,8 @@ export const getTokenPrice = function (
   const price = prices?.[priceSymbol] ?? '0'
   return price
 }
+
+export const getWrappedEther = (chainId: Chain['id']) =>
+  tokenList.tokens.find(
+    t => t.symbol === 'WETH' && t.chainId === chainId,
+  ) as EvmToken


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

FOLLOW UP OF #952

This PR does 2 things:

- After merging #942, it was no longer valid that the `address` of a `StakeToken` was a `0x${string}` type (`Address`) because we enabled Native token staking (which has no real Address). So for that, I updated the type in 6a3543dec937f8be3269dc74e4c3432e139657ae. This caused different places to need to be fixed. In some cases, just a suppression error (from using `string` where Address was expected) was enough. In others, I had to consider if the token was a Native one and handle that accordingly.
- 5a01ed091ee922e7b371c10c0b80c8c4beaa9efd Implements the issue to be closed, in which we show the WETH supply when staking ETH

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="471" alt="image" src="https://github.com/user-attachments/assets/a40e2b2b-92dc-4bc2-b684-f96e1db12513" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes https://github.com/hemilabs/ui-monorepo/issues/953

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
