### PR TITLE
Add missing $ sign in stake dashboard

### DIFF
--- a/webapp/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
@@ -85,7 +85,7 @@ export const TotalStaked = function () {
     if (prices === undefined) {
       return '-'
     }
-    return formatLargeFiatNumber(totalStake)
+    return `$ ${formatLargeFiatNumber(totalStake)}`
   }
 
   return (
@@ -124,7 +124,7 @@ export const YourStake = function () {
         ),
       Big(0),
     )
-    return formatFiatNumber(userPosition.toFixed())
+    return `$ ${formatFiatNumber(userPosition.toFixed())}`
   }
 
   return (


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

After adding the "Total Staked on Hemi" and "Your Stake" cards prices in USD, we were missing the `$` sign. This PR adds that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Mainnet

<img width="1617" alt="image" src="https://github.com/user-attachments/assets/9aca76bc-7e52-42e5-9714-4136a4e45c9f" />

Testnet

<img width="1639" alt="image" src="https://github.com/user-attachments/assets/501d11ed-77a8-4ffb-b9dc-9e9a6302fc7c" />


### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
