### PR TITLE
Fix Hemi Hatchlings url for mainnet

### DIFF
--- a/webapp/app/[locale]/demos/page.tsx
+++ b/webapp/app/[locale]/demos/page.tsx
@@ -64,7 +64,11 @@ const Demos = function () {
           event="demos - hatchlings"
           heading={t('hemihatchlings.heading')}
           headingColor="white"
-          href="https://testnet.hatchlings.hemi.xyz"
+          href={
+            networkType === 'mainnet'
+              ? 'https://hemihatchlings.hemi.xyz'
+              : 'https://testnet.hatchlings.hemi.xyz'
+          }
           icon={hemiHatchlingsIcon}
           subHeading={t('hemihatchlings.sub-heading')}
         />


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The Hemi Hatchlings URL for Mainnet is different for Testnet. This PR fixes that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Testnet

<img width="892" alt="image" src="https://github.com/user-attachments/assets/b0dfd9df-7268-4a44-8366-a13135ac57e9" />

Mainnet

<img width="899" alt="image" src="https://github.com/user-attachments/assets/81b2fa5a-12f0-487c-b293-8bbe9104cb2a" />


### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
