### PR TITLE
Fix the symbol used to get the USDC.e price

### DIFF
--- a/webapp/tokenList/stakeTokens.ts
+++ b/webapp/tokenList/stakeTokens.ts
@@ -142,7 +142,7 @@ export const stakeWhiteList: Partial<
     // USDC
     '0xad11a8BEb98bbf61dbb1aa0F6d6F2ECD87b35afA': {
       // token symbol in hemi mainnet is usdc.e
-      priceSymbol: 'usdc.e',
+      priceSymbol: 'usdc',
       protocol: 'circle',
       rewards: ['hemi'],
       website: websitesMap.circle,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The USDC.e token price was missing because the symbol used to get it was incorrectly set. This PR fixes that.