### PR TITLE
Fix Eslint warnings not firing on lint-staged

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,8 @@
 {
   "!(*.{js,md,ts,tsx}|package.json)": ["prettier --ignore-unknown --write"],
-  "*.{js,md,ts,tsx}": ["eslint --cache --fix --quiet", "prettier --write"],
+  "*.{js,md,ts,tsx}": [
+    "eslint --cache --fix --max-warnings 0",
+    "prettier --write"
+  ],
   "package.json": ["better-sort-package-json", "prettier --write"]
 }

--- a/webapp/hooks/useSyncHistory/reducer.ts
+++ b/webapp/hooks/useSyncHistory/reducer.ts
@@ -28,6 +28,9 @@ export const historyReducer = function (
   state: HistoryReducerState,
   action: HistoryActions,
 ): HistoryReducerState {
+  // Disabling "complexity" rule as this comes from being many actions for the reducer.
+  // I don't think using an object mapping (which would pass the rule) would make this more readable.
+  // eslint-disable-next-line complexity
   const getNewState = function (): Omit<HistoryReducerState, 'status'> {
     const { type } = action
     switch (type) {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Eslint warnings were silent when linting files through `lint-staged`. While this will prevent committing files with warnings, in the end of the day, it is the correct call. Either silence the warning (Acceptable in some cases), or fix it. The `--quiet` option was removed because, if there were warnings committed, it would fail, but it wouldn't show which the warnings were 😆 

There was also a historic warning that I silenced after seeing there tons of times in CI. I don't think it would improve readability fixing this, so I am suppressing it.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
