### PR TITLE
Add extra space to navbar, improve cmc attribution

### DIFF
--- a/webapp/app/[locale]/_components/navbar/_components/cmcAttribution.tsx
+++ b/webapp/app/[locale]/_components/navbar/_components/cmcAttribution.tsx
@@ -6,7 +6,10 @@ const cssLink = 'text-orange-500 hover:text-orange-700'
 export const CmcAttribution = function () {
   const t = useTranslations('navbar')
   return (
-    <p className="font-base mx-auto pt-4 text-center text-xs text-neutral-400 md:w-full md:text-left">
+    <p
+      className="font-base mx-auto items-center pt-4 text-center text-xs text-neutral-400
+      md:w-full md:text-left lg:flex lg:items-center lg:justify-between"
+    >
       {t.rich('data-attribution', {
         link: (chunk: string) => (
           <ExternalLink className={cssLink} href="https://coinmarketcap.com/">

--- a/webapp/app/[locale]/_components/navbar/index.tsx
+++ b/webapp/app/[locale]/_components/navbar/index.tsx
@@ -44,7 +44,7 @@ export const Navbar = function () {
   const href = useTunnelOperationByConnectedWallet()
 
   return (
-    <div className="md:h-98vh flex h-[calc(100dvh-56px)] flex-col px-3 pt-3 md:pt-0 [&>*]:md:ml-4 [&>*]:md:pr-4">
+    <div className="md:h-98vh flex h-[calc(100dvh-56px)] flex-col px-3 pt-3 md:pt-0 [&>*]:md:ml-3 [&>*]:md:pr-3">
       <div className="hidden h-24 items-center justify-center md:flex">
         <div className="flex h-1/3 w-1/3">
           <Link className="w-full" href={href}>


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

After discussing with Nahuel about [this comment](https://github.com/hemilabs/ui-monorepo/pull/969#issuecomment-2701956746) in PR #969, I'm applying this to improve the CMC attribution and give a bit more space on the navbar (4px extra per side)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/b6fe81a1-4fc1-409e-a060-39065e3f44a2

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
