### PR TITLE
Fixed transaction status column width

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/table.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/table.tsx
@@ -356,12 +356,15 @@ const columnsBuilder = (
   },
   {
     accessorKey: 'status',
-    cell: ({ row }) =>
-      isDeposit(row.original) ? (
-        <DepositStatus deposit={row.original} />
-      ) : (
-        <WithdrawStatus withdrawal={row.original} />
-      ),
+    cell: ({ row }) => (
+      <div className="w-36 text-wrap 2xl:w-48">
+        {isDeposit(row.original) ? (
+          <DepositStatus deposit={row.original} />
+        ) : (
+          <WithdrawStatus withdrawal={row.original} />
+        )}
+      </div>
+    ),
     header: () => <Header text={t('column-headers.status')} />,
     id: 'status',
   },


### PR DESCRIPTION
### Description

Fixed transaction status column width on Transaction History table

### Screenshots

Mobile:
<img width="425" alt="Captura de Tela 2025-03-06 às 13 36 17" src="https://github.com/user-attachments/assets/a2d8b2d2-3a2d-4a61-a278-346b4317a8e8" />

Laptop:
<img width="1180" alt="Captura de Tela 2025-03-06 às 13 37 13" src="https://github.com/user-attachments/assets/c5a043f4-585b-441e-812f-e08a27703254" />

Desktop:
![Captura de Tela 2025-03-06 às 13 41 24](https://github.com/user-attachments/assets/17c9de6f-a05c-4f44-bae4-23aa3e8c233f)


### Related issue(s)

Closes #696

### Checklist

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
