### PR TITLE
Set networkType url parameter to cryptochords

### DIFF
--- a/webapp/app/[locale]/demos/page.tsx
+++ b/webapp/app/[locale]/demos/page.tsx
@@ -78,7 +78,7 @@ const Demos = function () {
           event="demos - cryptochords"
           heading={t('cryptochords.heading')}
           headingColor="white"
-          href="https://cryptochords.hemi.xyz"
+          href={`https://cryptochords.hemi.xyz?networkType=${networkType}`}
           icon={cryptoChordsIcon}
           subHeading={t('cryptochords.sub-heading')}
         />


### PR DESCRIPTION
### Description

This PR adds networkType to open Cryptochords on the properly network.

### Related issue(s)

Closes #983 
Fixes #983 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
