### PR TITLE
Add z-index to 'Stake and Earn' card

### DIFF
--- a/webapp/app/[locale]/_components/stakeAndEarnCard.tsx
+++ b/webapp/app/[locale]/_components/stakeAndEarnCard.tsx
@@ -82,7 +82,7 @@ export const StakeAndEarnCard = function () {
   }
 
   return (
-    <div className="group/card-image h-22 fixed bottom-8 right-8 max-w-64 cursor-pointer">
+    <div className="group/card-image h-22 fixed bottom-8 right-8 z-10 max-w-64 cursor-pointer">
       <Link href="/stake" onClick={navigate}>
         <Image
           alt="Stake and Earn"

--- a/webapp/app/[locale]/_components/stakeAndEarnCard.tsx
+++ b/webapp/app/[locale]/_components/stakeAndEarnCard.tsx
@@ -14,17 +14,14 @@ import { isStakeEnabledOnTestnet } from 'utils/stake'
 import stakeAndEarn from '../_images/stakeAndEarn.png'
 import stakeAndEarnHovered from '../_images/stakeAndEarnHovered.png'
 
-const appearingElementsCss =
-  'opacity-0 transition-opacity duration-300 group-hover/card-image:visible group-hover/card-image:opacity-100'
-
 const CloseButton = ({
   onClick,
 }: {
   onClick: (e: MouseEvent<HTMLButtonElement>) => void
 }) => (
   <button
-    className={`${appearingElementsCss} group/close-button absolute right-2.5 top-2 z-10 flex h-5
-    w-5 items-center justify-center rounded-full bg-white/50 backdrop-blur-sm`}
+    className="group/close-button absolute right-2.5 top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-white/50
+    backdrop-blur-sm md:opacity-0 md:transition-opacity md:duration-300 md:group-hover/card-image:visible md:group-hover/card-image:opacity-100"
     onClick={onClick}
     type="button"
   >
@@ -92,7 +89,7 @@ export const StakeAndEarnCard = function () {
         />
         <Image
           alt="Stake and Earn"
-          className={appearingElementsCss}
+          className="opacity-0 transition-opacity duration-300 group-hover/card-image:visible group-hover/card-image:opacity-100"
           quality={100}
           src={stakeAndEarnHovered}
         />


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds a `z-index` so the "Stake and Earn" card appears on top. As Nahuel said, the user can close it / hide it.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

![image](https://github.com/user-attachments/assets/b7a855d0-7001-42d3-9da0-fae637d621bc)

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #964

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
