### PR TITLE
Drop 'Network' when referencing Hemi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16006,9 +16006,9 @@
       "link": true
     },
     "node_modules/hemi-viem": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.3.1.tgz",
-      "integrity": "sha512-A4yLRsUkhIshU88jmM7JKojefTZmxKeswLQL/p6JfKRdB5Xw/w5UrpLLWrD2U6KprzweQSYcyB5KcAeHD0uOEA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.3.2.tgz",
+      "integrity": "sha512-otAAVg8ztYecWrg+m3r57FuPOj/U3rzPXYO7ZMWRUXL5AJrY9p5ET1+mRuP3jf2dySNbcmlDdlFxk1/f2zdYfw==",
       "license": "MIT",
       "peerDependencies": {
         "viem": "^2.x"
@@ -27581,7 +27581,7 @@
         "eth-rpc-cache": "2.0.0",
         "fetch-plus-plus": "1.0.0",
         "hemi-socials": "1.0.0",
-        "hemi-viem": "2.3.1",
+        "hemi-viem": "2.3.2",
         "hemi-viem-stake-actions": "1.0.0",
         "javascript-time-ago": "2.5.10",
         "lodash": "4.17.21",

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "add": "Add",
-    "add-hemi-to-wallet": "Add Hemi Network to your wallet",
+    "add-hemi-to-wallet": "Add Hemi to your wallet",
     "added": "Added",
     "amount": "Amount",
     "approving": "Approving...",
@@ -73,7 +73,7 @@
     },
     "cryptochords": {
       "heading": "Crypto Chords",
-      "sub-heading": "An audio-visual depiction of transactions on the Hemi Network"
+      "sub-heading": "An audio-visual depiction of transactions on the Hemi network"
     },
     "demos": {
       "heading": "DEMOS",
@@ -86,7 +86,7 @@
     },
     "purefinance": {
       "heading": "Pure Finance",
-      "sub-heading": "Utility and smart contract interaction built directly into the Hemi Network"
+      "sub-heading": "Utility and smart contract interaction built directly into the Hemi network"
     },
     "sub-heading": "Learn and explore with Hemi developer demos"
   },

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "add": "Agregar",
-    "add-hemi-to-wallet": "Añadir la red Hemi a su billetera",
+    "add-hemi-to-wallet": "Añadir Hemi a su billetera",
     "added": "Agregada",
     "amount": "Monto",
     "approving": "Aprobando...",
@@ -73,7 +73,7 @@
     },
     "cryptochords": {
       "heading": "Crypto Chords",
-      "sub-heading": "Una representación audiovisual de transacciones en la Red Hemi"
+      "sub-heading": "Una representación audiovisual de transacciones en la red Hemi"
     },
     "demos": {
       "heading": "DEMOS",
@@ -86,7 +86,7 @@
     },
     "purefinance": {
       "heading": "Pure Finance",
-      "sub-heading": "Utilidad e interacciones de contratos inteligentes integrados directamente en la Red Hemi"
+      "sub-heading": "Utilidad e interacciones de contratos inteligentes integrados directamente en la red Hemi"
     },
     "sub-heading": "Aprenda y explore con las Demos de desarrolladores de Hemi"
   },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,7 @@
     "eth-rpc-cache": "2.0.0",
     "fetch-plus-plus": "1.0.0",
     "hemi-socials": "1.0.0",
-    "hemi-viem": "2.3.1",
+    "hemi-viem": "2.3.2",
     "hemi-viem-stake-actions": "1.0.0",
     "javascript-time-ago": "2.5.10",
     "lodash": "4.17.21",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Dropping references to "Hemi Network", by removing "Network" or using "Hemi network"

<img width="711" alt="image" src="https://github.com/user-attachments/assets/fc74a5bd-3b70-4f75-aa62-4afc7b33ad95" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #990

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
