### PR TITLE
Show '-' in 'Your Stake' if user is disconnected

### DIFF
--- a/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
+++ b/webapp/app/[locale]/stake/_hooks/useStakedBalance.ts
@@ -92,7 +92,7 @@ export const useStakePositions = function () {
 
   return useQueries({
     combine: results => ({
-      loading: results.some(({ isPending }) => isPending),
+      loading: results.some(({ isLoading }) => isLoading),
       tokensWithPosition: results
         .filter(
           ({ data, status }) =>

--- a/webapp/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
+++ b/webapp/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
@@ -8,6 +8,7 @@ import { ReactNode } from 'react'
 import { formatFiatNumber, formatTVL } from 'utils/format'
 import { getTokenPrice } from 'utils/token'
 import { formatUnits } from 'viem'
+import { useAccount } from 'wagmi'
 
 import { useStakePositions } from '../../../_hooks/useStakedBalance'
 import { useTotalStaked } from '../../../_hooks/useTotalStaked'
@@ -106,15 +107,12 @@ export const TotalStaked = function () {
 }
 
 export const YourStake = function () {
+  const { isConnected } = useAccount()
   const { data: prices, isPending: loadingPrices } = useTokenPrices()
   const { loading: loadingPosition, tokensWithPosition } = useStakePositions()
   const t = useTranslations('stake-page.dashboard')
 
   const getPosition = function () {
-    if (prices === undefined) {
-      // if Prices API is missing, return "-"
-      return '-'
-    }
     const userPosition = tokensWithPosition.reduce(
       (acc, staked) =>
         acc.plus(
@@ -127,13 +125,25 @@ export const YourStake = function () {
     return `$ ${formatFiatNumber(userPosition.toFixed())}`
   }
 
+  const getPoints = function () {
+    if (!isConnected) {
+      return '-'
+    }
+    if (loadingPosition || loadingPrices) {
+      return '...'
+    }
+    if (prices === undefined) {
+      // if Prices API is missing, return "-"
+      return '-'
+    }
+    return getPosition()
+  }
+
   return (
     <Container>
       <div className="flex flex-shrink-0 flex-col gap-y-3 p-6">
         <Heading heading={t('your-stake')} />
-        <Points
-          points={loadingPosition || loadingPrices ? '...' : getPosition()}
-        />
+        <Points points={getPoints()} />
       </div>
       <Image
         alt="Stake icon"


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR shows `-` in the "Your Stake" section if the user is not connected to the portal

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/7fcab8de-260f-42ac-a4a8-5e842554a8fd

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #998

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
