### PR TITLE
Add and whitelist uniBTC to stake on mainnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2659,10 +2659,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@hemilabs/token-list": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@hemilabs/token-list/-/token-list-1.11.1.tgz",
-      "integrity": "sha512-uCgaJyXxjJZS6RZvkYoJipsOP/5GsjOwfjlz3z2JJsi4Dzq0ygpB/0bl5ZBUbh/ZPbw6NPPrO8bCfQnvijtizg==",
-      "license": "MIT",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@hemilabs/token-list/-/token-list-1.12.0.tgz",
+      "integrity": "sha512-6Wn/LzvD9JERMERAc/ETXS5LCGe4646hu7kfQ8WBZrcxKydl3KsJoNpe5hi99lqE4dcKaeXnnAZKBp2FpZEMYw==",
       "engines": {
         "node": ">=20"
       }
@@ -27566,7 +27565,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@eth-optimism/sdk": "3.2.1",
-        "@hemilabs/token-list": "1.11.1",
+        "@hemilabs/token-list": "1.12.0",
         "@rainbow-me/rainbowkit": "2.0.1",
         "@sentry/nextjs": "8.35.0",
         "@tanstack/react-query": "5.24.8",

--- a/patches/@hemilabs+token-list+1.12.0.patch
+++ b/patches/@hemilabs+token-list+1.12.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json b/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
-index ba2991f..d354e9b 100644
+index e112ffd..11e9457 100644
 --- a/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
 +++ b/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
 @@ -173,8 +173,7 @@
@@ -86,7 +86,7 @@ index ba2991f..d354e9b 100644
        },
        "logoURI": "https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/usdt.svg",
        "name": "USDT",
-@@ -400,8 +409,7 @@
+@@ -402,8 +411,7 @@
        "chainId": 43111,
        "decimals": 8,
        "extensions": {
@@ -96,7 +96,7 @@ index ba2991f..d354e9b 100644
        },
        "logoURI": "https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/obtc.svg",
        "name": "Obelisk BTC",
-@@ -415,8 +423,7 @@
+@@ -417,8 +425,7 @@
        "name": "pumpBTC",
        "symbol": "pumpBTC",
        "extensions": {
@@ -106,7 +106,7 @@ index ba2991f..d354e9b 100644
        }
      },
      {
-@@ -427,8 +434,7 @@
+@@ -429,8 +436,7 @@
        "name": "Lorenzo stBTC",
        "symbol": "stBTC",
        "extensions": {
@@ -116,7 +116,7 @@ index ba2991f..d354e9b 100644
        }
      },
      {
-@@ -447,11 +453,16 @@
+@@ -460,11 +466,16 @@
        "chainId": 743111,
        "decimals": 8,
        "extensions": {
@@ -136,7 +136,7 @@ index ba2991f..d354e9b 100644
      },
      {
        "address": "0x3Adf21A6cbc9ce6D5a3ea401E7Bae9499d391298",
-@@ -490,8 +501,8 @@
+@@ -503,8 +514,8 @@
        "chainId": 743111,
        "decimals": 18,
        "logoURI": "https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/hdai.svg",

--- a/webapp/app/[locale]/stake/protocols/protocolImages.ts
+++ b/webapp/app/[locale]/stake/protocols/protocolImages.ts
@@ -41,6 +41,7 @@ export const protocolImages: Record<StakeProtocols, StaticImageData> = {
   stakeStone,
   tether,
   threshold,
+  uniBtc: bedRock,
   uniRouter,
   wbtc,
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@eth-optimism/sdk": "3.2.1",
-    "@hemilabs/token-list": "1.11.1",
+    "@hemilabs/token-list": "1.12.0",
     "@rainbow-me/rainbowkit": "2.0.1",
     "@sentry/nextjs": "8.35.0",
     "@tanstack/react-query": "5.24.8",

--- a/webapp/tokenList/stakeTokens.ts
+++ b/webapp/tokenList/stakeTokens.ts
@@ -22,6 +22,7 @@ const websitesMap: Partial<Record<StakeExtensions['protocol'], string>> = {
   stakeStone: 'https://stakestone.io/#/home',
   tether: 'https://tether.to/en',
   threshold: 'https://threshold.network',
+  uniBtc: 'https://app.bedrock.technology/unibtc?tab=swap_deposit',
   uniRouter: 'https://www.unirouter.io/#',
   wbtc: 'https://www.wbtc.network',
 }
@@ -138,6 +139,13 @@ export const stakeWhiteList: Partial<
       priceSymbol: 'btc',
       rewards: ['hemi', 'unirouter', 'bsquared'],
       website: websitesMap.uniRouter,
+    },
+    // uniBTC
+    '0xF9775085d726E782E83585033B58606f7731AB18': {
+      protocol: 'uniBtc',
+      priceSymbol: 'btc',
+      rewards: ['hemi', 'bedrock'],
+      website: websitesMap.uniBtc,
     },
     // USDC
     '0xad11a8BEb98bbf61dbb1aa0F6d6F2ECD87b35afA': {

--- a/webapp/types/stake.ts
+++ b/webapp/types/stake.ts
@@ -19,6 +19,7 @@ export const stakeProtocols = [
   'stakeStone',
   'tether',
   'threshold',
+  'uniBtc',
   'uniRouter',
   'wbtc',
 ] as const


### PR DESCRIPTION
### Description

As the title says, this PR adds and whitelists uniBTC token to be staked on mainnet.

### Screenshots

<img width="1107" alt="Captura de Tela 2025-03-10 às 15 32 41" src="https://github.com/user-attachments/assets/f31bcb16-81ce-4ba7-9997-6a9de614265e" />


### Related issue(s)

Closes #997 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
