### PR TITLE
Prevent leading/trailing spaces to crash input

### DIFF
--- a/webapp/test/utils/form.test.ts
+++ b/webapp/test/utils/form.test.ts
@@ -46,4 +46,14 @@ describe('sanitizeAmount', function () {
     const result = sanitizeAmount('00.123')
     expect(result).toEqual({ value: '0.123' })
   })
+
+  it('should return 0.123 if input is "0.123 " (Trailing spaces)', function () {
+    const result = sanitizeAmount('0.123   ')
+    expect(result).toEqual({ value: '0.123' })
+  })
+
+  it('should return 0.123 if input is " 0.123 " (Leading spaces)', function () {
+    const result = sanitizeAmount('    0.123')
+    expect(result).toEqual({ value: '0.123' })
+  })
 })

--- a/webapp/utils/form.ts
+++ b/webapp/utils/form.ts
@@ -13,9 +13,12 @@ export const sanitizeAmount = function (input: string) {
     return { error }
   }
 
-  // Remove any leading zeroes to address cases like "01", that must be
-  // converted to "1".
-  const _value = input.replace(/^0+/, '')
+  const _value = input
+    // Remove any leading zeroes to address cases like "01", that must be
+    // converted to "1".
+    .replace(/^0+/, '')
+    // Remove any empty spaces at the beginning or end of the input
+    .trim()
   // if input ends with a dot, add a zero so it is a valid number.
   if (_value.startsWith('.')) {
     return { value: `0${_value}` }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The app crashes when typing a leading / trailing space in the input. This is because, for [notJoi](https://github.com/hemilabs/ui-monorepo/blob/main/webapp/utils/notJoi.ts), `  123   ` (note the spaces) is a valid number. And this is because for `parseFloat`, this is also a valid number.

<img width="163" alt="image" src="https://github.com/user-attachments/assets/a56e8803-13cb-43a9-bf56-432aad316052" />

Spaces in the middle are invalid numbers (for example, if the user pastes an invalid number), so that's not an issue. 

This PR handles that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

I can't prove in a video that I'm pressing the space bar 😅, but they are now ignored.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1027

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
