### PR TITLE
Prevent crash when clicking 'Max' on btc tunnel

### DIFF
--- a/webapp/components/setMaxBalance.tsx
+++ b/webapp/components/setMaxBalance.tsx
@@ -83,6 +83,7 @@ export const SetMaxBtcBalance = function ({
     isLoadingBalance ||
     isLoadingFees ||
     btcBalance === 0 ||
+    fees === undefined ||
     btcBalance <= fees
 
   const handleClick = () =>

--- a/webapp/hooks/useEstimateBtcFees.ts
+++ b/webapp/hooks/useEstimateBtcFees.ts
@@ -47,7 +47,7 @@ export const useEstimateBtcFees = function (from: Account) {
 
   return {
     fees:
-      isLoading || utxos === undefined
+      isLoading || utxos === undefined || feePrices === undefined
         ? undefined
         : Math.ceil(feePrices.fastestFee * calculateTxSize(utxos)),
     isLoading,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

It seems some users are getting a `RangeError: Not a Number` when clicking `Max` on the btc tunnel. I think this PR solves that

First, it prevents the app crashing if btc `fees` can't be retrieved. After that, it also disables the `Max` if `fees` are undefined

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1029

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
