### PR TITLE
Filter out third party errors from Sentry

### DIFF
--- a/webapp/.env
+++ b/webapp/.env
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_THE_GRAPH_API_URL="https://gateway.thegraph.com/api"
 NEXT_PUBLIC_BTC_INPUTS_SIZE=105
 NEXT_PUBLIC_BTC_OUTPUTS_SIZE=25
+NEXT_PUBLIC_SENTRY_FILTER_KEY_ID="portal-file-identifier-sentry"

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -59,6 +59,10 @@ const sentryOptions = {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   release,
+  // eslint-disable-next-line camelcase
+  unstable_sentryWebpackPluginOptions: {
+    applicationKey: process.env.NEXT_PUBLIC_SENTRY_FILTER_KEY_ID,
+  },
   widenClientFileUpload: true,
 }
 

--- a/webapp/sentry.client.config.ts
+++ b/webapp/sentry.client.config.ts
@@ -30,6 +30,13 @@ function enableSentry() {
     enabled,
     ignoreErrors,
     integrations: [
+      // See https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/filtering/#using-thirdpartyerrorfilterintegration
+      Sentry.thirdPartyErrorFilterIntegration({
+        // Should skip all errors that are entirely made of third party frames in the stack trace.
+        // Let's start with this, we can make it more strict if needed.
+        behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
+        filterKeys: [process.env.NEXT_PUBLIC_SENTRY_FILTER_KEY_ID],
+      }),
       // This overrides the default implementation of the RewriteFrames
       // integration from sentry/nextjs. It adds the decodeURI() to fix a mismatch
       // of sourceMaps in reported issues.


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds an integration that should filter out errors from Chrome extensions. [Further info](https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/filtering/#using-thirdpartyerrorfilterintegration).

The Filter key does not need to be secret.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes visible to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #715 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
