### PR TITLE
Added USD price to wallet and review drawers

### DIFF
--- a/webapp/components/connectWallets/wallets.tsx
+++ b/webapp/components/connectWallets/wallets.tsx
@@ -12,6 +12,7 @@ import {
   ConnectedEvmChain,
 } from 'components/connectedWallet/connectedAccount'
 import { ExternalLink } from 'components/externalLink'
+import { FiatBalance } from 'components/fiatBalance'
 import { Chevron } from 'components/icons/chevron'
 import { useBitcoin } from 'hooks/useBitcoin'
 import { useChainIsSupported } from 'hooks/useChainIsSupported'
@@ -161,14 +162,20 @@ export const EvmWallet = function () {
         walletType={t('evm-wallet')}
       >
         {chainSupported ? (
-          <Balance
-            balance={
-              balance !== undefined
-                ? formatUnits(balance.value, balance.decimals)
-                : undefined
-            }
-            token={getNativeToken(chain.id)}
-          />
+          <div className="flex items-end justify-between">
+            <Balance
+              balance={
+                balance !== undefined
+                  ? formatUnits(balance.value, balance.decimals)
+                  : undefined
+              }
+              token={getNativeToken(chain.id)}
+            />
+            <div className="flex items-center gap-x-1 pr-2 font-normal text-neutral-500">
+              <span>$</span>
+              <FiatBalance token={getNativeToken(chain.id)} />
+            </div>
+          </div>
         ) : (
           <ConnectToSupportedChain />
         )}

--- a/webapp/components/reviewOperation/amount.tsx
+++ b/webapp/components/reviewOperation/amount.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { DisplayAmount } from 'components/displayAmount'
+import { FiatBalance } from 'components/fiatBalance'
 import { useTranslations } from 'next-intl'
 import { Token } from 'types/token'
 import { formatUnits } from 'viem'
@@ -15,11 +16,17 @@ export const Amount = function ({ token, value }: Props) {
   return (
     <div className="flex items-center justify-between text-sm font-medium">
       <span className="text-neutral-500">{t('total-amount')}</span>
-      <div className="text-neutral-950">
-        <DisplayAmount
-          amount={formatUnits(BigInt(value), token?.decimals ?? 18)}
-          token={token}
-        />
+      <div className="flex gap-x-1">
+        <div className="text-neutral-950">
+          <DisplayAmount
+            amount={formatUnits(BigInt(value), token?.decimals ?? 18)}
+            token={token}
+          />
+        </div>
+        <div className="flex items-center gap-x-1 font-normal text-neutral-500">
+          <span>($</span>
+          <FiatBalance token={token} />)
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
### Description

Added USD prices texts as following:

✅  1. Connect Wallet drawer [Approved by @dvnahuel]:

<img width="468" alt="Captura de Tela 2025-03-19 às 13 22 09" src="https://github.com/user-attachments/assets/3c400e19-3afb-4895-927b-5a104b5178a0" />

---

✅ 2. Review Operation drawer [Approved by @dvnahuel]:

<img width="468" alt="Captura de Tela 2025-03-19 às 13 48 45" src="https://github.com/user-attachments/assets/fd782534-cb38-49c8-957d-03e640cdcb01" />

---

❌ 3. Tunnel Form input [Rejected by @dvnahuel as it will change for v3]:

<img width="468" alt="Captura de Tela 2025-03-19 às 13 39 21" src="https://github.com/user-attachments/assets/3a8a3127-be72-4ea6-84cc-093111aa1128" />

---

❌ 4. Stake Form input [Rejected by @dvnahuel as it will change for v3]:

<img width="468" alt="Captura de Tela 2025-03-19 às 15 59 18" src="https://github.com/user-attachments/assets/621c98e8-737e-4c7f-bc47-3bf307d03e44" />

---

❌ 5. The transaction history (Could not get the USD price point in the past)

---

### Related issue(s)

Related to #913

### Checklist

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
