### PR TITLE
Minor changes pre react 19

### DIFF
--- a/webapp/app/[locale]/_components/analytics.tsx
+++ b/webapp/app/[locale]/_components/analytics.tsx
@@ -8,7 +8,7 @@ import { useNetworkType } from 'hooks/useNetworkType'
 import { useUmami } from 'hooks/useUmami'
 import { usePathname } from 'next/navigation'
 import { useLocale } from 'next-intl'
-import { ReactNode, useCallback, useEffect } from 'react'
+import { ComponentProps, useCallback, useEffect } from 'react'
 import { useConfig, useAccountEffect as useEvmAccountEffect } from 'wagmi'
 
 const GlobalTracking = function () {
@@ -77,7 +77,9 @@ const GlobalTracking = function () {
   return null
 }
 
-export const Analytics = function ({ children }: { children: ReactNode }) {
+export const Analytics = function ({
+  children,
+}: Pick<ComponentProps<typeof UmamiAnalyticsProvider>, 'children'>) {
   const locale = useLocale()
 
   const removeLocaleAndTrailingSlash = (url: string) =>

--- a/webapp/app/[locale]/_components/appOverlays.tsx
+++ b/webapp/app/[locale]/_components/appOverlays.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { featureFlags } from 'app/featureFlags'
+import dynamic from 'next/dynamic'
+
+const MainnetLiveModal = dynamic(
+  () => import('components/mainnetLiveModal').then(mod => mod.MainnetLiveModal),
+  {
+    ssr: false,
+  },
+)
+
+const StakeAndEarnCard = dynamic(
+  () => import('./stakeAndEarnCard').then(mod => mod.StakeAndEarnCard),
+  {
+    ssr: false,
+  },
+)
+
+export const AppOverlays = () => (
+  <>
+    {featureFlags.stakeCampaignEnabled && <StakeAndEarnCard />}
+    <MainnetLiveModal />
+  </>
+)

--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -4,13 +4,11 @@ import 'react-loading-skeleton/dist/skeleton.css'
 
 import { ConnectWalletDrawerProvider } from 'app/context/connectWalletDrawerContext'
 import { TunnelHistoryProvider } from 'app/context/tunnelHistoryContext'
-import { featureFlags } from 'app/featureFlags'
 import { interDisplay, interVariable } from 'app/fonts/index'
 import { locales, type Locale } from 'app/i18n'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { WalletsContext } from 'context/walletsContext'
 import { Metadata } from 'next'
-import dynamic from 'next/dynamic'
 import { notFound } from 'next/navigation'
 import { NextIntlClientProvider } from 'next-intl'
 import { PropsWithChildren, Suspense } from 'react'
@@ -18,22 +16,8 @@ import { SkeletonTheme } from 'react-loading-skeleton'
 
 import { Analytics } from './_components/analytics'
 import { AppLayout } from './_components/appLayout'
+import { AppOverlays } from './_components/appOverlays'
 import { Navbar } from './_components/navbar'
-
-const MainnetLiveModal = dynamic(
-  () => import('components/mainnetLiveModal').then(mod => mod.MainnetLiveModal),
-  {
-    ssr: false,
-  },
-)
-
-const StakeAndEarnCard = dynamic(
-  () =>
-    import('./_components/stakeAndEarnCard').then(mod => mod.StakeAndEarnCard),
-  {
-    ssr: false,
-  },
-)
 
 type PageProps = {
   params: { locale: Locale }
@@ -90,11 +74,7 @@ export default async function RootLayout({
                         </div>
                         <AppLayout>
                           <ErrorBoundary>{children}</ErrorBoundary>
-                          {/* Fixed card image */}
-                          {featureFlags.stakeCampaignEnabled && (
-                            <StakeAndEarnCard />
-                          )}
-                          <MainnetLiveModal />
+                          <AppOverlays />
                         </AppLayout>
                       </div>
                     </Analytics>


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

I did a quick check to see how easy was to upgrade to React 19. It was not easy as some libraries we depend on throw some conflicts with the newest type definitions. As part of this check, I did 2 minor changes that I'm committing here so we don't need to do in the future

- One is that using dynamic import with `ssr: false` only works on `'use client'` files in `next@15`. As the root layout can only be a server side component (Even though we're a static page 😆 ), I had to move them to a new file
- There's a conflict with the type definition of `ReactNode` between React's versions. So I updated it so `UmamiAnalyticsProvider` usage just uses the one that the library provides.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
