### PR TITLE
Do not hide 'Earn points' card on clicking it

### DIFF
--- a/webapp/app/[locale]/_components/earnCard.tsx
+++ b/webapp/app/[locale]/_components/earnCard.tsx
@@ -52,15 +52,12 @@ export const EarnCard = function () {
     return null
   }
 
-  const hideCard = function <T extends MouseEvent>(e: T) {
+  const close = function (e: MouseEvent<HTMLButtonElement>) {
     e.preventDefault()
     e.stopPropagation()
 
     setHideEarnAndStakeLink(true)
-  }
 
-  const close = function (e: MouseEvent<HTMLButtonElement>) {
-    hideCard(e)
     track?.('stake - close earn points card')
   }
 
@@ -69,8 +66,6 @@ export const EarnCard = function () {
   const navigate = function (e: MouseEvent<HTMLAnchorElement>) {
     e.preventDefault()
     e.stopPropagation()
-
-    hideCard(e)
 
     track?.('stake - click earn points card')
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR updates the "Earn Points on Hemi" card so it doesn't hide after the user clicks it. This is an inherited behavior from the previous card, which is linked to the Stake page. There, it made sense because it allowed the user to discover the page, so it was no longer needed.  
But as the page now links to an external site (Absinthe), we need the card to remain visible unless the user explicitly hides it.

This PR does that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/d4702ba7-1600-42c7-a4a7-ad9c85841914

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1050

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
