### PR TITLE
Update hemi points card key on storage

### DIFF
--- a/webapp/app/[locale]/_components/earnCard.tsx
+++ b/webapp/app/[locale]/_components/earnCard.tsx
@@ -37,7 +37,7 @@ const CloseButton = ({
 
 export const EarnCard = function () {
   const [hideEarnAndStakeLink, setHideEarnAndStakeLink] = useLocalStorageState(
-    'portal.hide-earn-points-card',
+    'portal.hide-earn-points-on-hemi-card',
     {
       defaultValue: false,
     },


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

After https://github.com/hemilabs/ui-monorepo/pull/1057 we replaced the "Earn and Stake" card with the new "Earn points on Hemi" card. When users clicked the old card, it would be marked as hidden, so users wouldn't see it again. This was a bug that was fixed in https://github.com/hemilabs/ui-monorepo/pull/1063 . After this PR, users would have to click on the "X" (close) instead of clicking the card to open the external link.

The bug that was fixed meant that for those users that already had clicked the card before the fix, the card wouldn't be visible again (like ever). Changing the local storage key would make this visible for all users again. We discussed with Nahuel not doing so, as the external link was having its UI revamped, so when that was the case we would have to do this again.

The external link's UI has been revamped, so we can now update the key so all users see it again (And can close it if they want to)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="331" alt="image" src="https://github.com/user-attachments/assets/69ad4fa9-aea3-453c-a7ff-4fd3159745ad" />

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
