### PR TITLE
Fix wait-hours translations rendering

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewBtcDeposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewBtcDeposit.tsx
@@ -106,8 +106,11 @@ const ReviewContent = function ({
             }
           : undefined,
       postAction: {
-        description: tCommon('wait-hours', {
-          hours: ExpectedManualConfirmationDepositTimeHours,
+        description: tCommon.rich('wait-hours', {
+          hours: () =>
+            tCommon('hours', {
+              hours: ExpectedManualConfirmationDepositTimeHours,
+            }),
         }),
         status: postActionStatusMap[depositStatus] ?? ProgressStatus.COMPLETED,
       },

--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -166,11 +166,14 @@ const ReviewContent = function ({
           }
         : undefined,
     postAction: {
-      description: tCommon('wait-hours', {
-        hours:
-          networkType === 'mainnet'
-            ? ExpectedProofWaitTimeHoursMainnet
-            : ExpectedProofWaitTimeHoursTestnet,
+      description: tCommon.rich('wait-hours', {
+        hours: () =>
+          tCommon('hours', {
+            hours:
+              networkType === 'mainnet'
+                ? ExpectedProofWaitTimeHoursMainnet
+                : ExpectedProofWaitTimeHoursTestnet,
+          }),
       }),
       status:
         withdrawal.status >= MessageStatus.READY_FOR_RELAY

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/depositStatus.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/depositStatus.tsx
@@ -20,7 +20,14 @@ export const DepositStatus = function ({ deposit }: Props) {
       <TxStatus.InStatus text={t('transaction-history.waiting-confirmation')} />
     ),
     [BtcDepositStatus.BTC_TX_CONFIRMED]: (
-      <TxStatus.InStatus text={t('common.wait-hours', { hours: 3 })} />
+      <TxStatus.InStatus
+        text={t.rich('common.wait-hours', {
+          hours: () =>
+            t('common.hours', {
+              hours: 3,
+            }),
+        })}
+      />
     ),
     [BtcDepositStatus.READY_TO_MANUAL_CONFIRM]: (
       <TxStatus.InStatus text={t('transaction-history.ready-to-confirm')} />

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/txStatus.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/txStatus.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from 'next-intl'
+import { ReactNode } from 'react'
 
 const Container = ({ children }: { children: React.ReactNode }) => (
   <div className="flex items-center gap-x-1.5">{children}</div>
@@ -22,7 +23,7 @@ const Failed = function () {
   )
 }
 
-const InStatus = ({ text }: { text: string }) => (
+const InStatus = ({ text }: { text: ReactNode }) => (
   <Container>
     <Dot className="border-amber-800/25 bg-amber-400" />
     <span className="text-amber-600">{text}</span>

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/withdrawStatus.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/withdrawStatus.tsx
@@ -51,7 +51,14 @@ const BitcoinWithdrawStatus = function ({ withdrawal }: Props) {
       <TxStatus.InStatus text={t('common.wait-minutes', { minutes: 10 })} />
     ),
     [BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED]: (
-      <TxStatus.InStatus text={t('common.wait-hours', { hours: 12 })} />
+      <TxStatus.InStatus
+        text={t.rich('common.wait-hours', {
+          hours: () =>
+            t('common.hours', {
+              hours: 12,
+            }),
+        })}
+      />
     ),
     [BtcWithdrawStatus.WITHDRAWAL_SUCCEEDED]: <TxStatus.Success />,
     // Initiate error path


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

As part of #1075 I updated the rendering of `t('common.wait-hours)` so it allowed rendering a Skeleton. This was needed because the Bitcoin grace period is loading in a async fashion, and that value tells us how many hours shall the user wait.

This change meant that all usages of `t('common.wait-hours)` need now to be rendered with `t.rich`.. and I failed to apply those changes, causing the image shown in the bug. This PR fixes that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Now, they are all rendered correctly:

**Withdraw to Ethereum**

<img width="461" alt="image" src="https://github.com/user-attachments/assets/435ed1a9-d3da-4d18-ab79-d22d91994936" />

**Deposit from BTC**

<img width="438" alt="image" src="https://github.com/user-attachments/assets/54726296-1c3f-4f78-b74f-666a1534c372" />

**Withdraw to BTC**

<img width="441" alt="image" src="https://github.com/user-attachments/assets/faa9ed30-1010-4422-ba31-eb4a7e4935aa" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1085

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
