### PR TITLE
Add missing status on isPendingOperation

### DIFF
--- a/webapp/test/utils/tunnel.test.ts
+++ b/webapp/test/utils/tunnel.test.ts
@@ -29,7 +29,7 @@ describe('utils/tunnel', function () {
   describe('isPendingOperation', function () {
     describe('when the operation is a deposit', function () {
       describe('BTC', function () {
-        it('should return true if status is not BTC_DEPOSITED or DEPOSIT_TX_FAILED', function () {
+        it('should return true if status is not BTC_DEPOSITED, BTC_DEPOSITED_MANUALLY or DEPOSIT_TX_FAILED', function () {
           const operation = {
             direction: MessageDirection.L1_TO_L2,
             l1ChainId: '123456',
@@ -54,6 +54,16 @@ describe('utils/tunnel', function () {
             direction: MessageDirection.L1_TO_L2,
             l1ChainId: '123456',
             status: BtcDepositStatus.DEPOSIT_MANUAL_CONFIRMATION_TX_FAILED,
+          }
+          // @ts-expect-error Ignore operation fields not required for this test
+          expect(isPendingOperation(operation)).toBe(false)
+        })
+
+        it('should return false if status is BTC_DEPOSITED_MANUALLY', function () {
+          const operation = {
+            direction: MessageDirection.L1_TO_L2,
+            l1ChainId: '123456',
+            status: BtcDepositStatus.BTC_DEPOSITED_MANUALLY,
           }
           // @ts-expect-error Ignore operation fields not required for this test
           expect(isPendingOperation(operation)).toBe(false)

--- a/webapp/types/tunnel.ts
+++ b/webapp/types/tunnel.ts
@@ -22,7 +22,7 @@ import { type Chain, type Hash } from 'viem'
  *   |_READY_TO_MANUAL_CONFIRM
  *      |_DEPOSIT_MANUAL_CONFIRMING
  *        |_DEPOSIT_MANUAL_CONFIRMATION_TX_FAILED
- *        |BTC_DEPOSITED_MANUALLY (Arrives here after manual confirmation)
+ *        |_BTC_DEPOSITED_MANUALLY (Arrives here after manual confirmation)
  */
 export const enum BtcDepositStatus {
   // The tx is in the mempool, but hasn't been included in a mined block

--- a/webapp/utils/tunnel.ts
+++ b/webapp/utils/tunnel.ts
@@ -46,6 +46,7 @@ export const isToEvmWithdraw = (
 
 const btcDepositCompletedActions = [
   BtcDepositStatus.BTC_DEPOSITED,
+  BtcDepositStatus.BTC_DEPOSITED_MANUALLY,
   BtcDepositStatus.DEPOSIT_MANUAL_CONFIRMATION_TX_FAILED,
 ]
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

While reviewing a PR, I noticed a BTC final status was missing from `isPendingOperation`. This PR adds it.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
