### PR TITLE
Added network selector to fixed navbar on mobile

### DIFF
--- a/webapp/app/[locale]/_components/navbar/_components/navItem.tsx
+++ b/webapp/app/[locale]/_components/navbar/_components/navItem.tsx
@@ -14,7 +14,7 @@ import {
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { useUmami } from 'hooks/useUmami'
 import { usePathname } from 'i18n/navigation'
-import { useLocale } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { ComponentProps, MutableRefObject, ReactNode, useState } from 'react'
 import { UrlObject } from 'url'
 import { isRelativeUrl } from 'utils/url'
@@ -209,6 +209,7 @@ export const NetworkSwitch = function () {
   const [isOpen, setIsOpen] = useState(false)
   const ref = useOnClickOutside<HTMLDivElement>(() => setIsOpen(false))
   const { track } = useUmami()
+  const t = useTranslations('navbar')
 
   const selectNetwork = function (type: NetworkType) {
     setNetworkType(type)
@@ -228,8 +229,11 @@ export const NetworkSwitch = function () {
           <IconContainer>
             <NetworkIcon />
           </IconContainer>
-          <ItemText selected={isOpen} text={networkType} />
-          <Chevron.Bottom className="ml-auto" />
+          <ItemText text={t('network')} />
+          <div className="ml-auto flex items-center gap-x-1">
+            <ItemText selected={isOpen} text={networkType} />
+            <Chevron.Bottom />
+          </div>
         </Row>
         {isOpen && (
           <div className="absolute right-0 top-0 z-20 -translate-y-full translate-x-3">

--- a/webapp/app/[locale]/_components/navbar/index.tsx
+++ b/webapp/app/[locale]/_components/navbar/index.tsx
@@ -165,7 +165,7 @@ export const Navbar = function () {
         </ul>
       </div>
       <ul className="fixed bottom-0 w-full border-t border-neutral-300 bg-neutral-50 px-3 pt-4 md:hidden">
-        <li className="rounded-lg border border-neutral-300 bg-neutral-100 px-2 py-1">
+        <li className="rounded-lg border border-neutral-300 bg-neutral-100 px-3 py-1">
           <NetworkSwitch />
         </li>
         <li className="mt-3">

--- a/webapp/app/[locale]/_components/navbar/index.tsx
+++ b/webapp/app/[locale]/_components/navbar/index.tsx
@@ -54,7 +54,7 @@ export const Navbar = function () {
             <Badge />
           </div>
         </div>
-        <ul className="flex h-[calc(100dvh-275px)] flex-col gap-y-1 overflow-y-auto md:h-full [&>li>div]:px-3">
+        <ul className="flex h-[calc(100dvh-335px)] flex-col gap-y-1 overflow-y-auto md:h-full [&>li>div]:px-3">
           <li className="order-1">
             <ItemLink
               event="nav - tunnel"
@@ -144,7 +144,7 @@ export const Navbar = function () {
               text={t('hemidocs')}
             />
           </li>
-          <li className="md:order-13 order-12">
+          <li className="md:order-13 hidden md:block">
             <NetworkSwitch />
           </li>
           <li className="hidden md:order-10 md:block">
@@ -165,7 +165,10 @@ export const Navbar = function () {
         </ul>
       </div>
       <ul className="fixed bottom-0 w-full border-t border-neutral-300 bg-neutral-50 px-3 pt-4 md:hidden">
-        <li>
+        <li className="rounded-lg border border-neutral-300 bg-neutral-100 px-2 py-1">
+          <NetworkSwitch />
+        </li>
+        <li className="mt-3">
           <GetStarted />
         </li>
         <li>

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -177,6 +177,7 @@
     "explorer": "Explorer",
     "get-started": "Get Started",
     "hemidocs": "Hemi Docs",
+    "network": "Network",
     "network-status": "Network Status",
     "swap": "Swap",
     "stake": "Stake",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -177,6 +177,7 @@
     "explorer": "Explorador",
     "get-started": "Comenzar",
     "hemidocs": "Documentación de Hemi",
+    "network": "Red",
     "network-status": "Estado de la red",
     "swap": "Intercambiar",
     "stake": "Apostar",


### PR DESCRIPTION
### Description

- Added "Network" text to network selector component;
- Added network selector component to fixed section of navbar on mobile;
- Added "Network" text to translation files.

### Screenshots

Mobile:
<img width="400" alt="Captura de Tela 2025-03-28 às 11 47 31" src="https://github.com/user-attachments/assets/e66dc997-b7e5-408c-9d53-dd3cc9abe02c" />

Desktop:
<img width="400" alt="Captura de Tela 2025-03-28 às 11 48 54" src="https://github.com/user-attachments/assets/30662545-ea25-4c5a-b8d9-00996875662f" />

### Related issue(s)

Closes #1037

### Checklist

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
