### PR TITLE
Ignore RSC and Wallets errors in Sentry

### DIFF
--- a/webapp/sentry.client.config.ts
+++ b/webapp/sentry.client.config.ts
@@ -3,7 +3,10 @@ import * as Sentry from '@sentry/nextjs'
 const enabled = !!process.env.NEXT_PUBLIC_SENTRY_DSN
 
 const unsupportedWalletErrors = [
+  '@polkadot/keyring requires direct dependencies',
   "Backpack couldn't override `window.ethereum`.",
+  // Nightly wallet
+  'Cannot set property ethereum of #<Window> which has only a getter',
   'shouldSetPelagusForCurrentProvider is not a function',
   'shouldSetTallyForCurrentProvider is not a function',
   'Talisman extension has not been configured yet',
@@ -17,6 +20,10 @@ const walletConnectErrors = [
 
 function enableSentry() {
   const ignoreErrors = [
+    // Nextjs errors when pre-fetching is aborted due to user navigation.
+    // See https://github.com/vercel/next.js/pull/73975 and https://github.com/vercel/next.js/pull/73985
+    // should not happen anymore after Next 15.3
+    'Falling back to browser navigation',
     // user rejected a confirmation in the wallet
     'rejected the request',
     // React internal error thrown when something outside react modifies the DOM


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR ignores 2 types of errors

- One related to RSC from Next. In newer versions of Next, this error apparently is not logged anymore. There's nothing we can do, it's not even an error
- An error related to Nightly wallet and another one related to a Polkadot extension

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1093
Closes #1094 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
