### PR TITLE
Add eth rpc cache support viem

### DIFF
--- a/webapp/test/utils/watch/bitcoinDeposit.test.ts
+++ b/webapp/test/utils/watch/bitcoinDeposit.test.ts
@@ -36,6 +36,10 @@ vi.mock(import('utils/btcApi'), async function (importOriginal) {
   }
 })
 
+vi.mock('utils/chainClients', () => ({
+  getHemiClient: vi.fn(),
+}))
+
 vi.mock('utils/hemi', () => ({
   getHemiStatusOfBtcDeposit: vi.fn(),
   getVaultAddressByDeposit: vi.fn(),

--- a/webapp/test/utils/watch/bitcoinWithdrawals.test.ts
+++ b/webapp/test/utils/watch/bitcoinWithdrawals.test.ts
@@ -29,6 +29,10 @@ const block = {
 
 const uuid = BigInt(1)
 
+vi.mock('utils/chainClients', () => ({
+  getHemiClient: vi.fn(),
+}))
+
 vi.mock('utils/evmApi', () => ({
   getEvmBlock: vi.fn(),
   getEvmTransactionReceipt: vi.fn(),

--- a/webapp/utils/transport.ts
+++ b/webapp/utils/transport.ts
@@ -1,5 +1,41 @@
+import {
+  createEthRpcCache,
+  perBlockStrategy,
+  permanentStrategy,
+} from 'eth-rpc-cache'
 import { OrderedChains } from 'types/chain'
-import { type Chain, fallback, http } from 'viem'
+import { withdrawalsStrategy } from 'utils/cacheStrategies'
+import { type Chain, fallback, http, type HttpTransport } from 'viem'
+
+const createHttpClient = function (
+  ...parameters: Parameters<typeof http>
+): HttpTransport {
+  const transport = http(...parameters)
+
+  return function (
+    ...args: Parameters<HttpTransport>
+  ): ReturnType<HttpTransport> {
+    const { request, ...rest } = transport(...args)
+    // http's transport.request expects 1 argument, being ({ method, params })
+    // However, the eth-rpc-cache's request function expects 2 arguments, being (method, params)
+    // So the function returned below (at the end of createHttpClient's function) converts from the object to 2 parameters
+    // and then, the function here below, converts it again into an object as viem's transport expects it.
+    const cachedRequest = createEthRpcCache(
+      (method, params) => request({ method, params }),
+      {
+        strategies: [perBlockStrategy, permanentStrategy, withdrawalsStrategy],
+      },
+    )
+    return {
+      // viem uses "unknown" for params, but eth-rpc-cache uses "unknown[]". While initially I thought "unknown" made more sense
+      // the EIP-1993 spec uses "unknown[]" https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#request
+      // so for the time being I'll keep it like that.
+      // @ts-expect-error mismatch between viem and eth-rpc-cache
+      request: ({ method, params }) => cachedRequest(method, params),
+      ...rest,
+    }
+  }
+}
 
 export const buildTransport = function (network: Chain) {
   const httpConfig = {
@@ -9,14 +45,14 @@ export const buildTransport = function (network: Chain) {
   const rpcUrls = network.rpcUrls.default.http
   if (rpcUrls.length > 1) {
     return fallback(
-      rpcUrls.map(rpcUrl => http(rpcUrl, httpConfig), {
+      rpcUrls.map(rpcUrl => createHttpClient(rpcUrl, httpConfig), {
         // rank every 30 seconds
         rank: { interval: 30_000 },
         retryCount: 1,
       }),
     )
   }
-  return http(rpcUrls[0], httpConfig)
+  return createHttpClient(rpcUrls[0], httpConfig)
 }
 
 export const buildTransports = (networks: Chain[] | OrderedChains) =>


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds `eth-rpc-cache` to the viem transport/clients. Before this PR, we were only using them on Ethers' transports (Which are part of the OP-SDK). 

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1096 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
