### PR TITLE
Add step to wait for Hemi deposit availability

### DIFF
--- a/webapp/app/[locale]/tunnel/transaction-history/_components/depositStatus.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/depositStatus.tsx
@@ -1,5 +1,10 @@
 import { useTranslations } from 'next-intl'
-import { BtcDepositStatus, DepositTunnelOperation } from 'types/tunnel'
+import {
+  BtcDepositStatus,
+  DepositTunnelOperation,
+  EvmDepositStatus,
+  ExpectedWaitTimeMinutesGetFundsHemi,
+} from 'types/tunnel'
 import { isBtcDeposit } from 'utils/tunnel'
 
 import { TxStatus } from './txStatus'
@@ -12,9 +17,21 @@ export const DepositStatus = function ({ deposit }: Props) {
   const t = useTranslations()
 
   if (!isBtcDeposit(deposit)) {
-    // Evm deposits are always successful if listed
-    return <TxStatus.Success />
+    const evmStatuses = {
+      [EvmDepositStatus.DEPOSIT_TX_CONFIRMED]: (
+        <TxStatus.InStatus
+          text={t('common.wait-minutes', {
+            minutes: ExpectedWaitTimeMinutesGetFundsHemi,
+          })}
+        />
+      ),
+      // Check if funds have been minted in Hemi
+      [EvmDepositStatus.DEPOSIT_RELAYED]: <TxStatus.Success />,
+    }
+
+    return evmStatuses[deposit.status] ?? '-'
   }
+
   const statuses = {
     [BtcDepositStatus.BTC_TX_PENDING]: (
       <TxStatus.InStatus text={t('transaction-history.waiting-confirmation')} />

--- a/webapp/components/reviewOperation/step.tsx
+++ b/webapp/components/reviewOperation/step.tsx
@@ -65,7 +65,9 @@ const Completed = function ({
             <>
               <GreenCheckIcon />
               <span className="mr-auto text-emerald-500">{t('confirmed')}</span>
-              <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+              {explorerChainId && txHash && (
+                <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+              )}
             </>
           ) : null
         }
@@ -126,7 +128,9 @@ const Progress = function ({
           <>
             <ClockIcon />
             <span className="mr-auto text-neutral-500">{t('pending')}</span>
-            <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+            {explorerChainId && txHash && (
+              <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+            )}
           </>
         }
         top={{
@@ -191,7 +195,9 @@ const Failed = function ({
             <>
               <RedErrorIcon />
               <span className="mr-auto text-rose-500">{t('error')}</span>
-              <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+              {explorerChainId && txHash && (
+                <SeeOnExplorer chainId={explorerChainId} txHash={txHash} />
+              )}
             </>
           ) : null
         }

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -302,6 +302,7 @@
       "confirm-deposit": "Confirm deposit",
       "deposit-finalized": "Deposit finalized",
       "deposit-on-its-way": "Your deposit is on its way! Please wait while the blockchain finalizes the transaction.",
+      "get-your-funds-on-hemi": "Get your funds on Hemi",
       "initiate-deposit": "Initiate deposit",
       "review-deposit": "Review Deposit",
       "we-could-not-process-this-deposit": "We couldn't process this deposit automatically",

--- a/webapp/messages/es.json
+++ b/webapp/messages/es.json
@@ -302,6 +302,7 @@
       "confirm-deposit": "Confirmar depósito",
       "deposit-finalized": "Depósito finalizado",
       "deposit-on-its-way": "¡Su depósito está en camino! Por favor espere mientras la blockchain confirma la transacción.",
+      "get-your-funds-on-hemi": "Obtenga sus fondos en Hemi",
       "initiate-deposit": "Iniciar depósito",
       "review-deposit": "Revisar Depósito",
       "we-could-not-process-this-deposit": "No pudimos procesar su depósito automáticamente",

--- a/webapp/test/utils/tunnel.test.ts
+++ b/webapp/test/utils/tunnel.test.ts
@@ -82,11 +82,11 @@ describe('utils/tunnel', function () {
           expect(isPendingOperation(operation)).toBe(true)
         })
 
-        it('should return false if status is DEPOSIT_TX_CONFIRMED', function () {
+        it('should return false if status is DEPOSIT_RELAYED', function () {
           const operation = {
             direction: MessageDirection.L1_TO_L2,
             l1ChainId: 123456,
-            status: EvmDepositStatus.DEPOSIT_TX_CONFIRMED,
+            status: EvmDepositStatus.DEPOSIT_RELAYED,
           }
           // @ts-expect-error Ignore operation fields not required for this test
           expect(isPendingOperation(operation)).toBe(false)

--- a/webapp/test/utils/watch/evmDeposits.test.ts
+++ b/webapp/test/utils/watch/evmDeposits.test.ts
@@ -1,7 +1,7 @@
 import { EvmDepositStatus, type EvmDepositOperation } from 'types/tunnel'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import { watchEvmDeposit } from 'utils/watch/evmDeposits'
-import { sepolia } from 'viem/chains'
+import { hemiSepolia, sepolia } from 'viem/chains'
 import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('utils/evmApi', () => ({
@@ -9,9 +9,24 @@ vi.mock('utils/evmApi', () => ({
   getEvmTransactionReceipt: vi.fn(),
 }))
 
+vi.mock('eth-rpc-cache', () => ({
+  createEthRpcCache: vi.fn(() => ({
+    request: vi.fn(),
+  })),
+  perBlockStrategy: vi.fn(),
+  permanentStrategy: vi.fn(),
+}))
+
+vi.mock('utils/crossChainMessenger', () => ({
+  createQueuedCrossChainMessenger: vi.fn(() => ({
+    getMessageStatus: vi.fn(() => 0),
+  })),
+}))
+
 // @ts-expect-error only use the minimum required properties
 const deposit: EvmDepositOperation = {
   l1ChainId: sepolia.id,
+  l2ChainId: hemiSepolia.id,
   status: EvmDepositStatus.DEPOSIT_TX_PENDING,
   transactionHash: '0x0000000000000000000000000000000000000005',
 }
@@ -22,19 +37,14 @@ const block = { timestamp: BigInt(1630000000) }
 describe('watchEvmDeposit', function () {
   it('should not return any update if the transaction is still pending', async function () {
     vi.mocked(getEvmTransactionReceipt).mockResolvedValue(null)
-
     const updates = await watchEvmDeposit(deposit)
-
     expect(updates).toEqual({})
     expect(getEvmBlock).not.toHaveBeenCalled()
   })
-
   it(`should return the new status set to ${EvmDepositStatus.DEPOSIT_TX_CONFIRMED} if the transaction was confirmed`, async function () {
     vi.mocked(getEvmTransactionReceipt).mockResolvedValue(receipt)
     vi.mocked(getEvmBlock).mockResolvedValue(block)
-
     const updates = await watchEvmDeposit(deposit)
-
     expect(updates.status).toBe(EvmDepositStatus.DEPOSIT_TX_CONFIRMED)
     expect(updates.blockNumber).toBe(Number(receipt.blockNumber))
     expect(updates.timestamp).toBe(Number(block.timestamp))
@@ -47,16 +57,13 @@ describe('watchEvmDeposit', function () {
       deposit.l1ChainId,
     )
   })
-
   it(`should update status to ${EvmDepositStatus.DEPOSIT_TX_FAILED} if the transaction reverted`, async function () {
     vi.mocked(getEvmTransactionReceipt).mockResolvedValue({
       ...receipt,
       status: 'reverted',
     })
     vi.mocked(getEvmBlock).mockResolvedValue(block)
-
     const updates = await watchEvmDeposit(deposit)
-
     expect(updates.status).toBe(EvmDepositStatus.DEPOSIT_TX_FAILED)
     expect(updates.blockNumber).toBe(Number(receipt.blockNumber))
     expect(updates.timestamp).toBe(Number(block.timestamp))

--- a/webapp/types/tunnel.ts
+++ b/webapp/types/tunnel.ts
@@ -111,7 +111,11 @@ export const enum EvmDepositStatus {
   DEPOSIT_TX_FAILED = 4,
   // Approval failed
   APPROVAL_TX_FAILED = 5,
+  // Funds have been minted in Hemi
+  DEPOSIT_RELAYED = 6,
 }
+
+export const ExpectedWaitTimeMinutesGetFundsHemi = 3
 
 type CommonOperation = {
   amount: string

--- a/webapp/utils/tunnel.ts
+++ b/webapp/utils/tunnel.ts
@@ -105,7 +105,7 @@ const btcWithdrawCompletedActions = [
 ]
 
 const evmDepositCompletedActions = [
-  EvmDepositStatus.DEPOSIT_TX_CONFIRMED,
+  EvmDepositStatus.DEPOSIT_RELAYED,
   EvmDepositStatus.DEPOSIT_TX_FAILED,
 ]
 

--- a/webapp/utils/watch/evmDeposits.ts
+++ b/webapp/utils/watch/evmDeposits.ts
@@ -1,8 +1,35 @@
+import { MessageStatus } from '@eth-optimism/sdk'
+import pMemoize from 'promise-mem'
 import { EvmDepositStatus, type EvmDepositOperation } from 'types/tunnel'
+import { findChainById } from 'utils/chain'
+import { createQueuedCrossChainMessenger } from 'utils/crossChainMessenger'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
+import { createProvider } from 'utils/providers'
+import { Chain } from 'viem'
+
+const getCrossChainMessenger = pMemoize(
+  function (l1Chain: Chain, l2Chain: Chain) {
+    const l1Provider = createProvider(l1Chain)
+
+    const l2Provider = createProvider(l2Chain)
+
+    return createQueuedCrossChainMessenger({
+      l1ChainId: l1Chain.id,
+      l1Signer: l1Provider,
+      l2Chain,
+      l2Signer: l2Provider,
+    })
+  },
+  { resolver: (l1Chain, l2Chain) => `${l1Chain.id}-${l2Chain.id}` },
+)
 
 export const watchEvmDeposit = async function (deposit: EvmDepositOperation) {
   const updates: Partial<EvmDepositOperation> = {}
+
+  const l1Chain = findChainById(deposit.l1ChainId) as Chain
+  const l2Chain = findChainById(deposit.l2ChainId) as Chain
+
+  const crossChainMessenger = await getCrossChainMessenger(l1Chain, l2Chain)
 
   // check if it has completed on the background
   const receipt = await getEvmTransactionReceipt(
@@ -13,10 +40,22 @@ export const watchEvmDeposit = async function (deposit: EvmDepositOperation) {
   if (!receipt) {
     return updates
   }
-  const newStatus =
-    receipt.status === 'success'
-      ? EvmDepositStatus.DEPOSIT_TX_CONFIRMED
-      : EvmDepositStatus.DEPOSIT_TX_FAILED
+
+  const status = await crossChainMessenger.getMessageStatus(
+    deposit.transactionHash,
+    0,
+    deposit.direction,
+  )
+
+  let newStatus: EvmDepositStatus
+  if (status === MessageStatus.RELAYED) {
+    newStatus = EvmDepositStatus.DEPOSIT_RELAYED
+  } else if (receipt.status === 'success') {
+    newStatus = EvmDepositStatus.DEPOSIT_TX_CONFIRMED
+  } else {
+    newStatus = EvmDepositStatus.DEPOSIT_TX_FAILED
+  }
+
   // if the status has changed, save the update
   if (deposit.status !== newStatus) {
     updates.status = newStatus


### PR DESCRIPTION
### Description

This PR introduces a new step in the deposit flow that informs the user to wait approximately three minutes for their funds to become available in Hemi.

To achieve this, we added a call to `crossChainMessenger.getMessageStatus` to check when the transaction has been fully relayed and acknowledged.

Additionally, an `invalidateQueries` call was added to `evmDepositsStatusUpdater.tsx` to ensure the balance is refreshed immediately after the deposit is confirmed by getMessageStatus.

With these changes, the user’s balance is now updated almost in real time.

### Screenshots


https://github.com/user-attachments/assets/35465e88-7b64-4769-ad3e-308a3d56a6db


### Related issue(s)

Related to #1013

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
