### PR TITLE
Replace "getMessageStatus" when getting deposit status

### DIFF
--- a/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
+++ b/webapp/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
@@ -123,10 +123,12 @@ const ReviewContent = function ({
 
   const getFundsHemiStep = (): StepPropsWithoutPosition => ({
     description: t('get-your-funds-on-hemi'),
+    explorerChainId: deposit.l2ChainId,
     status:
       depositStatus === EvmDepositStatus.DEPOSIT_RELAYED
         ? ProgressStatus.COMPLETED
         : ProgressStatus.NOT_READY,
+    txHash: deposit.l2TransactionHash,
   })
 
   // Show the approval only if it's a not native token and there is a approval.

--- a/webapp/app/[locale]/tunnel/_hooks/useDeposit.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useDeposit.ts
@@ -146,15 +146,13 @@ export const useDeposit = function ({
     data: depositReceipt,
     error: depositReceiptError,
     queryKey: depositQueryKey,
-    status: depositTxStatus,
   } = useWaitForTransactionReceipt({
     hash: depositingNative ? depositNativeTokenTxHash : depositErc20TokenTxHash,
   })
 
   useReloadBalances({
     fromToken,
-    status: depositTxStatus,
-    toToken,
+    status: depositReceipt?.status,
   })
 
   const clearDepositNativeState = useCallback(

--- a/webapp/app/[locale]/tunnel/_hooks/useWithdraw.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useWithdraw.ts
@@ -91,13 +91,12 @@ export const useWithdraw = function ({
     data: withdrawReceipt,
     error: withdrawReceiptError,
     queryKey: withdrawQueryKey,
-    status: withdrawTxStatus,
     // @ts-expect-error string is `0x${string}`
   } = useWaitForTransactionReceipt({ hash: txHash })
+
   useReloadBalances({
     fromToken,
-    status: withdrawTxStatus,
-    toToken,
+    status: withdrawReceipt?.status,
   })
 
   const clearWithdrawNativeState = useCallback(
@@ -201,7 +200,6 @@ export const useWithdraw = function ({
       withdrawGasFees: withdrawNativeTokenGasFees,
       withdrawReceipt,
       withdrawReceiptError,
-      withdrawStatus: withdrawTxStatus,
     }
   }
   return {
@@ -214,6 +212,5 @@ export const useWithdraw = function ({
     withdrawGasFees: withdrawErc20TokenGasFees,
     withdrawReceipt,
     withdrawReceiptError,
-    withdrawStatus: withdrawTxStatus,
   }
 }

--- a/webapp/app/[locale]/tunnel/transaction-history/_components/depositStatus.tsx
+++ b/webapp/app/[locale]/tunnel/transaction-history/_components/depositStatus.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from 'next-intl'
+import Skeleton from 'react-loading-skeleton'
 import {
   BtcDepositStatus,
   DepositTunnelOperation,
@@ -29,7 +30,7 @@ export const DepositStatus = function ({ deposit }: Props) {
       [EvmDepositStatus.DEPOSIT_RELAYED]: <TxStatus.Success />,
     }
 
-    return evmStatuses[deposit.status] ?? '-'
+    return evmStatuses[deposit.status] ?? <Skeleton className="w-15 h-8" />
   }
 
   const statuses = {

--- a/webapp/hooks/useReloadBalances.ts
+++ b/webapp/hooks/useReloadBalances.ts
@@ -5,12 +5,10 @@ import { isNativeToken } from 'utils/nativeToken'
 
 type UseReloadBalances = {
   fromToken: EvmToken
-  toToken: EvmToken
-  status: string
+  status: string | undefined
 }
 export const useReloadBalances = function ({
   fromToken,
-  toToken,
   status,
 }: UseReloadBalances) {
   const operatesNativeToken = isNativeToken(fromToken)
@@ -23,29 +21,17 @@ export const useReloadBalances = function ({
     fromToken.address,
   )
 
-  const { refetchBalance: refetchToToken } = useNativeTokenBalance(
-    toToken.chainId,
-    operatesNativeToken,
-  )
-
-  const { refetchTokenBalance: refetchToTokenBalance } = useTokenBalance(
-    toToken.chainId,
-    toToken.address,
-  )
-
   useEffect(
     function refetchBalances() {
-      if (!['error', 'success'].includes(status)) {
+      if (status === undefined) {
         return undefined
       }
       // Native token balance in "From" should always reload
+      // as fees were paid
       refetchFromNativeToken()
 
-      if (operatesNativeToken) {
-        refetchToToken()
-      } else {
+      if (!operatesNativeToken) {
         refetchFromTokenBalance()
-        refetchToTokenBalance()
       }
       return undefined
     },
@@ -53,8 +39,6 @@ export const useReloadBalances = function ({
       operatesNativeToken,
       refetchFromNativeToken,
       refetchFromTokenBalance,
-      refetchToToken,
-      refetchToTokenBalance,
       status,
     ],
   )

--- a/webapp/test/utils/watch/evmDeposits.test.ts
+++ b/webapp/test/utils/watch/evmDeposits.test.ts
@@ -2,25 +2,16 @@ import { EvmDepositStatus, type EvmDepositOperation } from 'types/tunnel'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import { watchEvmDeposit } from 'utils/watch/evmDeposits'
 import { hemiSepolia, sepolia } from 'viem/chains'
-import { describe, it, expect, vi } from 'vitest'
+import { getL2TransactionHashes } from 'viem/op-stack'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 
 vi.mock('utils/evmApi', () => ({
   getEvmBlock: vi.fn(),
   getEvmTransactionReceipt: vi.fn(),
 }))
 
-vi.mock('eth-rpc-cache', () => ({
-  createEthRpcCache: vi.fn(() => ({
-    request: vi.fn(),
-  })),
-  perBlockStrategy: vi.fn(),
-  permanentStrategy: vi.fn(),
-}))
-
-vi.mock('utils/crossChainMessenger', () => ({
-  createQueuedCrossChainMessenger: vi.fn(() => ({
-    getMessageStatus: vi.fn(() => 0),
-  })),
+vi.mock('viem/op-stack', () => ({
+  getL2TransactionHashes: vi.fn(),
 }))
 
 // @ts-expect-error only use the minimum required properties
@@ -35,35 +26,49 @@ const receipt = { blockNumber: BigInt(100), status: 'success' }
 const block = { timestamp: BigInt(1630000000) }
 
 describe('watchEvmDeposit', function () {
+  beforeEach(function () {
+    vi.clearAllMocks()
+  })
+
   it('should not return any update if the transaction is still pending', async function () {
     vi.mocked(getEvmTransactionReceipt).mockResolvedValue(null)
+
     const updates = await watchEvmDeposit(deposit)
-    expect(updates).toEqual({})
+
+    expect(updates).toStrictEqual({})
     expect(getEvmBlock).not.toHaveBeenCalled()
   })
-  it(`should return the new status set to ${EvmDepositStatus.DEPOSIT_TX_CONFIRMED} if the transaction was confirmed`, async function () {
-    vi.mocked(getEvmTransactionReceipt).mockResolvedValue(receipt)
+
+  it(`should return the new status set to ${EvmDepositStatus.DEPOSIT_TX_CONFIRMED} if the L1 transaction was confirmed but the L2 was not`, async function () {
+    vi.mocked(getEvmTransactionReceipt)
+      // L1 deposit transaction
+      .mockResolvedValueOnce(receipt)
+      // L2 transaction
+      .mockResolvedValueOnce(null)
     vi.mocked(getEvmBlock).mockResolvedValue(block)
+    vi.mocked(getL2TransactionHashes).mockReturnValue([])
+
     const updates = await watchEvmDeposit(deposit)
+
     expect(updates.status).toBe(EvmDepositStatus.DEPOSIT_TX_CONFIRMED)
     expect(updates.blockNumber).toBe(Number(receipt.blockNumber))
     expect(updates.timestamp).toBe(Number(block.timestamp))
-    expect(getEvmTransactionReceipt).toHaveBeenCalledWith(
-      deposit.transactionHash,
-      deposit.l1ChainId,
-    )
+    expect(getEvmTransactionReceipt).toHaveBeenCalledTimes(2)
     expect(getEvmBlock).toHaveBeenCalledWith(
       receipt.blockNumber,
       deposit.l1ChainId,
     )
   })
-  it(`should update status to ${EvmDepositStatus.DEPOSIT_TX_FAILED} if the transaction reverted`, async function () {
+
+  it(`should return the new status set to ${EvmDepositStatus.DEPOSIT_TX_FAILED} if the transaction reverted`, async function () {
     vi.mocked(getEvmTransactionReceipt).mockResolvedValue({
       ...receipt,
       status: 'reverted',
     })
     vi.mocked(getEvmBlock).mockResolvedValue(block)
+
     const updates = await watchEvmDeposit(deposit)
+
     expect(updates.status).toBe(EvmDepositStatus.DEPOSIT_TX_FAILED)
     expect(updates.blockNumber).toBe(Number(receipt.blockNumber))
     expect(updates.timestamp).toBe(Number(block.timestamp))
@@ -75,5 +80,27 @@ describe('watchEvmDeposit', function () {
       receipt.blockNumber,
       deposit.l1ChainId,
     )
+  })
+
+  it(`should return the new status set to ${EvmDepositStatus.DEPOSIT_RELAYED} if both the L1 and L2 transactions were confirmed`, async function () {
+    const l2TransactionHash = '0x0000000000000000000000000000000000000007'
+    vi.mocked(getEvmTransactionReceipt)
+      // L1 deposit transaction
+      .mockResolvedValueOnce(receipt)
+      // L2 transaction
+      .mockResolvedValueOnce(receipt)
+
+    vi.mocked(getL2TransactionHashes).mockReturnValue([l2TransactionHash])
+
+    const updates = await watchEvmDeposit({
+      ...deposit,
+      blockNumber: 100,
+      timestamp: new Date().getTime(),
+    })
+
+    expect(updates).toStrictEqual({
+      l2TransactionHash,
+      status: EvmDepositStatus.DEPOSIT_RELAYED,
+    })
   })
 })

--- a/webapp/types/tunnel.ts
+++ b/webapp/types/tunnel.ts
@@ -158,6 +158,7 @@ export type EvmDepositOperation = CommonOperation &
     approvalTxHash?: Hash // only used for ERC20 deposits
     l1ChainId: Chain['id']
     l2ChainId: Chain['id']
+    l2TransactionHash?: Hash // The transaction hash of tokens minted in the L2 chain
     status?: EvmDepositStatus // If undefined, assume completed
   }
 

--- a/webapp/utils/sync-history/evm.ts
+++ b/webapp/utils/sync-history/evm.ts
@@ -190,16 +190,7 @@ export const createEvmSync = function ({
           fromBlock,
           limit,
           skip,
-        }).then(deps =>
-          deps.map(
-            d =>
-              ({
-                // if found, it's a confirmed deposit
-                ...d,
-                status: EvmDepositStatus.DEPOSIT_TX_CONFIRMED,
-              }) satisfies EvmDepositOperation,
-          ),
-        )
+        })
 
         // save the deposits
         saveHistory({


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR is a follow-up of #1109. It drops the added usage of `getMessageStatus` and replaces it with its equivalent call from `viem`.

- 95fd0420776e6ab1a15bb1658fb59c1627e3cbaa Does that replacement. In addition to that, it also adds the `l2TransactionHash`. We could not get it with the `eth-optimism/sdk`, but we can now get this hash with `viem`, so it is now stored in the deposit.
- cd1055207a360881308b9b52977897cea18fa41b Updates the drawer to show this hash in the last step
- 260ea03620ce31882679c92cf9b56c7248d6a3d6 As we learnt from the changes applied from Artur, the hemi balance is not updated as soon as the deposit is confirmed on the L1 chain. Samewise, the balance on the L1 is not updated as soon as the L2 withdrawal is initiated. Because of this, after initiating a deposit/withdrawal, there's no need to invalidate the balance on the target chain. This commit, then, removes the code that was doing exactly that. It also waits for the receipt.status to be defined
- e56e8b3517232f78dcd4f21cc91efefe71df0525 Removes the default status for EVM deposits when resyncing. Before #1109 the default status was `DEPOSIT_TX_CONFIRMED`, which was final. That is no longer the case. So when resyncing, all deposits would appear in their history as "Wait up to 3 minutes (Estimated)". By removing the status (letting the statusUpdater to pick up the appropriate status), a loading skeleton is shown, until the appropriate status is loaded.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

The Hemi transaction hash is now linked to the drawer in the last step

![image](https://github.com/user-attachments/assets/fdae7e57-8d0f-42a6-bd05-42846c4fc7f9)

See now how the tx-history is reload

https://github.com/user-attachments/assets/ba5428f7-8944-4c82-9a69-329a99345bb6

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #37
Related to #1013

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
