### PR TITLE
Fix typo in "unexpected-error" message

### DIFF
--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -36,7 +36,7 @@
       "rejected": "Tx rejected"
     },
     "try-again": "Try again",
-    "unexpected-error": "An unexpected error has ocurred. Please try again.",
+    "unexpected-error": "An unexpected error has occurred. Please try again.",
     "unstake": "Unstake",
     "unsupported-chain-heading": "You're not connected to a supported chain",
     "wait-hours": "Wait up to <hours></hours> (estimated wait time)",


### PR DESCRIPTION
### Description

This PR fixes a typo in the English error message for "unexpected-error".

Changes:
- Corrected the spelling in the error message from "occured" to "occurred"
- Maintained consistent formatting with other error messages