### PR TITLE
Removed tHEMI text when network is mainnet

### DIFF
--- a/webapp/app/[locale]/get-started/_components/learnMore.tsx
+++ b/webapp/app/[locale]/get-started/_components/learnMore.tsx
@@ -3,6 +3,7 @@ import { ButtonLink } from 'components/button'
 import { Card } from 'components/card'
 import { ExternalLink } from 'components/externalLink'
 import { Tab, Tabs } from 'components/tabs'
+import { useNetworkType } from 'hooks/useNetworkType'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
@@ -75,6 +76,9 @@ const DeveloperTooling = function () {
 
 const PoPMiner = function () {
   const t = useTranslations('get-started.learn-more-tutorials')
+  const [networkType] = useNetworkType()
+  const isTestnet = networkType === 'testnet'
+
   return (
     <div className="flex flex-col gap-y-3">
       <Box
@@ -83,12 +87,14 @@ const PoPMiner = function () {
         href="https://docs.hemi.xyz/how-to-tutorials/tutorials/setup-part-1"
         subheading={t('set-up-cli-pop-miner')}
       />
-      <Box
-        event="tut - add hemi"
-        heading={t('add-themi-wallet')}
-        href="https://docs.hemi.xyz/how-to-tutorials/tutorials/add-themi-to-metamask"
-        subheading={t('learn-to-add-themi-wallet')}
-      />
+      {isTestnet && (
+        <Box
+          event="tut - add hemi"
+          heading={t('add-themi-wallet')}
+          href="https://docs.hemi.xyz/how-to-tutorials/tutorials/add-themi-to-metamask"
+          subheading={t('learn-to-add-themi-wallet')}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
### Description

Removed tHEMI text from Get Started page when network is not testnet;

### Screenshots

Testnet

![Captura de Tela 2025-04-08 às 13 07 01](https://github.com/user-attachments/assets/3f2d40a1-6458-4d10-8ab5-171596d11316)

Mainnet

![Captura de Tela 2025-04-08 às 13 06 53](https://github.com/user-attachments/assets/4981f9b4-7859-4bed-baa9-875f29b16fea)

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1092

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
