### PR TITLE
Drop OP SDK pt 6: Add initiateWithdraw to hemi-tunnel-actions

### DIFF
--- a/packages/hemi-tunnel-actions/index.ts
+++ b/packages/hemi-tunnel-actions/index.ts
@@ -1,2 +1,7 @@
 export { depositErc20, encodeDepositErc20 } from './src/depositErc20'
 export { depositEth, encodeDepositEth } from './src/depositEth'
+export {
+  encodeInitiateWithdraw,
+  initiateWithdrawEth,
+  initiateWithdrawErc20,
+} from './src/initiateWithdraw'

--- a/packages/hemi-tunnel-actions/src/abis.ts
+++ b/packages/hemi-tunnel-actions/src/abis.ts
@@ -789,3 +789,667 @@ export const l1StandardBridgeAbi = [
     type: 'receive',
   },
 ] as const
+
+export const l2BridgeAbi = [
+  {
+    inputs: [],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l1Token',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l2Token',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'DepositFinalized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'localToken',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'remoteToken',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'ERC20BridgeFinalized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'localToken',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'remoteToken',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'ERC20BridgeInitiated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'ETHBridgeFinalized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'ETHBridgeInitiated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint8',
+        name: 'version',
+        type: 'uint8',
+      },
+    ],
+    name: 'Initialized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l1Token',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l2Token',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'WithdrawalInitiated',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'MESSENGER',
+    outputs: [
+      {
+        internalType: 'contract CrossDomainMessenger',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'OTHER_BRIDGE',
+    outputs: [
+      {
+        internalType: 'contract StandardBridge',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_localToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_remoteToken',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint32',
+        name: '_minGasLimit',
+        type: 'uint32',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'bridgeERC20',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_localToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_remoteToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint32',
+        name: '_minGasLimit',
+        type: 'uint32',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'bridgeERC20To',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint32',
+        name: '_minGasLimit',
+        type: 'uint32',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'bridgeETH',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint32',
+        name: '_minGasLimit',
+        type: 'uint32',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'bridgeETHTo',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'deposits',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_localToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_remoteToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'finalizeBridgeERC20',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'finalizeBridgeETH',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l1Token',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l2Token',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'finalizeDeposit',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract StandardBridge',
+        name: '_otherBridge',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'l1TokenBridge',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'messenger',
+    outputs: [
+      {
+        internalType: 'contract CrossDomainMessenger',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'otherBridge',
+    outputs: [
+      {
+        internalType: 'contract StandardBridge',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'paused',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'version',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l2Token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint32',
+        name: '_minGasLimit',
+        type: 'uint32',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l2Token',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint32',
+        name: '_minGasLimit',
+        type: 'uint32',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'withdrawTo',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    stateMutability: 'payable',
+    type: 'receive',
+  },
+] as const

--- a/packages/hemi-tunnel-actions/src/initiateWithdraw.ts
+++ b/packages/hemi-tunnel-actions/src/initiateWithdraw.ts
@@ -1,0 +1,232 @@
+import { EventEmitter } from 'events'
+import {
+  Address,
+  Chain,
+  encodeFunctionData,
+  PublicClient,
+  WalletClient,
+} from 'viem'
+import { writeContract } from 'viem/actions'
+import { erc20PublicActions } from 'viem-erc20'
+
+import { l2BridgeAbi } from './abis'
+import { WithdrawEvents } from './types'
+import { getL2BridgeAddress, toPromiseEvent, validateInputs } from './utils'
+
+const hasErc20Balance = ({
+  account,
+  publicClient,
+  tokenAddress,
+}: {
+  account: Address
+  publicClient: PublicClient
+  tokenAddress: Address
+}) =>
+  publicClient.extend(erc20PublicActions()).getErc20TokenBalance({
+    account,
+    address: tokenAddress,
+  })
+
+const hasEthBalance = ({
+  account,
+  publicClient,
+}: {
+  account: Address
+  publicClient: PublicClient
+}) => publicClient.getBalance({ address: account })
+
+const canInitiateWithdraw = async function ({
+  account,
+  amount,
+  checkBalance,
+  l1Chain,
+  l2Chain,
+}: {
+  account: Address
+  amount: bigint
+  checkBalance: () => Promise<string | undefined>
+  l1Chain: Chain
+  l2Chain: Chain
+}): Promise<{
+  canWithdraw: boolean
+  reason?: string
+}> {
+  const reason = validateInputs({
+    account,
+    amount,
+    l1Chain,
+    l2Chain,
+  })
+  if (reason) {
+    return { canWithdraw: false, reason }
+  }
+
+  const balanceReason = await checkBalance()
+
+  if (balanceReason) {
+    return { canWithdraw: false, reason: balanceReason }
+  }
+  return { canWithdraw: true }
+}
+
+type InitiateWithdraw = {
+  account: Address
+  amount: bigint
+  checkBalance: () => Promise<string | undefined>
+  l1Chain: Chain
+  l2Chain: Chain
+  l2PublicClient: PublicClient
+  l2TokenAddress: Address
+  l2WalletClient: WalletClient
+  value?: bigint | undefined
+}
+
+const runInitiateWithdraw = ({
+  account,
+  amount,
+  checkBalance,
+  l1Chain,
+  l2Chain,
+  l2PublicClient,
+  l2TokenAddress,
+  l2WalletClient,
+  value,
+}: InitiateWithdraw) =>
+  async function (emitter: EventEmitter<WithdrawEvents>) {
+    try {
+      const l2Bridge = getL2BridgeAddress({ l1Chain, l2Chain })
+
+      const { canWithdraw, reason } = await canInitiateWithdraw({
+        account,
+        amount,
+        checkBalance,
+        l1Chain,
+        l2Chain,
+      }).catch(() => ({
+        canWithdraw: false,
+        reason: 'failed to validate inputs',
+      }))
+
+      if (!canWithdraw) {
+        // reason must be defined because canWithdraw is false
+        emitter.emit('withdraw-failed-validation', reason!)
+        return
+      }
+
+      emitter.emit('pre-withdraw')
+
+      // Using @ts-expect-error fails to compile so I need to use @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore because it works on IDE, and when building on its own, but fails when compiling from the portal through next
+      const hash = await writeContract(l2WalletClient, {
+        abi: l2BridgeAbi,
+        account,
+        address: l2Bridge,
+        // See https://github.com/ethereum-optimism/ecosystem/blob/8da00d3b9044dcb58558df28bae278b613562725/packages/sdk/src/adapters/eth-bridge.ts#L178
+        args: [l2TokenAddress, amount, 0, '0x'],
+        chain: l2Chain,
+        functionName: 'withdraw',
+        value,
+      }).catch(function (error) {
+        emitter.emit('user-signing-withdraw-error', error)
+      })
+
+      if (!hash) {
+        return
+      }
+
+      emitter.emit('user-signed-withdraw', hash)
+
+      const withdrawalReceipt = await l2PublicClient
+        .waitForTransactionReceipt({
+          hash,
+        })
+        .catch(function (err) {
+          emitter.emit('withdraw-failed', err)
+        })
+      if (!withdrawalReceipt) {
+        return
+      }
+
+      emitter.emit(
+        withdrawalReceipt.status === 'success'
+          ? 'withdraw-transaction-succeeded'
+          : 'withdraw-transaction-reverted',
+        withdrawalReceipt,
+      )
+    } catch (error) {
+      emitter.emit('unexpected-error', error as Error)
+    } finally {
+      emitter.emit('withdraw-settled')
+    }
+  }
+
+export const encodeInitiateWithdraw = ({
+  amount = BigInt(0),
+  l2TokenAddress,
+}: {
+  amount: bigint | undefined
+  l2TokenAddress: Address
+}) =>
+  encodeFunctionData({
+    abi: l2BridgeAbi,
+    // See https://github.com/ethereum-optimism/ecosystem/blob/8da00d3b9044dcb58558df28bae278b613562725/packages/sdk/src/adapters/eth-bridge.ts#L178
+    args: [l2TokenAddress, amount, 0, '0x'],
+    functionName: 'withdraw',
+  })
+
+export const initiateWithdrawEth = ({
+  account,
+  amount,
+  l2PublicClient,
+  ...args
+}: Omit<InitiateWithdraw, 'checkBalance' | 'value'>) =>
+  toPromiseEvent<WithdrawEvents>(
+    runInitiateWithdraw({
+      account,
+      amount,
+      async checkBalance() {
+        const balance = await hasEthBalance({
+          account,
+          publicClient: l2PublicClient,
+        })
+        // using >= because we need to consider gas fees
+        if (amount >= balance) {
+          return 'insufficient balance'
+        }
+        return undefined
+      },
+      l2PublicClient,
+      // withdrawing ETH requires to send ETH as value, so we add it here
+      value: amount,
+      ...args,
+    }),
+  )
+
+export const initiateWithdrawErc20 = ({
+  account,
+  amount,
+  l2PublicClient,
+  l2TokenAddress,
+  ...args
+}: Omit<InitiateWithdraw, 'checkBalance' | 'value'>) =>
+  toPromiseEvent<WithdrawEvents>(
+    runInitiateWithdraw({
+      account,
+      amount,
+      async checkBalance() {
+        const balance = await hasErc20Balance({
+          account,
+          publicClient: l2PublicClient,
+          tokenAddress: l2TokenAddress,
+        })
+        if (amount > balance) {
+          return 'insufficient balance'
+        }
+        return undefined
+      },
+      l2PublicClient,
+      l2TokenAddress,
+      ...args,
+    }),
+  )

--- a/packages/hemi-tunnel-actions/src/initiateWithdraw.ts
+++ b/packages/hemi-tunnel-actions/src/initiateWithdraw.ts
@@ -215,13 +215,22 @@ export const initiateWithdrawErc20 = ({
       account,
       amount,
       async checkBalance() {
-        const balance = await getErc20Balance({
-          account,
-          publicClient: l2PublicClient,
-          tokenAddress: l2TokenAddress,
-        })
-        if (amount > balance) {
+        const [erc20Balance, ethBalance] = await Promise.all([
+          getErc20Balance({
+            account,
+            publicClient: l2PublicClient,
+            tokenAddress: l2TokenAddress,
+          }),
+          getEthBalance({
+            account,
+            publicClient: l2PublicClient,
+          }),
+        ])
+        if (amount > erc20Balance) {
           return 'insufficient balance'
+        }
+        if (ethBalance === BigInt(0)) {
+          return 'insufficient balance to pay for gas'
         }
         return undefined
       },

--- a/packages/hemi-tunnel-actions/src/initiateWithdraw.ts
+++ b/packages/hemi-tunnel-actions/src/initiateWithdraw.ts
@@ -13,7 +13,7 @@ import { l2BridgeAbi } from './abis'
 import { WithdrawEvents } from './types'
 import { getL2BridgeAddress, toPromiseEvent, validateInputs } from './utils'
 
-const hasErc20Balance = ({
+const getErc20Balance = ({
   account,
   publicClient,
   tokenAddress,
@@ -27,7 +27,7 @@ const hasErc20Balance = ({
     address: tokenAddress,
   })
 
-const hasEthBalance = ({
+const getEthBalance = ({
   account,
   publicClient,
 }: {
@@ -186,7 +186,7 @@ export const initiateWithdrawEth = ({
       account,
       amount,
       async checkBalance() {
-        const balance = await hasEthBalance({
+        const balance = await getEthBalance({
           account,
           publicClient: l2PublicClient,
         })
@@ -215,7 +215,7 @@ export const initiateWithdrawErc20 = ({
       account,
       amount,
       async checkBalance() {
-        const balance = await hasErc20Balance({
+        const balance = await getErc20Balance({
           account,
           publicClient: l2PublicClient,
           tokenAddress: l2TokenAddress,

--- a/packages/hemi-tunnel-actions/src/types.ts
+++ b/packages/hemi-tunnel-actions/src/types.ts
@@ -20,3 +20,15 @@ export type DepositErc20Events = DepositEvents & {
   'user-signed-approve': [Hash]
   'user-signing-approve-error': [Error]
 }
+
+export type WithdrawEvents = {
+  'pre-withdraw': []
+  'unexpected-error': [Error]
+  'user-signed-withdraw': [Hash]
+  'user-signing-withdraw-error': [Error]
+  'withdraw-failed': [Error]
+  'withdraw-settled': []
+  'withdraw-transaction-reverted': [TransactionReceipt]
+  'withdraw-transaction-succeeded': [TransactionReceipt]
+  'withdraw-failed-validation': [string]
+}

--- a/packages/hemi-tunnel-actions/src/utils.ts
+++ b/packages/hemi-tunnel-actions/src/utils.ts
@@ -49,6 +49,26 @@ export const getL1StandardBridgeAddress = function ({
   return l1StandardBridge
 }
 
+export const getL2BridgeAddress = function ({
+  l1Chain,
+  l2Chain,
+}: {
+  l1Chain: Chain
+  l2Chain: Chain
+}) {
+  const l2Bridge = (
+    l2Chain.contracts?.l2Bridge as {
+      [sourceId: number]: ChainContract
+    }
+  )?.[l1Chain.id].address as Address | undefined
+  if (!l2Bridge) {
+    throw new Error(
+      `Chain ${l2Chain.id} is missing L2Bridge contract for source chain ${l1Chain.id}`,
+    )
+  }
+  return l2Bridge
+}
+
 export const handleWaitDeposit = async function <T extends DepositEvents>({
   emitter,
   hash,

--- a/packages/hemi-tunnel-actions/test/initiateWithdraw.test.ts
+++ b/packages/hemi-tunnel-actions/test/initiateWithdraw.test.ts
@@ -1,0 +1,363 @@
+import { hemiSepolia } from 'hemi-viem'
+import { type PublicClient, WalletClient, zeroAddress, zeroHash } from 'viem'
+import { writeContract } from 'viem/actions'
+import { sepolia } from 'viem/chains'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+
+import {
+  initiateWithdrawErc20,
+  initiateWithdrawEth,
+} from '../src/initiateWithdraw'
+
+vi.mock('viem/actions', () => ({
+  writeContract: vi.fn(),
+}))
+
+const createL2PublicClient = ({
+  getBalance = vi.fn().mockResolvedValue(BigInt(1000)),
+  getErc20TokenBalance = vi.fn().mockResolvedValue(BigInt(1000)),
+  waitForTransactionReceipt = vi.fn().mockResolvedValue({ status: 'success' }),
+} = {}): PublicClient =>
+  ({
+    extend: vi.fn().mockReturnValue({
+      getErc20TokenBalance,
+    }),
+    getBalance,
+    waitForTransactionReceipt,
+  }) as PublicClient
+
+const validParameters = {
+  account: zeroAddress,
+  amount: BigInt(100),
+  l1Chain: sepolia,
+  l2Chain: hemiSepolia,
+  l2PublicClient: createL2PublicClient(),
+  l2TokenAddress: zeroAddress,
+  l2WalletClient: {} as WalletClient,
+}
+
+const runCommonTests = function (
+  // Both functions have the same signature
+  initiateWithdraw: typeof initiateWithdrawErc20,
+) {
+  it('should emit "withdraw-failed-validation" if the account is not a valid address', async function () {
+    const { emitter, promise } = initiateWithdraw({
+      ...validParameters,
+      account: 'invalid-address',
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+    emitter.on('withdraw-failed-validation', failedValidation)
+    emitter.on('withdraw-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'account is not a valid address',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "withdraw-failed-validation" if the amount is not a bigint', async function () {
+    const { emitter, promise } = initiateWithdraw({
+      ...validParameters,
+      amount: '100',
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('withdraw-failed-validation', failedValidation)
+    emitter.on('withdraw-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'amount is not a bigint',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "withdraw-failed-validation" if the amount equals 0', async function () {
+    const { emitter, promise } = initiateWithdraw({
+      ...validParameters,
+      amount: BigInt(0),
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('withdraw-failed-validation', failedValidation)
+    emitter.on('withdraw-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'amount is not greater than 0',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "withdraw-failed-validation" if the amount is less than 0', async function () {
+    const { emitter, promise } = initiateWithdraw({
+      ...validParameters,
+      amount: BigInt(-1),
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('withdraw-failed-validation', failedValidation)
+    emitter.on('withdraw-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'amount is not greater than 0',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "withdraw-transaction-succeeded" when withdraw succeeds', async function () {
+    const receipt = { status: 'success' }
+    const amount = BigInt(1)
+
+    const l2PublicClient = createL2PublicClient({
+      getErc20TokenBalance: vi.fn().mockResolvedValue(BigInt(1000)),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(receipt),
+    })
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+
+    const { emitter, promise } = initiateWithdraw({
+      ...validParameters,
+      amount,
+      l2PublicClient,
+    })
+
+    const onWithdraw = vi.fn()
+    const userSignedTransaction = vi.fn()
+    const withdrawTransactionSucceeded = vi.fn()
+    const onWithdrawTransactionReverted = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-withdraw', onWithdraw)
+    emitter.on('user-signed-withdraw', userSignedTransaction)
+    emitter.on('withdraw-transaction-succeeded', withdrawTransactionSucceeded)
+    emitter.on('withdraw-transaction-reverted', onWithdrawTransactionReverted)
+    emitter.on('withdraw-settled', onSettled)
+
+    await promise
+
+    expect(onWithdraw).toHaveBeenCalled()
+    expect(userSignedTransaction).toHaveBeenCalledWith(zeroHash)
+    expect(withdrawTransactionSucceeded).toHaveBeenCalledExactlyOnceWith(
+      receipt,
+    )
+    expect(onWithdrawTransactionReverted).not.toHaveBeenCalled()
+    expect(writeContract).toHaveBeenCalledExactlyOnceWith(
+      validParameters.l2WalletClient,
+      expect.objectContaining({
+        account: zeroAddress,
+        args: [validParameters.l2TokenAddress, amount, 0, '0x'],
+      }),
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "user-signing-withdraw-error" when signing fails', async function () {
+    const amount = BigInt(1)
+
+    const l2PublicClient = createL2PublicClient({
+      getErc20TokenBalance: vi.fn().mockResolvedValue(BigInt(1000)),
+      waitForTransactionReceipt: vi.fn(),
+    })
+
+    vi.mocked(writeContract).mockRejectedValue(new Error('Signing error'))
+
+    const { emitter, promise } = initiateWithdraw({
+      ...validParameters,
+      amount,
+      l2PublicClient,
+    })
+
+    const onWithdrawCallback = vi.fn()
+    const onSigningError = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-withdraw', onWithdrawCallback)
+    emitter.on('user-signing-withdraw-error', onSigningError)
+    emitter.on('withdraw-settled', onSettled)
+
+    await promise
+
+    expect(onWithdrawCallback).toHaveBeenCalledOnce()
+    expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "withdraw-failed" when transaction receipt fails', async function () {
+    const amount = BigInt(1)
+
+    const l2PublicClient = createL2PublicClient({
+      getErc20TokenBalance: vi.fn().mockResolvedValue(BigInt(1000)),
+      waitForTransactionReceipt: vi
+        .fn()
+        .mockRejectedValue(new Error('Transaction receipt error')),
+    })
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+
+    const { emitter, promise } = initiateWithdraw({
+      ...validParameters,
+      amount,
+      l2PublicClient,
+    })
+
+    const onWithdraw = vi.fn()
+    const onUserSignedTransaction = vi.fn()
+    const onWithdrawFailed = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-withdraw', onWithdraw)
+    emitter.on('user-signed-withdraw', onUserSignedTransaction)
+    emitter.on('withdraw-failed', onWithdrawFailed)
+    emitter.on('withdraw-settled', onSettled)
+
+    await promise
+
+    expect(onWithdraw).toHaveBeenCalledOnce()
+    expect(onUserSignedTransaction).toHaveBeenCalledExactlyOnceWith(zeroHash)
+    expect(onWithdrawFailed).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "withdraw-transaction-reverted" when transaction reverts', async function () {
+    const receipt = { status: 'reverted' }
+    const amount = BigInt(1)
+
+    const l2PublicClient = createL2PublicClient({
+      getErc20TokenBalance: vi.fn().mockResolvedValue(BigInt(1000)),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(receipt),
+    })
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+
+    const { emitter, promise } = initiateWithdraw({
+      ...validParameters,
+      amount,
+      l2PublicClient,
+    })
+
+    const onWithdraw = vi.fn()
+    const onUserSignedTransaction = vi.fn()
+    const withdrawTransactionSucceeded = vi.fn()
+    const onWithdrawTransactionReverted = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-withdraw', onWithdraw)
+    emitter.on('user-signed-withdraw', onUserSignedTransaction)
+    emitter.on('withdraw-transaction-succeeded', withdrawTransactionSucceeded)
+    emitter.on('withdraw-transaction-reverted', onWithdrawTransactionReverted)
+    emitter.on('withdraw-settled', onSettled)
+
+    await promise
+
+    expect(onWithdraw).toHaveBeenCalledOnce()
+    expect(onUserSignedTransaction).toHaveBeenCalledExactlyOnceWith(zeroHash)
+    expect(withdrawTransactionSucceeded).not.toHaveBeenCalled()
+    expect(onWithdrawTransactionReverted).toHaveBeenCalledExactlyOnceWith(
+      receipt,
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+}
+
+describe('withdraw', function () {
+  beforeEach(function () {
+    vi.clearAllMocks()
+  })
+
+  describe('initiateWithdrawEth', function () {
+    // eslint-disable-next-line @vitest/require-hook
+    runCommonTests(initiateWithdrawEth)
+
+    it('should emit "withdraw-failed-validation" if the account balance is insufficient', async function () {
+      const l2PublicClient = createL2PublicClient({
+        getBalance: vi.fn().mockResolvedValue(BigInt(50)),
+      })
+
+      const { emitter, promise } = initiateWithdrawEth({
+        ...validParameters,
+        l2PublicClient,
+      })
+
+      const failedValidation = vi.fn()
+      const onSettled = vi.fn()
+
+      emitter.on('withdraw-failed-validation', failedValidation)
+      emitter.on('withdraw-settled', onSettled)
+
+      await promise
+
+      expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+        'insufficient balance',
+      )
+      expect(onSettled).toHaveBeenCalledOnce()
+    })
+
+    it('should emit "withdraw-failed-validation" if the account balance is the same as the withdrawn amount', async function () {
+      const l2PublicClient = createL2PublicClient({
+        getBalance: vi.fn().mockResolvedValue(BigInt(validParameters.amount)),
+      })
+
+      const { emitter, promise } = initiateWithdrawEth({
+        ...validParameters,
+        l2PublicClient,
+      })
+
+      const failedValidation = vi.fn()
+      const onSettled = vi.fn()
+
+      emitter.on('withdraw-failed-validation', failedValidation)
+      emitter.on('withdraw-settled', onSettled)
+
+      await promise
+
+      expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+        'insufficient balance',
+      )
+      expect(onSettled).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('initiateWithdrawErc20', function () {
+    // eslint-disable-next-line @vitest/require-hook
+    runCommonTests(initiateWithdrawErc20)
+
+    it('should emit "withdraw-failed-validation" if the account balance is insufficient', async function () {
+      const l2PublicClient = createL2PublicClient({
+        getErc20TokenBalance: vi.fn().mockResolvedValue(BigInt(50)),
+      })
+
+      const { emitter, promise } = initiateWithdrawErc20({
+        ...validParameters,
+        l2PublicClient,
+      })
+
+      const failedValidation = vi.fn()
+      const onSettled = vi.fn()
+
+      emitter.on('withdraw-failed-validation', failedValidation)
+      emitter.on('withdraw-settled', onSettled)
+
+      await promise
+
+      expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+        'insufficient balance',
+      )
+      expect(onSettled).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/packages/hemi-tunnel-actions/test/initiateWithdraw.test.ts
+++ b/packages/hemi-tunnel-actions/test/initiateWithdraw.test.ts
@@ -359,5 +359,30 @@ describe('withdraw', function () {
       )
       expect(onSettled).toHaveBeenCalledOnce()
     })
+
+    it('should emit "withdraw-failed-validation" if the account ETH balance is zero', async function () {
+      const l2PublicClient = createL2PublicClient({
+        getBalance: vi.fn().mockResolvedValue(BigInt(0)),
+        getErc20TokenBalance: vi.fn().mockResolvedValue(BigInt(100)),
+      })
+
+      const { emitter, promise } = initiateWithdrawErc20({
+        ...validParameters,
+        l2PublicClient,
+      })
+
+      const failedValidation = vi.fn()
+      const onSettled = vi.fn()
+
+      emitter.on('withdraw-failed-validation', failedValidation)
+      emitter.on('withdraw-settled', onSettled)
+
+      await promise
+
+      expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+        'insufficient balance to pay for gas',
+      )
+      expect(onSettled).toHaveBeenCalledOnce()
+    })
   })
 })


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR creates the functions to initiate a withdraw using `viem`. These are added to `hemi-tunnel-actions`.

It works both for ETH and `erc20`. The next PR will be using this function to run the withdraw from the portal

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #37 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
