### PR TITLE
Adds social media metadata for link preview

### DIFF
--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -1,13 +1,8 @@
 import { locales } from 'app/i18n'
-import type { Metadata } from 'next'
 import { ReactNode } from 'react'
 
 type Props = {
   children: ReactNode
-}
-
-export const metadata: Metadata = {
-  title: 'Hemi Portal',
 }
 
 export const generateStaticParams = async () =>

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -1,4 +1,29 @@
+import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
+
+export const metadata: Metadata = {
+  description:
+    'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
+  openGraph: {
+    description:
+      'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
+    images: [
+      {
+        url: 'https://hemi.xyz/image/portal.png',
+      },
+    ],
+    title: 'Hemi Portal',
+    type: 'website',
+  },
+  title: 'Hemi Portal',
+  twitter: {
+    card: 'summary_large_image',
+    description:
+      'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
+    images: ['https://hemi.xyz/image/portal.png'],
+    title: 'Hemi Portal',
+  },
+}
 
 export default function RootPage() {
   redirect('/tunnel')

--- a/webapp/scripts/generateHeaders.js
+++ b/webapp/scripts/generateHeaders.js
@@ -80,6 +80,7 @@ customRpcOrigins.forEach(function (url) {
 
 // these are domains where we download images from
 const imageSrcUrls = [
+  'https://hemi.xyz',
   'https://raw.githubusercontent.com',
   'https://*.walletconnect.com',
 ]


### PR DESCRIPTION
### Description

As the title suggests, this PR adds social media metadata for link preview. Since the Portal is currently a static Next.js app, it’s not possible to dynamically handle multiple languages for metadata. For now, we’re starting with English-only support.
In the future, we can explore ways to support localized previews and route-specific metadata.. for example, one preview for /tunnel, another for /stake, etc.

### Screenshots

<img width="694" alt="Captura de Tela 2025-04-10 às 16 29 41" src="https://github.com/user-attachments/assets/7ec2051a-8f9c-4f2e-a862-9a941f62efb3" />


### Related issue(s)

Closes #81

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
