### PR TITLE
Add metadata support per route

### DIFF
--- a/webapp/app/[locale]/demos/layout.tsx
+++ b/webapp/app/[locale]/demos/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { PropsWithChildren } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Demos | Hemi Portal',
+}
+
+export default function DemosLayout({ children }: PropsWithChildren) {
+  return <>{children}</>
+}

--- a/webapp/app/[locale]/get-started/layout.tsx
+++ b/webapp/app/[locale]/get-started/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { PropsWithChildren } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Get Started | Hemi Portal',
+}
+
+export default function GetStartedLayout({ children }: PropsWithChildren) {
+  return <>{children}</>
+}

--- a/webapp/app/[locale]/stake/_components/stakeLayoutClient.tsx
+++ b/webapp/app/[locale]/stake/_components/stakeLayoutClient.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { StakeTabs } from 'components/stakeTabs'
+import { useNetworkType } from 'hooks/useNetworkType'
+import { useStakeTokens } from 'hooks/useStakeTokens'
+import dynamic from 'next/dynamic'
+import { Suspense } from 'react'
+import { isStakeEnabledOnTestnet } from 'utils/stake'
+
+import { useDrawerStakeQueryString } from '../_hooks/useDrawerStakeQueryString'
+
+import { StakeDisabledTestnet } from './stakeDisabledTestnet'
+
+const ManageStake = dynamic(
+  () => import('./manageStake').then(mod => mod.ManageStake),
+  {
+    ssr: false,
+  },
+)
+
+const SideDrawer = function () {
+  const { drawerMode, setDrawerQueryString, tokenAddress } =
+    useDrawerStakeQueryString()
+  const stakeTokens = useStakeTokens()
+
+  if (!tokenAddress || !drawerMode) {
+    return null
+  }
+
+  const token = stakeTokens.find(t => t.address === tokenAddress)
+
+  if (!token) {
+    return null
+  }
+
+  return (
+    <ManageStake
+      closeDrawer={() => setDrawerQueryString(null, null)}
+      initialOperation={drawerMode === 'manage' ? 'unstake' : 'stake'}
+      mode={drawerMode}
+      token={token}
+    />
+  )
+}
+
+type Props = {
+  children: React.ReactNode
+}
+
+const StakeLayoutClient = function ({ children }: Props) {
+  const [networkType] = useNetworkType()
+
+  if (!isStakeEnabledOnTestnet(networkType)) {
+    return <StakeDisabledTestnet />
+  }
+
+  return (
+    <>
+      <div className="mb-4 mt-5 md:hidden">
+        <StakeTabs />
+      </div>
+      {children}
+      <Suspense>
+        <SideDrawer />
+      </Suspense>
+    </>
+  )
+}
+
+export default StakeLayoutClient

--- a/webapp/app/[locale]/stake/layout.tsx
+++ b/webapp/app/[locale]/stake/layout.tsx
@@ -1,69 +1,11 @@
-'use client'
+import { Metadata } from 'next'
 
-import { StakeTabs } from 'components/stakeTabs'
-import { useNetworkType } from 'hooks/useNetworkType'
-import { useStakeTokens } from 'hooks/useStakeTokens'
-import dynamic from 'next/dynamic'
-import { Suspense } from 'react'
-import { isStakeEnabledOnTestnet } from 'utils/stake'
+import StakeLayoutClient from './_components/stakeLayoutClient'
 
-import { StakeDisabledTestnet } from './_components/stakeDisabledTestnet'
-import { useDrawerStakeQueryString } from './_hooks/useDrawerStakeQueryString'
-
-const ManageStake = dynamic(
-  () => import('./_components/manageStake').then(mod => mod.ManageStake),
-  {
-    ssr: false,
-  },
-)
-
-const SideDrawer = function () {
-  const { drawerMode, setDrawerQueryString, tokenAddress } =
-    useDrawerStakeQueryString()
-  const stakeTokens = useStakeTokens()
-
-  if (!tokenAddress || !drawerMode) {
-    return null
-  }
-
-  const token = stakeTokens.find(t => t.address === tokenAddress)
-
-  if (!token) {
-    return null
-  }
-
-  return (
-    <ManageStake
-      closeDrawer={() => setDrawerQueryString(null, null)}
-      initialOperation={drawerMode === 'manage' ? 'unstake' : 'stake'}
-      mode={drawerMode}
-      token={token}
-    />
-  )
+export const metadata: Metadata = {
+  title: 'Stake | Hemi Portal',
 }
 
-type Props = {
-  children: React.ReactNode
+export default function StakeLayout(props: { children: React.ReactNode }) {
+  return <StakeLayoutClient {...props} />
 }
-
-const Layout = function ({ children }: Props) {
-  const [networkType] = useNetworkType()
-
-  if (!isStakeEnabledOnTestnet(networkType)) {
-    return <StakeDisabledTestnet />
-  }
-
-  return (
-    <>
-      <div className="mb-4 mt-5 md:hidden">
-        <StakeTabs />
-      </div>
-      {children}
-      <Suspense>
-        <SideDrawer />
-      </Suspense>
-    </>
-  )
-}
-
-export default Layout

--- a/webapp/app/[locale]/tunnel/layout.tsx
+++ b/webapp/app/[locale]/tunnel/layout.tsx
@@ -1,21 +1,25 @@
 import { TunnelTabs } from 'components/tunnelTabs'
 import { TransactionsInProgressProvider } from 'context/transactionsInProgressContext'
+import { Metadata } from 'next'
 
 import { ViewOperation } from './_components/viewOperation'
+
+export const metadata: Metadata = {
+  title: 'Tunnel | Hemi Portal',
+}
 
 type Props = {
   children: React.ReactNode
 }
 
-const Layout = ({ children }: Props) => (
-  <TransactionsInProgressProvider>
-    {/* only visible in mobile, for larger viewports check header.tsx */}
-    <div className="mb-4 mt-5 md:hidden">
-      <TunnelTabs />
-    </div>
-    {children}
-    <ViewOperation />
-  </TransactionsInProgressProvider>
-)
-
-export default Layout
+export default function Layout({ children }: Props) {
+  return (
+    <TransactionsInProgressProvider>
+      <div className="mb-4 mt-5 md:hidden">
+        <TunnelTabs />
+      </div>
+      {children}
+      <ViewOperation />
+    </TransactionsInProgressProvider>
+  )
+}

--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -1,8 +1,31 @@
 import { locales } from 'app/i18n'
+import { Metadata } from 'next'
 import { ReactNode } from 'react'
 
 type Props = {
   children: ReactNode
+}
+
+export const metadata: Metadata = {
+  description:
+    'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
+  openGraph: {
+    description:
+      'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
+    images: [
+      {
+        url: 'https://hemi.xyz/image/portal.png',
+      },
+    ],
+    type: 'website',
+  },
+  title: 'Hemi Portal',
+  twitter: {
+    card: 'summary_large_image',
+    description:
+      'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
+    images: ['https://hemi.xyz/image/portal.png'],
+  },
 }
 
 export const generateStaticParams = async () =>

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -1,29 +1,4 @@
-import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
-
-export const metadata: Metadata = {
-  description:
-    'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
-  openGraph: {
-    description:
-      'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
-    images: [
-      {
-        url: 'https://hemi.xyz/image/portal.png',
-      },
-    ],
-    title: 'Hemi Portal',
-    type: 'website',
-  },
-  title: 'Hemi Portal',
-  twitter: {
-    card: 'summary_large_image',
-    description:
-      'Hemi | Powered by Bitcoin and Ethereum — Bridge, swap, build, and more. All on Hemi.',
-    images: ['https://hemi.xyz/image/portal.png'],
-    title: 'Hemi Portal',
-  },
-}
 
 export default function RootPage() {
   redirect('/tunnel')


### PR DESCRIPTION
### Description

This update introduces support for route-specific metadata, allowing us to customize the title, description, and social preview per page (e.g. Tunnel, Stake, etc). The idea and initial test came from a conversation with @gndelia. As a next step, we’d like to explore adding multilingual support for metadata as well. That’s a bit trickier since the project is statically generated and would require dynamic or per-locale handling at build time.

### Screenshots

### App
<img width="694" alt="Captura de Tela 2025-04-10 às 16 29 41" src="https://github.com/user-attachments/assets/7689157d-0554-4ae1-a2e7-c1477daa40ef" />

### Tunnel
<img width="612" alt="Captura de Tela 2025-04-10 às 18 23 24" src="https://github.com/user-attachments/assets/28b9e60c-ad33-4c50-ad03-b7d7ce1fe17d" />

### Stake
<img width="608" alt="Captura de Tela 2025-04-10 às 18 23 45" src="https://github.com/user-attachments/assets/00d7788f-374f-44ea-82a9-512db709835d" />

### Demos
<img width="627" alt="Captura de Tela 2025-04-10 às 18 24 18" src="https://github.com/user-attachments/assets/7eb1b819-384b-4953-ade9-01546daac114" />

### Get Started
<img width="617" alt="Captura de Tela 2025-04-10 às 18 24 07" src="https://github.com/user-attachments/assets/8585f619-985d-4d45-8d6d-93acd875475f" />

### Related issue(s)

Closes #81

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
