### PR TITLE
Drop OP SDK Part 8: Add proveWithdrawal action to hemi-tunnel-actions

### DIFF
--- a/packages/hemi-tunnel-actions/index.ts
+++ b/packages/hemi-tunnel-actions/index.ts
@@ -5,3 +5,4 @@ export {
   initiateWithdrawEth,
   initiateWithdrawErc20,
 } from './src/initiateWithdraw'
+export { prepareProveWithdrawal, proveWithdrawal } from './src/proveWithdrawal'

--- a/packages/hemi-tunnel-actions/src/proveWithdrawal.ts
+++ b/packages/hemi-tunnel-actions/src/proveWithdrawal.ts
@@ -1,0 +1,189 @@
+import { EventEmitter } from 'events'
+import {
+  Address,
+  Hash,
+  PublicClient,
+  WalletClient,
+  publicActions,
+  isAddress,
+  isHash,
+  PublicActions,
+} from 'viem'
+import {
+  getWithdrawalStatus,
+  PublicActionsL1,
+  publicActionsL1,
+  PublicActionsL2,
+  publicActionsL2,
+  walletActionsL1,
+} from 'viem/op-stack'
+
+import { ProveEvents } from './types'
+import { toPromiseEvent } from './utils'
+
+type ProveWithdrawalParams = {
+  account: Address
+  l1WalletClient: WalletClient
+  l2PublicClient: PublicClient
+  withdrawalTransactionHash: Hash
+}
+
+const canProveWithdrawal = async function ({
+  account,
+  l1WalletClient,
+  l2PublicClient,
+  withdrawalTransactionHash,
+}: {
+  account: Address
+  l1WalletClient: WalletClient
+  l2PublicClient: PublicClient
+  withdrawalTransactionHash: Hash
+}): Promise<{ canProve: boolean; reason?: string }> {
+  if (!isHash(withdrawalTransactionHash)) {
+    return { canProve: false, reason: 'invalid withdrawal transaction hash' }
+  }
+  if (!isAddress(account)) {
+    return { canProve: false, reason: 'account is not a valid address' }
+  }
+
+  const receipt = await l2PublicClient
+    .getTransactionReceipt({
+      hash: withdrawalTransactionHash,
+    })
+    .catch(() => null)
+
+  if (!receipt || receipt.status !== 'success') {
+    return {
+      canProve: false,
+      reason: 'Invalid or unsuccessful transaction receipt',
+    }
+  }
+
+  // Using @ts-expect-error fails to compile so I need to use @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore because it works on IDE, and when building on its own, but fails when compiling from the portal through next
+  const withdrawalStatus = await getWithdrawalStatus(l1WalletClient, {
+    chain: l1WalletClient.chain,
+    receipt,
+    targetChain: l2PublicClient.chain,
+  })
+
+  if (withdrawalStatus !== 'ready-to-prove') {
+    return {
+      canProve: false,
+      reason: `Withdrawal status is not ready-to-prove, current status: ${withdrawalStatus}`,
+    }
+  }
+
+  return { canProve: true }
+}
+
+export const prepareProveWithdrawal = ({
+  account,
+  hash,
+  l1PublicClient,
+  l2PublicClient,
+}: {
+  account: Address
+  hash: Hash
+  l1PublicClient: PublicActions & PublicActionsL1
+  l2PublicClient: PublicClient & PublicActionsL2
+}) =>
+  l2PublicClient
+    .getTransactionReceipt({
+      hash,
+    })
+    .then(withdrawalReceipt =>
+      // withdrawals is ready-to-prove, as checked above, so this will
+      // return the data we need
+      l1PublicClient.waitToProve({
+        receipt: withdrawalReceipt,
+        // @ts-expect-error chain is a valid chain
+        targetChain: l2PublicClient.chain,
+      }),
+    )
+    .then(({ output, withdrawal }) =>
+      // @ts-expect-error chain is not required, unsure why TS marks it as required
+      l2PublicClient.buildProveWithdrawal({
+        account,
+        output,
+        withdrawal,
+      }),
+    )
+
+const runProveWithdrawal = ({
+  account,
+  l1WalletClient,
+  l2PublicClient,
+  withdrawalTransactionHash,
+}: ProveWithdrawalParams) =>
+  async function (emitter: EventEmitter<ProveEvents>) {
+    try {
+      const extendedClientL2 = l2PublicClient.extend(publicActionsL2())
+      const extendedWalletClientL1 = l1WalletClient
+        // Extending the WalletClient with PublicActions, so we don't need another publicClient connected to the
+        // same chain. This is valid.
+        // See https://viem.sh/docs/clients/wallet#optional-extend-with-public-actions
+        .extend(publicActions)
+        .extend(publicActionsL1())
+        .extend(walletActionsL1())
+
+      const { canProve, reason } = await canProveWithdrawal({
+        account,
+        l1WalletClient: extendedWalletClientL1,
+        l2PublicClient: extendedClientL2,
+        withdrawalTransactionHash,
+      })
+
+      if (!canProve) {
+        emitter.emit('prove-failed-validation', reason!)
+        return
+      }
+
+      emitter.emit('pre-prove')
+
+      const proveHash = await prepareProveWithdrawal({
+        account,
+        hash: withdrawalTransactionHash,
+        l1PublicClient: extendedWalletClientL1,
+        l2PublicClient: extendedClientL2,
+      })
+        // @ts-expect-error chain is not required, unsure why TS marks it as required
+        .then(proveArgs => extendedWalletClientL1.proveWithdrawal(proveArgs))
+        .catch(function (error) {
+          emitter.emit('user-signed-prove-error', error)
+        })
+
+      if (!proveHash) {
+        return
+      }
+
+      emitter.emit('user-signed-prove', proveHash)
+
+      const proveReceipt = await extendedWalletClientL1
+        .waitForTransactionReceipt({
+          hash: proveHash,
+        })
+        .catch(function (err) {
+          emitter.emit('prove-failed', err)
+        })
+
+      if (!proveReceipt) {
+        return
+      }
+
+      emitter.emit(
+        proveReceipt.status === 'success'
+          ? 'prove-transaction-succeeded'
+          : 'prove-transaction-reverted',
+        proveReceipt,
+      )
+    } catch (error) {
+      emitter.emit('unexpected-error', error as Error)
+    } finally {
+      emitter.emit('prove-settled')
+    }
+  }
+
+export const proveWithdrawal = (args: ProveWithdrawalParams) =>
+  toPromiseEvent<ProveEvents>(runProveWithdrawal(args))

--- a/packages/hemi-tunnel-actions/src/types.ts
+++ b/packages/hemi-tunnel-actions/src/types.ts
@@ -1,13 +1,16 @@
 import { type Hash, TransactionReceipt } from 'viem'
 
-export type DepositEvents = {
+type CommonEvents = {
+  'unexpected-error': [Error]
+}
+
+export type DepositEvents = CommonEvents & {
   'deposit-failed': [Error]
   'deposit-failed-validation': [string]
   'deposit-settled': []
   'deposit-transaction-reverted': [TransactionReceipt]
   'deposit-transaction-succeeded': [TransactionReceipt]
   'pre-deposit': []
-  'unexpected-error': [Error]
   'user-signed-deposit': [Hash]
   'user-signing-deposit-error': [Error]
 }
@@ -21,9 +24,8 @@ export type DepositErc20Events = DepositEvents & {
   'user-signing-approve-error': [Error]
 }
 
-export type WithdrawEvents = {
+export type WithdrawEvents = CommonEvents & {
   'pre-withdraw': []
-  'unexpected-error': [Error]
   'user-signed-withdraw': [Hash]
   'user-signing-withdraw-error': [Error]
   'withdraw-failed': [Error]
@@ -31,4 +33,15 @@ export type WithdrawEvents = {
   'withdraw-transaction-reverted': [TransactionReceipt]
   'withdraw-transaction-succeeded': [TransactionReceipt]
   'withdraw-failed-validation': [string]
+}
+
+export type ProveEvents = CommonEvents & {
+  'pre-prove': []
+  'prove-failed-validation': [string]
+  'prove-failed': [Error]
+  'prove-settled': []
+  'prove-transaction-reverted': [TransactionReceipt]
+  'prove-transaction-succeeded': [TransactionReceipt]
+  'user-signed-prove': [Hash]
+  'user-signed-prove-error': [Error]
 }

--- a/packages/hemi-tunnel-actions/test/proveWithdrawal.test.ts
+++ b/packages/hemi-tunnel-actions/test/proveWithdrawal.test.ts
@@ -1,0 +1,240 @@
+import { PublicClient, WalletClient, zeroAddress, zeroHash } from 'viem'
+import { getWithdrawalStatus } from 'viem/op-stack'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { proveWithdrawal } from '../src/proveWithdrawal'
+
+vi.mock('viem/op-stack', async function (importOriginal) {
+  const opStack = (await importOriginal()) as object
+  return {
+    ...opStack,
+    getWithdrawalStatus: vi.fn(),
+  }
+})
+
+const createL2PublicClient = ({
+  getTransactionReceipt = vi.fn().mockResolvedValue({ status: 'success' }),
+  buildProveWithdrawal = vi.fn().mockResolvedValue({}),
+} = {}): PublicClient =>
+  ({
+    extend: vi.fn().mockReturnValue({
+      buildProveWithdrawal,
+      getTransactionReceipt,
+    }),
+  }) as PublicClient
+
+const createL1WalletClient = function ({
+  proveWithdrawal: prove = vi.fn().mockResolvedValue(zeroHash),
+  waitForTransactionReceipt = vi.fn().mockResolvedValue({ status: 'success' }),
+  waitToProve = vi.fn().mockResolvedValue({ output: {}, withdrawal: {} }),
+} = {}): WalletClient {
+  const mockClient = {
+    extend: vi
+      .fn()
+      .mockImplementation(actions => ({ ...mockClient, ...actions })),
+    proveWithdrawal: prove,
+    waitForTransactionReceipt,
+    waitToProve,
+  }
+  return mockClient as WalletClient
+}
+
+const validParameters = {
+  account: zeroAddress,
+  l1WalletClient: createL1WalletClient(),
+  l2PublicClient: createL2PublicClient(),
+  withdrawalTransactionHash: zeroHash,
+}
+
+describe('proveWithdrawal', function () {
+  beforeEach(function () {
+    vi.clearAllMocks()
+  })
+
+  it('should emit "prove-failed-validation" if the withdrawal transaction hash is not a valid hash', async function () {
+    const { emitter, promise } = proveWithdrawal({
+      ...validParameters,
+      withdrawalTransactionHash: 'invalid-hash',
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('prove-failed-validation', failedValidation)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'invalid withdrawal transaction hash',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "prove-failed-validation" if the account is not a valid address', async function () {
+    const { emitter, promise } = proveWithdrawal({
+      ...validParameters,
+      account: 123,
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('prove-failed-validation', failedValidation)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'account is not a valid address',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "prove-failed-validation" if the transaction receipt was not found', async function () {
+    const { emitter, promise } = proveWithdrawal({
+      ...validParameters,
+      l2PublicClient: createL2PublicClient({
+        getTransactionReceipt: vi.fn().mockResolvedValue(null),
+      }),
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('prove-failed-validation', failedValidation)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'Invalid or unsuccessful transaction receipt',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "prove-failed-validation" if the transaction receipt status was reverted', async function () {
+    const { emitter, promise } = proveWithdrawal({
+      ...validParameters,
+      l2PublicClient: createL2PublicClient({
+        getTransactionReceipt: vi
+          .fn()
+          .mockResolvedValue({ status: 'reverted' }),
+      }),
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('prove-failed-validation', failedValidation)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'Invalid or unsuccessful transaction receipt',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "prove-failed-validation" if getWithdrawalStatus does not return "ready-to-prove"', async function () {
+    const withdrawalStatus = 'not-ready-to-prove'
+    const { emitter, promise } = proveWithdrawal(validParameters)
+    vi.mocked(getWithdrawalStatus).mockResolvedValue(withdrawalStatus)
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('prove-failed-validation', failedValidation)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      `Withdrawal status is not ready-to-prove, current status: ${withdrawalStatus}`,
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "user-signed-prove-error" if the user rejects signing the prove transaction', async function () {
+    const l1WalletClient = createL1WalletClient({
+      proveWithdrawal: vi.fn().mockRejectedValue(new Error('User rejected')),
+    })
+    vi.mocked(getWithdrawalStatus).mockResolvedValue('ready-to-prove')
+
+    const { emitter, promise } = proveWithdrawal({
+      ...validParameters,
+      l1WalletClient,
+    })
+
+    const onPreProve = vi.fn()
+    const onSigningError = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-prove', onPreProve)
+    emitter.on('user-signed-prove-error', onSigningError)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(onPreProve).toHaveBeenCalledOnce()
+    expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "prove-transaction-succeeded" if the prove transaction is successful', async function () {
+    const proveReceipt = { status: 'success' }
+
+    const l1WalletClient = createL1WalletClient({
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(proveReceipt),
+    })
+    vi.mocked(getWithdrawalStatus).mockResolvedValue('ready-to-prove')
+
+    const { emitter, promise } = proveWithdrawal({
+      ...validParameters,
+      l1WalletClient,
+    })
+
+    const onPreProve = vi.fn()
+    const onProveSucceeded = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-prove', onPreProve)
+    emitter.on('prove-transaction-succeeded', onProveSucceeded)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(onPreProve).toHaveBeenCalledOnce()
+    expect(onProveSucceeded).toHaveBeenCalledExactlyOnceWith(proveReceipt)
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "prove-transaction-reverted" if the prove transaction reverts', async function () {
+    const proveReceipt = { status: 'reverted' }
+
+    const l1WalletClient = createL1WalletClient({
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(proveReceipt),
+    })
+    vi.mocked(getWithdrawalStatus).mockResolvedValue('ready-to-prove')
+
+    const { emitter, promise } = proveWithdrawal({
+      ...validParameters,
+      l1WalletClient,
+    })
+
+    const onPreProve = vi.fn()
+    const onProveReverted = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-prove', onPreProve)
+    emitter.on('prove-transaction-reverted', onProveReverted)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(onPreProve).toHaveBeenCalledOnce()
+    expect(onProveReverted).toHaveBeenCalledExactlyOnceWith(proveReceipt)
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the `proveWithdrawal` action in `hemi-tunnel-actions` using `viem` instead of the OP SDK code. Next PR will use this action to prove withdrawals.

Note that while for `deposit` and `initiateWithdrawal` I had to use custom interactions with `L1StandardBridge` and `L2Bridge`, for the prove and claim actions, I was able to use `viem` extensions from `op-stack`.

Because of this, it is not needed to export a function that returns the encoded data because there's already a viem function to [estimate proving withdrawals](https://viem.sh/op-stack/actions/estimateProveWithdrawalGas)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users - this just adds a function into the package

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #37 (Removing OP SDK code)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
