### PR TITLE
Get timestamp for failed withdrawals

### DIFF
--- a/webapp/app/[locale]/tunnel/_hooks/useWithdraw.ts
+++ b/webapp/app/[locale]/tunnel/_hooks/useWithdraw.ts
@@ -111,6 +111,7 @@ export const useWithdraw = function ({
         track?.('evm - init withdraw failed', { chain: networkType })
 
         updateWithdrawal(withdrawal, {
+          blockNumber: Number(receipt.blockNumber),
           status: MessageStatus.FAILED_L1_TO_L2_MESSAGE,
         })
       })

--- a/webapp/context/tunnelHistoryContext/withdrawalsStateUpdater.tsx
+++ b/webapp/context/tunnelHistoryContext/withdrawalsStateUpdater.tsx
@@ -23,21 +23,21 @@ const getMinutes = (minutes: number) => getSeconds(minutes * 60)
 const refetchInterval = {
   [hemiMainnet.id]: {
     [MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE]: getSeconds(24),
-    [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: false,
+    [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: getMinutes(3),
     [MessageStatus.STATE_ROOT_NOT_PUBLISHED]: getMinutes(1),
     [MessageStatus.READY_TO_PROVE]: getMinutes(1),
     [MessageStatus.IN_CHALLENGE_PERIOD]: getMinutes(3),
     [MessageStatus.READY_FOR_RELAY]: getMinutes(3),
-    [MessageStatus.RELAYED]: false,
+    [MessageStatus.RELAYED]: getMinutes(3),
   },
   [hemiTestnet.id]: {
     [MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE]: getSeconds(24),
-    [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: false,
+    [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: getMinutes(3),
     [MessageStatus.STATE_ROOT_NOT_PUBLISHED]: getMinutes(1),
     [MessageStatus.READY_TO_PROVE]: getMinutes(2),
     [MessageStatus.IN_CHALLENGE_PERIOD]: getMinutes(2),
     [MessageStatus.READY_FOR_RELAY]: getMinutes(2),
-    [MessageStatus.RELAYED]: false,
+    [MessageStatus.RELAYED]: getMinutes(3),
   },
 } satisfies { [chainId: number]: { [status: number]: number | false } }
 

--- a/webapp/utils/tunnel.ts
+++ b/webapp/utils/tunnel.ts
@@ -43,7 +43,7 @@ const mapStatusToOpMessageStatus = function (
   }
 }
 
-export const getEvmWithdrawalStatus = async ({
+export const getEvmWithdrawalStatus = async function ({
   l1publicClient,
   l2ChainId,
   receipt,
@@ -51,13 +51,17 @@ export const getEvmWithdrawalStatus = async ({
   l1publicClient: PublicClient
   l2ChainId: Chain['id']
   receipt: TransactionReceipt
-}) =>
+}) {
+  if (receipt.status === 'reverted') {
+    return MessageStatus.FAILED_L1_TO_L2_MESSAGE
+  }
   // @ts-expect-error Can't make the viem types to work. This works on runtime
-  getWithdrawalStatus(l1publicClient, {
+  return getWithdrawalStatus(l1publicClient, {
     chain: l1publicClient.chain,
     receipt,
     targetChain: findChainById(l2ChainId),
   }).then(mapStatusToOpMessageStatus)
+}
 
 export const isDeposit = (
   operation: TunnelOperation,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR fixes failed withdrawals that do not show the timestamp in the TX history.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

![image](https://github.com/user-attachments/assets/02137903-d378-4094-b088-16c7ccec249c)


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1127

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
