### PR TITLE
Drop OP SDK part 10: Add action to finalize a withdrawal

### DIFF
--- a/packages/hemi-tunnel-actions/index.ts
+++ b/packages/hemi-tunnel-actions/index.ts
@@ -1,5 +1,6 @@
 export { depositErc20, encodeDepositErc20 } from './src/depositErc20'
 export { depositEth, encodeDepositEth } from './src/depositEth'
+export { finalizeWithdrawal } from './src/finalizeWithdrawal'
 export {
   encodeInitiateWithdraw,
   initiateWithdrawEth,

--- a/packages/hemi-tunnel-actions/src/depositErc20.ts
+++ b/packages/hemi-tunnel-actions/src/depositErc20.ts
@@ -171,6 +171,9 @@ const runDepositErc20 = ({
         return
       }
 
+      // Using @ts-expect-error fails to compile so I need to use @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore because it works on IDE, and when building on its own, but fails when compiling from the portal through next
       await handleWaitDeposit({
         emitter,
         hash: depositHash,

--- a/packages/hemi-tunnel-actions/src/finalizeWithdrawal.ts
+++ b/packages/hemi-tunnel-actions/src/finalizeWithdrawal.ts
@@ -61,12 +61,14 @@ const canFinalizeWithdrawal = async function ({
     chain: l1WalletClient.chain,
     receipt,
     targetChain: l2PublicClient.chain,
-  })
+  }).catch(() => null)
 
   if (withdrawalStatus !== 'ready-to-finalize') {
     return {
       canFinalize: false,
-      reason: `Withdrawal status is not ready-to-finalize, current status: ${withdrawalStatus}`,
+      reason: withdrawalStatus
+        ? `Withdrawal status is not ready-to-finalize, current status: ${withdrawalStatus}`
+        : 'Failed to get Withdrawal status',
     }
   }
 

--- a/packages/hemi-tunnel-actions/src/finalizeWithdrawal.ts
+++ b/packages/hemi-tunnel-actions/src/finalizeWithdrawal.ts
@@ -1,0 +1,155 @@
+import { EventEmitter } from 'events'
+import {
+  Address,
+  Hash,
+  isAddress,
+  isHash,
+  PublicClient,
+  WalletClient,
+  publicActions,
+} from 'viem'
+import {
+  getWithdrawalStatus,
+  getWithdrawals,
+  publicActionsL1,
+  walletActionsL1,
+} from 'viem/op-stack'
+
+import { FinalizeEvents } from './types'
+import { toPromiseEvent } from './utils'
+
+type FinalizeWithdrawalParams = {
+  account: Address
+  l1WalletClient: WalletClient
+  l2PublicClient: PublicClient
+  withdrawalTransactionHash: Hash
+}
+
+const canFinalizeWithdrawal = async function ({
+  account,
+  l1WalletClient,
+  l2PublicClient,
+  withdrawalTransactionHash,
+}: FinalizeWithdrawalParams): Promise<{
+  canFinalize: boolean
+  reason?: string
+}> {
+  if (!isHash(withdrawalTransactionHash)) {
+    return { canFinalize: false, reason: 'invalid withdrawal transaction hash' }
+  }
+  if (!isAddress(account)) {
+    return { canFinalize: false, reason: 'account is not a valid address' }
+  }
+
+  const receipt = await l2PublicClient
+    .getTransactionReceipt({
+      hash: withdrawalTransactionHash,
+    })
+    .catch(() => null)
+
+  if (!receipt || receipt.status !== 'success') {
+    return {
+      canFinalize: false,
+      reason: 'Invalid or unsuccessful transaction receipt',
+    }
+  }
+
+  // Using @ts-expect-error fails to compile so I need to use @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore because it works on IDE, and when building on its own, but fails when compiling from the portal through next
+  const withdrawalStatus = await getWithdrawalStatus(l1WalletClient, {
+    chain: l1WalletClient.chain,
+    receipt,
+    targetChain: l2PublicClient.chain,
+  })
+
+  if (withdrawalStatus !== 'ready-to-finalize') {
+    return {
+      canFinalize: false,
+      reason: `Withdrawal status is not ready-to-finalize, current status: ${withdrawalStatus}`,
+    }
+  }
+
+  return { canFinalize: true }
+}
+
+const runFinalizeWithdrawal = ({
+  account,
+  l1WalletClient,
+  l2PublicClient,
+  withdrawalTransactionHash,
+}: FinalizeWithdrawalParams) =>
+  async function (emitter: EventEmitter<FinalizeEvents>) {
+    try {
+      const extendedL1WalletClient = l1WalletClient
+        // Extending the WalletClient with PublicActions, so we don't need another publicClient connected to the
+        // same chain. This is valid.
+        // See https://viem.sh/docs/clients/wallet#optional-extend-with-public-actions
+        .extend(publicActions)
+        .extend(publicActionsL1())
+        .extend(walletActionsL1())
+
+      const { canFinalize, reason } = await canFinalizeWithdrawal({
+        account,
+        l1WalletClient: extendedL1WalletClient,
+        l2PublicClient,
+        withdrawalTransactionHash,
+      })
+
+      if (!canFinalize) {
+        emitter.emit('finalize-failed-validation', reason!)
+        return
+      }
+
+      const receipt = await l2PublicClient.getTransactionReceipt({
+        hash: withdrawalTransactionHash,
+      })
+
+      const [withdrawal] = getWithdrawals(receipt)
+
+      emitter.emit('pre-finalize')
+
+      const finalizeHash = await extendedL1WalletClient
+        .finalizeWithdrawal({
+          account,
+          // @ts-expect-error This works, it fails due to viem bad inference
+          targetChain: l2PublicClient.chain,
+          withdrawal,
+        })
+        .catch(function (error) {
+          emitter.emit('user-signed-finalize-error', error)
+        })
+
+      if (!finalizeHash) {
+        return
+      }
+
+      emitter.emit('user-signed-finalize', finalizeHash)
+
+      const finalizeReceipt = await extendedL1WalletClient
+        .waitForTransactionReceipt({
+          hash: finalizeHash,
+        })
+        .catch(function (err) {
+          emitter.emit('finalize-failed', err)
+        })
+
+      if (!finalizeReceipt) {
+        return
+      }
+
+      emitter.emit(
+        finalizeReceipt.status === 'success'
+          ? 'finalize-transaction-succeeded'
+          : 'finalize-transaction-reverted',
+        finalizeReceipt,
+      )
+    } catch (error) {
+      emitter.emit('unexpected-error', error as Error)
+    } finally {
+      emitter.emit('finalize-settled')
+    }
+  }
+
+export const finalizeWithdrawal = (args: FinalizeWithdrawalParams) =>
+  toPromiseEvent<FinalizeEvents>(runFinalizeWithdrawal(args))

--- a/packages/hemi-tunnel-actions/src/proveWithdrawal.ts
+++ b/packages/hemi-tunnel-actions/src/proveWithdrawal.ts
@@ -66,12 +66,14 @@ const canProveWithdrawal = async function ({
     chain: l1WalletClient.chain,
     receipt,
     targetChain: l2PublicClient.chain,
-  })
+  }).catch(() => null)
 
   if (withdrawalStatus !== 'ready-to-prove') {
     return {
       canProve: false,
-      reason: `Withdrawal status is not ready-to-prove, current status: ${withdrawalStatus}`,
+      reason: withdrawalStatus
+        ? `Withdrawal status is not ready-to-prove, current status: ${withdrawalStatus}`
+        : 'Failed to get Withdrawal status',
     }
   }
 

--- a/packages/hemi-tunnel-actions/src/types.ts
+++ b/packages/hemi-tunnel-actions/src/types.ts
@@ -45,3 +45,14 @@ export type ProveEvents = CommonEvents & {
   'user-signed-prove': [Hash]
   'user-signed-prove-error': [Error]
 }
+
+export type FinalizeEvents = CommonEvents & {
+  'finalize-failed-validation': [string]
+  'finalize-failed': [Error]
+  'finalize-settled': []
+  'finalize-transaction-reverted': [TransactionReceipt]
+  'finalize-transaction-succeeded': [TransactionReceipt]
+  'pre-finalize': []
+  'user-signed-finalize': [Hash]
+  'user-signed-finalize-error': [Error]
+}

--- a/packages/hemi-tunnel-actions/test/finalizeWithdrawal.test.ts
+++ b/packages/hemi-tunnel-actions/test/finalizeWithdrawal.test.ts
@@ -151,6 +151,24 @@ describe('finalizeWithdrawal', function () {
     expect(onSettled).toHaveBeenCalledOnce()
   })
 
+  it('should emit "finalize-failed-validation" if it fails to get Withdrawal status', async function () {
+    const { emitter, promise } = finalizeWithdrawal(validParameters)
+    vi.mocked(getWithdrawalStatus).mockRejectedValue(new Error())
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('finalize-failed-validation', failedValidation)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'Failed to get Withdrawal status',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
   it('should emit "user-signed-finalize-error" if the user rejects signing the finalize transaction', async function () {
     const withdrawal = {}
     const l1WalletClient = createL1WalletClient({

--- a/packages/hemi-tunnel-actions/test/finalizeWithdrawal.test.ts
+++ b/packages/hemi-tunnel-actions/test/finalizeWithdrawal.test.ts
@@ -1,0 +1,247 @@
+import { PublicClient, WalletClient, zeroAddress, zeroHash } from 'viem'
+import { getWithdrawals, getWithdrawalStatus } from 'viem/op-stack'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { finalizeWithdrawal } from '../src/finalizeWithdrawal'
+
+vi.mock('viem/op-stack', async function (importOriginal) {
+  const opStack = (await importOriginal()) as object
+  return {
+    ...opStack,
+    getWithdrawals: vi.fn(),
+    getWithdrawalStatus: vi.fn(),
+  }
+})
+
+const createL2PublicClient = ({
+  getTransactionReceipt = vi.fn().mockResolvedValue({ status: 'success' }),
+} = {}): PublicClient =>
+  ({
+    getTransactionReceipt,
+  }) as PublicClient
+
+const createL1WalletClient = function ({
+  finalizeWithdrawal: finalize = vi.fn().mockResolvedValue(zeroHash),
+  waitForTransactionReceipt = vi.fn().mockResolvedValue({ status: 'success' }),
+} = {}): WalletClient {
+  const mockClient = {
+    extend: vi
+      .fn()
+      .mockImplementation(actions => ({ ...mockClient, ...actions })),
+    finalizeWithdrawal: finalize,
+    waitForTransactionReceipt,
+  }
+  return mockClient as WalletClient
+}
+
+const validParameters = {
+  account: zeroAddress,
+  l1WalletClient: createL1WalletClient(),
+  l2PublicClient: createL2PublicClient(),
+  withdrawalTransactionHash: zeroHash,
+}
+
+describe('finalizeWithdrawal', function () {
+  beforeEach(function () {
+    vi.clearAllMocks()
+  })
+
+  it('should emit "finalize-failed-validation" if the withdrawal transaction hash is not a valid hash', async function () {
+    const { emitter, promise } = finalizeWithdrawal({
+      ...validParameters,
+      withdrawalTransactionHash: 'invalid-hash',
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('finalize-failed-validation', failedValidation)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'invalid withdrawal transaction hash',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "finalize-failed-validation" if the account is not a valid address', async function () {
+    const { emitter, promise } = finalizeWithdrawal({
+      ...validParameters,
+      account: 123,
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('finalize-failed-validation', failedValidation)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'account is not a valid address',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "finalize-failed-validation" if the transaction receipt was not found', async function () {
+    const { emitter, promise } = finalizeWithdrawal({
+      ...validParameters,
+      l2PublicClient: createL2PublicClient({
+        getTransactionReceipt: vi.fn().mockResolvedValue(null),
+      }),
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('finalize-failed-validation', failedValidation)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'Invalid or unsuccessful transaction receipt',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "finalize-failed-validation" if the withdrawal transaction reverted', async function () {
+    const { emitter, promise } = finalizeWithdrawal({
+      ...validParameters,
+      l2PublicClient: createL2PublicClient({
+        getTransactionReceipt: vi
+          .fn()
+          .mockResolvedValue({ status: 'reverted' }),
+      }),
+    })
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('finalize-failed-validation', failedValidation)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'Invalid or unsuccessful transaction receipt',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "finalize-failed-validation" if getWithdrawalStatus does not return "ready-to-finalize"', async function () {
+    const withdrawalStatus = 'ready-to-prove'
+    const { emitter, promise } = finalizeWithdrawal(validParameters)
+    vi.mocked(getWithdrawalStatus).mockResolvedValue(withdrawalStatus)
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('finalize-failed-validation', failedValidation)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      `Withdrawal status is not ready-to-finalize, current status: ${withdrawalStatus}`,
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "user-signed-finalize-error" if the user rejects signing the finalize transaction', async function () {
+    const withdrawal = {}
+    const l1WalletClient = createL1WalletClient({
+      finalizeWithdrawal: vi.fn().mockRejectedValue(new Error('User rejected')),
+    })
+    vi.mocked(getWithdrawalStatus).mockResolvedValue('ready-to-finalize')
+    vi.mocked(getWithdrawals).mockReturnValue([withdrawal])
+
+    const { emitter, promise } = finalizeWithdrawal({
+      ...validParameters,
+      l1WalletClient,
+    })
+
+    const onPreFinalize = vi.fn()
+    const onSigningError = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-finalize', onPreFinalize)
+    emitter.on('user-signed-finalize-error', onSigningError)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(onPreFinalize).toHaveBeenCalledOnce()
+    expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "finalize-transaction-succeeded" if the finalize transaction is successful', async function () {
+    const finalizeReceipt = { status: 'success' }
+    const withdrawal = {}
+
+    const l1WalletClient = createL1WalletClient({
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(finalizeReceipt),
+    })
+    vi.mocked(getWithdrawalStatus).mockResolvedValue('ready-to-finalize')
+    vi.mocked(getWithdrawals).mockReturnValue([withdrawal])
+
+    const { emitter, promise } = finalizeWithdrawal({
+      ...validParameters,
+      l1WalletClient,
+    })
+
+    const onPreFinalize = vi.fn()
+    const onFinalizeReverted = vi.fn()
+    const onFinalizeSucceeded = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-finalize', onPreFinalize)
+    emitter.on('finalize-transaction-reverted', onFinalizeReverted)
+    emitter.on('finalize-transaction-succeeded', onFinalizeSucceeded)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(onPreFinalize).toHaveBeenCalledOnce()
+    expect(onFinalizeReverted).not.toHaveBeenCalled()
+    expect(onFinalizeSucceeded).toHaveBeenCalledExactlyOnceWith(finalizeReceipt)
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('should emit "finalize-transaction-reverted" if the finalize transaction reverts', async function () {
+    const finalizeReceipt = { status: 'reverted' }
+    const withdrawal = {}
+
+    const l1WalletClient = createL1WalletClient({
+      waitForTransactionReceipt: vi.fn().mockResolvedValue(finalizeReceipt),
+    })
+    vi.mocked(getWithdrawalStatus).mockResolvedValue('ready-to-finalize')
+    vi.mocked(getWithdrawals).mockReturnValue([withdrawal])
+
+    const { emitter, promise } = finalizeWithdrawal({
+      ...validParameters,
+      l1WalletClient,
+    })
+
+    const onPreFinalize = vi.fn()
+    const onFinalizeReverted = vi.fn()
+    const onFinalizeSuccess = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('pre-finalize', onPreFinalize)
+    emitter.on('finalize-transaction-reverted', onFinalizeReverted)
+    emitter.on('finalize-transaction-succeeded', onFinalizeSuccess)
+    emitter.on('finalize-settled', onSettled)
+
+    await promise
+
+    expect(onPreFinalize).toHaveBeenCalledOnce()
+    expect(onFinalizeReverted).toHaveBeenCalledExactlyOnceWith(finalizeReceipt)
+    expect(onFinalizeSuccess).not.toHaveBeenCalled()
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/hemi-tunnel-actions/test/proveWithdrawal.test.ts
+++ b/packages/hemi-tunnel-actions/test/proveWithdrawal.test.ts
@@ -156,6 +156,24 @@ describe('proveWithdrawal', function () {
     expect(onSettled).toHaveBeenCalledOnce()
   })
 
+  it('should emit "prove-failed-validation" if it fails to get Withdrawal status', async function () {
+    const { emitter, promise } = proveWithdrawal(validParameters)
+    vi.mocked(getWithdrawalStatus).mockRejectedValue(new Error())
+
+    const failedValidation = vi.fn()
+    const onSettled = vi.fn()
+
+    emitter.on('prove-failed-validation', failedValidation)
+    emitter.on('prove-settled', onSettled)
+
+    await promise
+
+    expect(failedValidation).toHaveBeenCalledExactlyOnceWith(
+      'Failed to get Withdrawal status',
+    )
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
   it('should emit "user-signed-prove-error" if the user rejects signing the prove transaction', async function () {
     const l1WalletClient = createL1WalletClient({
       proveWithdrawal: vi.fn().mockRejectedValue(new Error('User rejected')),


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

We're getting there! This is the PR 10 of the series to drop the OP SDK. The next one is the last one!

This PR adds the `finalize` action into `hemi-tunnel-actions`. This will be used in the Claim step. Note that I use _Finalize_ because that's the method name in the contract (And in `viem`). Claiming is something from our UI.

Next PR will use this action to claim withdrawals.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes - this just adds an action.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #37

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
