### PR TITLE
Fix error when btc balance is null

### DIFF
--- a/webapp/components/connectWallets/wallets.tsx
+++ b/webapp/components/connectWallets/wallets.tsx
@@ -129,7 +129,7 @@ export const BtcWallet = function () {
       >
         {chainSupported ? (
           <Balance
-            balance={balance !== undefined ? getBalance() : undefined}
+            balance={balance ? getBalance() : undefined}
             token={getNativeToken(bitcoin.id)}
           />
         ) : (


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR fixes an error in which btc balance failed to retrieve. The `balance` variable is an object, and we were checking for `undefined`, but it seems (according to the stack trace) that when it fails to return, `balance` is null. So this PR will check for a truthy value.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1105

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
