### PR TITLE
Prevent subgraph api to get "limit" parameter larger than 5000

### DIFF
--- a/portal/utils/sync-history/common.ts
+++ b/portal/utils/sync-history/common.ts
@@ -1,0 +1,23 @@
+import { TunnelOperation } from 'types/tunnel'
+
+export const calculateSkip = function ({
+  limit,
+  skip,
+  operations,
+}: {
+  limit: number
+  skip: number
+  operations: Pick<TunnelOperation, 'blockNumber'>[]
+}) {
+  // it turns out that GraphQL does not allow $skip larger than 5000
+  // if we hit that limit, we better use a different "fromBlock"
+  if (skip <= 4900) {
+    return { skip: skip + limit }
+  }
+  // if we hit the limit, we need to increase the fromBlock. So grab the last one known as valid
+  // and reset the "skip" to 0
+  return {
+    fromBlock: operations.at(-1).blockNumber?.toString() ?? '0',
+    skip: 0,
+  }
+}

--- a/portal/utils/sync-history/common.ts
+++ b/portal/utils/sync-history/common.ts
@@ -17,7 +17,7 @@ export const calculateSkip = function ({
   // if we hit the limit, we need to increase the fromBlock. So grab the last one known as valid
   // and reset the "skip" to 0
   return {
-    fromBlock: operations.at(-1).blockNumber?.toString() ?? '0',
+    fromBlock: operations.at(-1).blockNumber ?? 0,
     skip: 0,
   }
 }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR solves a corner case of the resync history process, in which when a user has more than 5000 tunneling operations, the subgraphs API would crash because graphQL does not allow `skip` values larger than 5000. When (if) we hit that limit, the solution is to increase the `fromBlock`, and reset `skip` to 0. 
Note that duplicates are already handled in our history reducer, so we don't need to worry about that in the worker.

The solution was inspired in the [stake-operations-script repo](https://github.com/hemilabs/stake-operations-script) where I originally found this issue

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1145

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
