### PR TITLE
Add loading animation to step icons

### DIFF
--- a/portal/components/reviewOperation/positionStatus.tsx
+++ b/portal/components/reviewOperation/positionStatus.tsx
@@ -27,7 +27,13 @@ export const PositionStatus = function ({ position, status }: Props) {
         isNotReady ? 'bg-neutral-300/50' : 'bg-orange-100'
       }`}
     >
-      {isInProgress && <Image alt="Loading icon" src={gradientLoadingImg} />}
+      {isInProgress && (
+        <Image
+          alt="Loading icon"
+          className="animate-spin"
+          src={gradientLoadingImg}
+        />
+      )}
       <div
         className={`absolute inset-0 flex items-center justify-center text-[11px] font-medium leading-none ${
           isNotReady ? 'text-neutral-500' : 'text-orange-500'

--- a/portal/components/reviewOperation/subStep.tsx
+++ b/portal/components/reviewOperation/subStep.tsx
@@ -30,7 +30,7 @@ export function SubStep({ description, status }: Props) {
           {isProgress && (
             <Image
               alt="Loading indicator"
-              className="object-contain"
+              className="animate-spin object-contain"
               fill
               priority
               src={gradientLoadingImg}


### PR DESCRIPTION
### Description

This PR adds a spinning animation to the loading indicators for steps and sub-steps. All steps were reviewed to ensure they follow the proposed design.

### Screenshots


https://github.com/user-attachments/assets/2121801c-4db8-498e-b336-30cdd9273cee


### Related issue(s)

Closes #1156 
Closes #695 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
