### PR TITLE
Restore missing active state on nav bar

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/navItem.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/navItem.tsx
@@ -12,9 +12,9 @@ import {
   useNetworkType,
 } from 'hooks/useNetworkType'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
+import { usePathnameWithoutLocale } from 'hooks/usePathnameWithoutLocale'
 import { useUmami } from 'hooks/useUmami'
-import { usePathname } from 'i18n/navigation'
-import { useLocale, useTranslations } from 'next-intl'
+import { useTranslations } from 'next-intl'
 import { ComponentProps, RefObject, ReactNode, useState } from 'react'
 import { UrlObject } from 'url'
 import { isRelativeUrl } from 'utils/url'
@@ -133,15 +133,14 @@ const PageLink = function ({
   text,
   urlToBeSelected = href,
 }: ItemLinkProps) {
-  const locale = useLocale()
   const [networkType] = useNetworkType()
-  const pathname = usePathname()
+  const pathname = usePathnameWithoutLocale()
   const { track } = useUmami()
 
   const selected =
     typeof urlToBeSelected === 'string'
-      ? pathname.startsWith(`/${locale}${urlToBeSelected}`)
-      : pathname.startsWith(`/${locale}${urlToBeSelected.pathname}`)
+      ? pathname.startsWith(urlToBeSelected)
+      : pathname.startsWith(urlToBeSelected.pathname)
 
   return (
     <ItemContainer


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Nahuel noticed that the "Active state" on the navbar was missing. It was likely introduced when bumping `next-intl` to v4 (See #1062) because that PR affected the hooks used to get the URL. I must have missed this.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

| Before  | Now |
| ------------- | ------------- |
| <img width="571" alt="image" src="https://github.com/user-attachments/assets/dc02e0e8-5924-4fa5-899b-3c37acbfff9f" />  | ![image](https://github.com/user-attachments/assets/df6f3216-6604-4da2-ac7c-0210c4ffcd22)  |

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
