### PR TITLE
Replace 'javascript-time-ago' with custom function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17225,14 +17225,6 @@
         "node": "*"
       }
     },
-    "node_modules/javascript-time-ago": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/javascript-time-ago/-/javascript-time-ago-2.5.10.tgz",
-      "integrity": "sha512-EUxp4BP74QH8xiYHyeSHopx1XhMMJ9qEX4rcBdFtpVWmKRdzpxbNzz2GSbuekZr5wt0rmLehuyp0PE34EAJT9g==",
-      "dependencies": {
-        "relative-time-format": "^1.1.6"
-      }
-    },
     "node_modules/jayson": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
@@ -23276,11 +23268,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/relative-time-format": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/relative-time-format/-/relative-time-format-1.1.6.tgz",
-      "integrity": "sha512-aCv3juQw4hT1/P/OrVltKWLlp15eW1GRcwP1XdxHrPdZE9MtgqFpegjnTjLhi2m2WI9MT/hQQtE+tjEWG1hgkQ=="
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
@@ -27887,7 +27874,6 @@
         "hemi-tunnel-actions": "1.0.0",
         "hemi-viem": "2.3.2",
         "hemi-viem-stake-actions": "1.0.0",
-        "javascript-time-ago": "2.5.10",
         "lodash": "4.17.21",
         "next": "14.2.16",
         "next-intl": "4.0.2",

--- a/portal/app/[locale]/tunnel/transaction-history/_components/timeAgo.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/timeAgo.tsx
@@ -1,10 +1,5 @@
-import JsTimeAgo from 'javascript-time-ago'
-import enLocale from 'javascript-time-ago/locale/en'
-import esLocale from 'javascript-time-ago/locale/es'
-import { useEffect, useMemo, useState } from 'react'
-
-const modules = [enLocale, esLocale]
-modules.forEach(module => JsTimeAgo.addLocale(module))
+import { useEffect, useState } from 'react'
+import { formatPastTime } from 'utils/format'
 
 const second = 1
 const minute = second * 60
@@ -19,6 +14,10 @@ const getTimeoutInterval = function (timestamp: number, now: number) {
   // render every second if less than 60 seconds
   if (difference <= toMs(second * 60)) {
     return toMs(second)
+  }
+  // render every 30 seconds if less than 10 minutes
+  if (difference <= toMs(toSeconds(10))) {
+    return toMs(toSeconds(minute))
   }
   // render every minute if less than one hour
   if (difference <= toMs(toSeconds(toMinutes(hour)))) {
@@ -49,15 +48,11 @@ type Props = {
 }
 
 export const TimeAgo = function ({ locale, timestamp }: Props) {
-  const timeAgo = useMemo(() => new JsTimeAgo(locale), [locale])
-
-  // timestamp is unix format
-  const date = timestamp * 1000
-  const formattedDate = timeAgo.format(date, 'round')
-
+  const milliseconds = timestamp * 1000
   // force rerender depending on how old the timestamp is
-  // for better ux
-  useRerender(date)
+  useRerender(milliseconds)
 
-  return <>{formattedDate}</>
+  const difference = Math.floor((new Date().getTime() - milliseconds) / 1000)
+
+  return <>{formatPastTime(difference, locale)}</>
 }

--- a/portal/package.json
+++ b/portal/package.json
@@ -32,7 +32,6 @@
     "hemi-tunnel-actions": "1.0.0",
     "hemi-viem": "2.3.2",
     "hemi-viem-stake-actions": "1.0.0",
-    "javascript-time-ago": "2.5.10",
     "lodash": "4.17.21",
     "next": "14.2.16",
     "next-intl": "4.0.2",

--- a/portal/test/utils/format.test.ts
+++ b/portal/test/utils/format.test.ts
@@ -2,6 +2,7 @@ import {
   formatBtcAddress,
   formatEvmAddress,
   formatEvmHash,
+  formatPastTime,
   formatTVL,
 } from 'utils/format'
 import { describe, expect, it } from 'vitest'
@@ -31,6 +32,53 @@ describe('utils/format', function () {
         ),
       ).toBe('0x5a3f...c8e6')
     })
+  })
+
+  describe('formatPastTime', function () {
+    const cases = [
+      [1, 'en', '1 second ago'],
+      [10, 'en', '10 seconds ago'],
+      [59, 'en', '59 seconds ago'],
+      [60, 'en', '1 minute ago'],
+      [119, 'en', '2 minutes ago'],
+      [120, 'en', '2 minutes ago'],
+      [3600, 'en', '1 hour ago'],
+      [7200, 'en', '2 hours ago'],
+      [86400, 'en', '1 day ago'],
+      [172800, 'en', '2 days ago'],
+      [604800, 'en', '1 week ago'],
+      [1209600, 'en', '2 weeks ago'],
+      [2592000, 'en', '1 month ago'],
+      [5184000, 'en', '2 months ago'],
+      [31162468, 'en', '1 year ago'],
+      [30328739, 'en', '1 year ago'],
+      [31536000, 'en', '1 year ago'],
+      [63072000, 'en', '2 years ago'],
+      [1, 'es', 'hace 1 segundo'],
+      [10, 'es', 'hace 10 segundos'],
+      [59, 'es', 'hace 59 segundos'],
+      [60, 'es', 'hace 1 minuto'],
+      [119, 'es', 'hace 2 minutos'],
+      [120, 'es', 'hace 2 minutos'],
+      [3600, 'es', 'hace 1 hora'],
+      [7200, 'es', 'hace 2 horas'],
+      [86400, 'es', 'hace 1 día'],
+      [172800, 'es', 'hace 2 días'],
+      [604800, 'es', 'hace 1 semana'],
+      [1209600, 'es', 'hace 2 semanas'],
+      [2592000, 'es', 'hace 1 mes'],
+      [5184000, 'es', 'hace 2 meses'],
+      [31536000, 'es', 'hace 1 año'],
+      [63072000, 'es', 'hace 2 años'],
+    ]
+
+    it.each(cases)(
+      'should return correct relative time for %i seconds in %s locale',
+      function (seconds: number, locale: string, expected: string) {
+        const result = formatPastTime(seconds, locale)
+        expect(result).toBe(expected)
+      },
+    )
   })
 
   describe('formatTVL', function () {

--- a/portal/utils/format.ts
+++ b/portal/utils/format.ts
@@ -43,7 +43,7 @@ export const formatPastTime = function (
     minute: 59, // 59 seconds
     second: 1, // 1 second
   }
-  /* eslint-disable sort-keys */
+  /* eslint-enable sort-keys */
 
   const rtf = new Intl.RelativeTimeFormat(locale, { style: 'long' })
 

--- a/portal/utils/format.ts
+++ b/portal/utils/format.ts
@@ -23,6 +23,42 @@ export const formatNumber = (value: number | string) =>
 export const formatFiatNumber = (value: number | string) =>
   fiatRounder(value, { shouldFormat: true })
 
+export const formatPastTime = function (
+  secondsFromNow: number,
+  locale: string,
+) {
+  // We need to iterate from the largest unit to the smallest unit - so I prefer
+  // so sort them like that
+  /* eslint-disable sort-keys */
+  const thresholdsInSeconds: Partial<
+    Record<Intl.RelativeTimeFormatUnit, number>
+  > = {
+    // Defined to loosely match blockscout relative timestamps - all converted to seconds
+    // See https://github.com/hemilabs/blockscout-frontend/blob/4f993ce5e62382ea98f42c6d79818630af331b9d/lib/date/dayjs.ts#L13
+    year: 28944000, // 11 months, assuming 365 days - 30 days
+    month: 2419200, // 4 weeks
+    week: 518400, // 4 days
+    day: 82800, // 23 hours
+    hour: 3540, // 59 minutes
+    minute: 59, // 59 seconds
+    second: 1, // 1 second
+  }
+  /* eslint-disable sort-keys */
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { style: 'long' })
+
+  for (const [unit, secondsInUnit] of Object.entries(thresholdsInSeconds)) {
+    if (secondsFromNow > secondsInUnit || unit === 'second') {
+      const value = Math.floor(secondsFromNow / secondsInUnit) * -1
+
+      return rtf.format(value, unit as Intl.RelativeTimeFormatUnit)
+    }
+  }
+  // should never reach here, adding this return it to avoid
+  // adding "undefined" to the inferred returned type
+  return ''
+}
+
 const formatFiatNumberTVL = (value: number | string) =>
   fiatRounderTVL(value, { shouldFormat: true })
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR intends to replace [javascript-time-ago](https://www.npmjs.com/package/javascript-time-ago) with a small custom implementation, loosely based on what Blockscout uses (except for the fact that Blockscout uses [dayjs](https://www.npmjs.com/package/dayjs)

As we just use this to list the "Time ago" in the TX history, I think it was best to remove this library which only add little to offer, and it was only used here. Instead, for formatting, I'm using [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) which is widely supported and offers the same functionality

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
