### PR TITLE
Improve load times on get-started page

### DIFF
--- a/portal/app/[locale]/get-started/_components/addChain/addChainButton.tsx
+++ b/portal/app/[locale]/get-started/_components/addChain/addChainButton.tsx
@@ -1,0 +1,55 @@
+import { useIsMutating } from '@tanstack/react-query'
+import { CheckMark } from 'components/icons/checkMark'
+import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
+import { useTranslations } from 'next-intl'
+import { type Chain } from 'viem'
+import { useAccount } from 'wagmi'
+
+import { useChainAdded } from '../../_hooks/useChainAdded'
+
+type Props = {
+  chain: Chain
+}
+
+export const AddChainButton = function ({ chain }: Props) {
+  const { status: accountStatus } = useAccount()
+  const [isChainAdded] = useChainAdded(chain)
+  const isConnectedToChain = useIsConnectedToExpectedNetwork(chain.id)
+  const isMutating =
+    useIsMutating({
+      mutationKey: ['add-chain-mutation', chain.id],
+    }) > 0
+
+  const t = useTranslations('get-started')
+  const tCommon = useTranslations('common')
+
+  if (isChainAdded || isConnectedToChain) {
+    return (
+      <div className="flex items-center gap-x-1">
+        <span className="text-neutral-500">{tCommon('added')}</span>
+        <CheckMark className="[&>path]:stroke-emerald-500" />
+      </div>
+    )
+  }
+
+  const getText = function () {
+    if (isMutating) {
+      return t('adding-chain')
+    }
+
+    if (accountStatus === 'disconnected') {
+      return tCommon('connect-wallet')
+    }
+
+    return t('add-to-wallet')
+  }
+
+  return (
+    <button
+      className="cursor-pointer text-orange-500 hover:text-orange-700"
+      type="button"
+    >
+      {getText()}
+    </button>
+  )
+}

--- a/portal/app/[locale]/get-started/_components/addChain/container.tsx
+++ b/portal/app/[locale]/get-started/_components/addChain/container.tsx
@@ -1,0 +1,12 @@
+import { type ComponentProps } from 'react'
+
+export const Container = ({
+  className = '',
+  ...props
+}: ComponentProps<'div'>) => (
+  <div
+    className={`border-neutral/55 flex flex-col rounded-xl border border-solid
+      p-4 text-sm font-medium ${className}`}
+    {...props}
+  />
+)

--- a/portal/app/[locale]/get-started/_components/addChain/index.tsx
+++ b/portal/app/[locale]/get-started/_components/addChain/index.tsx
@@ -1,0 +1,76 @@
+import { useConnectModal } from '@rainbow-me/rainbowkit'
+import { useMutation } from '@tanstack/react-query'
+import { useUmami } from 'app/analyticsEvents'
+import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
+import { hemiMainnet } from 'networks/hemiMainnet'
+import { hemiTestnet } from 'networks/hemiTestnet'
+import { sepolia } from 'networks/sepolia'
+import { useEffect } from 'react'
+import { Chain } from 'viem'
+import { useAccount, useWalletClient } from 'wagmi'
+
+import { useChainAdded } from '../../_hooks/useChainAdded'
+
+import { Container } from './container'
+
+type Props = { chain: Chain; children: React.ReactNode }
+
+export const AddChain = function ({ chain, children }: Props) {
+  const { isConnected } = useAccount()
+  const [isChainAdded, setIsChainAdded] = useChainAdded(chain)
+  const { openConnectModal } = useConnectModal()
+  const isConnectedToChain = useIsConnectedToExpectedNetwork(chain.id)
+  const { track } = useUmami()
+  const { data: walletClient } = useWalletClient()
+
+  const { mutate: addChain } = useMutation({
+    mutationFn: (c: Chain) => walletClient?.addChain({ chain: c }),
+    mutationKey: ['add-chain-mutation', chain.id],
+    onSuccess() {
+      setIsChainAdded(true)
+      switch (chain.id) {
+        case sepolia.id:
+          track?.('add to wallet - sepolia')
+          break
+        case hemiMainnet.id:
+          track?.('add to wallet - hemi mainnet')
+          break
+        case hemiTestnet.id:
+          track?.('add to wallet - hemi sepolia')
+          break
+      }
+    },
+  })
+
+  useEffect(
+    function addChainIfConnected() {
+      if (isConnectedToChain) {
+        setIsChainAdded(true)
+      }
+    },
+    [isConnectedToChain, setIsChainAdded],
+  )
+
+  const onClick = function () {
+    if (!isConnected) {
+      openConnectModal()
+      return
+    }
+    if (!isChainAdded && !isConnectedToChain) {
+      addChain(chain)
+    }
+  }
+
+  return (
+    <Container
+      className={
+        isConnected && (isChainAdded || isConnectedToChain)
+          ? ''
+          : 'cursor-pointer hover:bg-gray-50'
+      }
+      onClick={onClick}
+    >
+      {children}
+    </Container>
+  )
+}

--- a/portal/app/[locale]/get-started/_components/addChainAutomatically.tsx
+++ b/portal/app/[locale]/get-started/_components/addChainAutomatically.tsx
@@ -1,127 +1,47 @@
-import { useConnectModal } from '@rainbow-me/rainbowkit'
-import { useMutation } from '@tanstack/react-query'
-import { useUmami } from 'app/analyticsEvents'
 import { ChainLogo } from 'components/chainLogo'
-import { CheckMark } from 'components/icons/checkMark'
-import { hemiMainnet } from 'networks/hemiMainnet'
-import { hemiTestnet } from 'networks/hemiTestnet'
-import { sepolia } from 'networks/sepolia'
+import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { useEffect } from 'react'
+import { lazy, Suspense } from 'react'
 import { type Chain } from 'viem'
-import { useAccount, useWalletClient } from 'wagmi'
+
+import { Container } from './addChain/container'
 
 type Props = {
   chain: Chain
   layer: number
 }
 
+const AddChain = lazy(() =>
+  import('./addChain').then(mod => ({ default: mod.AddChain })),
+)
+
+const AddChainButton = dynamic(
+  () => import('./addChain/addChainButton').then(mod => mod.AddChainButton),
+  {
+    loading: () => (
+      <span className="text-sm font-medium text-neutral-950">...</span>
+    ),
+    ssr: false,
+  },
+)
+
 export const AddChainAutomatically = function ({ chain, layer }: Props) {
-  const { openConnectModal } = useConnectModal()
-  const tCommon = useTranslations('common')
   const t = useTranslations('get-started')
-  const { track } = useUmami()
 
-  const { chain: connectedChain, isConnected } = useAccount()
-  const { data: walletClient } = useWalletClient()
-
-  const { mutate: addChain, status } = useMutation({
-    mutationFn: (c: Chain) => walletClient?.addChain({ chain: c }),
-    onSuccess() {
-      localStorage.setItem(
-        `portal.get-started.configure-networks-added-${chain.id}`,
-        'true',
-      )
-      switch (chain.id) {
-        case sepolia.id:
-          track?.('add to wallet - sepolia')
-          break
-        case hemiMainnet.id:
-          track?.('add to wallet - hemi mainnet')
-          break
-        case hemiTestnet.id:
-          track?.('add to wallet - hemi sepolia')
-          break
-      }
-    },
-  })
-
-  const connectedToChain = connectedChain?.id === chain.id
-  const isChainAdded =
-    localStorage.getItem(
-      `portal.get-started.configure-networks-added-${chain.id}`,
-    ) === 'true'
-
-  useEffect(
-    function () {
-      if (connectedChain) {
-        localStorage.setItem(
-          `portal.get-started.configure-networks-added-${connectedChain.id}`,
-          'true',
-        )
-      }
-    },
-    [connectedChain],
+  const content = (
+    <div className="flex flex-row gap-x-1">
+      <div className="w-5">
+        <ChainLogo chainId={chain.id} />
+      </div>
+      <span className="ml-1 text-neutral-950">{chain.name}</span>
+      <span className="text-neutral-500">{t('layer', { layer })}</span>
+      <div className="ml-auto">{<AddChainButton chain={chain} />}</div>
+    </div>
   )
 
-  const getButton = function () {
-    if (!isConnected) {
-      return (
-        <button
-          className="cursor-pointer text-orange-500 hover:text-orange-700"
-          type="button"
-        >
-          {tCommon('connect-wallet')}
-        </button>
-      )
-    }
-    if (isChainAdded || connectedToChain) {
-      return (
-        <div className="flex items-center gap-x-1">
-          <span className="text-neutral-500">{tCommon('added')}</span>
-          <CheckMark className="[&>path]:stroke-emerald-500" />
-        </div>
-      )
-    }
-    return (
-      <button
-        className="cursor-pointer text-orange-500 hover:text-orange-700"
-        disabled={status === 'pending'}
-        type="button"
-      >
-        {t('add-to-wallet')}
-      </button>
-    )
-  }
-
-  const onClick = function () {
-    if (!isConnected) {
-      openConnectModal()
-      return
-    }
-    if (!isChainAdded && !connectedToChain) {
-      addChain(chain)
-    }
-  }
-
   return (
-    <div
-      className={`border-neutral/55 flex flex-col rounded-xl border border-solid
-      p-4 text-sm font-medium ${
-        isConnected && (isChainAdded || connectedToChain)
-          ? ''
-          : 'cursor-pointer hover:bg-gray-50'
-      }`}
-      onClick={onClick}
-    >
-      <div className="flex flex-row gap-x-1">
-        <div className="w-5">
-          <ChainLogo chainId={chain.id} />
-        </div>
-        <span className="ml-1 text-neutral-950">{chain.name}</span>
-        <span className="text-neutral-500">{t('layer', { layer })}</span>
-        <div className="ml-auto">{getButton()}</div>
-      </div>
-    </div>
+    <Suspense fallback={<Container>{content}</Container>}>
+      <AddChain chain={chain}>{content}</AddChain>
+    </Suspense>
   )
 }

--- a/portal/app/[locale]/get-started/_hooks/useChainAdded.ts
+++ b/portal/app/[locale]/get-started/_hooks/useChainAdded.ts
@@ -1,0 +1,10 @@
+import useLocalStorageState from 'use-local-storage-state'
+import { Chain } from 'viem'
+
+export const useChainAdded = (chain: Chain) =>
+  useLocalStorageState(
+    `portal.get-started.configure-networks-added-${chain.id}`,
+    {
+      defaultValue: false,
+    },
+  )

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -111,6 +111,7 @@
     "add-networks-testnet": "Add Ethereum Sepolia & Hemi testnet to your wallet.",
     "add-networks-to-wallet": "Add networks to your wallet",
     "add-to-wallet": "Add to wallet",
+    "adding-chain": "Adding...",
     "bitcoin-faucet": "Bitcoin Faucet",
     "block-explorer-url": "Block explorer URL",
     "buy-sell-swap": "Buy, sell, and swap crypto",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -111,6 +111,7 @@
     "add-networks-testnet": "Añada Ethereum Sepolia y Hemi testnet a su billetera.",
     "add-networks-to-wallet": "Agregue las redes a su billetera",
     "add-to-wallet": "Añadir a la billetera",
+    "adding-chain": "Añadiendo...",
     "bitcoin-faucet": "Faucet de Bitcoin",
     "block-explorer-url": "URL del explorador de bloques",
     "buy-sell-swap": "Compre, venda, e intercambie crypto",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Another PR reducing bundle size and doing minor improvements on the `/get-started` page. This time, adding Hemi or Ethereum required to load `@rainbow-kit` to check that the wallet was connected, and that the chain wasn't previously added.

In the initial render, this is not known because we need to wait for the wallet to reconnect (if previously connected). If the user were not connected, this wouldn't even be checked. So this was another reason not to load on the first attempt this library

This PR tweaks a bit the code that adds a chain programmatically to add a `...` while reconnecting, and loads `@rainbow-kit` dynamically after the initial render. Note at this point the lib is only needed if the user needs to connect to the site, after clicking "Connect wallet" - for the rest of the interactions, `wagmi` does all the work.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes on users - See reduction on `/get-started`

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/83d7aec7-fe4a-4a95-bed3-3492bd122508) | ![image](https://github.com/user-attachments/assets/c6f7fb0c-a36c-4004-a083-58df81b13367) |

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to https://github.com/hemilabs/ui-monorepo/issues/1071 https://github.com/hemilabs/ui-monorepo/issues/1066 and https://github.com/hemilabs/ui-monorepo/issues/1065

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
