### PR TITLE
Add stake fee estimation hook and encode functions

### DIFF
--- a/hemi-viem-stake-actions/actions/wallet/stakeManager.ts
+++ b/hemi-viem-stake-actions/actions/wallet/stakeManager.ts
@@ -1,4 +1,4 @@
-import { type Address, type Client } from 'viem'
+import { encodeFunctionData, type Address, type Client } from 'viem'
 import { writeContract } from 'viem/actions'
 
 import {
@@ -100,3 +100,43 @@ export function unstakeToken(
     functionName: 'withdraw',
   })
 }
+
+/**
+ * Encodes the transaction data for staking an ERC-20 token using the `depositFor` function.
+ *
+ * @param {Object} parameters - The transaction parameters for staking.
+ * @param {bigint} [parameters.amount=BigInt(0)] - The amount of tokens to be staked.
+ * @param {Address} parameters.forAccount - The address for which the tokens are being staked.
+ * @param {Address} parameters.tokenAddress - The ERC-20 token address to be staked.
+ *
+ * @returns {Hex} - The encoded transaction data.
+ */
+export const encodeStakeErc20 = ({
+  amount = BigInt(0),
+  forAccount,
+  tokenAddress,
+}: {
+  amount: bigint
+  forAccount: Address
+  tokenAddress: Address
+}) =>
+  encodeFunctionData({
+    abi: stakeManagerAbi,
+    args: [tokenAddress, forAccount, amount],
+    functionName: 'depositFor',
+  })
+
+/**
+ * Encodes the transaction data for staking native ETH using the `depositETHFor` function.
+ *
+ * @param {Object} parameters - The transaction parameters for staking.
+ * @param {Address} parameters.forAccount - The address for which the ETH is being staked.
+ *
+ * @returns {Hex} - The encoded transaction data.
+ */
+export const encodeStakeEth = ({ forAccount }: { forAccount: Address }) =>
+  encodeFunctionData({
+    abi: stakeManagerAbi,
+    args: [forAccount],
+    functionName: 'depositETHFor',
+  })

--- a/hemi-viem-stake-actions/index.ts
+++ b/hemi-viem-stake-actions/index.ts
@@ -39,3 +39,5 @@ export const hemiWalletStakeActions = () => (client: Client) => ({
   unstakeToken: (params: Parameters<typeof unstakeToken>[1]) =>
     unstakeToken(client, params),
 })
+
+export { encodeStakeErc20, encodeStakeEth } from './actions/wallet/stakeManager'

--- a/portal/app/[locale]/stake/_components/manageStake/fees.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/fees.tsx
@@ -5,7 +5,11 @@ import { useTranslations } from 'next-intl'
 import { getNativeToken } from 'utils/nativeToken'
 import { formatUnits } from 'viem'
 
-const Fees = function ({ estimatedFees }: { estimatedFees: bigint }) {
+type Props = {
+  estimatedFees: bigint
+}
+
+export const Fees = function ({ estimatedFees }: Props) {
   const hemi = useHemi()
   const t = useTranslations('common')
 
@@ -22,16 +26,6 @@ const Fees = function ({ estimatedFees }: { estimatedFees: bigint }) {
       <EvmFeesSummary gas={gas} operationToken={nativeToken} />
     </div>
   )
-}
-
-export const StakeFees = function () {
-  const hemi = useHemi()
-  const estimatedFees = useEstimateFees({
-    chainId: hemi.id,
-    operation: 'stake',
-    overEstimation: 1.5,
-  })
-  return <Fees estimatedFees={estimatedFees} />
 }
 
 export const UnstakeFees = function () {

--- a/portal/app/[locale]/stake/_components/manageStake/maxBalance.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/maxBalance.tsx
@@ -1,9 +1,6 @@
 import { MaxButton, SetMaxEvmBalance } from 'components/setMaxBalance'
-import { useEstimateFees } from 'hooks/useEstimateFees'
-import { useHemi } from 'hooks/useHemi'
 import { ComponentProps } from 'react'
 import { StakeToken } from 'types/stake'
-import { isNativeToken } from 'utils/nativeToken'
 import { formatUnits } from 'viem'
 
 import { useStakedBalance } from '../../_hooks/useStakedBalance'
@@ -12,16 +9,11 @@ type Props = Omit<ComponentProps<typeof SetMaxEvmBalance>, 'gas'> & {
   token: StakeToken
 }
 
-export const StakeMaxBalance = function (props: Props) {
-  const hemi = useHemi()
-  // we really only need to exclude fees for native tokens from the "max" option
-  const estimateFees = useEstimateFees({
-    chainId: hemi.id,
-    enabled: isNativeToken(props.token),
-    operation: 'stake',
-  })
-  return <SetMaxEvmBalance {...props} gas={estimateFees} />
-}
+export const StakeMaxBalance = (
+  props: Props & {
+    estimateFees: bigint
+  },
+) => <SetMaxEvmBalance {...props} gas={props.estimateFees} />
 
 export const UnstakeMaxBalance = function ({
   disabled,

--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -5,7 +5,6 @@ import { stakeManagerAddresses } from 'hemi-viem-stake-actions'
 import { useAllowance } from 'hooks/useAllowance'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
-import { useEstimateFees } from 'hooks/useEstimateFees'
 import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
 import { StakeOperations, StakeStatusEnum, type StakeToken } from 'types/stake'
@@ -15,10 +14,11 @@ import { formatUnits, parseUnits } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { useAmount } from '../../_hooks/useAmount'
+import { useEstimateStakeFees } from '../../_hooks/useEstimateStakeFees'
 import { useStake } from '../../_hooks/useStake'
 import { StakeToast } from '../stakeToast'
 
-import { StakeFees } from './fees'
+import { Fees } from './fees'
 import { StakeMaxBalance } from './maxBalance'
 import { Operation } from './operation'
 import { Preview } from './preview'
@@ -72,10 +72,13 @@ export const StakeOperation = function ({
     token,
   })
 
-  const stakeEstimatedFees = useEstimateFees({
-    chainId: token.chainId,
-    operation: 'stake',
+  const stakeEstimatedFees = useEstimateStakeFees({
+    amount: parseUnits(amount, token.decimals),
+    enabled: allowance > 0 || operatesNativeToken,
+    forAccount: address,
+    token,
   })
+
   const hemi = useHemi()
 
   const {
@@ -214,11 +217,12 @@ export const StakeOperation = function ({
         preview={
           <Preview
             amount={amount}
-            fees={<StakeFees />}
+            fees={<Fees estimatedFees={stakeEstimatedFees} />}
             isOperating={isOperating}
             maxBalance={
               <StakeMaxBalance
                 disabled={isSubmitting}
+                estimateFees={stakeEstimatedFees}
                 onSetMaxBalance={setAmount}
                 token={token}
               />

--- a/portal/app/[locale]/stake/_hooks/useEstimateStakeFees.ts
+++ b/portal/app/[locale]/stake/_hooks/useEstimateStakeFees.ts
@@ -1,0 +1,47 @@
+import {
+  encodeStakeErc20,
+  encodeStakeEth,
+  stakeManagerAddresses,
+} from 'hemi-viem-stake-actions'
+import { useEstimateFees } from 'hooks/useEstimateFees'
+import { StakeToken } from 'types/stake'
+import { isNativeToken } from 'utils/nativeToken'
+import { Address } from 'viem'
+import { useEstimateGas } from 'wagmi'
+
+export const useEstimateStakeFees = function ({
+  amount,
+  enabled = true,
+  forAccount,
+  token,
+}: {
+  amount: bigint
+  enabled?: boolean
+  forAccount: Address
+  token: StakeToken
+}) {
+  const isNative = isNativeToken(token)
+  const bridgeAddress = stakeManagerAddresses[token.chainId]
+
+  const data = isNative
+    ? encodeStakeEth({ forAccount })
+    : encodeStakeErc20({
+        amount,
+        forAccount,
+        tokenAddress: token.address as `0x${string}`,
+      })
+
+  const { data: gasUnits, isSuccess } = useEstimateGas({
+    data,
+    query: { enabled },
+    to: bridgeAddress,
+    value: isNative ? amount : undefined,
+  })
+
+  return useEstimateFees({
+    chainId: token.chainId,
+    enabled: isSuccess,
+    gasUnits,
+    overEstimation: 1.5,
+  })
+}

--- a/portal/hooks/useEstimateFees.ts
+++ b/portal/hooks/useEstimateFees.ts
@@ -19,7 +19,6 @@ const mean = function (rewards: bigint[] = []) {
 type OperationsToEstimate =
   | 'challenge-btc-withdrawal'
   | 'confirm-btc-deposit'
-  | 'stake'
   | 'unstake'
   | 'withdraw-btc'
 
@@ -28,8 +27,6 @@ const GasUnitsEstimations: Record<OperationsToEstimate, bigint> = {
   'challenge-btc-withdrawal': BigInt(400_000),
   // TODO review estimations https://github.com/hemilabs/ui-monorepo/issues/826
   'confirm-btc-deposit': BigInt(400_000),
-  // TODO define proper estimation https://github.com/hemilabs/ui-monorepo/issues/774
-  'stake': BigInt(400_000),
   // TODO define proper estimation https://github.com/hemilabs/ui-monorepo/issues/774
   'unstake': BigInt(400_000),
   // TODO review estimations https://github.com/hemilabs/ui-monorepo/issues/826


### PR DESCRIPTION
### Description

This PR introduces the useEstimateStakeFees hook to estimate gas fees for staking operations, covering both native ETH and ERC-20 tokens.

Two new encode helper functions were also added:

- **encodeStakeErc20**: encodes the depositFor function call for ERC-20 staking.
- **encodeStakeEth**: encodes the depositETHFor function call for native ETH staking.

No changes were made to unstake-related flows at this point. Unstake will be covered in upcoming PRs.

### Screenshots

No UI changes.

### Related issue(s)

Related to #866 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
