### PR TITLE
Fixed exclamation mark svg attributes to camelCase

### DIFF
--- a/portal/components/icons/exclamationMark.tsx
+++ b/portal/components/icons/exclamationMark.tsx
@@ -15,14 +15,14 @@ export const ExclamationMark = (props: ComponentProps<'svg'>) => (
       <path
         d="M16 13.5V16.625M23.5 16C23.5 16.9849 23.306 17.9602 22.9291 18.8701C22.5522 19.7801 21.9997 20.6069 21.3033 21.3033C20.6069 21.9997 19.7801 22.5522 18.8701 22.9291C17.9602 23.306 16.9849 23.5 16 23.5C15.0151 23.5 14.0398 23.306 13.1299 22.9291C12.2199 22.5522 11.3931 21.9997 10.6967 21.3033C10.0003 20.6069 9.44781 19.7801 9.0709 18.8701C8.69399 17.9602 8.5 16.9849 8.5 16C8.5 14.0109 9.29018 12.1032 10.6967 10.6967C12.1032 9.29018 14.0109 8.5 16 8.5C17.9891 8.5 19.8968 9.29018 21.3033 10.6967C22.7098 12.1032 23.5 14.0109 23.5 16ZM16 19.125H16.0067V19.1317H16V19.125Z"
         stroke="#FF6C15"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
       />
     </g>
     <defs>
       <filter
-        color-interpolation-filters="sRGB"
+        colorInterpolationFilters="sRGB"
         filterUnits="userSpaceOnUse"
         height="16.5"
         id="filter0_i_6648_148365"
@@ -30,7 +30,7 @@ export const ExclamationMark = (props: ComponentProps<'svg'>) => (
         x="7.75"
         y="7.75"
       >
-        <feFlood flood-opacity="0" result="BackgroundImageFix" />
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
         <feBlend
           in="SourceGraphic"
           in2="BackgroundImageFix"


### PR DESCRIPTION
### Description

Updated `exclamationMark.tsx` svg attributes names to camelCase

> I've look in all icons `.tsx` files inside `*/icons` folders and did not see any other place that needs this fix.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1163

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
