### PR TITLE
Add unstake fee estimation hook and encode fn

### DIFF
--- a/hemi-viem-stake-actions/actions/wallet/stakeManager.ts
+++ b/hemi-viem-stake-actions/actions/wallet/stakeManager.ts
@@ -140,3 +140,25 @@ export const encodeStakeEth = ({ forAccount }: { forAccount: Address }) =>
     args: [forAccount],
     functionName: 'depositETHFor',
   })
+
+/**
+ * Encodes the transaction data for unstaking a token using the `withdraw` function.
+ *
+ * @param {Object} parameters - The transaction parameters for unstaking.
+ * @param {bigint} parameters.amount - The amount of tokens to be withdrawn.
+ * @param {Address} parameters.tokenAddress - The ERC-20 token address to be withdrawn.
+ *
+ * @returns {Hex} - The encoded transaction data.
+ */
+export const encodeUnstake = ({
+  amount,
+  tokenAddress,
+}: {
+  amount: bigint
+  tokenAddress: Address
+}) =>
+  encodeFunctionData({
+    abi: stakeManagerAbi,
+    args: [tokenAddress, amount],
+    functionName: 'withdraw',
+  })

--- a/hemi-viem-stake-actions/index.ts
+++ b/hemi-viem-stake-actions/index.ts
@@ -40,4 +40,8 @@ export const hemiWalletStakeActions = () => (client: Client) => ({
     unstakeToken(client, params),
 })
 
-export { encodeStakeErc20, encodeStakeEth } from './actions/wallet/stakeManager'
+export {
+  encodeStakeErc20,
+  encodeStakeEth,
+  encodeUnstake,
+} from './actions/wallet/stakeManager'

--- a/portal/app/[locale]/stake/_components/manageStake/fees.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/fees.tsx
@@ -1,5 +1,4 @@
 import { EvmFeesSummary } from 'components/evmFeesSummary'
-import { useEstimateFees } from 'hooks/useEstimateFees'
 import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
 import { getNativeToken } from 'utils/nativeToken'
@@ -26,14 +25,4 @@ export const Fees = function ({ estimatedFees }: Props) {
       <EvmFeesSummary gas={gas} operationToken={nativeToken} />
     </div>
   )
-}
-
-export const UnstakeFees = function () {
-  const hemi = useHemi()
-  const estimatedFees = useEstimateFees({
-    chainId: hemi.id,
-    operation: 'unstake',
-    overEstimation: 1.5,
-  })
-  return <Fees estimatedFees={estimatedFees} />
 }

--- a/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
@@ -1,6 +1,5 @@
 import { ProgressStatus } from 'components/reviewOperation/progressStatus'
 import { StepPropsWithoutPosition } from 'components/reviewOperation/step'
-import { useEstimateFees } from 'hooks/useEstimateFees'
 import { useHemi } from 'hooks/useHemi'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
@@ -15,11 +14,12 @@ import { canSubmit } from 'utils/stake'
 import { formatUnits, parseUnits } from 'viem'
 
 import { useAmount } from '../../_hooks/useAmount'
+import { useEstimateUnstakeFees } from '../../_hooks/useEstimateUnstakeFees'
 import { useStakedBalance } from '../../_hooks/useStakedBalance'
 import { useUnstake } from '../../_hooks/useUnstake'
 import { StakeToast } from '../stakeToast'
 
-import { UnstakeFees } from './fees'
+import { Fees } from './fees'
 import { UnstakeMaxBalance } from './maxBalance'
 import { Operation } from './operation'
 import { Preview } from './preview'
@@ -52,10 +52,7 @@ export const UnstakeOperation = function ({
   token,
 }: Props) {
   const [amount, setAmount] = useAmount()
-  const unstakeEstimatedFees = useEstimateFees({
-    chainId: token.chainId,
-    operation: 'unstake',
-  })
+
   const hemi = useHemi()
   const { balance, isPending: isStakedPositionPending } =
     useStakedBalance(token)
@@ -73,6 +70,12 @@ export const UnstakeOperation = function ({
       connectedChainId: token.chainId,
       token,
     }).error
+
+  const unstakeEstimatedFees = useEstimateUnstakeFees({
+    amount: parseUnits(amount, token.decimals),
+    enabled: canUnstake,
+    token,
+  })
 
   const statusMap = {
     [UnstakeStatusEnum.UNSTAKE_TX_PENDING]: ProgressStatus.PROGRESS,
@@ -126,7 +129,7 @@ export const UnstakeOperation = function ({
           <Preview
             amount={amount}
             balanceComponent={StakedBalance}
-            fees={<UnstakeFees />}
+            fees={<Fees estimatedFees={unstakeEstimatedFees} />}
             isOperating={isOperating}
             maxBalance={
               <UnstakeMaxBalance

--- a/portal/app/[locale]/stake/_hooks/useEstimateUnstakeFees.ts
+++ b/portal/app/[locale]/stake/_hooks/useEstimateUnstakeFees.ts
@@ -1,0 +1,32 @@
+import { encodeUnstake, stakeManagerAddresses } from 'hemi-viem-stake-actions'
+import { useEstimateFees } from 'hooks/useEstimateFees'
+import { StakeToken } from 'types/stake'
+import { useEstimateGas } from 'wagmi'
+
+export const useEstimateUnstakeFees = function ({
+  amount,
+  enabled = true,
+  token,
+}: {
+  amount: bigint
+  enabled?: boolean
+  token: StakeToken
+}) {
+  const bridgeAddress = stakeManagerAddresses[token.chainId]
+
+  const { data: gasUnits, isSuccess } = useEstimateGas({
+    data: encodeUnstake({
+      amount,
+      tokenAddress: token.address as `0x${string}`,
+    }),
+    query: { enabled },
+    to: bridgeAddress,
+  })
+
+  return useEstimateFees({
+    chainId: token.chainId,
+    enabled: isSuccess,
+    gasUnits,
+    overEstimation: 1.5,
+  })
+}

--- a/portal/hooks/useEstimateFees.ts
+++ b/portal/hooks/useEstimateFees.ts
@@ -19,7 +19,6 @@ const mean = function (rewards: bigint[] = []) {
 type OperationsToEstimate =
   | 'challenge-btc-withdrawal'
   | 'confirm-btc-deposit'
-  | 'unstake'
   | 'withdraw-btc'
 
 const GasUnitsEstimations: Record<OperationsToEstimate, bigint> = {
@@ -27,8 +26,6 @@ const GasUnitsEstimations: Record<OperationsToEstimate, bigint> = {
   'challenge-btc-withdrawal': BigInt(400_000),
   // TODO review estimations https://github.com/hemilabs/ui-monorepo/issues/826
   'confirm-btc-deposit': BigInt(400_000),
-  // TODO define proper estimation https://github.com/hemilabs/ui-monorepo/issues/774
-  'unstake': BigInt(400_000),
   // TODO review estimations https://github.com/hemilabs/ui-monorepo/issues/826
   'withdraw-btc': BigInt(400_000),
 }


### PR DESCRIPTION
### Description

This PR introduces the useEstimateUnstakeFees hook to estimate gas fees for unstaking operations. It also adds an encode function.

### Screenshots

No UI changes.

### Related issue(s)

Related to #866 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
