### PR TITLE
Prevent stake page to crash when toggling network

### DIFF
--- a/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -25,6 +25,9 @@ import { Column, ColumnHeader, Header } from '../table'
 import { TokenBalance } from '../tokenBalance'
 import { TokenRewards } from '../tokenRewards'
 
+// created here so there's a stable reference between renders when using it
+const emptyData = new Array(4).fill(null)
+
 const columnsBuilder = (
   t: ReturnType<typeof useTranslations<'stake-page'>>,
 ): ColumnDef<StakeToken>[] => [
@@ -128,7 +131,7 @@ const StakeStrategyTableImp = function ({
 
   const table = useReactTable({
     columns,
-    data: data.length === 0 ? new Array(4).fill(null) : data,
+    data: data.length === 0 ? emptyData : data,
     getCoreRowModel: getCoreRowModel(),
     state: {
       columnOrder:


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solves. -->

After adding sorting to the Stake page, there are now some instances where the table renders as "loading". Before, we would just hide the entire table, instead of rendering "loading" rows as we do now.


When rendering these rows, we created an empty array on each render. `react-table` requires stable references (For example, using `useMemo` or creating the variables outside of the render function). If not, an infinite loop of rendering happens, which causes the app to freeze.

This PR fixes that.
 
### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/ffce8f98-3d70-4511-ac50-755cb2c68152

Now the user can toggle the network without the app crashing.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1190

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
