### PR TITLE
Fix crash when estimating fees disconnected

### DIFF
--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -75,7 +75,6 @@ export const StakeOperation = function ({
   const stakeEstimatedFees = useEstimateStakeFees({
     amount: parseUnits(amount, token.decimals),
     enabled: allowance > 0 || operatesNativeToken,
-    forAccount: address,
     token,
   })
 

--- a/portal/app/[locale]/stake/_hooks/useEstimateStakeFees.ts
+++ b/portal/app/[locale]/stake/_hooks/useEstimateStakeFees.ts
@@ -6,34 +6,34 @@ import {
 import { useEstimateFees } from 'hooks/useEstimateFees'
 import { StakeToken } from 'types/stake'
 import { isNativeToken } from 'utils/nativeToken'
-import { Address } from 'viem'
-import { useEstimateGas } from 'wagmi'
+import { useAccount, useEstimateGas } from 'wagmi'
 
 export const useEstimateStakeFees = function ({
   amount,
   enabled = true,
-  forAccount,
   token,
 }: {
   amount: bigint
   enabled?: boolean
-  forAccount: Address
   token: StakeToken
 }) {
+  const { address: forAccount, isConnected } = useAccount()
   const isNative = isNativeToken(token)
   const bridgeAddress = stakeManagerAddresses[token.chainId]
 
-  const data = isNative
-    ? encodeStakeEth({ forAccount })
-    : encodeStakeErc20({
-        amount,
-        forAccount,
-        tokenAddress: token.address as `0x${string}`,
-      })
+  const data = isConnected
+    ? isNative
+      ? encodeStakeEth({ forAccount })
+      : encodeStakeErc20({
+          amount,
+          forAccount,
+          tokenAddress: token.address as `0x${string}`,
+        })
+    : undefined
 
   const { data: gasUnits, isSuccess } = useEstimateGas({
     data,
-    query: { enabled },
+    query: { enabled: isConnected && enabled },
     to: bridgeAddress,
     value: isNative ? amount : undefined,
   })


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

When the user is disconnected and opens the "Stake" drawer, the app crashes. This is because when encoding the data for fees estimation, it requires the user's address. This PR fixes that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/fc3305ce-3a77-4947-a273-9f14cb3edbd9

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1198 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
