### PR TITLE
Removed chain selector on all pages except tunnel

### DIFF
--- a/portal/components/connectedWallet/connectedAccount.tsx
+++ b/portal/components/connectedWallet/connectedAccount.tsx
@@ -12,6 +12,7 @@ import {
 } from 'hooks/useConnectedToUnsupportedChain'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
+import { usePathname } from 'i18n/navigation'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { formatBtcAddress, formatEvmAddress } from 'utils/format'
@@ -160,10 +161,10 @@ const ConnectedWallet = function ({
 export const ConnectedEvmChain = function () {
   const { chain, isConnected } = useAccount()
   const isChainUnsupported = useConnectedToUnsupportedEvmChain()
-
+  const pathname = usePathname()
   const [menuOpen, setMenuOpen] = useState(false)
 
-  if (!isConnected) {
+  if (!isConnected || !pathname.includes('tunnel')) {
     return null
   }
 


### PR DESCRIPTION
### Description

Removed network selector from all pages except for tunnel.

### Screenshots

Tunnel Page:
<img width="1433" alt="Captura de Tela 2025-05-06 às 15 23 29" src="https://github.com/user-attachments/assets/f0afe71f-9a08-43c1-aa64-83bc507f212c" />

Stake Page:
<img width="1433" alt="Captura de Tela 2025-05-06 às 15 20 53" src="https://github.com/user-attachments/assets/c09dcab0-281e-4a16-8225-e75123f23a57" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1004

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
