### PR TITLE
Bump promise-mem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27874,7 +27874,7 @@
         "p-all": "5.0.0",
         "p-do-whilst": "2.1.0",
         "p-queue": "8.0.1",
-        "promise-mem": "1.0.2",
+        "promise-mem": "1.0.3",
         "rc-tooltip": "6.2.1",
         "react": "18.2.0",
         "react-device-detect": "2.2.3",
@@ -28047,6 +28047,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
+      }
+    },
+    "portal/node_modules/promise-mem": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/promise-mem/-/promise-mem-1.0.3.tgz",
+      "integrity": "sha512-UgUXVrQyFtNJ02Ud82P0Xtok84a4Ein7znKTUlftV79JE3pBni2zt+FC7eg9k117auNdrqA3SKFZ+0m3XTEgTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "portal/node_modules/quick-lru": {

--- a/portal/package.json
+++ b/portal/package.json
@@ -39,7 +39,7 @@
     "p-all": "5.0.0",
     "p-do-whilst": "2.1.0",
     "p-queue": "8.0.1",
-    "promise-mem": "1.0.2",
+    "promise-mem": "1.0.3",
     "rc-tooltip": "6.2.1",
     "react": "18.2.0",
     "react-device-detect": "2.2.3",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

I published a new version of [promise-mem](https://www.npmjs.com/package/promise-mem) which reduces considerably the bundle size

![image](https://github.com/user-attachments/assets/14b546af-723a-4298-afab-e4277b7fc60e)

[source](https://bundlephobia.com/package/promise-mem@1.0.3)

This PR just bumps the version. The reduction was by removing a debugging lib inside `promise-mem`

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Gains on the bundle size

| Before  | After |
| ------------- | ------------- |
| <img width="505" alt="image" src="https://github.com/user-attachments/assets/edbfe7f4-4a78-4907-affb-08cc483a40f1" />  | <img width="563" alt="image" src="https://github.com/user-attachments/assets/cc446ebd-3c0d-4935-960d-fc29eaf46f20" />  |

It's a very small gain, but hey it's honest work

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1065

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
