### PR TITLE
Hide both network selectors

### DIFF
--- a/portal/components/connectWallets/index.tsx
+++ b/portal/components/connectWallets/index.tsx
@@ -2,6 +2,7 @@ import { useAccount as useBtcAccount } from 'btc-wallet/hooks/useAccount'
 import { DrawerLoader } from 'components/drawer/drawerLoader'
 import { useDrawerContext } from 'hooks/useDrawerContext'
 import { useNetworkType } from 'hooks/useNetworkType'
+import { usePathnameWithoutLocale } from 'hooks/usePathnameWithoutLocale'
 import { useUmami } from 'hooks/useUmami'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
@@ -33,6 +34,7 @@ const WalletIcon = () => (
 export const WalletConnection = function () {
   const { closeDrawer, isDrawerOpen, openDrawer } = useDrawerContext()
   const [networkType] = useNetworkType()
+  const pathname = usePathnameWithoutLocale()
   const t = useTranslations()
 
   const { status: btcStatus } = useBtcAccount()
@@ -56,7 +58,7 @@ export const WalletConnection = function () {
     <div className="ml-auto mr-2 md:mr-6">
       <div className="flex items-center gap-x-3">
         <div className="hidden md:block">
-          <ConnectedChains />
+          {pathname.startsWith('/tunnel') && <ConnectedChains />}
         </div>
         <button
           className="flex h-8 items-center gap-x-2 rounded-lg border border-solid border-neutral-300/55 bg-white 

--- a/portal/components/connectedWallet/connectedAccount.tsx
+++ b/portal/components/connectedWallet/connectedAccount.tsx
@@ -12,7 +12,6 @@ import {
 } from 'hooks/useConnectedToUnsupportedChain'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
-import { usePathname } from 'i18n/navigation'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { formatBtcAddress, formatEvmAddress } from 'utils/format'
@@ -161,10 +160,9 @@ const ConnectedWallet = function ({
 export const ConnectedEvmChain = function () {
   const { chain, isConnected } = useAccount()
   const isChainUnsupported = useConnectedToUnsupportedEvmChain()
-  const pathname = usePathname()
   const [menuOpen, setMenuOpen] = useState(false)
 
-  if (!isConnected || !pathname.includes('tunnel')) {
+  if (!isConnected) {
     return null
   }
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

I reverted #1024 because it did not completely fix #1004 : The bitcoin selector was still visible. In addition to this, it also broke the Connect Wallets drawer when the user opened it outside of the tunnel

![image](https://github.com/user-attachments/assets/b329d29f-5967-442b-9d8a-cb28559997b9)

This is how it should look 

<img width="427" alt="image" src="https://github.com/user-attachments/assets/69bf5b7e-d959-4c82-93d6-42d77db63c72" />


This PR then hides both the EVM and BTC selectors in the header + fixes the Connects wallet drawer

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/0c2e9c89-2c39-43f7-a1f7-14773adf66ab

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1004 
Closes #1011 (No longer a problem as the network selector will be hidden for all pages except the tunnel one)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
