### PR TITLE
Prevent stake hang prices api

### DIFF
--- a/portal/app/[locale]/stake/_hooks/useTotalStaked.ts
+++ b/portal/app/[locale]/stake/_hooks/useTotalStaked.ts
@@ -11,11 +11,15 @@ import { formatUnits } from 'viem'
  */
 export const useTotalStaked = function () {
   const hemi = useHemi()
-  const { data: prices, isPending: isLoadingPrices } = useTokenPrices()
+  const {
+    data: prices,
+    isError: isTokenPricesError,
+    isPending: isLoadingPrices,
+  } = useTokenPrices()
 
   const {
     data: totalPerToken = [],
-    isError,
+    isError: isTotalStakedError,
     isPending: isLoadingTotalStaked,
   } = useQuery({
     queryFn: () => getTotalStaked(hemi.id),
@@ -24,6 +28,7 @@ export const useTotalStaked = function () {
     refetchInterval: 2 * 60 * 1000,
   })
 
+  const isError = isTokenPricesError || isTotalStakedError
   const isPending = isLoadingTotalStaked || isLoadingPrices
 
   const calculateTotalStake = () =>

--- a/portal/app/[locale]/stake/_hooks/useWalletBalances.ts
+++ b/portal/app/[locale]/stake/_hooks/useWalletBalances.ts
@@ -28,6 +28,8 @@ export const useWalletBalances = function () {
               })
           : BigInt(0),
       queryKey: ['wallet-token-balance', token.chainId, token.address],
+      // refetch every 5 minutes
+      refetchInterval: 5 * 60 * 1000,
       select: (balance: bigint) => ({ ...token, balance }) satisfies StakeToken,
     })),
   })

--- a/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -277,9 +277,24 @@ export const StakeAssetsTable = function () {
   const { track } = useUmami()
   const { loading: isLoadingBalance, tokensWithPosition } = useStakePositions()
 
-  const { data: prices, isPending: isLoadingPrices } = useTokenPrices()
+  const {
+    data: prices,
+    errorUpdateCount,
+    isPending: isLoadingPrices,
+  } = useTokenPrices()
+
   const isLoading = isLoadingBalance || isLoadingPrices
-  const sortedTokens = isLoading ? [] : sortTokens(tokensWithPosition, prices)
+
+  const sortedTokens = useMemo(
+    () =>
+      // If prices errored, let's show the tokens without price ordering.
+      // If the prices API eventually comes back, prices will be redefined and they will
+      // be sorted as expected.
+      !isLoading || errorUpdateCount > 0
+        ? sortTokens(tokensWithPosition, prices)
+        : [],
+    [isLoading, errorUpdateCount, tokensWithPosition, prices],
+  )
 
   if (tokensWithPosition.length === 0) {
     return <WelcomeStake />

--- a/portal/components/fiatBalance.tsx
+++ b/portal/components/fiatBalance.tsx
@@ -33,7 +33,7 @@ const RenderFiatBalanceUnsafe = function ({
     data,
     fetchStatus: tokenPricesFetchStatus,
     status: pricesStatus,
-  } = useTokenPrices()
+  } = useTokenPrices({ retryOnMount: false })
 
   const stringBalance = formatUnits(balance, token.decimals)
 

--- a/portal/hooks/useTokenPrices.ts
+++ b/portal/hooks/useTokenPrices.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import fetch from 'fetch-plus-plus'
 import { useEffect } from 'react'
 import { isValidUrl } from 'utils/url'
@@ -8,7 +8,9 @@ const pricesUrl = process.env.NEXT_PUBLIC_TOKEN_PRICES_URL
 
 type Prices = Record<string, string>
 
-export const useTokenPrices = function () {
+export const useTokenPrices = function (
+  options: Omit<UseQueryOptions<Prices, Error>, 'queryKey' | 'queryFn'> = {},
+) {
   const query = useQuery({
     // If the URL is not set, prices are not returned. Consumers of the hook
     // should consider this scenario
@@ -18,6 +20,8 @@ export const useTokenPrices = function () {
     queryKey: ['token-prices'],
     // refetch every 5 min
     refetchInterval: 5 * 60 * 1000,
+    retry: 2,
+    ...options,
   })
 
   const { error } = query


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR allows Stake to render both the stake and dashboard tables if the Prices API fails (something we've noticed failing from time to time in Sentry). 
For this, it does not apply sorting, and if the API eventually recovers, it sorts at that moment. Although this means shuffling the rows, I think it is correct, as before, there was no info on how to sort, but now with prices, there is. Reshuffling would also happen if the user stakes (or unstakes) a position and their relative sorting changes, so if that shuffling makes sense, I think this one too.

This bug took me a while because there was a weird infinite re-rendering loop when I enabled rendering the table:

We were showing `loading` indicators when fetching prices, and after failure, the `isLoadingPrices` was set to false. However, when I made the changes to render the table (Without sorting), a child component was using the same `useTokenPrices` hook, which, as there was no cached data, would retry fetching, converting the flag `isLoadingPrices`  into `true`, thus unmounting the table to show the loading spinners, and after the request failed, this would render again the table without sorting, and this child component would re-render again.. and so on indefinitely

This was fixed by adding a `retryOnMount: false` on the `useTokenPrices` usage on the child component. Fixing that cost me like 2 hours 😢 

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

The beginning of the video shows the Token Prices API turned off, simulating its failure. Note that normally, the FE would refetch every 5 minutes, but for a better visualization, I locally updated the refetching of prices every 15 seconds.

https://github.com/user-attachments/assets/68411196-e230-4e69-bbdd-9ab2e9a9e5e6

As you can see, the table renders normally (so users can operate if desired), and from time to time, the Prices are refetched. Once loaded, the table sorts accordingly. 

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1206

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
