### PR TITLE
Prevent Drawer to crash if container wasn't found

### DIFF
--- a/portal/components/drawer/index.tsx
+++ b/portal/components/drawer/index.tsx
@@ -29,6 +29,14 @@ export const Drawer = function ({
     }
   }, drawerRef)
 
+  const drawerContainer =
+    container ?? document.getElementById('app-layout-container')
+
+  if (!drawerContainer) {
+    // container not found, prevent "ReactDOM.createPortal" from crashing
+    return null
+  }
+
   return ReactDOM.createPortal(
     <>
       <div
@@ -44,7 +52,7 @@ export const Drawer = function ({
       </div>
       <OverlayComponent />
     </>,
-    container ?? document.getElementById('app-layout-container'),
+    drawerContainer,
   )
 }
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Refreshing the Stake pages crashes if the drawer was opened app. This was because the Drawer, rendered in the `Stake` layout, would not find the Drawer container that was rendered in the Root Layout. My understanding of why this is happening is that both layouts render together initially, so the initial DOM is not flushed and painted by the moment the Drawer component renders the first time.  
So when the drawer uses the `document.querySelector` API, no elements are found, returning `null`. This makes the `ReactDom.render` function crash.

By checking the container is defined, we can ensure it does not crash, and in the subsequent renders, as the initial DOM rendering is done, the `document.querySelector` finds the element and everything works

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/201ef09d-485b-4d52-8520-3179ea578b0a

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1213

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
