### PR TITLE
Add more evm wallets

### DIFF
--- a/portal/context/evmWalletContext.tsx
+++ b/portal/context/evmWalletContext.tsx
@@ -7,6 +7,7 @@ import {
   type Locale,
 } from '@rainbow-me/rainbowkit'
 import {
+  coinbaseWallet,
   metaMaskWallet,
   okxWallet,
   rabbyWallet,
@@ -30,6 +31,7 @@ const connectors = connectorsForWallets(
     {
       groupName: 'Wallets',
       wallets: [
+        coinbaseWallet,
         metaMaskWallet,
         okxWallet,
         rabbyWallet,

--- a/portal/context/evmWalletContext.tsx
+++ b/portal/context/evmWalletContext.tsx
@@ -8,6 +8,7 @@ import {
 } from '@rainbow-me/rainbowkit'
 import {
   metaMaskWallet,
+  rabbyWallet,
   walletConnectWallet,
 } from '@rainbow-me/rainbowkit/wallets'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -26,7 +27,7 @@ const connectors = connectorsForWallets(
   [
     {
       groupName: 'Wallets',
-      wallets: [metaMaskWallet, walletConnectWallet],
+      wallets: [metaMaskWallet, rabbyWallet, walletConnectWallet],
     },
   ],
   {

--- a/portal/context/evmWalletContext.tsx
+++ b/portal/context/evmWalletContext.tsx
@@ -8,6 +8,7 @@ import {
 } from '@rainbow-me/rainbowkit'
 import {
   metaMaskWallet,
+  okxWallet,
   rabbyWallet,
   walletConnectWallet,
 } from '@rainbow-me/rainbowkit/wallets'
@@ -27,7 +28,7 @@ const connectors = connectorsForWallets(
   [
     {
       groupName: 'Wallets',
-      wallets: [metaMaskWallet, rabbyWallet, walletConnectWallet],
+      wallets: [metaMaskWallet, okxWallet, rabbyWallet, walletConnectWallet],
     },
   ],
   {

--- a/portal/context/evmWalletContext.tsx
+++ b/portal/context/evmWalletContext.tsx
@@ -10,6 +10,7 @@ import {
   metaMaskWallet,
   okxWallet,
   rabbyWallet,
+  tokenPocketWallet,
   walletConnectWallet,
 } from '@rainbow-me/rainbowkit/wallets'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -28,7 +29,13 @@ const connectors = connectorsForWallets(
   [
     {
       groupName: 'Wallets',
-      wallets: [metaMaskWallet, okxWallet, rabbyWallet, walletConnectWallet],
+      wallets: [
+        metaMaskWallet,
+        okxWallet,
+        rabbyWallet,
+        tokenPocketWallet,
+        walletConnectWallet,
+      ],
     },
   ],
   {

--- a/portal/scripts/generateServerConfig.js
+++ b/portal/scripts/generateServerConfig.js
@@ -45,6 +45,10 @@ const fetchDomains = new Set([
   'https://*.walletconnect.org',
   // cookie3
   'https://a.markfi.xyz',
+  // coinbase wallet
+  'https://chain-proxy.wallet.coinbase.com',
+  'https://keys.coinbase.com',
+  'wss://www.walletlink.org/rpc',
 ])
 
 if (process.env.NEXT_PUBLIC_THE_GRAPH_API_URL) {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR enables a few EVM wallets. Note that `Binance Wallet` and Phantom do not allow adding or connecting to a custom RPC, and do not support Hemi. For the rest, I tested tunneling and staking and I was able to confirm all the transactions.

Each commit is one wallet, though all of them are supported by RainbowKit, and this issue was mostly testing-related.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="766" alt="image" src="https://github.com/user-attachments/assets/b0c44667-af85-4357-8787-0fb397a491f9" />

Note that some appear as forks of MM, which are detected as an Injected Wallet.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1224 - I am keeping the issue open as if this works ok and we see these wallets being used, we could make another round for more wallets.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
