### PR TITLE
Fix intellisense and type-checking for next-intl

### DIFF
--- a/portal/intl.d.ts
+++ b/portal/intl.d.ts
@@ -1,4 +1,9 @@
-// Use type safe message keys with `next-intl`
-type Messages = typeof import('./messages/en.json')
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-declare interface IntlMessages extends Messages {}
+import { routing } from './i18n/routing'
+import messages from './messages/en.json'
+
+declare module 'next-intl' {
+  interface AppConfig {
+    Locale: (typeof routing.locales)[number]
+    Messages: typeof messages
+  }
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

It seems that after https://github.com/hemilabs/ui-monorepo/pull/1062, the type-checking and intellisense were not working when using `next-intl`. I checked the [docs](https://next-intl.dev/docs/workflows/typescript) and in v4, they've changed how to achieve this. So this PR fixes that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Before
![image](https://github.com/user-attachments/assets/21c39d54-c346-4d65-8632-12871b179976)

Now
![image](https://github.com/user-attachments/assets/90bb56b6-72a3-4bde-9e30-5a8009f24bb9)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
