### PR TITLE
Add fee estimation hooks to use new encoders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27846,7 +27846,7 @@
         "fetch-plus-plus": "1.0.0",
         "hemi-socials": "1.0.0",
         "hemi-tunnel-actions": "1.0.0",
-        "hemi-viem": "2.3.2",
+        "hemi-viem": "2.4.1",
         "hemi-viem-stake-actions": "1.0.0",
         "lodash": "4.17.21",
         "next": "14.2.16",
@@ -27934,6 +27934,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "portal/node_modules/hemi-viem": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.4.1.tgz",
+      "integrity": "sha512-fc8s7z6kdYychVbVvwgKv5oxAsoLxD+Fu6tbm3zgY8KpTloNCiU564ynLYG0WlQvdKWOmEhgdbUcLL9fAGjLAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "viem": "^2.x"
       }
     },
     "portal/node_modules/map-obj": {

--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -67,13 +67,17 @@ export const StakeOperation = function ({
     },
   })
 
-  const approvalEstimatedFees = useEstimateApproveErc20Fees({
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: approvalEstimatedFees } = useEstimateApproveErc20Fees({
     amount: parseUnits(amount, token.decimals),
     spender,
     token,
   })
 
-  const stakeEstimatedFees = useEstimateStakeFees({
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: stakeEstimatedFees } = useEstimateStakeFees({
     amount: parseUnits(amount, token.decimals),
     enabled: allowance > 0 || operatesNativeToken,
     token,

--- a/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
@@ -71,7 +71,9 @@ export const UnstakeOperation = function ({
       token,
     }).error
 
-  const unstakeEstimatedFees = useEstimateUnstakeFees({
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: unstakeEstimatedFees } = useEstimateUnstakeFees({
     amount: parseUnits(amount, token.decimals),
     enabled: canUnstake,
     token,

--- a/portal/app/[locale]/tunnel/_components/evmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/evmDeposit.tsx
@@ -165,13 +165,17 @@ export const EvmDeposit = function ({ state }: EvmDepositProps) {
 
   const fromChain = useChain(fromNetworkId)
 
-  const approvalTokenGasFees = useEstimateApproveErc20Fees({
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: approvalTokenGasFees } = useEstimateApproveErc20Fees({
     amount,
     spender: l1StandardBridgeAddress,
     token: fromToken,
   })
 
-  const depositGasFees = useEstimateDepositFees({
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: depositGasFees } = useEstimateDepositFees({
     amount,
     fromToken,
     toToken,

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcDeposit.tsx
@@ -4,7 +4,6 @@ import { WarningBox } from 'components/warningBox'
 import { useBitcoin } from 'hooks/useBitcoin'
 import { useChain } from 'hooks/useChain'
 import { useGetFeePrices } from 'hooks/useEstimateBtcFees'
-import { useEstimateFees } from 'hooks/useEstimateFees'
 import { useHemi } from 'hooks/useHemi'
 import { useToken } from 'hooks/useToken'
 import { useTranslations } from 'next-intl'
@@ -15,6 +14,7 @@ import { getNativeToken } from 'utils/nativeToken'
 import { formatUnits } from 'viem'
 import { useAccount } from 'wagmi'
 
+import { useEstimateBtcDepositFees } from '../../_hooks/useEstimateBtcDepositFees'
 import { ConfirmBtcDeposit } from '../confirmBtcDeposit'
 import { RetryBtcDeposit } from '../retryBtcDeposit'
 
@@ -50,12 +50,7 @@ const ReviewContent = function ({
 
   const { isConnected } = useAccount()
   const bitcoin = useBitcoin()
-  // fees for bitcoin deposit confirmation
-  const estimatedFees = useEstimateFees({
-    chainId: deposit.l2ChainId,
-    operation: 'confirm-btc-deposit',
-    overEstimation: 1.5,
-  })
+
   const hemi = useHemi()
   const l2chain = useChain(deposit.l2ChainId)
 
@@ -71,6 +66,13 @@ const ReviewContent = function ({
       BtcDepositStatus.DEPOSIT_MANUAL_CONFIRMATION_TX_FAILED,
       BtcDepositStatus.READY_TO_MANUAL_CONFIRM,
     ].includes(depositStatus)
+
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: estimatedFees } = useEstimateBtcDepositFees({
+    deposit,
+    enabled: showDepositConfirmationFees,
+  })
 
   const shouldAddManualConfirmationStep = () =>
     [

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
@@ -49,7 +49,10 @@ const ReviewContent = function ({
   const toChain = useChain(deposit.l2ChainId)
 
   const l1StandardBridgeAddress = useL1StandardBridgeAddress(fromToken.chainId)
-  const approvalTokenGasFees = useEstimateApproveErc20Fees({
+
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: approvalTokenGasFees } = useEstimateApproveErc20Fees({
     amount: BigInt(deposit.amount),
     enabled: [
       EvmDepositStatus.APPROVAL_TX_FAILED,
@@ -59,7 +62,9 @@ const ReviewContent = function ({
     token: fromToken,
   })
 
-  const depositGasFees = useEstimateDepositFees({
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: depositGasFees } = useEstimateDepositFees({
     amount: BigInt(deposit.amount),
     enabled: [
       EvmDepositStatus.APPROVAL_TX_COMPLETED,

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -61,16 +61,23 @@ const ReviewContent = function ({
   const t = useTranslations('tunnel-page.review-withdrawal')
   const tCommon = useTranslations('common')
 
-  const claimWithdrawalTokenGasFees = useEstimateFinalizeWithdrawalFees({
-    withdrawal,
-  })
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: claimWithdrawalTokenGasFees } =
+    useEstimateFinalizeWithdrawalFees({
+      withdrawal,
+    })
 
-  const proveWithdrawalTokenGasFees = useEstimateProveWithdrawalFees({
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: proveWithdrawalTokenGasFees } = useEstimateProveWithdrawalFees({
     enabled: withdrawal.status === MessageStatus.READY_TO_PROVE,
     withdrawal,
   })
 
-  const withdrawGasFees = useEstimateWithdrawFees({
+  // TODO: We need to decide what to render when `isError` is true (This hook is handling errors).
+  // Issue: https://github.com/hemilabs/ui-monorepo/issues/866
+  const { fees: withdrawGasFees } = useEstimateWithdrawFees({
     amount: BigInt(withdrawal.amount),
     enabled: withdrawal.status === MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE,
     fromToken,

--- a/portal/app/[locale]/tunnel/_hooks/useEstimateBtcChallengeWithdrawFees.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useEstimateBtcChallengeWithdrawFees.ts
@@ -1,0 +1,39 @@
+import {
+  bitcoinTunnelManagerAddresses,
+  encodeChallengeWithdrawal,
+} from 'hemi-viem'
+import { useEstimateFees } from 'hooks/useEstimateFees'
+import { useEstimateGas } from 'wagmi'
+
+export function useEstimateChallengeBtcWithdrawFees({
+  enabled = true,
+  l2ChainId,
+  uuid,
+}: {
+  enabled?: boolean
+  l2ChainId: number
+  uuid: bigint
+}) {
+  const bitcoinManagerAddresses = bitcoinTunnelManagerAddresses[l2ChainId]
+
+  const {
+    data: gasUnits,
+    isError,
+    isSuccess,
+  } = useEstimateGas({
+    data: encodeChallengeWithdrawal({
+      extraInfo: '0x',
+      uuid,
+    }),
+    query: { enabled },
+    to: bitcoinManagerAddresses,
+  })
+
+  return useEstimateFees({
+    chainId: l2ChainId,
+    enabled: isSuccess,
+    gasUnits,
+    isGasUnitsError: isError,
+    overEstimation: 1.5,
+  })
+}

--- a/portal/app/[locale]/tunnel/_hooks/useEstimateBtcDepositFees.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useEstimateBtcDepositFees.ts
@@ -1,0 +1,66 @@
+import { useQuery } from '@tanstack/react-query'
+import { bitcoinTunnelManagerAddresses, encodeConfirmDeposit } from 'hemi-viem'
+import { useEstimateFees } from 'hooks/useEstimateFees'
+import { HemiPublicClient, useHemiClient } from 'hooks/useHemiClient'
+import { BtcDepositOperation } from 'types/tunnel'
+import { calculateDepositOutputIndex } from 'utils/bitcoin'
+import { createBtcApi, mapBitcoinNetwork } from 'utils/btcApi'
+import { getVaultIndexByBTCAddress } from 'utils/hemiMemoized'
+import { useEstimateGas } from 'wagmi'
+
+async function getEncodedConfirmDeposit({
+  deposit,
+  hemiClient,
+}: {
+  deposit: BtcDepositOperation
+  hemiClient: HemiPublicClient
+}) {
+  const vaultIndex = await getVaultIndexByBTCAddress(hemiClient, deposit)
+
+  const btcApi = createBtcApi(mapBitcoinNetwork(deposit.l1ChainId))
+  const receipt = await btcApi.getTransactionReceipt(deposit.transactionHash)
+  const outputIndex = await calculateDepositOutputIndex(receipt!, deposit.to)
+
+  return encodeConfirmDeposit({
+    extraInfo: '0x',
+    outputIndex: BigInt(outputIndex),
+    txId: deposit.transactionHash,
+    vaultIndex,
+  })
+}
+
+export function useEstimateBtcDepositFees({
+  deposit,
+  enabled = true,
+}: {
+  deposit: BtcDepositOperation
+  enabled?: boolean
+}) {
+  const hemiClient = useHemiClient()
+  const bitcoinManagerAddresses =
+    bitcoinTunnelManagerAddresses[deposit.l2ChainId]
+
+  const { data: encodedData, isSuccess } = useQuery({
+    enabled: !!deposit && enabled,
+    queryFn: () => getEncodedConfirmDeposit({ deposit, hemiClient }),
+    queryKey: ['encode-confirm-deposit', deposit.transactionHash],
+  })
+
+  const {
+    data: gasUnits,
+    isError: isGasError,
+    isSuccess: gasSuccess,
+  } = useEstimateGas({
+    data: encodedData,
+    query: { enabled: isSuccess && !!encodedData },
+    to: bitcoinManagerAddresses,
+  })
+
+  return useEstimateFees({
+    chainId: deposit.l2ChainId,
+    enabled: gasSuccess,
+    gasUnits,
+    isGasUnitsError: isGasError,
+    overEstimation: 1.5,
+  })
+}

--- a/portal/app/[locale]/tunnel/_hooks/useEstimateBtcWithdrawFees.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useEstimateBtcWithdrawFees.ts
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  bitcoinTunnelManagerAddresses,
+  encodeInitiateWithdrawal,
+} from 'hemi-viem'
+import { useEstimateFees } from 'hooks/useEstimateFees'
+import { HemiPublicClient, useHemiClient } from 'hooks/useHemiClient'
+import { useEstimateGas } from 'wagmi'
+
+async function getEncodeInitiateWithdrawal({
+  amount,
+  btcAddress,
+  hemiClient,
+}: {
+  amount: bigint
+  btcAddress: string
+  hemiClient: HemiPublicClient
+}) {
+  const vaultIndex = await hemiClient.getVaultChildIndex()
+
+  return encodeInitiateWithdrawal({
+    amount,
+    btcAddress,
+    vaultIndex,
+  })
+}
+
+export function useEstimateBtcWithdrawFees({
+  amount,
+  btcAddress,
+  enabled = true,
+  l2ChainId,
+}: {
+  btcAddress: string
+  amount: bigint
+  l2ChainId: number
+  enabled?: boolean
+}) {
+  const hemiClient = useHemiClient()
+  const bitcoinManagerAddresses = bitcoinTunnelManagerAddresses[l2ChainId]
+
+  const { data: encodedData, isSuccess } = useQuery({
+    enabled,
+    queryFn: () =>
+      getEncodeInitiateWithdrawal({ amount, btcAddress, hemiClient }),
+    queryKey: [
+      'encode-initiate-withdrawal',
+      btcAddress,
+      amount.toString(),
+      l2ChainId,
+    ],
+  })
+
+  const {
+    data: gasUnits,
+    isError: isGasError,
+    isSuccess: gasSuccess,
+  } = useEstimateGas({
+    data: encodedData,
+    query: { enabled: isSuccess && !!encodedData },
+    to: bitcoinManagerAddresses,
+  })
+
+  return useEstimateFees({
+    chainId: l2ChainId,
+    enabled: gasSuccess,
+    gasUnits,
+    isGasUnitsError: isGasError,
+    overEstimation: 1.5,
+  })
+}

--- a/portal/app/[locale]/tunnel/_hooks/useEstimateDepositFees.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useEstimateDepositFees.ts
@@ -18,7 +18,11 @@ export const useEstimateDepositFees = function ({
 }) {
   const isNative = isNativeToken(fromToken)
   const l1StandardBridge = useL1StandardBridgeAddress(fromToken.chainId)
-  const { data: gasUnits, isSuccess } = useEstimateGas({
+  const {
+    data: gasUnits,
+    isError,
+    isSuccess,
+  } = useEstimateGas({
     data: isNative
       ? encodeDepositEth()
       : encodeDepositErc20({
@@ -37,6 +41,7 @@ export const useEstimateDepositFees = function ({
     chainId: fromToken.chainId,
     enabled: isSuccess,
     gasUnits,
+    isGasUnitsError: isError,
     overEstimation: 1.5,
   })
 }

--- a/portal/app/[locale]/tunnel/_hooks/useEstimateFinalizeWithdrawalFees.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useEstimateFinalizeWithdrawalFees.ts
@@ -21,7 +21,11 @@ export const useEstimateFinalizeWithdrawalFees = function ({
   const hemi = useHemi()
   const hemiClient = useHemiClient()
 
-  const { data: gasUnits, isSuccess } = useQuery({
+  const {
+    data: gasUnits,
+    isError,
+    isSuccess,
+  } = useQuery({
     enabled,
     async queryFn() {
       const publicClient = getEvmL1PublicClient(l1ChainId)
@@ -50,6 +54,7 @@ export const useEstimateFinalizeWithdrawalFees = function ({
     chainId: l1ChainId,
     enabled: isSuccess,
     gasUnits,
+    isGasUnitsError: isError,
     overEstimation: 1.5,
   })
 }

--- a/portal/app/[locale]/tunnel/_hooks/useEstimateProveWithdrawalFees.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useEstimateProveWithdrawalFees.ts
@@ -21,7 +21,11 @@ export const useEstimateProveWithdrawalFees = function ({
   const { address: account } = useAccount()
   const hemiClient = useHemiClient()
 
-  const { data: gasUnits, isSuccess } = useQuery({
+  const {
+    data: gasUnits,
+    isError,
+    isSuccess,
+  } = useQuery({
     enabled,
     async queryFn() {
       const publicClient = getEvmL1PublicClient(l1ChainId)
@@ -50,6 +54,7 @@ export const useEstimateProveWithdrawalFees = function ({
     chainId: l1ChainId,
     enabled: isSuccess,
     gasUnits,
+    isGasUnitsError: isError,
     overEstimation: 1.5,
   })
 }

--- a/portal/app/[locale]/tunnel/_hooks/useEstimateWithdrawFees.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useEstimateWithdrawFees.ts
@@ -20,7 +20,11 @@ export const useEstimateWithdrawFees = function ({
 }) {
   const l2BridgeAddress = useL2BridgeAddress(l1ChainId)
   const isNative = isNativeAddress(fromToken.address)
-  const { data: gasUnits, isSuccess } = useEstimateGas({
+  const {
+    data: gasUnits,
+    isError,
+    isSuccess,
+  } = useEstimateGas({
     data: encodeInitiateWithdraw({
       amount,
       l2TokenAddress: isNative
@@ -36,6 +40,7 @@ export const useEstimateWithdrawFees = function ({
     chainId: fromToken.chainId,
     enabled: isSuccess,
     gasUnits,
+    isGasUnitsError: isError,
     overEstimation: 1.5,
   })
 }

--- a/portal/hooks/useEstimateApproveErc20Fees.ts
+++ b/portal/hooks/useEstimateApproveErc20Fees.ts
@@ -14,7 +14,11 @@ export const useEstimateApproveErc20Fees = function ({
   spender: Address
   token: EvmToken
 }) {
-  const { data: gasUnits, isSuccess } = useEstimateGas({
+  const {
+    data: gasUnits,
+    isError,
+    isSuccess,
+  } = useEstimateGas({
     abi: erc20Abi,
     address: token.address,
     args: [spender, amount],
@@ -26,6 +30,7 @@ export const useEstimateApproveErc20Fees = function ({
     chainId: token.chainId,
     enabled: isSuccess,
     gasUnits,
+    isGasUnitsError: isError,
     overEstimation: 1.5,
   })
 }

--- a/portal/package.json
+++ b/portal/package.json
@@ -30,7 +30,7 @@
     "fetch-plus-plus": "1.0.0",
     "hemi-socials": "1.0.0",
     "hemi-tunnel-actions": "1.0.0",
-    "hemi-viem": "2.3.2",
+    "hemi-viem": "2.4.1",
     "hemi-viem-stake-actions": "1.0.0",
     "lodash": "4.17.21",
     "next": "14.2.16",

--- a/portal/utils/hemiMemoized.ts
+++ b/portal/utils/hemiMemoized.ts
@@ -53,7 +53,6 @@ export const getVaultIndexByBTCAddress = pMemoize(
 
 // Memoizing it as it is unlikely to change
 export const getBitcoinKitAddress = pMemoize(
-  // @ts-expect-error needs to be fixed https://github.com/hemilabs/hemi-viem/issues/30
   (hemiClient: HemiPublicClient) => hemiClient.getBitcoinKitAddress(),
   { resolver: hemiClient => hemiClient.chain.id },
 )


### PR DESCRIPTION
### Description

This PR adds all the fee estimation hooks to rely on the encoder functions recently added to `hemi-viem`. It also introduces an `isError` flag in the returned fee object.. this allows us to detect when the estimation fails. An eventually follow-up PR will define how we want to handle and display this state to the user. Finally, it removes the old `operation` and hardcoded gas unit logic, which is no longer needed.

### Screenshots

No UI changes.

### Related issue(s)

Related to #866 
Related to #826  

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
