### PR TITLE
Fix null pointer on workers

### DIFF
--- a/portal/workers/history.ts
+++ b/portal/workers/history.ts
@@ -103,6 +103,9 @@ async function syncTunnelHistory(parameters: StartSyncing) {
 
 // wait for the UI to send chain and address once ready
 worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (!e?.data) {
+    return
+  }
   if (e.data.type === 'start') {
     syncTunnelHistory(e.data)
   }

--- a/portal/workers/watchBitcoinDeposits.ts
+++ b/portal/workers/watchBitcoinDeposits.ts
@@ -60,6 +60,9 @@ const watchDeposit = function (deposit: BtcDepositOperation) {
 
 // wait for the UI to send chain and address once ready
 worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (!e?.data) {
+    return
+  }
   if (e.data.type === 'watch-btc-deposit') {
     watchDeposit(e.data.deposit)
   }

--- a/portal/workers/watchBitcoinWithdrawals.ts
+++ b/portal/workers/watchBitcoinWithdrawals.ts
@@ -67,6 +67,9 @@ const watchWithdrawal = (withdrawal: ToBtcWithdrawOperation) =>
 
 // wait for the UI to send chain and address once ready
 worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (!e?.data) {
+    return
+  }
   if (e.data.type === 'watch-btc-withdrawal') {
     watchWithdrawal(e.data.withdrawal)
   }

--- a/portal/workers/watchEvmDeposits.ts
+++ b/portal/workers/watchEvmDeposits.ts
@@ -55,6 +55,9 @@ const watchDeposit = (deposit: EvmDepositOperation) =>
 
 // wait for the UI to send chain and address once ready
 worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (!e?.data) {
+    return
+  }
   if (e.data.type === 'watch-evm-deposit') {
     watchDeposit(e.data.deposit)
   }

--- a/portal/workers/watchEvmWithdrawals.ts
+++ b/portal/workers/watchEvmWithdrawals.ts
@@ -88,6 +88,9 @@ const watchWithdrawal = (withdrawal: ToEvmWithdrawOperation) =>
 
 // wait for the UI to send chain and address once ready
 worker.onmessage = function runWorker(e: MessageEvent<AppToWebWorkerActions>) {
+  if (!e?.data) {
+    return
+  }
   if (e.data.type === 'watch-withdrawal') {
     watchWithdrawal(e.data.withdrawal)
   }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds an extra check for safety on the web workers. All the messages broadcasted by our workers have a `e.data` defined, but we got a report on Sentry of a undefined reference access (meaning `e.data` was undefined).
I'm suspicious that some other unrelated worker to our portal has somewhat reached our web workers. This check then should prevent this from happening.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1247

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
