### PR TITLE
Fix double slash in stake page URL generation

### DIFF
--- a/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -300,7 +300,7 @@ export const StakeAssetsTable = function () {
     return <WelcomeStake />
   }
 
-  const stakeMoreUrl = '/stake'
+  const stakeMoreUrl = 'stake'
 
   function goToStakePage(e: MouseEvent<HTMLAnchorElement>) {
     e.preventDefault()


### PR DESCRIPTION
### Description

This PR fixes an issue where the stake more button would generate an incorrect URL containing a double slash (e.g., /en//stake) when using router.push. Adjusted router.push call to avoid double slashes by removing the leading / when using stakeMoreUrl.

### Screenshots

https://github.com/user-attachments/assets/0c815fbd-994d-4323-8fc0-f2bb8a7935e4

### Related issue(s)

Closes #1215
Fixes #1215

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
