### PR TITLE
Preserve query params on locale change

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/help.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help.tsx
@@ -9,6 +9,7 @@ import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { usePathnameWithoutLocale } from 'hooks/usePathnameWithoutLocale'
 import { useRouter } from 'i18n/navigation'
 import { locales } from 'i18n/routing'
+import { useSearchParams } from 'next/navigation'
 import { Locale, useLocale, useTranslations } from 'next-intl'
 import { ComponentProps, ReactNode, RefObject, useState } from 'react'
 
@@ -135,10 +136,14 @@ const ItemWithSubmenu = function ({
 const LanguageMenu = function ({ active }: LanguageProps) {
   const t = useTranslations('navbar.help')
   const pathname = usePathnameWithoutLocale()
+  const searchParams = useSearchParams()
   const router = useRouter()
 
   const onClick = function (locale: Locale) {
-    router.push(pathname, { locale })
+    const query = searchParams.toString()
+    const fullPath = query ? `${pathname}?${query}` : pathname
+
+    router.push(fullPath, { locale })
   }
 
   return (


### PR DESCRIPTION
### Description

This PR ensures that all existing query parameters (e.g. `networkType=testnet`) are preserved when switching between locales. Previously, changing the language via the locale selector would reset the query string, causing a fallback to `mainnet` due to the absence of the `networkType` parameter.

### Screenshots

https://github.com/user-attachments/assets/ebc44ea7-d8ce-424d-935f-20e514985831

### Related issue(s)

Closes #1249
Fixes #1249 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
