### PR TITLE
Fix drawer closing when RainbowKit modal is open

### DIFF
--- a/portal/app/[locale]/stake/_components/manageStake/index.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/index.tsx
@@ -1,5 +1,10 @@
 'use client'
 
+import {
+  useAccountModal,
+  useChainModal,
+  useConnectModal,
+} from '@rainbow-me/rainbowkit'
 import { Drawer } from 'components/drawer'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
@@ -11,7 +16,7 @@ import { StakeOperation } from './stakeOperation'
 import { UnstakeOperation } from './unstakeOperation'
 
 type Props = {
-  closeDrawer: () => void
+  closeDrawer: VoidFunction
   initialOperation: StakeOperations
   mode: DrawerModes
   token: StakeToken
@@ -30,6 +35,9 @@ export const ManageStake = function ({
   )
 
   const t = useTranslations('stake-page.drawer')
+  const { accountModalOpen } = useAccountModal()
+  const { chainModalOpen } = useChainModal()
+  const { connectModalOpen } = useConnectModal()
 
   const { heading, subheading } = {
     manage: {
@@ -44,11 +52,19 @@ export const ManageStake = function ({
 
   const isStaking = mode === 'stake' || operation === 'stake'
 
+  // Prevent closing the drawer when a RainbowKit modal is open.
+  // Without this check, clicks on the wallet modal (e.g., Connect Wallet)
+  // are interpreted as outside clicks and trigger onClose unintentionally.
+  function safeCloseDrawer() {
+    if (accountModalOpen || chainModalOpen || connectModalOpen) return
+    closeDrawer()
+  }
+
   return (
-    <Drawer onClose={closeDrawer}>
+    <Drawer onClose={safeCloseDrawer}>
       {isStaking ? (
         <StakeOperation
-          closeDrawer={closeDrawer}
+          closeDrawer={safeCloseDrawer}
           heading={heading}
           onOperationChange={setOperation}
           showTabs={isManaging}
@@ -57,7 +73,7 @@ export const ManageStake = function ({
         />
       ) : (
         <UnstakeOperation
-          closeDrawer={closeDrawer}
+          closeDrawer={safeCloseDrawer}
           heading={heading}
           onOperationChange={setOperation}
           subheading={subheading}


### PR DESCRIPTION
### Description

This PR introduces a `safeCloseDrawer` wrapper that prevents closing the drawer when any RainbowKit modal (connect, account, or chain) is open.

### Screenshots

https://github.com/user-attachments/assets/5410844b-3cb7-481a-b01a-e9bc0e11aa54

### Related issue(s)

Closes #1199
Fixes #1199

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
