### PR TITLE
Fix loading of .env locally

### DIFF
--- a/portal/scripts/generateServerConfig.js
+++ b/portal/scripts/generateServerConfig.js
@@ -1,6 +1,6 @@
 'use strict'
 
-require('dotenv').config({ override: true, path: ['../.env', '.env.local'] })
+require('dotenv').config({ override: true, path: ['.env', '.env.local'] })
 const { writeFile } = require('fs/promises')
 const path = require('path')
 const { mainnet, sepolia } = require('viem/chains')


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

While locally testing a PR, I found that the `.env` file was not loaded correctly when generating the headers. This PR fixes that. This is not a problem in the GH actions context - it is only when serving locally

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users 

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #899

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
