### PR TITLE
Filter more errors on Sentry

### DIFF
--- a/portal/sentry.client.config.ts
+++ b/portal/sentry.client.config.ts
@@ -60,10 +60,12 @@ function enableSentry() {
 
   Sentry.init({
     denyUrls: [
+      // Filter all Wallet Connect related urls
+      /(https|wss):\/\/*\.walletconnect\.(com|org)/,
       process.env.NEXT_PUBLIC_POINTS_URL,
       process.env.NEXT_PUBLIC_TOKEN_PRICES_URL,
       process.env.NEXT_PUBLIC_COOKIE3_URL,
-      // filter in case any is undefined, although in prod all should be defined.
+      // filter in case any of the env variables are undefined, although in prod all should be defined.
     ].filter(Boolean),
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enabled,

--- a/portal/sentry.client.config.ts
+++ b/portal/sentry.client.config.ts
@@ -51,6 +51,9 @@ function enableSentry() {
     // See https://blog.sentry.io/making-your-javascript-projects-less-noisy/#ignore-un-actionable-errors
     'The node to be removed is not a child of this node.',
     'The node before which the new node is to be inserted is not a child of this node.',
+    // MM already prompts to add the chain if switching to an unknown chain.
+    // All the other wallets tested work too, although without this error.
+    'Try adding the chain using wallet_addEthereumChain first',
     // Thrown when firefox prevents an add-on from referencing a DOM element that has been removed.
     `TypeError: can't access dead object`,
     'User denied transaction signature',


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

- 533393aea8a4cf63a46eaf903645eb37815c1f1a A few wallet connect URLs are added into [denyUrls](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-allowurls-and-denyurls) to filter them from logging errors
- bfc7ec8156594689b22bd87cbe8196dac4a3a264 Fixes #1267 by ignoring the error 😅  We can't detect if a chain's been added to a wallet. So when some CTA shows "Connect to Hemi", the app uses `switchChain({ chain: hemi })`. If the chain has not been added to the wallet, it logs the error

> MetaMask - RPC Error: Unrecognized chain ID "0xa867". Try adding the chain using wallet_addEthereumChain first.,

However, this error is useless because Metamask and all the other wallets enabled automatically prompt an "Add Hemi chain" if it has not been added. Once accepted, it proceeds to the regular switch. Thus, there's nothing for us to do, as users are able to operate regularly despite this log. Because of this, I am ignoring this error.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1267 
Related to #1229

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
