### PR TITLE
Fix completed deposit text

### DIFF
--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
@@ -189,7 +189,7 @@ const ReviewContent = function ({
       onClose={onClose}
       steps={steps}
       subheading={
-        depositStatus === EvmDepositStatus.DEPOSIT_TX_CONFIRMED
+        depositStatus === EvmDepositStatus.DEPOSIT_RELAYED
           ? t('your-deposit-is-complete')
           : t('deposit-on-its-way')
       }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

When the user completed the deposit, the wrong text was shown.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

| Before  | Now |
| ------------- | ------------- |
| <img width="475" alt="Image" src="https://github.com/user-attachments/assets/a43eca14-3457-45e9-abfb-1a5c4361400a" /> | <img width="493" alt="image" src="https://github.com/user-attachments/assets/3bcf65f6-2b25-4b00-bf7a-5d00b9a64a68" />  |

(Nothe the old one has one approval, but that's not relevant)

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1218

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
