### PR TITLE
Improve Fee Estimation Logic Using EIP-1559

### DIFF
--- a/portal/hooks/useEstimateFees.ts
+++ b/portal/hooks/useEstimateFees.ts
@@ -1,19 +1,30 @@
 import Big from 'big.js'
-import { useAccount, useFeeHistory } from 'wagmi'
+import { hemiSepolia } from 'hemi-viem'
+import {
+  useAccount,
+  useEstimateMaxPriorityFeePerGas,
+  useFeeHistory,
+} from 'wagmi'
 
 import { useIsConnectedToExpectedNetwork } from './useIsConnectedToExpectedNetwork'
 
 const defaultBlockCount = 4
 const defaultOverEstimation = 1
+const defaultFeeMultiplier = 2
 
-const mean = function (rewards: bigint[] = []) {
-  if (rewards.length === 0) {
-    return '0'
-  }
-  return rewards
-    .reduce((a, b) => Big(a).plus(b.toString()), Big(0))
-    .div(rewards.length)
-    .toFixed(0)
+// Fallback priority fee values (in wei) used when the estimation API returns 0 or unrealistic values.
+// - `default`: 1 Gwei (suitable for mainnet and most testnets)
+// - `low`: 0.0001 Gwei (used for testnets with very low gas requirements)
+const fallbackPriorityFeeOptions = {
+  default: Big(1e9),
+  low: Big(1e5),
+}
+
+// Fallback priority fee:
+// - Use 1 Gwei for most networks.
+// - Use a lower fallback (0.0001 Gwei) for Hemi Sepolia due to low gas usage.
+const fallbackPriorityFeeByChain: Record<number, Big> = {
+  [hemiSepolia.id]: fallbackPriorityFeeOptions.low,
 }
 
 type UseEstimateFees = {
@@ -24,7 +35,25 @@ type UseEstimateFees = {
   gasUnits?: bigint
 }
 
-export const useEstimateFees = function ({
+/**
+ * Custom hook to estimate the total transaction fee for an EIP-1559 compatible network.
+ *
+ * It uses recent base fee history and a suggested or fallback maxPriorityFeePerGas to
+ * calculate a conservative `maxFeePerGas`, and multiplies it by the estimated gas units.
+ * This hook supports a custom `overEstimation` factor to pad the result for safety.
+ *
+ * @param {Object} params - Hook parameters.
+ * @param {number} params.chainId - The chain ID of the target network.
+ * @param {boolean} [params.enabled=true] - Whether the hook is enabled.
+ * @param {boolean} [params.isGasUnitsError=false] - Whether there was an error in estimating gas units.
+ * @param {number} [params.overEstimation=1] - Optional multiplier to pad the estimated fee for safety.
+ * @param {bigint} [params.gasUnits] - Estimated gas units for the transaction.
+ *
+ * @returns {Object} Result object.
+ * @returns {bigint} result.fees - Estimated total fee in wei.
+ * @returns {boolean} result.isError - Indicates whether there was a gas estimation error.
+ */
+export function useEstimateFees({
   chainId,
   enabled = true,
   isGasUnitsError = false,
@@ -33,35 +62,60 @@ export const useEstimateFees = function ({
 }: UseEstimateFees) {
   const { isConnected } = useAccount()
   const isConnectedToExpectedChain = useIsConnectedToExpectedNetwork(chainId)
-  const { data: feeHistory } = useFeeHistory({
+
+  const { data: feeHistory, isError: isFeeHistoryError } = useFeeHistory({
     blockCount: defaultBlockCount,
     blockTag: 'latest',
     chainId,
     query: {
       enabled: isConnected && isConnectedToExpectedChain && enabled,
-      // refetch every minute
       refetchInterval: 60 * 1000,
     },
     rewardPercentiles: [30],
   })
 
-  const baseFeePerGas =
-    feeHistory?.baseFeePerGas?.[defaultBlockCount] ?? BigInt(0)
+  // Use the base fee from the latest block in the fee history.
+  // This value is in wei and reflects the current network congestion.
+  const baseFeePerGas = feeHistory?.baseFeePerGas?.at(-1) ?? BigInt(0)
+
+  const { data: maxPriorityFeePerGas, isError: isMaxPriorityFeePerGasError } =
+    useEstimateMaxPriorityFeePerGas({
+      chainId,
+    })
+
+  // Convert the suggested priority fee (in wei) to a Big number.
+  // If not available, fallback to zero for now and correct below.
+  const rawPriorityFeeWei = Big(maxPriorityFeePerGas?.toString() ?? '0')
+
+  // Determine the fallback priority fee for the given chain.
+  // If the current chain has a custom fallback (e.g., Hemi Sepolia with very low gas costs), use it.
+  // Otherwise, default to 1 Gwei, which is appropriate for most networks.
+  const fallbackPriorityFee =
+    fallbackPriorityFeeByChain[chainId] ?? fallbackPriorityFeeOptions.default
+
+  // Use the estimated priority fee if it's above the fallback,
+  // otherwise use the fallback to avoid underestimating the fee.
+  const safePriorityFeeWei = rawPriorityFeeWei.gt(fallbackPriorityFee)
+    ? rawPriorityFeeWei
+    : fallbackPriorityFee
+
+  // Calculate the maxFeePerGas using EIP-1559 strategy:
+  // maxFeePerGas = baseFee * multiplier + priorityFee
+  const maxFeePerGasWei = Big(baseFeePerGas.toString())
+    .times(defaultFeeMultiplier)
+    .plus(safePriorityFeeWei)
 
   const gasUnits = props.gasUnits ?? BigInt(0)
 
-  const maxPriorityFeePerGas = mean(feeHistory?.reward.map(r => r[0]))
-  const fees = BigInt(
-    Big(gasUnits.toString())
-      .times(
-        Big(baseFeePerGas.toString()).plus(maxPriorityFeePerGas.toString()),
-      )
-      .times(overEstimation)
-      .toFixed(0),
-  )
+  // Estimate the total fee by multiplying gas units by the max fee per gas,
+  // and applying an overestimation multiplier (typically 1.0 or 1.5 for safety).
+  const totalFeeEstimate = Big(gasUnits.toString())
+    .times(maxFeePerGasWei)
+    .times(overEstimation)
 
   return {
-    fees,
-    isError: isGasUnitsError,
+    fees: BigInt(totalFeeEstimate.toFixed(0)),
+    isError:
+      isGasUnitsError || isFeeHistoryError || isMaxPriorityFeePerGasError,
   }
 }


### PR DESCRIPTION
### Description

This PR improves the internal logic of the useEstimateFees hook to provide more consistent EIP-1559 fee estimations.. The total fee is estimated by computing **gasUnits * maxFeePerGas, where maxFeePerGas = baseFee * 2 + priorityFee**.

As a result of these improvements, I think the overestimation factor could be reduced from 1.5 to around 1.2. This would be a very small refinement though.

References: [EIP-1559 - Cheatsheet for Implementers](https://hackmd.io/4YVYKxxvRZGDto7aq7rVkg?view)

### Screenshots

#### Comparatives

**Sepolia** (L1 to L2)
TX: https://sepolia.etherscan.io/tx/0x1175eac2f09cf6f90b275443d9816a822e5b05fac613f48c3db78437fa121f84
<img width="824" alt="Captura de Tela 2025-06-02 às 13 53 23" src="https://github.com/user-attachments/assets/fb3f19bc-1adb-482c-a47a-74ec77ae66e4" />


**Mainnet** (L1 to L2)
TX: https://etherscan.io/tx/0x4665951d3979b0dd088856bcc14e941b4c3348fdb367c881fb70e751606908c6
<img width="817" alt="Captura de Tela 2025-06-02 às 14 14 14" src="https://github.com/user-attachments/assets/f7653088-9712-4082-aa15-baee518b31b8" />

**Mainnet summary** (L1 to L2)
<img width="582" alt="Captura de Tela 2025-06-02 às 14 15 45" src="https://github.com/user-attachments/assets/e1f5260d-785d-474f-939a-8658d2f78d32" />

**Sepolia** (L2 to L1)
<img width="547" alt="Captura de Tela 2025-06-02 às 20 47 07" src="https://github.com/user-attachments/assets/c81840c4-7bbd-452f-8594-efa4ee3cdbe0" />

**Mainnet** (L2 to L1) 
Note: Similar to MM estimations, which was also far above the actual fee.
<img width="600" alt="Captura de Tela 2025-06-02 às 20 55 59" src="https://github.com/user-attachments/assets/d8fddbd9-1475-4661-8c85-ce734b0a65db" />

Note the last comparison 

### Related issue(s)

Closes #1124 
Fixes #1124

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
