### PR TITLE
Balance wrong btc chain

### DIFF
--- a/packages/btc-wallet/hooks/useBalance.ts
+++ b/packages/btc-wallet/hooks/useBalance.ts
@@ -5,7 +5,9 @@ import { GlobalContext } from '../context/globalContext'
 
 import { useAccount } from './useAccount'
 
-export const useBalance = function () {
+export const useBalance = function ({
+  enabled = true,
+}: { enabled?: boolean } = {}) {
   const { address, chainId, isConnected } = useAccount()
   const { currentConnector } = useContext(GlobalContext)
 
@@ -15,10 +17,11 @@ export const useBalance = function () {
     address,
     chainId,
     currentConnector?.id,
+    enabled,
   ]
 
   const { data: balance, ...rest } = useQuery({
-    enabled: isConnected && currentConnector !== undefined,
+    enabled: enabled && isConnected && currentConnector !== undefined,
     // use "!" because "enabled" already checks currentConnector is defined
     queryFn: () => currentConnector!.getBalance(),
     queryKey,

--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useUmami } from 'app/analyticsEvents'
-import { useBalance } from 'btc-wallet/hooks/useBalance'
 import { useAccounts } from 'hooks/useAccounts'
 import { useBitcoin } from 'hooks/useBitcoin'
+import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useDepositBitcoin } from 'hooks/useBtcTunnel'
 import { useGetFeePrices } from 'hooks/useEstimateBtcFees'
 import { useNetworkType } from 'hooks/useNetworkType'
@@ -51,7 +51,7 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
 
   const { btcChainId, btcWalletStatus, evmAddress } = useAccounts()
   const bitcoin = useBitcoin()
-  const { balance, isSuccess: balanceLoaded } = useBalance()
+  const { balance, isSuccess: balanceLoaded } = useBitcoinBalance()
   const { isPending: isMinDepositsSatsLoading, minDepositFormattedSats } =
     useMinDepositSats()
   const [networkType] = useNetworkType()

--- a/portal/app/[locale]/tunnel/_components/confirmBtcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/confirmBtcDeposit.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useUmami } from 'app/analyticsEvents'
-import { useBalance } from 'btc-wallet/hooks/useBalance'
 import { Button } from 'components/button'
+import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useConfirmBitcoinDeposit } from 'hooks/useBtcTunnel'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
@@ -31,7 +31,7 @@ export const ConfirmBtcDeposit = function ({ deposit }: Props) {
   const t = useTranslations()
   const { updateDeposit } = useTunnelHistory()
   const { track } = useUmami()
-  const { queryKey: btcBalanceQueryKey } = useBalance()
+  const { queryKey: btcBalanceQueryKey } = useBitcoinBalance()
   const queryClient = useQueryClient()
 
   const isConfirming =

--- a/portal/components/connectWallets/wallets.tsx
+++ b/portal/components/connectWallets/wallets.tsx
@@ -2,7 +2,6 @@ import { useConnectModal } from '@rainbow-me/rainbowkit'
 import { AnalyticsEventsWithChain } from 'app/analyticsEvents'
 import { ConnectorGroup } from 'btc-wallet/connectors/types'
 import { useAccount as useBtcAccount } from 'btc-wallet/hooks/useAccount'
-import { useBalance as useBtcBalance } from 'btc-wallet/hooks/useBalance'
 import { useConfig } from 'btc-wallet/hooks/useConfig'
 import { useConnect } from 'btc-wallet/hooks/useConnect'
 import {
@@ -15,6 +14,7 @@ import { ExternalLink } from 'components/externalLink'
 import { FiatBalance } from 'components/fiatBalance'
 import { Chevron } from 'components/icons/chevron'
 import { useBitcoin } from 'hooks/useBitcoin'
+import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useChainIsSupported } from 'hooks/useChainIsSupported'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useUmami } from 'hooks/useUmami'
@@ -88,7 +88,7 @@ const InstallUnisat = function ({ connector }: { connector: ConnectorGroup }) {
 export const BtcWallet = function () {
   const { chainId, connector, status } = useBtcAccount()
   const bitcoin = useBitcoin()
-  const { balance } = useBtcBalance()
+  const { balance } = useBitcoinBalance()
   const chainSupported = useChainIsSupported(chainId)
   const { connect } = useConnect()
   const { connectors } = useConfig()

--- a/portal/components/cryptoBalance.tsx
+++ b/portal/components/cryptoBalance.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useBalance as useBtcBalance } from 'btc-wallet/hooks/useBalance'
 import { DisplayAmount } from 'components/displayAmount'
 import { useTokenBalance, useNativeTokenBalance } from 'hooks/useBalance'
+import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import Skeleton from 'react-loading-skeleton'
 import { type BtcToken, type EvmToken, type Token } from 'types/token'
 import { isNativeToken } from 'utils/nativeToken'
@@ -74,7 +74,7 @@ const EvmBalance = (props: Props<EvmToken>) =>
   )
 
 const BtcBalance = function ({ token }: Props<BtcToken>) {
-  const { balance, fetchStatus, status } = useBtcBalance()
+  const { balance, fetchStatus, status } = useBitcoinBalance()
   return (
     <RenderCryptoBalance
       balance={BigInt(balance?.confirmed ?? 0)}

--- a/portal/components/fiatBalance.tsx
+++ b/portal/components/fiatBalance.tsx
@@ -1,7 +1,7 @@
 import { type FetchStatus, QueryStatus } from '@tanstack/react-query'
 import Big from 'big.js'
-import { useBalance as useBtcBalance } from 'btc-wallet/hooks/useBalance'
 import { useTokenBalance, useNativeTokenBalance } from 'hooks/useBalance'
+import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useTokenPrices } from 'hooks/useTokenPrices'
 import { ComponentProps } from 'react'
 import Skeleton from 'react-loading-skeleton'
@@ -130,7 +130,7 @@ const EvmBalance = (props: Props<EvmToken>) =>
   )
 
 const BtcBalance = function ({ token }: Props<BtcToken>) {
-  const { balance, fetchStatus, status } = useBtcBalance()
+  const { balance, fetchStatus, status } = useBitcoinBalance()
   return (
     <RenderFiatBalance
       balance={BigInt(balance?.confirmed ?? 0)}

--- a/portal/components/setMaxBalance.tsx
+++ b/portal/components/setMaxBalance.tsx
@@ -1,7 +1,7 @@
 import Big from 'big.js'
 import { useAccount as useBtcAccount } from 'btc-wallet/hooks/useAccount'
-import { useBalance as useBtcBalance } from 'btc-wallet/hooks/useBalance'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
+import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useEstimateBtcFees } from 'hooks/useEstimateBtcFees'
 import { useTranslations } from 'next-intl'
 import { type BtcToken, type EvmToken, type Token } from 'types/token'
@@ -73,7 +73,7 @@ export const SetMaxBtcBalance = function ({
   token,
 }: Props<BtcToken>) {
   const { address } = useBtcAccount()
-  const { balance, isLoading: isLoadingBalance } = useBtcBalance()
+  const { balance, isLoading: isLoadingBalance } = useBitcoinBalance()
   const btcBalance = balance?.confirmed ?? 0
 
   const { fees, isLoading: isLoadingFees } = useEstimateBtcFees(address)

--- a/portal/components/tunnelStatusUpdaters/bitcoinDepositsStatusUpdater.tsx
+++ b/portal/components/tunnelStatusUpdaters/bitcoinDepositsStatusUpdater.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useQueryClient } from '@tanstack/react-query'
-import { useBalance } from 'btc-wallet/hooks/useBalance'
 import { WithWorker } from 'components/withWorker'
+import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useBtcDeposits } from 'hooks/useBtcDeposits'
 import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
@@ -32,7 +32,7 @@ const WatchBtcDeposit = function ({
   worker: AppToWorker
 }) {
   const { updateDeposit } = useTunnelHistory()
-  const { queryKey: btcBalanceQueryKey } = useBalance()
+  const { queryKey: btcBalanceQueryKey } = useBitcoinBalance()
   const queryClient = useQueryClient()
 
   useEffect(

--- a/portal/components/tunnelStatusUpdaters/bitcoinWithdrawalsStatusUpdater.tsx
+++ b/portal/components/tunnelStatusUpdaters/bitcoinWithdrawalsStatusUpdater.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useQueryClient } from '@tanstack/react-query'
-import { useBalance } from 'btc-wallet/hooks/useBalance'
 import { WithWorker } from 'components/withWorker'
+import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useBtcWithdrawals } from 'hooks/useBtcWithdrawals'
 import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
@@ -24,7 +24,7 @@ function WatchBitcoinWithdrawal({
   worker: AppToWorker
 }) {
   const { updateWithdrawal } = useTunnelHistory()
-  const { queryKey: btcBalanceQueryKey } = useBalance()
+  const { queryKey: btcBalanceQueryKey } = useBitcoinBalance()
   const queryClient = useQueryClient()
 
   useEffect(

--- a/portal/hooks/useBitcoinBalance.ts
+++ b/portal/hooks/useBitcoinBalance.ts
@@ -1,0 +1,16 @@
+import { bitcoinMainnet, bitcoinTestnet } from 'btc-wallet/chains'
+import { useAccount } from 'btc-wallet/hooks/useAccount'
+import { useBalance as useBtcBalance } from 'btc-wallet/hooks/useBalance'
+
+import { useNetworkType } from './useNetworkType'
+
+export const useBitcoinBalance = function () {
+  const { chainId } = useAccount()
+  const [networkType] = useNetworkType()
+
+  const btcChain = networkType === 'mainnet' ? bitcoinMainnet : bitcoinTestnet
+
+  return useBtcBalance({
+    enabled: btcChain.id === chainId,
+  })
+}

--- a/portal/hooks/useNetworkType.ts
+++ b/portal/hooks/useNetworkType.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs'
 import { useQueryState, parseAsStringLiteral } from 'nuqs'
 import { useEffect } from 'react'
 
-// Once mainnet goes live, default should be changed to mainnet
-// See https://github.com/hemilabs/ui-monorepo/issues/479
 export const networkTypes = ['mainnet', 'testnet'] as const
 export type NetworkType = (typeof networkTypes)[number]
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR solves the problem in which users sees balance from other BTC chains when connected to the incorrect chain. For that, I created a wrapper of `useBtcBalance` that takes in consideration what is the expected BTC chain, based on `networkType`

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/9ed6c0a0-6241-4189-a933-f91becacf60a

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1257

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
