### PR TITLE
Fix wallet connection to prevent flickering

### DIFF
--- a/portal/utils/wallet.ts
+++ b/portal/utils/wallet.ts
@@ -1,7 +1,7 @@
 import { UseAccountReturnType } from 'wagmi'
 
-// When navigating across pages, wagmi performs an automatic reconnection. Depending on the previous step
-// status may be one of these 3. For smoother UX, when checking for "isConnected", use this util instead of the "isConnected" flag
-// exported from useAccount.
+// When navigating between routes, Wagmi can briefly report 'reconnecting' even if the wallet is already connected.
+// We consider both 'connected' and 'reconnecting' as valid states to indicate that a wallet is connected.
+// 'connecting' is intentionally excluded to avoid false positives when no wallet is actually connected.
 export const walletIsConnected = (status: UseAccountReturnType['status']) =>
-  ['connected', 'connecting', 'reconnecting'].includes(status)
+  ['connected', 'reconnecting'].includes(status)


### PR DESCRIPTION
### Description

During navigation, Wagmi temporarily reports status as `connecting` even when no wallet is actually `connected`. Since the `walletIsConnected()` helper was considering `connecting` as a valid state, the UI briefly rendered as `connected` before switching back to `disconnected`, causing the flicker.

### Screenshots


https://github.com/user-attachments/assets/d2ceb168-6032-4e65-82dc-a6264d50c8ad



### Related issue(s)

Closes #1220
Fixes #1220 

### Checklist


- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
