### PR TITLE
Use tsconfig/bases in hemi packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27956,6 +27956,7 @@
         "hemi-viem": "2.4.2"
       },
       "devDependencies": {
+        "@tsconfig/node20": "20.1.5",
         "typescript": "5.6.3",
         "viem": "2.22.10"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27939,6 +27939,7 @@
         "viem-erc20": "1.0.0"
       },
       "devDependencies": {
+        "@tsconfig/node20": "20.1.5",
         "@types/node": "20.12.12",
         "typescript": "5.6.3",
         "viem": "2.22.10",

--- a/packages/hemi-tunnel-actions/package.json
+++ b/packages/hemi-tunnel-actions/package.json
@@ -23,6 +23,7 @@
     "viem-erc20": "1.0.0"
   },
   "devDependencies": {
+    "@tsconfig/node20": "20.1.5",
     "@types/node": "20.12.12",
     "typescript": "5.6.3",
     "viem": "2.22.10",

--- a/packages/hemi-tunnel-actions/tsconfig.json
+++ b/packages/hemi-tunnel-actions/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": "./",
     "noEmit": true
   },
-  "extends": "@tsconfig/node20/tsconfig.json",
   "exclude": ["node_modules", "test/*"],
+  "extends": "@tsconfig/node20/tsconfig.json",
   "include": ["**/*.ts"]
 }

--- a/packages/hemi-tunnel-actions/tsconfig.json
+++ b/packages/hemi-tunnel-actions/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
-    "strict": true,
-    "strictNullChecks": true
+    "noEmit": true
   },
-  "extends": "../../tsconfig.base.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "exclude": ["node_modules", "test/*"],
   "include": ["**/*.ts"]
 }

--- a/packages/hemi-viem-stake-actions/package.json
+++ b/packages/hemi-viem-stake-actions/package.json
@@ -22,6 +22,7 @@
     "hemi-viem": "2.4.2"
   },
   "devDependencies": {
+    "@tsconfig/node20": "20.1.5",
     "typescript": "5.6.3",
     "viem": "2.22.10"
   },

--- a/packages/hemi-viem-stake-actions/tsconfig.json
+++ b/packages/hemi-viem-stake-actions/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
-    "strictNullChecks": true
+    "noEmit": true
   },
-  "extends": "../../tsconfig.base.json",
-  "exclude": ["node_modules"],
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "exclude": ["node_modules", "test/*"],
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR drops the custom Typescript config for some of the packages in favor of using [tsconfig/bases](https://github.com/tsconfig/bases). As `viem-erc20` is going to be published on its own, I updated the other packages.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #105

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
