### PR TITLE
Add 2.5x River Points mult to satUSD on Staking

### DIFF
--- a/portal/app/[locale]/stake/_components/pointsTag.tsx
+++ b/portal/app/[locale]/stake/_components/pointsTag.tsx
@@ -32,6 +32,7 @@ type Props = {
     | 'seeds'
     | 'x2-eigenpie-points'
     | 'x2-babypie-jewels'
+    | 'x2point5-river-points'
   icon: ReactNode
   style?: CSSProperties
   textColor:
@@ -218,7 +219,7 @@ export const RiverPoints = () => (
   <PointsTag
     backgroundColor="bg-black"
     icon={<RiverPointsIcon />}
-    label="points"
+    label="x2point5-river-points"
     textColor="text-white"
   />
 )

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -236,7 +236,8 @@
       "points": "Points",
       "seeds": "Seeds",
       "x2-babypie-jewels": "x2 Babypie Jewels",
-      "x2-eigenpie-points": "x2 Eigenpie Points"
+      "x2-eigenpie-points": "x2 Eigenpie Points",
+      "x2point5-river-points": "x2.5 River Points"
     },
     "protocol": "Protocol",
     "rewards": "Rewards",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -236,7 +236,8 @@
       "points": "Puntos",
       "seeds": "Semillas",
       "x2-babypie-jewels": "x2 Joyas Babypie",
-      "x2-eigenpie-points": "x2 Eigenpie Puntos"
+      "x2-eigenpie-points": "x2 Eigenpie Puntos",
+      "x2point5-river-points": "x2.5 River Puntos"
     },
     "protocol": "Protocolo",
     "rewards": "Recompensas",


### PR DESCRIPTION
### Description

This PR pdates the UI texts to reflect the 2.5× River Points promotion for satUSD provided by River. No logic changes, pure UI update.

### Screenshots

<img width="925" alt="Captura de Tela 2025-06-11 às 10 16 09" src="https://github.com/user-attachments/assets/4ac68712-9566-4823-89db-0a6816686732" />


### Related issue(s)

Closes #1293 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
