### PR TITLE
Fix RegEx for WalletConnect denyUrl in Sentry

### DIFF
--- a/portal/instrumentation-client.ts
+++ b/portal/instrumentation-client.ts
@@ -64,7 +64,7 @@ function enableSentry() {
   Sentry.init({
     denyUrls: [
       // Filter all Wallet Connect related urls
-      /(https|wss):\/\/*\.walletconnect\.(com|org)/,
+      /(https|wss):\/\/.*\.walletconnect\.(com|org)/,
       process.env.NEXT_PUBLIC_COOKIE3_URL,
       process.env.NEXT_PUBLIC_POINTS_URL,
       process.env.NEXT_PUBLIC_TOKEN_PRICES_URL,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The RegEx for `denyUrl` in Sentry wasn't matching any WalletConnect subdomain. This PR fixes that.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No visible changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
