### PR TITLE
Display locale names in their native language

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/help.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help.tsx
@@ -8,7 +8,7 @@ import { useNetworkType } from 'hooks/useNetworkType'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { usePathnameWithoutLocale } from 'hooks/usePathnameWithoutLocale'
 import { useRouter } from 'i18n/navigation'
-import { locales } from 'i18n/routing'
+import { getLocalizedLocaleName, locales } from 'i18n/routing'
 import { useSearchParams } from 'next/navigation'
 import { Locale, useLocale, useTranslations } from 'next-intl'
 import { ComponentProps, ReactNode, RefObject, useState } from 'react'
@@ -134,7 +134,6 @@ const ItemWithSubmenu = function ({
 }
 
 const LanguageMenu = function ({ active }: LanguageProps) {
-  const t = useTranslations('navbar.help')
   const pathname = usePathnameWithoutLocale()
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -165,7 +164,7 @@ const LanguageMenu = function ({ active }: LanguageProps) {
         >
           <ItemText
             selected={active === locale}
-            text={t(`locales.${locale}`)}
+            text={getLocalizedLocaleName(locale)}
           />
           <div className={active === locale ? 'block' : 'invisible'}>
             <CheckMark className="[&>path]:stroke-emerald-500" />
@@ -236,7 +235,7 @@ export const Help = function () {
             icon={<LanguageIcon className="h-5 w-5 md:h-4 md:w-4" />}
             subMenu={<LanguageMenu active={activeLocale} />}
             text={t('language')}
-            value={t(`locales.${activeLocale}`)}
+            value={getLocalizedLocaleName(activeLocale)}
           />
           <ItemWithSubmenu
             event="nav - legal and privacy"

--- a/portal/i18n/routing.ts
+++ b/portal/i18n/routing.ts
@@ -5,6 +5,11 @@ export const locales = [defaultLocale, 'es', 'pt'] as const
 
 export type Locale = (typeof locales)[number]
 
+export function getLocalizedLocaleName(locale: Locale) {
+  const displayNames = new Intl.DisplayNames([locale], { type: 'language' })
+  return displayNames.of(locale)
+}
+
 export const routing = defineRouting({
   defaultLocale,
   localeDetection: false,

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -197,12 +197,7 @@
     "get-started": "Get Started",
     "help": {
       "language": "Language",
-      "legal-and-privacy": "Legal and Privacy",
-      "locales": {
-        "en": "English",
-        "es": "Spanish",
-        "pt": "Portuguese"
-      }
+      "legal-and-privacy": "Legal and Privacy"
     },
     "learn-how-to-start": "Learn how to start using the Hemi network",
     "network": "Network",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -197,12 +197,7 @@
     "get-started": "Comenzar",
     "help": {
       "language": "Idioma",
-      "legal-and-privacy": "Privacidad y Legales",
-      "locales": {
-        "en": "Inglés",
-        "es": "Español",
-        "pt": "Portugués"
-      }
+      "legal-and-privacy": "Privacidad y Legales"
     },
     "learn-how-to-start": "Aprenda cómo empezar a utilizar la red Hemi",
     "network": "Red",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -197,12 +197,7 @@
     "get-started": "Começar",
     "help": {
       "language": "Idioma",
-      "legal-and-privacy": "Legal e Privacidade",
-      "locales": {
-        "en": "Inglês",
-        "es": "Espanhol",
-        "pt": "Português"
-      }
+      "legal-and-privacy": "Legal e Privacidade"
     },
     "learn-how-to-start": "Aprenda como começar a usar a rede Hemi",
     "network": "Rede",


### PR DESCRIPTION
### Description

This PR updates the language selector to display each locale using its own native language name, e.g.:

- `English` for `en`
- `Español` for `es`
- `Português` for `pt`

### Screenshots

https://github.com/user-attachments/assets/9fba5a06-456e-48b0-8647-89cdf45a2e31

### Related issue(s)

Closes #1298 
Fixes #1298 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
