### PR TITLE
Add subgraph for prove/claim events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ subgraphs/hemi-stake-operations-subgraph/build
 subgraphs/hemi-stake-operations-subgraph/generated
 subgraphs/hemi-tunnel-deposits-subgraph/build
 subgraphs/hemi-tunnel-deposits-subgraph/generated
+subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/build
+subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/generated
 subgraphs/hemi-tunnel-withdrawals-subgraph/build
 subgraphs/hemi-tunnel-withdrawals-subgraph/generated
 

--- a/.knip.json
+++ b/.knip.json
@@ -20,6 +20,9 @@
     },
     "subgraphs/hemi-tunnel-withdrawals-subgraph": {
       "entry": "src/mappings/*.ts"
+    },
+    "subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph": {
+      "entry": "src/mappings/*.ts"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15725,6 +15725,10 @@
       "resolved": "subgraphs/hemi-tunnel-deposits-subgraph",
       "link": true
     },
+    "node_modules/hemi-tunnel-withdrawals-proof-claim-subgraph": {
+      "resolved": "subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph",
+      "link": true
+    },
     "node_modules/hemi-tunnel-withdrawals-subgraph": {
       "resolved": "subgraphs/hemi-tunnel-withdrawals-subgraph",
       "link": true
@@ -28442,6 +28446,13 @@
     },
     "subgraphs/hemi-tunnel-deposits-subgraph": {
       "version": "1.0.0",
+      "dependencies": {
+        "@graphprotocol/graph-cli": "0.95.0",
+        "@graphprotocol/graph-ts": "0.36.0"
+      }
+    },
+    "subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph": {
+      "license": "UNLICENSED",
       "dependencies": {
         "@graphprotocol/graph-cli": "0.95.0",
         "@graphprotocol/graph-ts": "0.36.0"

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/abis/portal.json
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/abis/portal.json
@@ -1,0 +1,345 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "version",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "opaqueData",
+        "type": "bytes"
+      }
+    ],
+    "name": "TransactionDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "withdrawalHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "name": "WithdrawalFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "withdrawalHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "WithdrawalProven",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "GUARDIAN",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "L2_ORACLE",
+    "outputs": [
+      {
+        "internalType": "contract L2OutputOracle",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "SYSTEM_CONFIG",
+    "outputs": [
+      { "internalType": "contract SystemConfig", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_value", "type": "uint256" },
+      { "internalType": "uint64", "name": "_gasLimit", "type": "uint64" },
+      { "internalType": "bool", "name": "_isCreation", "type": "bool" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" }
+    ],
+    "name": "depositTransaction",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "donateETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+          { "internalType": "address", "name": "sender", "type": "address" },
+          { "internalType": "address", "name": "target", "type": "address" },
+          { "internalType": "uint256", "name": "value", "type": "uint256" },
+          { "internalType": "uint256", "name": "gasLimit", "type": "uint256" },
+          { "internalType": "bytes", "name": "data", "type": "bytes" }
+        ],
+        "internalType": "struct Types.WithdrawalTransaction",
+        "name": "_tx",
+        "type": "tuple"
+      }
+    ],
+    "name": "finalizeWithdrawalTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "finalizedWithdrawals",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "guardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract L2OutputOracle",
+        "name": "_l2Oracle",
+        "type": "address"
+      },
+      {
+        "internalType": "contract SystemConfig",
+        "name": "_systemConfig",
+        "type": "address"
+      },
+      {
+        "internalType": "contract SuperchainConfig",
+        "name": "_superchainConfig",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_l2OutputIndex", "type": "uint256" }
+    ],
+    "name": "isOutputFinalized",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2Oracle",
+    "outputs": [
+      {
+        "internalType": "contract L2OutputOracle",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2Sender",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint64", "name": "_byteCount", "type": "uint64" }
+    ],
+    "name": "minimumGasLimit",
+    "outputs": [{ "internalType": "uint64", "name": "", "type": "uint64" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "params",
+    "outputs": [
+      { "internalType": "uint128", "name": "prevBaseFee", "type": "uint128" },
+      { "internalType": "uint64", "name": "prevBoughtGas", "type": "uint64" },
+      { "internalType": "uint64", "name": "prevBlockNum", "type": "uint64" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "paused_", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+          { "internalType": "address", "name": "sender", "type": "address" },
+          { "internalType": "address", "name": "target", "type": "address" },
+          { "internalType": "uint256", "name": "value", "type": "uint256" },
+          { "internalType": "uint256", "name": "gasLimit", "type": "uint256" },
+          { "internalType": "bytes", "name": "data", "type": "bytes" }
+        ],
+        "internalType": "struct Types.WithdrawalTransaction",
+        "name": "_tx",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2OutputIndex",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          { "internalType": "bytes32", "name": "version", "type": "bytes32" },
+          { "internalType": "bytes32", "name": "stateRoot", "type": "bytes32" },
+          {
+            "internalType": "bytes32",
+            "name": "messagePasserStorageRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "latestBlockhash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Types.OutputRootProof",
+        "name": "_outputRootProof",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "_withdrawalProof",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "proveWithdrawalTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "provenWithdrawals",
+    "outputs": [
+      { "internalType": "bytes32", "name": "outputRoot", "type": "bytes32" },
+      { "internalType": "uint128", "name": "timestamp", "type": "uint128" },
+      { "internalType": "uint128", "name": "l2OutputIndex", "type": "uint128" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "superchainConfig",
+    "outputs": [
+      {
+        "internalType": "contract SuperchainConfig",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "systemConfig",
+    "outputs": [
+      { "internalType": "contract SystemConfig", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/networks.json
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/networks.json
@@ -1,0 +1,14 @@
+{
+  "mainnet": {
+    "portal": {
+      "address": "0x39a0005415256B9863aFE2d55Edcf75ECc3A4D7e",
+      "startBlock": 20711664
+    }
+  },
+  "sepolia": {
+    "portal": {
+      "address": "0xB6f9579980aE46f61217A99145645341E49E2516",
+      "startBlock": 5302666
+    }
+  }
+}

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "hemi-tunnel-withdrawals-proof-claim-subgraph",
+  "scripts": {
+    "build": "graph build",
+    "build:mainnet": "npm run build -- --network mainnet",
+    "build:sepolia": "npm run build -- --network sepolia",
+    "codegen": "graph codegen",
+    "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
+    "deploy-local:mainnet": "npm run deploy-local -- --network mainnet",
+    "deploy-local:sepolia": "npm run deploy-local -- --network sepolia",
+    "deploy-studio:mainnet": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-mainnet  --version-label $(jq -r .version package.json) --network mainnet",
+    "deploy-studio:sepolia": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-sepolia  --version-label $(jq -r .version package.json) --network sepolia",
+    "graph:auth": "graph auth",
+    "prepare": "npm run codegen",
+    "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
+  },
+  "dependencies": {
+    "@graphprotocol/graph-cli": "0.95.0",
+    "@graphprotocol/graph-ts": "0.36.0"
+  }
+}

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/schema.graphql
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/schema.graphql
@@ -1,0 +1,5 @@
+type Withdrawal @entity {
+  id: Bytes!
+  claimTxHash: Bytes
+  proveTxHash: Bytes
+}

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/src/entities/withdrawal.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/src/entities/withdrawal.ts
@@ -1,0 +1,73 @@
+import { Entity, Value, ValueKind, store, Bytes } from '@graphprotocol/graph-ts'
+
+export class Withdrawal extends Entity {
+  constructor(id: Bytes) {
+    super()
+    this.setBytes('id', id)
+  }
+
+  get id(): Bytes {
+    const value = this.get('id')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set id(value: Bytes) {
+    this.setBytes('id', value)
+  }
+
+  get claimTxHash(): Bytes | null {
+    const value = this.get('claimTxHash')
+    if (!value || value.kind == ValueKind.NULL) {
+      return null
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set claimTxHash(value: Bytes | null) {
+    if (value === null) {
+      this.unset('claimTxHash')
+    } else {
+      this.setBytes('claimTxHash', value)
+    }
+  }
+
+  get proveTxHash(): Bytes | null {
+    const value = this.get('proveTxHash')
+    if (!value || value.kind == ValueKind.NULL) {
+      return null
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set proveTxHash(value: Bytes | null) {
+    if (value === null) {
+      this.unset('proveTxHash')
+    } else {
+      this.setBytes('proveTxHash', value)
+    }
+  }
+
+  save(): void {
+    const id = this.get('id')
+    assert(id != null, 'Cannot save Withdrawal entity without an id')
+    if (id) {
+      assert(
+        id.kind == ValueKind.BYTES,
+        `Entities of type Withdrawal must have an id of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+      )
+      store.set('Withdrawal', id.toBytes().toHexString(), this)
+    }
+  }
+
+  static load(id: Bytes): Withdrawal | null {
+    return changetype<Withdrawal | null>(
+      store.get('Withdrawal', id.toHexString()),
+    )
+  }
+}

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/src/mappings/portal.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/src/mappings/portal.ts
@@ -1,0 +1,35 @@
+import {
+  WithdrawalFinalized as WithdrawalFinalizedEvent,
+  WithdrawalProven as WithdrawalProvenEvent,
+} from '../../generated/portal/portal'
+import { log } from '@graphprotocol/graph-ts'
+import { Withdrawal } from '../entities/withdrawal'
+
+export function handleWithdrawalProven(event: WithdrawalProvenEvent): void {
+  let withdrawal = Withdrawal.load(event.params.withdrawalHash)
+  if (withdrawal == null) {
+    withdrawal = new Withdrawal(event.params.withdrawalHash)
+  }
+  withdrawal.proveTxHash = event.transaction.hash
+  withdrawal.save()
+}
+
+export function handleWithdrawalFinalized(
+  event: WithdrawalFinalizedEvent,
+): void {
+  if (!event.params.success) {
+    return
+  }
+  let withdrawal = Withdrawal.load(event.params.withdrawalHash)
+  if (withdrawal == null) {
+    // This should never happen, as before being finalized , the withdrawal should've been proved
+    // Regardless, let's save it to avoid missing data
+    log.warning(
+      'Withdrawal entity not found for withdrawalHash {}. Creating new.',
+      [event.params.withdrawalHash.toHexString()],
+    )
+    withdrawal = new Withdrawal(event.params.withdrawalHash)
+  }
+  withdrawal.claimTxHash = event.transaction.hash
+  withdrawal.save()
+}

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/subgraph.yaml
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/subgraph.yaml
@@ -1,0 +1,29 @@
+specVersion: 1.0.0
+indexerHints:
+  prune: auto
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum
+    name: portal
+    network: sepolia
+    source:
+      abi: portal
+      address: '0xB6f9579980aE46f61217A99145645341E49E2516'
+      startBlock: 5302666
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - WithdrawalFinalized
+        - WithdrawalProven
+      abis:
+        - name: portal
+          file: ./abis/portal.json
+      eventHandlers:
+        - event: WithdrawalFinalized(indexed bytes32,bool)
+          handler: handleWithdrawalFinalized
+        - event: WithdrawalProven(indexed bytes32,indexed address,indexed address)
+          handler: handleWithdrawalProven
+      file: ./src/mappings/portal.ts

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/tsconfig.json
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR is the first part of what I expect to be 3 PRs to allow resync withdrawals to retrieve the Prove and claim tx if they exist:

- [x] Add the Subgraph to filter Prove and Claim events (This PR)
- [ ] Update the subgraph API, adding a new endpoint to call this subgraph (Next PR)
- [ ] Update the portal to consume the new endpoint

When a withdrawal is proven, the [WithdrawalProven](https://github.com/hemilabs/optimism/blob/bde08fd3e335c235455b4cee6a6f8dbf88446201/packages/contracts-bedrock/src/L1/OptimismPortal2.sol#L579) event is emitted.   
When a withdrawal is claimed, the [WithdrawalFinalized](https://github.com/hemilabs/optimism/blob/bde08fd3e335c235455b4cee6a6f8dbf88446201/packages/contracts-bedrock/src/L1/OptimismPortal2.sol#L640) event is emitted.

With that in mind, we can track all instances of these events in the [portal](https://github.com/hemilabs/hemi-viem/blob/8a79159eadf7e72f3190a4f60cbc7c351d4982f3/src/chains/hemi.ts#L45) contract in the L1 chain. 

In incoming PRs, we will discuss more on how to match a withdrawal against this `withdrawalHash`, as that `withdrawalHash` is NOT the transaction hash of the initiated withdrawal 😮 

For the time being, this PR only creates the subgraph. I will need to coordinate with John to get these deployed

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #558

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
