### PR TITLE
Add endpoint to retrieve Proof and Claim transaction hashes

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -2,7 +2,6 @@
   "ignore": ["portal/i18n/request.ts", "subgraphs/utils/index.ts"],
   "ignoreBinaries": ["ipconfig"],
   "ignoreDependencies": [
-    "@tsconfig/node20",
     "@wagmi/core",
     "eslint-config-next",
     "eslint-config-prettier"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28234,14 +28234,14 @@
         "dotenv": "16.4.7",
         "express": "4.21.2",
         "fetch-plus-plus": "1.0.0",
-        "hemi-viem": "2.4.2",
         "tsx": "4.19.3",
         "viem": "2.24.1"
       },
       "devDependencies": {
         "@types/config": "3.3.5",
         "@types/cors": "2.8.17",
-        "@types/express": "4.17.21"
+        "@types/express": "4.17.21",
+        "typescript": "5.6.3"
       },
       "engines": {
         "node": ">=20"
@@ -28452,7 +28452,6 @@
       }
     },
     "subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph": {
-      "license": "UNLICENSED",
       "dependencies": {
         "@graphprotocol/graph-cli": "0.95.0",
         "@graphprotocol/graph-ts": "0.36.0"

--- a/subgraph-api/config/default.json
+++ b/subgraph-api/config/default.json
@@ -18,6 +18,10 @@
       "withdrawals": {
         "mainnet": "77x4fbDsVMm66pGUWBfVMzsUDec71eNSfHb1PeMhxKco",
         "testnet": "VNKvTQZiMR4awsoKuB7eRYJBrrQ1Aq3yvCKhW7N22a6"
+      },
+      "withdrawalProofs": {
+        "mainnet": "7B7h8up4FdvVAtBgzgG7rWQkW3kd8W6a73L89efr9o9k",
+        "testnet": "6aTMqKg6Et48FzbAL9uYu8GZGoCMwYE9qWWTXpXmwgDR"
       }
     }
   }

--- a/subgraph-api/package.json
+++ b/subgraph-api/package.json
@@ -2,6 +2,7 @@
   "name": "subgraph-api",
   "version": "1.0.0",
   "scripts": {
+    "build": "tsc",
     "start": "tsx server.ts"
   },
   "dependencies": {
@@ -11,14 +12,14 @@
     "dotenv": "16.4.7",
     "express": "4.21.2",
     "fetch-plus-plus": "1.0.0",
-    "hemi-viem": "2.4.2",
     "tsx": "4.19.3",
     "viem": "2.24.1"
   },
   "devDependencies": {
     "@types/config": "3.3.5",
     "@types/cors": "2.8.17",
-    "@types/express": "4.17.21"
+    "@types/express": "4.17.21",
+    "typescript": "5.6.3"
   },
   "engines": {
     "node": ">=20"

--- a/subgraph-api/server.ts
+++ b/subgraph-api/server.ts
@@ -3,4 +3,9 @@ import config from 'config'
 
 import { createApiServer } from './src/api-server.ts'
 
-createApiServer().listen(config.get('port'))
+const port = config.get<number>('port')
+
+createApiServer().listen(port)
+
+// eslint-disable-next-line no-console
+console.info(`API server listening on port ${port}`)

--- a/subgraph-api/src/api-server.ts
+++ b/subgraph-api/src/api-server.ts
@@ -6,6 +6,7 @@ import express from 'express'
 import { hemi, hemiSepolia } from 'hemi-viem'
 import { mainnet, sepolia } from 'viem/chains'
 
+import { getWithdrawalProofAndClaimHandler } from './route-handlers/get-withdrawal-proof-and-claim.ts'
 import {
   getBtcWithdrawals,
   getEvmDeposits,
@@ -13,11 +14,7 @@ import {
   getLastIndexedBlock,
   getTotalStaked,
 } from './subgraph.ts'
-
-function sendJsonResponse(res, statusCode: number, data: object) {
-  res.writeHead(statusCode, { 'Content-Type': 'application/json' })
-  res.end(JSON.stringify(data))
-}
+import { sendJsonResponse } from './utils.ts'
 
 function parseChainId(req, res, next) {
   const { chainIdStr } = req.params
@@ -117,6 +114,13 @@ export function createApiServer() {
         })
         .catch(next)
     },
+  )
+
+  app.get(
+    '/:chainIdStr(\\d+)/hashedWithdrawals/:hash',
+    parseChainId,
+    validateChainIsEthereum,
+    getWithdrawalProofAndClaimHandler,
   )
 
   app.get(

--- a/subgraph-api/src/route-handlers/get-withdrawal-proof-and-claim.ts
+++ b/subgraph-api/src/route-handlers/get-withdrawal-proof-and-claim.ts
@@ -1,0 +1,33 @@
+/* eslint-disable promise/no-callback-in-promise */
+
+import { Request, Response, NextFunction } from 'express'
+
+import { getWithdrawalProofAndClaim } from '../subgraph.ts'
+import { sendJsonResponse } from '../utils.ts'
+
+type PathParameters = {
+  chainIdStr: string
+  hash: string
+}
+
+type Data = {
+  chainId: number
+}
+
+export const getWithdrawalProofAndClaimHandler = function (
+  req: Request<PathParameters> & { data?: Data },
+  res: Response,
+  next: NextFunction,
+) {
+  const { hash } = req.params
+  const { chainId } = req.data
+  getWithdrawalProofAndClaim({ chainId, hashedWithdrawal: hash })
+    .then(function (withdrawal) {
+      if (!withdrawal) {
+        sendJsonResponse(res, 404, { error: 'Withdrawal not found' })
+        return
+      }
+      sendJsonResponse(res, 200, withdrawal)
+    })
+    .catch(next)
+}

--- a/subgraph-api/src/subgraph.ts
+++ b/subgraph-api/src/subgraph.ts
@@ -3,9 +3,8 @@
 
 import config from 'config'
 import fetch from 'fetch-plus-plus'
-import { hemi, hemiSepolia } from 'hemi-viem'
 import { type Address, type Chain, checksumAddress as toChecksum } from 'viem'
-import { mainnet, sepolia } from 'viem/chains'
+import { hemi, hemiSepolia, mainnet, sepolia } from 'viem/chains'
 
 import {
   type EvmDepositOperation,
@@ -24,7 +23,7 @@ type GraphResponse<T> = SuccessResponse<T> | ErrorResponse
 
 type ConfigType = typeof import('../config/default.json')
 
-const subgraphConfig: ConfigType['subgraph'] = config.get('subgraph')
+const subgraphConfig = config.get<ConfigType['subgraph']>('subgraph')
 
 const getSubgraphUrl = function ({
   chainId,

--- a/subgraph-api/src/utils.ts
+++ b/subgraph-api/src/utils.ts
@@ -1,5 +1,7 @@
 import { Response } from 'express'
 
+export const isInteger = (string: string) => /^\d+$/.test(string)
+
 export const sendJsonResponse = function (
   res: Response,
   statusCode: number,

--- a/subgraph-api/src/utils.ts
+++ b/subgraph-api/src/utils.ts
@@ -1,0 +1,10 @@
+import { Response } from 'express'
+
+export const sendJsonResponse = function (
+  res: Response,
+  statusCode: number,
+  data: object,
+) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(data))
+}

--- a/subgraph-api/types/server.ts
+++ b/subgraph-api/types/server.ts
@@ -1,0 +1,12 @@
+export type ReqData = {
+  data: Partial<{
+    chainId: number
+    fromBlock: number
+    limit: number
+    orderBy: string
+    skip: number
+    orderDirection: 'asc' | 'desc'
+  }>
+}
+
+export type ChainIdPathParams = { chainIdStr: string }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Follow-up PR after #1306 

**NOTE** There's a Github Action job failing, due to a security issue - a vulnerability has been disclosed for GO this past week (See [report](https://avd.aquasec.com/nvd/2025/cve-2025-22874/)) - this causes the image for the subgraph-api to fail as we use [tsx](https://github.com/privatenumber/tsx) to run typescript, which internally uses [esbuild](https://www.npmjs.com/package/esbuild), which is written in GO. See https://github.com/evanw/esbuild/issues/4204. There's no fix yet, so we must wait.

This PR is the second part of what I expect to be 3 PRs to allow resynced withdrawals to retrieve the Prove and claim tx if they exist:

- [x] Add the Subgraph to filter Prove and Claim events 
- [x] Update the subgraph API, adding a new endpoint to call this subgraph (This PR)
- [ ] Update the portal to consume the new endpoint

The subgraph from the previous PR  was published for both [mainnet](https://thegraph.com/explorer/subgraphs/7B7h8up4FdvVAtBgzgG7rWQkW3kd8W6a73L89efr9o9k?view=Query&chain=arbitrum-one) and [sepolia](https://thegraph.com/explorer/subgraphs/6aTMqKg6Et48FzbAL9uYu8GZGoCMwYE9qWWTXpXmwgDR?view=Query&chain=arbitrum-one). These subgraphs are already synced and ready to use.  

Changes in this PR:

- e8d7a35ce809a9ce568ab5bf7405eb96e8183681 Adds the new subgraph, and adds an endpoint to call this subgraph. The endpoint is `:chainId/hashedWithdrawals/:hash`, and returns, if found, the Prove Withdrawal transaction hash and the Claim Withdrawal Transaction hash.. If any is missing, `null` is returned. Example responses:

```js
// A withdrawal proven but not claimed
{
    "claimTxHash": null,
    "id": "0x8d7284b0fdfe2b7deffd56ad219023dca890416a3943f63135378e63fc5b67c9",
    "proveTxHash": "0x0a47bd705a0cd72ec5764c3ce91c59b70c861372ae87c0af39a1f6b0b3f3c4db"
}
// A withdrawal proved and claimed
{
    "claimTxHash": "0x36440d57f5df8b183aadc5d520359b25070887fe1021ea522e318e9a4855a5dd",
    "id": "0x593e9dedc35a7f28ffe4266004feb610fd1fc1a48cecf9cd07b6bb1b920ccf1f",
    "proveTxHash": "0xd0d66741bbf03a7af02b3e9815ef7caa379ebee4bc2fc1cec33c57e689863ccf"
}
```

If the withdrawal does not exist, or has not been proven, 404 is returned

- bb455daec7ef59498c1301e239f3f560bf3cbff3 Applies a minor refactor, adding missing dependencies (That were used but not added in `package.json`) and adding missing types

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #558

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
