### PR TITLE
Added dynamic wait times for EVM withdrawals

### DIFF
--- a/portal/app/[locale]/tunnel/_components/evmWithdrawalWaitTime.tsx
+++ b/portal/app/[locale]/tunnel/_components/evmWithdrawalWaitTime.tsx
@@ -1,0 +1,106 @@
+import { useNetworkType } from 'hooks/useNetworkType'
+import { useTranslations } from 'next-intl'
+import Skeleton from 'react-loading-skeleton'
+import { MessageStatus, ToEvmWithdrawOperation } from 'types/tunnel'
+import { secondsToHours, secondsToMinutes } from 'utils/time'
+
+import {
+  useEvmWithdrawTimeToFinalize,
+  useEvmWithdrawTimeToProve,
+} from '../_hooks/useWaitTime'
+
+type Props = {
+  withdrawal: ToEvmWithdrawOperation
+}
+
+const ExpectedWithdrawalWaitTimeSecondsTestnet = 20 * 60
+const ExpectedWithdrawalWaitTimeSecondsMainnet = 40 * 60
+const ExpectedProofWaitTimeSecondsTestnet = 3 * 60 * 60
+const ExpectedProofWaitTimeSecondsMainnet = 24 * 60 * 60
+
+const renderTime = function (
+  timeInSeconds: number,
+  tCommon: ReturnType<typeof useTranslations>,
+) {
+  const minuteInSeconds = 60
+  const hourInSeconds = 60 * 60
+
+  if (timeInSeconds > hourInSeconds) {
+    return tCommon.rich('wait-hours', {
+      hours: () =>
+        tCommon('hours', {
+          hours: Math.ceil(secondsToHours(timeInSeconds)),
+        }),
+    })
+  }
+
+  if (timeInSeconds > minuteInSeconds) {
+    return tCommon('wait-minutes', {
+      minutes: Math.ceil(secondsToMinutes(timeInSeconds)),
+    })
+  }
+
+  return tCommon('wait-minutes', {
+    minutes: 1,
+  })
+}
+
+export const EvmWithdrawalWaitTimeToProve = function ({ withdrawal }: Props) {
+  const [networkType] = useNetworkType()
+  const tCommon = useTranslations('common')
+  const { data, isError, isPending } = useEvmWithdrawTimeToProve(withdrawal)
+
+  if (isPending) {
+    return <Skeleton className="w-12" />
+  }
+
+  if (isError) {
+    return (
+      <span>
+        {renderTime(
+          networkType === 'mainnet'
+            ? ExpectedWithdrawalWaitTimeSecondsMainnet
+            : ExpectedWithdrawalWaitTimeSecondsTestnet,
+          tCommon,
+        )}
+      </span>
+    )
+  }
+
+  if (data === 0) {
+    return <span> {tCommon('waiting-completed')} </span>
+  }
+
+  return <span> {renderTime(data, tCommon)} </span>
+}
+
+export const EvmWithdrawalWaitTimeToFinalize = function ({
+  withdrawal,
+}: Props) {
+  const [networkType] = useNetworkType()
+  const tCommon = useTranslations('common')
+  const { data, isError, isPending } = useEvmWithdrawTimeToFinalize(withdrawal)
+
+  if (isPending) {
+    return <Skeleton className="w-12" />
+  }
+
+  if (isError || withdrawal.status < MessageStatus.READY_FOR_RELAY) {
+    return (
+      <span>
+        {renderTime(
+          networkType === 'mainnet'
+            ? ExpectedProofWaitTimeSecondsMainnet
+            : ExpectedProofWaitTimeSecondsTestnet,
+          tCommon,
+        )}
+      </span>
+    )
+  }
+
+  if (data === 0) {
+    return <span> {tCommon('waiting-completed')} </span>
+  }
+
+  return <span> {renderTime(data, tCommon)} </span>
+}

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -1,7 +1,6 @@
 import { ProgressStatus } from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { useChain } from 'hooks/useChain'
-import { useNetworkType } from 'hooks/useNetworkType'
 import { useToken } from 'hooks/useToken'
 import { useTranslations } from 'next-intl'
 import { useContext } from 'react'
@@ -19,16 +18,15 @@ import { useEstimateFinalizeWithdrawalFees } from '../../_hooks/useEstimateFinal
 import { useEstimateProveWithdrawalFees } from '../../_hooks/useEstimateProveWithdrawalFees'
 import { useEstimateWithdrawFees } from '../../_hooks/useEstimateWithdrawFees'
 import { ClaimEvmWithdrawal } from '../claimEvmWithdrawal'
+import {
+  EvmWithdrawalWaitTimeToFinalize,
+  EvmWithdrawalWaitTimeToProve,
+} from '../evmWithdrawalWaitTime'
 import { ProveWithdrawal } from '../proveEvmWithdrawal'
 import { RetryEvmWithdrawal } from '../retryEvmWithdrawal'
 
 import { ChainLabel } from './chainLabel'
 import { Operation } from './operation'
-
-const ExpectedWithdrawalWaitTimeMinutesTestnet = 20
-const ExpectedWithdrawalWaitTimeMinutesMainnet = 40
-const ExpectedProofWaitTimeHoursTestnet = 3
-const ExpectedProofWaitTimeHoursMainnet = 24
 
 const getCallToAction = (withdrawal: ToEvmWithdrawOperation) =>
   ({
@@ -57,9 +55,7 @@ const ReviewContent = function ({
   const fromChain = useChain(withdrawal.l2ChainId)
   const toChain = useChain(withdrawal.l1ChainId)
   const [operationStatus] = useContext(ToEvmWithdrawalContext)
-  const [networkType] = useNetworkType()
   const t = useTranslations('tunnel-page.review-withdrawal')
-  const tCommon = useTranslations('common')
 
   const {
     fees: claimWithdrawalTokenGasFees,
@@ -118,12 +114,7 @@ const ReviewContent = function ({
           }
         : undefined,
     postAction: {
-      description: tCommon('wait-minutes', {
-        minutes:
-          networkType === 'mainnet'
-            ? ExpectedWithdrawalWaitTimeMinutesMainnet
-            : ExpectedWithdrawalWaitTimeMinutesTestnet,
-      }),
+      description: <EvmWithdrawalWaitTimeToProve withdrawal={withdrawal} />,
       status: getWithdrawalStatus(),
     },
     status:
@@ -188,15 +179,7 @@ const ReviewContent = function ({
           }
         : undefined,
     postAction: {
-      description: tCommon.rich('wait-hours', {
-        hours: () =>
-          tCommon('hours', {
-            hours:
-              networkType === 'mainnet'
-                ? ExpectedProofWaitTimeHoursMainnet
-                : ExpectedProofWaitTimeHoursTestnet,
-          }),
-      }),
+      description: <EvmWithdrawalWaitTimeToFinalize withdrawal={withdrawal} />,
       status:
         withdrawal.status >= MessageStatus.READY_FOR_RELAY
           ? ProgressStatus.COMPLETED

--- a/portal/app/[locale]/tunnel/_hooks/useWaitTime.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useWaitTime.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import { ToEvmWithdrawOperation } from 'types/tunnel'
+import {
+  getTimeToProveInSeconds,
+  getTimeToFinalizeInSeconds,
+} from 'utils/wait-times/evmWithdrawals'
+
+export const useEvmWithdrawTimeToProve = (withdrawal: ToEvmWithdrawOperation) =>
+  useQuery({
+    enabled: !!withdrawal,
+    queryFn: () => getTimeToProveInSeconds(withdrawal),
+    queryKey: ['time-to-prove-withdraw', withdrawal.transactionHash],
+  })
+
+export const useEvmWithdrawTimeToFinalize = (
+  withdrawal: ToEvmWithdrawOperation,
+) =>
+  useQuery({
+    enabled: !!withdrawal,
+    queryFn: () => getTimeToFinalizeInSeconds(withdrawal),
+    queryKey: ['time-to-finalize-withdraw', withdrawal.transactionHash],
+  })

--- a/portal/app/[locale]/tunnel/transaction-history/_components/withdrawStatus.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/withdrawStatus.tsx
@@ -3,9 +3,12 @@ import Skeleton from 'react-loading-skeleton'
 import {
   BtcWithdrawStatus,
   MessageStatus,
+  ToEvmWithdrawOperation,
   WithdrawTunnelOperation,
 } from 'types/tunnel'
 import { isToEvmWithdraw } from 'utils/tunnel'
+
+import { EvmWithdrawalWaitTimeToProve } from '../../_components/evmWithdrawalWaitTime'
 
 import { TxStatus } from './txStatus'
 
@@ -15,17 +18,21 @@ type Props = {
 
 const EvmWithdrawStatus = function ({ withdrawal }: Props) {
   const t = useTranslations()
-  const waitMinutes = t('common.wait-minutes', { minutes: 20 })
+  const waitTime = (
+    <EvmWithdrawalWaitTimeToProve
+      withdrawal={withdrawal as ToEvmWithdrawOperation}
+    />
+  )
 
   const statuses = {
     // This status should never be rendered, but just to be defensive
     // let's render the next status:
     [MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE]: (
-      <TxStatus.InStatus text={waitMinutes} />
+      <TxStatus.InStatus text={waitTime} />
     ),
     [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: <TxStatus.Failed />,
     [MessageStatus.STATE_ROOT_NOT_PUBLISHED]: (
-      <TxStatus.InStatus text={waitMinutes} />
+      <TxStatus.InStatus text={waitTime} />
     ),
     [MessageStatus.READY_TO_PROVE]: (
       <TxStatus.InStatus text={t('transaction-history.ready-to-prove')} />

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -45,6 +45,7 @@
     "unsupported-chain-heading": "You're not connected to a supported chain",
     "wait-hours": "Wait ~<hours></hours>",
     "wait-minutes": "Wait ~{minutes} minutes",
+    "waiting-completed": "Waiting completed",
     "wallets-connected": "{count} Connected {count, plural, =1 {Wallet} other {Wallets}} ",
     "wrong-network": "Wrong Network",
     "wrong-type-network": "Wrong {type} Network",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -45,6 +45,7 @@
     "unsupported-chain-heading": "Usted no se encuentra conectado a una red soportada",
     "wait-hours": "Espere hasta ~<hours></hours>",
     "wait-minutes": "Espere hasta ~{minutes} minutos",
+    "waiting-completed": "Espera completada",
     "wallets-connected": "{count} {count, plural, =1 {Billetera Conectada} other {Billeteras Conectadas}} ",
     "wrong-network": "Red Incorrecta",
     "wrong-type-network": "Red {type} Incorrecta",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -45,6 +45,7 @@
     "unsupported-chain-heading": "Não está conectado a uma rede suportada",
     "wait-hours": "Aguarde ~<hours></hours>",
     "wait-minutes": "Aguarde ~{minutes} minutos",
+    "waiting-completed": "Espera concluída",
     "wallets-connected": "{count} {count, plural, =1 {Carteira Conectada} other {Carteiras Conectadas}}",
     "wrong-network": "Rede Errada",
     "wrong-type-network": "Rede {type} Errada",

--- a/portal/utils/time.ts
+++ b/portal/utils/time.ts
@@ -1,1 +1,3 @@
 export const secondsToHours = (seconds: number) => seconds / 60 / 60
+
+export const secondsToMinutes = (seconds: number) => seconds / 60

--- a/portal/utils/wait-times/evmWithdrawals.ts
+++ b/portal/utils/wait-times/evmWithdrawals.ts
@@ -1,0 +1,43 @@
+import { ToEvmWithdrawOperation } from 'types/tunnel'
+import { getEvmL1PublicClient, getHemiClient } from 'utils/chainClients'
+import { getWithdrawals } from 'viem/op-stack'
+
+export const getTimeToProveInSeconds = async function (
+  withdrawal: ToEvmWithdrawOperation,
+): Promise<number> {
+  const hemiClient = getHemiClient(withdrawal.l2ChainId)
+  const publicClientL1 = getEvmL1PublicClient(withdrawal.l1ChainId)
+
+  const receipt = await hemiClient.getTransactionReceipt({
+    hash: withdrawal.transactionHash,
+  })
+
+  const { seconds } = await publicClientL1.getTimeToProve({
+    receipt,
+    // @ts-expect-error Typescript doesn't recognize the type of hemiClient.chain as viem Chain
+    targetChain: hemiClient.chain,
+  })
+
+  return seconds
+}
+
+export const getTimeToFinalizeInSeconds = async function (
+  withdrawal: ToEvmWithdrawOperation,
+): Promise<number> {
+  const hemiClient = getHemiClient(withdrawal.l2ChainId)
+  const publicClientL1 = getEvmL1PublicClient(withdrawal.l1ChainId)
+
+  const receipt = await hemiClient.getTransactionReceipt({
+    hash: withdrawal.transactionHash,
+  })
+
+  const [message] = getWithdrawals(receipt)
+
+  const { seconds } = await publicClientL1.getTimeToFinalize({
+    // @ts-expect-error Typescript doesn't recognize the type of hemiClient.chain as viem Chain
+    targetChain: hemiClient.chain,
+    withdrawalHash: message.withdrawalHash,
+  })
+
+  return seconds
+}


### PR DESCRIPTION
### Description

Added dynamic wait times for EVM withdrawals

### Screenshots

When the transaction is pending or the request returns an error it shows the hardcoded wait times as before:

<img width="446" alt="pending" src="https://github.com/user-attachments/assets/1d90f766-891a-4b64-aeb8-a59463e57763" />

---

When the transaction is confirmed it shows the exact waiting time for prove and claim:

<screenshot missing because my latest transaction got stuck in pending status, but I did a lot of tests before and it was working fine>

Please test it in your local environment.

--- 

When all the steps are done and there is no more wait times it show "Waiting completed":

<img width="446" alt="ready-to-claim" src="https://github.com/user-attachments/assets/72f02135-eeef-478f-8e1a-174036ae2018" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #118

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [X] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
