### PR TITLE
Add prices token list

### DIFF
--- a/portal/docs/add-new-token-to-stake.md
+++ b/portal/docs/add-new-token-to-stake.md
@@ -36,7 +36,6 @@ export const stakeWhiteList: Partial<
         // satUSD
         '0xb4818BB69478730EF4e33Cc068dD94278e2766cB': {
             protocol: 'satoshi',
-            priceSymbol: 'usdc',
             rewards: ['hemi3x', 'satoshi'],
             website: 'https://www.satoshiprotocol.org',
         },
@@ -46,7 +45,25 @@ export const stakeWhiteList: Partial<
 }
 ```
 
-## Step 3 - Add the protocol logo image (if needed)
+## Step 3 - Add the price symbol (if needed)
+
+If the token has not a symbol that's mapped to the returned tokens from the Token Prices API, then a mapping into a known token is needed. For that, the [priceWhiteList](../tokenList/priceTokens.ts) needs to be updated, adding the price symbol as below:
+
+```tsx
+export const priceWhiteList = {
+  [hemi.id]: {
+    ...
+    // satUSD
+    '0xb4818BB69478730EF4e33Cc068dD94278e2766cB': {
+      priceSymbol: 'usdc',
+    }
+  }
+}
+```
+
+If the token is also on the tunnel, make sure to also map to the sourceId chain.
+
+## Step 4 - Add the protocol logo image (if needed)
 
 If the new token protocol is not already in the [protocolImages.ts](../app/[locale]/stake/protocols/protocolImages.ts) file you need to add the protocol logo image to the [/stake/protocols/images](../app/[locale]/stake/protocols/images) folder and add it to the `protocolImages` list as below:
 
@@ -64,7 +81,7 @@ export const protocolImages: Record<StakeProtocols, StaticImageData> = {
 }
 ```
 
-## Step 4 - Add the new rewards icon images (if needed)
+## Step 5 - Add the new rewards icon images (if needed)
 
 If the new token you added have rewards that are not already in the [tokenRewards.tsx](../app/[locale]/stake/_components/tokenRewards.tsx) list you must add the icon image file to the [rewards icons](../app/[locale]/stake/_components/icons) folder and create the reward points tag component as follows:
 
@@ -103,7 +120,7 @@ const rewardComponentMap: Record<Reward, ReactNode> = {
 }
 ```
 
-## Step 5 - Check if token is whitelisted
+## Step 6 - Check if token is whitelisted
 
 Before merging your changes to the `main` branch you need to make sure the new token you added is already whitelisted to staking and you can do that by calling `tokenAllowlist` method in the [staking pool smart contract](https://explorer.hemi.xyz/address/0x4F5E928763CBFaF5fFD8907ebbB0DAbd5f78bA83) as shown in the screenshot below:
 

--- a/portal/tokenList/index.ts
+++ b/portal/tokenList/index.ts
@@ -7,6 +7,7 @@ import { type Address } from 'viem'
 
 import { customTunnelPartnersWhitelist } from './customTunnelPartnersWhitelist'
 import { nativeTokens } from './nativeTokens'
+import { priceWhiteList } from './priceTokens'
 import { stakeWhiteList } from './stakeTokens'
 import { tunnelWhiteList } from './tunnelTokens'
 
@@ -68,8 +69,9 @@ export const tokenList = {
   timestamp: hemilabsTokenList.timestamp,
   tokens: tokens
     .concat(nativeTokens)
+    .map(extendWithWhiteList(customTunnelPartnersWhitelist))
+    .map(extendWithWhiteList(priceWhiteList))
     .map(extendWithWhiteList(stakeWhiteList))
     .map(extendWithWhiteList(tunnelWhiteList))
-    .map(extendWithWhiteList(customTunnelPartnersWhitelist))
     .sort((a, b) => a.symbol.localeCompare(b.symbol)),
 }

--- a/portal/tokenList/priceTokens.ts
+++ b/portal/tokenList/priceTokens.ts
@@ -1,0 +1,116 @@
+import hemilabsTokenList from '@hemilabs/token-list'
+import { hemi, hemiSepolia } from 'hemi-viem'
+import { Extensions } from 'types/token'
+import { Address, Chain } from 'viem'
+
+type PriceMap = Record<Address, Pick<Extensions, 'priceSymbol'>>
+
+// BTC tokens on Hemi
+const btcAddresses = [
+  // brBTC
+  '0x93919784C523f39CACaa98Ee0a9d96c3F32b593e',
+  // enzoBTC
+  '0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a',
+  // hemiBTC
+  '0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28',
+  // iBTC
+  '0x8154Aaf094c2f03Ad550B6890E1d4264B5DdaD9A',
+  // MBTC - Liquid Staked BTC
+  '0x0Af3EC6F9592C193196bEf220BC0Ce4D9311527D',
+  // oBTC
+  '0xe3C0FF176eF92FC225096C6d1788cCB818808b35',
+  // stBTC
+  '0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3',
+  // suBTC
+  '0xe85411C030fB32A9D8b14Bbbc6CB19417391F711',
+  // tBTC v2
+  '0x12B6e6FC45f81cDa81d2656B974E8190e4ab8D93',
+  // uBTC
+  '0x78E26E8b953C7c78A58d69d8B9A91745C2BbB258',
+  // uniBTC
+  '0xF9775085d726E782E83585033B58606f7731AB18',
+  // ynCoBTCk
+  '0x8970a6A9Eae065aA81a94E86ebCAF4F3d4dd6DA1',
+]
+
+// ETH tokens on Hemi
+const ethAddresses = [
+  // egETH
+  '0x027a9d301FB747cd972CFB29A63f3BDA551DFc5c',
+  // rsETH
+  '0xc3eACf0612346366Db554C991D7858716db09f58',
+]
+
+// USDC tokens on Hemi
+const usdcAddresses = [
+  // satUSD
+  '0xb4818BB69478730EF4e33Cc068dD94278e2766cB',
+  // USDC (token symbol in Hemi is usdc.e)
+  '0xad11a8BEb98bbf61dbb1aa0F6d6F2ECD87b35afA',
+]
+
+const getL1TokenMaps = (priceMaps: PriceMap, hemiChain: Chain) =>
+  Object.fromEntries(
+    Object.entries(priceMaps)
+      .map(function ([address, { priceSymbol }]) {
+        const l1Address = hemilabsTokenList.tokens.find(
+          t => t.chainId === hemiChain.id && t.address === address,
+        )?.extensions?.bridgeInfo?.[hemiChain.sourceId]?.tokenAddress
+        if (!l1Address) {
+          return null
+        }
+        return [l1Address, { priceSymbol }]
+      })
+      // Remove those that don't have a L1 address, like some stake tokens
+      .filter(Boolean),
+  )
+
+function getMainnetPriceList() {
+  const tokenMaps = {
+    // Prefer ordering by symbol in comments, instead of by address, which makes it harder
+    // to search for a specific token.
+    // VUSD
+    '0x7A06C4AeF988e7925575C50261297a946aD204A8': {
+      priceSymbol: 'usdt',
+    },
+    ...Object.fromEntries([
+      ...btcAddresses.map(address => [address, { priceSymbol: 'btc' }]),
+      ...ethAddresses.map(address => [address, { priceSymbol: 'eth' }]),
+      ...usdcAddresses.map(address => [address, { priceSymbol: 'usdc' }]),
+    ]),
+  } satisfies PriceMap
+
+  return {
+    [hemi.id]: tokenMaps,
+    [hemi.sourceId]: getL1TokenMaps(tokenMaps, hemi),
+  }
+}
+
+function getSepoliaPriceList() {
+  // Prefer ordering by symbol in comments, instead of by address, which makes it harder
+  // to search for a specific token.
+  /* eslint-disable sort-keys */
+  const tokenMaps = {
+    // USDC
+    '0xD47971C7F5B1067d25cd45d30b2c9eb60de96443': {
+      // token symbol in Hemi Sepolia is usdc.e
+      priceSymbol: 'usdc',
+    },
+    // USDT
+    '0x3Adf21A6cbc9ce6D5a3ea401E7Bae9499d391298': {
+      // token symbol in Hemi Sepolia is usdt.e
+      priceSymbol: 'usdt',
+    },
+  } satisfies PriceMap
+  /* eslint-disable sort-keys */
+
+  return {
+    [hemiSepolia.id]: tokenMaps,
+    [hemiSepolia.sourceId]: getL1TokenMaps(tokenMaps, hemiSepolia),
+  }
+}
+
+export const priceWhiteList: Record<Chain['id'], PriceMap> = {
+  ...getMainnetPriceList(),
+  ...getSepoliaPriceList(),
+}

--- a/portal/tokenList/priceTokens.ts
+++ b/portal/tokenList/priceTokens.ts
@@ -69,6 +69,11 @@ function getMainnetPriceList() {
   const tokenMaps = {
     // Prefer ordering by symbol in comments, instead of by address, which makes it harder
     // to search for a specific token.
+    /* eslint-disable sort-keys */
+    // bwAJNA
+    '0x63D367531B460Da78a9EBBAF6c1FBFC397E5d40A': {
+      priceSymbol: 'ajna',
+    },
     // VUSD
     '0x7A06C4AeF988e7925575C50261297a946aD204A8': {
       priceSymbol: 'usdt',
@@ -78,6 +83,7 @@ function getMainnetPriceList() {
       ...ethAddresses.map(address => [address, { priceSymbol: 'eth' }]),
       ...usdcAddresses.map(address => [address, { priceSymbol: 'usdc' }]),
     ]),
+    /* eslint-disable sort-keys */
   } satisfies PriceMap
 
   return {

--- a/portal/tokenList/stakeTokens.ts
+++ b/portal/tokenList/stakeTokens.ts
@@ -13,7 +13,6 @@ export const stakeWhiteList: Partial<
     // brBTC
     '0x93919784C523f39CACaa98Ee0a9d96c3F32b593e': {
       protocol: 'bedRock',
-      priceSymbol: 'btc',
       rewards: ['hemi', 'bedrock'],
       stakeSymbol: 'brBTC',
       website: 'https://www.bedrock.technology',
@@ -27,7 +26,6 @@ export const stakeWhiteList: Partial<
     // egETH
     '0x027a9d301FB747cd972CFB29A63f3BDA551DFc5c': {
       protocol: 'egEth',
-      priceSymbol: 'eth',
       rewards: ['hemi2x', 'eigenpie'],
       stakeSymbol: 'egETH',
       website: 'https://www.eigenlayer.magpiexyz.io/restake',
@@ -35,7 +33,6 @@ export const stakeWhiteList: Partial<
     // enzoBTC
     '0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a': {
       protocol: 'lorenzo',
-      priceSymbol: 'btc',
       rewards: ['hemi', 'lorenzo'],
       website: 'https://lorenzo-protocol.xyz',
     },
@@ -48,21 +45,18 @@ export const stakeWhiteList: Partial<
     // hemiBTC
     '0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28': {
       protocol: 'hemi',
-      priceSymbol: 'btc',
       rewards: ['hemi2x'],
       website: 'https://www.hemi.xyz',
     },
     // iBTC
     '0x8154Aaf094c2f03Ad550B6890E1d4264B5DdaD9A': {
       protocol: 'exSat',
-      priceSymbol: 'btc',
       rewards: ['hemi'],
       website: 'https://exsat.network',
     },
     // MBTC - Liquid Staked BTC
     '0x0Af3EC6F9592C193196bEf220BC0Ce4D9311527D': {
       protocol: 'babypie',
-      priceSymbol: 'btc',
       rewards: ['hemi2x', 'babypie'],
       stakeSymbol: 'mBTC',
       website: 'https://www.babylon.magpiexyz.io/stake',
@@ -76,7 +70,6 @@ export const stakeWhiteList: Partial<
     // oBTC
     '0xe3C0FF176eF92FC225096C6d1788cCB818808b35': {
       protocol: 'obeliskNodeDao',
-      priceSymbol: 'btc',
       rewards: ['hemi'],
       website: 'https://obelisk.nodedao.com/',
     },
@@ -89,56 +82,47 @@ export const stakeWhiteList: Partial<
     // rsETH
     '0xc3eACf0612346366Db554C991D7858716db09f58': {
       protocol: 'kelp',
-      priceSymbol: 'eth',
       rewards: ['hemi'],
       website: 'https://kerneldao.com/kelp',
     },
     // satUSD - The protocol is now River
     '0xb4818BB69478730EF4e33Cc068dD94278e2766cB': {
       protocol: 'river',
-      priceSymbol: 'usdc',
       rewards: ['hemi3x', 'river'],
       website: 'https://www.river.inc',
     },
     // stBTC
     '0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3': {
       protocol: 'lorenzo',
-      priceSymbol: 'btc',
       rewards: ['hemi', 'lorenzo'],
       website: 'https://lorenzo-protocol.xyz',
     },
     // suBTC
     '0xe85411C030fB32A9D8b14Bbbc6CB19417391F711': {
       protocol: 'sumer',
-      priceSymbol: 'btc',
       rewards: ['hemi'],
       website: 'https://sumer.money',
     },
     // tBTC v2
     '0x12B6e6FC45f81cDa81d2656B974E8190e4ab8D93': {
       protocol: 'threshold',
-      priceSymbol: 'btc',
       rewards: ['hemi'],
       website: 'https://threshold.network',
     },
     // uBTC
     '0x78E26E8b953C7c78A58d69d8B9A91745C2BbB258': {
       protocol: 'uniRouter',
-      priceSymbol: 'btc',
       rewards: ['hemi', 'unirouter', 'bsquared'],
       website: 'https://www.unirouter.io/#',
     },
     // uniBTC
     '0xF9775085d726E782E83585033B58606f7731AB18': {
       protocol: 'uniBtc',
-      priceSymbol: 'btc',
       rewards: ['hemi', 'bedrock'],
       website: 'https://app.bedrock.technology/unibtc?tab=swap_deposit',
     },
     // USDC
     '0xad11a8BEb98bbf61dbb1aa0F6d6F2ECD87b35afA': {
-      // token symbol in hemi mainnet is usdc.e
-      priceSymbol: 'usdc',
       protocol: 'circle',
       rewards: ['hemi2x'],
       website: 'https://www.circle.com',
@@ -152,7 +136,6 @@ export const stakeWhiteList: Partial<
     // VUSD
     '0x7A06C4AeF988e7925575C50261297a946aD204A8': {
       protocol: 'hemi',
-      priceSymbol: 'usdt',
       rewards: ['hemi'],
       website: 'https://www.hemi.xyz',
     },
@@ -176,7 +159,6 @@ export const stakeWhiteList: Partial<
     },
     // ynCoBTCk
     '0x8970a6A9Eae065aA81a94E86ebCAF4F3d4dd6DA1': {
-      priceSymbol: 'btc',
       protocol: 'yieldNest',
       rewards: ['hemi', 'kernel', 'yieldnest'],
       website: 'https://app.yieldnest.finance/restake/ynCoBTCk',
@@ -201,16 +183,12 @@ export const stakeWhiteList: Partial<
     },
     // USDC
     '0xD47971C7F5B1067d25cd45d30b2c9eb60de96443': {
-      // token symbol in Hemi Sepolia is usdc.e
-      priceSymbol: 'usdc',
       protocol: 'hemi',
       rewards: [],
       website: 'https://www.hemi.xyz',
     },
     // USDT
     '0x3Adf21A6cbc9ce6D5a3ea401E7Bae9499d391298': {
-      // token symbol in Hemi Sepolia is usdt.e
-      priceSymbol: 'usdt',
       protocol: 'hemi',
       rewards: [],
       website: 'https://www.hemi.xyz',


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

There were a couple of issues with the prices, and this PR solves them all. First, the price maps were defined on Hemi addresses. This was done like this because originally the prices were added for Stake only.  
However, for L1 tokens in the tunnel, there was no price-mapping. For the majority of the tokens, that wasn't a problem, as most of tokens had their symbol matching the price from the Token Prices API, but there were 2 tokens in the Tunnel that needed a custom price map: `VUSD` (mapping to `USDT`), and `bwAJNA` mapping to `AJNA`. The former was mapped to `USDT` on Hemi, but not on the L1, causing the price to be only half-shown

<details>
  <summary>See the example screenshot</summary>

<img width="642" alt="image" src="https://github.com/user-attachments/assets/fc3b20fe-160d-4740-8645-3f642058d3b7" />

</details>

The latter was missing its price Map, so there was no price at all

<details>
  <summary>See the example screenshot</summary>

<img width="692" alt="image" src="https://github.com/user-attachments/assets/d2898f79-1dcf-471d-8028-47ed18caf2fa" />

</details>

For this, I removed the `priceSymbol` from stake, and created a custom `priceTokens` whitelist. That's done in 350e46c77fc61e290a8b75baf93e3a803decdcd3. 

Once that was completed, I added the missing price mapping for `bwAJNA` in 58873218151103e0a79fd927264721c4b95530d3

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Now all prices are shown, in the tunnel and in stake

https://github.com/user-attachments/assets/102046b2-1ca3-4fab-aeca-c6cf4fb314f3

Closes #1326

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
