### PR TITLE
Vaults monitor tweaks

### DIFF
--- a/vaults-monitor/README.md
+++ b/vaults-monitor/README.md
@@ -15,7 +15,7 @@ These control the `api` server:
 
 | Variable      | Description                                                     | Default                |
 | ------------- | --------------------------------------------------------------- | ---------------------- |
-| CACHE_MINUTES | The time to cache the status in minutes.                        | 5                      |
+| CACHE_MINUTES | The time to cache the status in minutes.                        | 1                      |
 | CHAIN         | The Hemi chain to monitor: mainnet or testnet.                  | mainnet                |
 | ORIGINS       | Comma-separated list of allowed origins. '\*' is not supported. | `http://localhos:3000` |
 | PORT          | The HTTP port the server listens for requests.                  | 3004                   |

--- a/vaults-monitor/README.md
+++ b/vaults-monitor/README.md
@@ -22,12 +22,13 @@ These control the `api` server:
 
 These environment variables control how the `cron` job behaves:
 
-| Variable             | Description                                                                         | Default                 |
-| -------------------- | ----------------------------------------------------------------------------------- | ----------------------- |
-| API_URL              | The URL of the API service.                                                         | `http://localhost:3004` |
-| REFRESH_INTERVAL_SEC | How frequently the cache will be refreshed. If set to 0, it will run once and exit. | 300                     |
-| SLACK_MENTION        | The user to tag when sending alerts                                                 |                         |
-| SLACK_WEBHOOK_URL    | The full URL of the webhook to send the alerts to.                                  |                         |
+| Variable             | Description                                                                                 | Default                 |
+| -------------------- | ------------------------------------------------------------------------------------------- | ----------------------- |
+| API_URL              | The URL of the API service.                                                                 | `http://localhost:3004` |
+| MAX_BLOCKS_BEHIND    | The maximum difference between Bitcoin kit last header and the actual Bitcoin chain height. | 4                       |
+| REFRESH_INTERVAL_SEC | How frequently the cache will be refreshed. If set to 0, it will run once and exit.         | 300                     |
+| SLACK_MENTION        | The user to tag when sending alerts                                                         |                         |
+| SLACK_WEBHOOK_URL    | The full URL of the webhook to send the alerts to.                                          |                         |
 
 ## Local development and testing
 

--- a/vaults-monitor/api/package.json
+++ b/vaults-monitor/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaults-monitor-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "dependencies": {
     "esplora-client": "1.2.0",
     "hemi-viem": "2.5.0",

--- a/vaults-monitor/api/server.js
+++ b/vaults-monitor/api/server.js
@@ -6,7 +6,7 @@ const pMemoize = require('promise-mem')
 
 const { getBtcVaultsData } = require('./src/btc-vaults')
 
-const cacheMinutesStr = process.env.CACHE_MINUTES || '5'
+const cacheMinutesStr = process.env.CACHE_MINUTES || '1'
 const chain = process.env.CHAIN || 'mainnet'
 const originsStr = process.env.ORIGINS || `http://localhost:3000`
 const portStr = process.env.PORT || '3004'

--- a/vaults-monitor/cron/package.json
+++ b/vaults-monitor/cron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaults-monitor-cron",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "scripts": {
     "prestart": "sleep ${SLEEP:-0}"
   },

--- a/vaults-monitor/cron/server.js
+++ b/vaults-monitor/cron/server.js
@@ -6,15 +6,22 @@ const checkVaults = require('./src/check-vaults')
 const safeAsyncFn = require('./src/safe-async-fn')
 
 const apiUrl = process.env.API_URL || 'http://localhost:3004'
+const maxBlocksBehind = Number.parseInt(process.env.MAX_BLOCKS_BEHIND || '4')
 const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL
 const slackMention = process.env.SLACK_MENTION
-const refreshIntervalStr = process.env.REFRESH_INTERVAL_SEC || '300' // 5m
-const refreshInterval = parseInt(refreshIntervalStr)
+const refreshInterval = Number.parseInt(
+  process.env.REFRESH_INTERVAL_SEC || '300',
+)
 
 const safeCheckVaults = safeAsyncFn(checkVaults)
 
 async function run() {
-  const [err] = await safeCheckVaults({ apiUrl, slackMention, slackWebhookUrl })
+  const [err] = await safeCheckVaults({
+    apiUrl,
+    maxBlocksBehind,
+    slackMention,
+    slackWebhookUrl,
+  })
   if (err) {
     console.error(`Failed to check vaults: ${err.stack}`)
   }

--- a/vaults-monitor/cron/src/check-vaults.js
+++ b/vaults-monitor/cron/src/check-vaults.js
@@ -18,15 +18,14 @@ const VaultStatus = {
 
 const toBtc = sats => (sats / 100000000).toFixed(8)
 
-function analyzeVaultsData({
-  bitcoinChainData,
-  tunnelManagerData,
-  vaultsData,
-}) {
+function analyzeVaultsData(
+  { bitcoinChainData, tunnelManagerData, vaultsData },
+  { maxBlocksBehind },
+) {
   const alerts = []
   const blocksBehind =
     bitcoinChainData.bitcoin.height - bitcoinChainData.bitcoinKit.height
-  if (blocksBehind > 2) {
+  if (blocksBehind > maxBlocksBehind) {
     alerts.push(
       `BitcoinKit is ${blocksBehind} blocks behind the bitcoin blockchain`,
     )
@@ -77,10 +76,15 @@ async function sendAlertsToSlack({ alerts, slackMention, slackWebhookUrl }) {
   await postMessageToSlack(message, slackWebhookUrl, slackMention)
 }
 
-async function checkVaults({ apiUrl, slackMention, slackWebhookUrl }) {
+async function checkVaults({
+  apiUrl,
+  maxBlocksBehind,
+  slackMention,
+  slackWebhookUrl,
+}) {
   console.log('Running checks...')
   const state = await fetchJson(apiUrl)
-  const alerts = analyzeVaultsData(state)
+  const alerts = analyzeVaultsData(state, { maxBlocksBehind })
   if (alerts.length && slackWebhookUrl) {
     await sendAlertsToSlack({ alerts, slackMention, slackWebhookUrl })
   } else if (alerts.length) {

--- a/vaults-monitor/docker-compose.yml
+++ b/vaults-monitor/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       context: cron
     environment:
       API_URL: http://api:${PORT:-3004}
+      MAX_BLOCKS_BEHIND: ${MAX_BLOCKS_BEHIND}
       NODE_ENV: production
       REFRESH_INTERVAL_SEC: ${REFRESH_INTERVAL_SEC}
       SLACK_MENTION: ${SLACK_MENTION}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The alerts threshold for BitcoinKit delay seems to be "too sensitive". This PR increases the allowed delay from 2 to 4 and makes it configurable. 

It also reduces the API cache to allow fresh-er data to be fed to the cron and other consumers.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #721 
