### PR TITLE
Add subgraph that tracks btc deposits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ subgraphs/data
 # Graph CLI generated artifacts
 subgraphs/hemi-stake-operations-subgraph/build
 subgraphs/hemi-stake-operations-subgraph/generated
+subgraphs/hemi-tunnel-btc-deposits-subgraph/build
+subgraphs/hemi-tunnel-btc-deposits-subgraph/generated
 subgraphs/hemi-tunnel-deposits-subgraph/build
 subgraphs/hemi-tunnel-deposits-subgraph/generated
 subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/build

--- a/.knip.json
+++ b/.knip.json
@@ -11,16 +11,7 @@
     "staking-points": {
       "entry": "server.ts"
     },
-    "subgraphs/hemi-stake-operations-subgraph": {
-      "entry": "src/mappings/*.ts"
-    },
-    "subgraphs/hemi-tunnel-deposits-subgraph": {
-      "entry": "src/mappings/*.ts"
-    },
-    "subgraphs/hemi-tunnel-withdrawals-subgraph": {
-      "entry": "src/mappings/*.ts"
-    },
-    "subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph": {
+    "subgraphs/*": {
       "entry": "src/mappings/*.ts"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15722,6 +15722,10 @@
       "resolved": "packages/hemi-tunnel-actions",
       "link": true
     },
+    "node_modules/hemi-tunnel-btc-deposits-subgraph": {
+      "resolved": "subgraphs/hemi-tunnel-btc-deposits-subgraph",
+      "link": true
+    },
     "node_modules/hemi-tunnel-deposits-subgraph": {
       "resolved": "subgraphs/hemi-tunnel-deposits-subgraph",
       "link": true
@@ -28462,6 +28466,13 @@
         "@graphprotocol/graph-ts": "0.36.0"
       }
     },
+    "subgraphs/hemi-tunnel-btc-deposits-subgraph": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@graphprotocol/graph-cli": "0.95.0",
+        "@graphprotocol/graph-ts": "0.36.0"
+      }
+    },
     "subgraphs/hemi-tunnel-deposits-subgraph": {
       "version": "1.0.0",
       "dependencies": {
@@ -28521,7 +28532,7 @@
     },
     "vaults-monitor/api": {
       "name": "vaults-monitor-api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "esplora-client": "1.2.0",
         "hemi-viem": "2.5.0",
@@ -28733,7 +28744,7 @@
     },
     "vaults-monitor/cron": {
       "name": "vaults-monitor-cron",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "startinterval2": "1.0.1"
       },

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/abis/BitcoinTunnelManager.json
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/abis/BitcoinTunnelManager.json
@@ -1,0 +1,305 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "initialAdmin", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "initialVaultFactoryUpgradeDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minimumVaultFactoryUpgradeDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "initialBitcoinKitUpgradeDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "initialGlobalConfigAdminUpgradeDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IBitcoinKitV1",
+        "name": "bitcoinKitAddr",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "depositTxId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositSats",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netSatsAfterFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositConfirmed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "setupAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operatorAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vaultAddress",
+        "type": "address"
+      }
+    ],
+    "name": "VaultCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "withdrawer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "uuid",
+        "type": "uint64"
+      }
+    ],
+    "name": "WithdrawalChallengeSuccess",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "withdrawer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "btcAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawalSats",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netSatsAfterFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "uuid",
+        "type": "uint64"
+      }
+    ],
+    "name": "WithdrawalInitiated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "btcTokenContract",
+    "outputs": [
+      { "internalType": "contract BTCToken", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burnLiquidatedBTC",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint64", "name": "uuid", "type": "uint64" },
+      { "internalType": "bytes", "name": "extraInfo", "type": "bytes" }
+    ],
+    "name": "challengeWithdrawal",
+    "outputs": [{ "internalType": "bool", "name": "success", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "vaultIndex", "type": "uint32" },
+      { "internalType": "bytes32", "name": "txid", "type": "bytes32" },
+      { "internalType": "uint256", "name": "outputIndex", "type": "uint256" },
+      { "internalType": "bytes", "name": "extraInfo", "type": "bytes" }
+    ],
+    "name": "confirmDeposit",
+    "outputs": [
+      { "internalType": "bool", "name": "successful", "type": "bool" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "setupAdmin", "type": "address" },
+      { "internalType": "address", "name": "operatorAdmin", "type": "address" },
+      { "internalType": "uint256", "name": "vaultType", "type": "uint256" },
+      { "internalType": "bytes", "name": "extraInfo", "type": "bytes" }
+    ],
+    "name": "createVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "globalConfig",
+    "outputs": [
+      { "internalType": "contract GlobalConfig", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "vaultIndex", "type": "uint32" },
+      { "internalType": "string", "name": "btcAddress", "type": "string" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "initiateWithdrawal",
+    "outputs": [
+      { "internalType": "uint256", "name": "feeSats", "type": "uint256" },
+      { "internalType": "uint64", "name": "uuid", "type": "uint64" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "vaultIndex", "type": "uint32" },
+      { "internalType": "uint256", "name": "amountToMint", "type": "uint256" }
+    ],
+    "name": "mintOperatorFees",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountMinted", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "originalBitcoinKitContract",
+    "outputs": [
+      {
+        "internalType": "contract IBitcoinKitV1",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "vaultIndex", "type": "uint32" },
+      { "internalType": "bytes32", "name": "txid", "type": "bytes32" },
+      { "internalType": "uint256", "name": "outputIndex", "type": "uint256" },
+      { "internalType": "bytes", "name": "extraInfo", "type": "bytes" }
+    ],
+    "name": "preconfirmDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vaultCounter",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "vaultList",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "name": "vaults",
+    "outputs": [
+      {
+        "internalType": "contract IBitcoinVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/networks.json
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/networks.json
@@ -1,0 +1,14 @@
+{
+  "hemi": {
+    "BitcoinTunnelManager": {
+      "address": "0xEAcA824F46c000fB89403846Bb57e6b913321081",
+      "startBlock": 1125154
+    }
+  },
+  "hemi-sepolia": {
+    "BitcoinTunnelManager": {
+      "address": "0x8221CFD3Eca3c5F9FA27b2AE774151642f1C449e",
+      "startBlock": 2165818
+    }
+  }
+}

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hemi-tunnel-btc-deposits-subgraph",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "graph build",
+    "build:hemi": "npm run build -- --network hemi",
+    "build:hemi-sepolia": "npm run build -- --network hemi-sepolia",
+    "codegen": "graph codegen",
+    "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
+    "deploy-local:hemi": "npm run deploy-local -- --network hemi",
+    "deploy-local:hemi-sepolia": "npm run deploy-local -- --network hemi-sepolia",
+    "deploy-studio:hemi": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-hemi  --version-label $(jq -r .version package.json) --network hemi",
+    "deploy-studio:hemi-sepolia": "graph deploy --node https://api.studio.thegraph.com/deploy/ $(jq -r .name package.json)-hemi-sepolia  --version-label $(jq -r .version package.json) --network hemi-sepolia",
+    "graph:auth": "graph auth",
+    "prepare": "npm run codegen",
+    "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
+  },
+  "dependencies": {
+    "@graphprotocol/graph-cli": "0.95.0",
+    "@graphprotocol/graph-ts": "0.36.0"
+  }
+}

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/schema.graphql
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/schema.graphql
@@ -1,0 +1,11 @@
+type BtcConfirmedDeposit @entity(immutable: true) {
+  blockNumber: BigInt!
+  depositTxId: Bytes! # bytes32
+  depositSats: BigInt! # uint256
+  id: Bytes!
+  netSatsAfterFee: BigInt! # uint256
+  recipient: Bytes! # address
+  timestamp: BigInt!
+  transactionHash: Bytes!
+  vault: Bytes! # address
+}

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/src/mappings/bitcoin-tunnel-manager.ts
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/src/mappings/bitcoin-tunnel-manager.ts
@@ -1,0 +1,23 @@
+import { log } from '@graphprotocol/graph-ts'
+
+import { DepositConfirmed as DepositConfirmedEvent } from '../../generated/BitcoinTunnelManager/BitcoinTunnelManager'
+import { BtcConfirmedDeposit } from '../../generated/schema'
+
+export function handleDepositConfirmed(event: DepositConfirmedEvent): void {
+  let entity = new BtcConfirmedDeposit(event.transaction.hash)
+
+  entity.blockNumber = event.block.number
+  entity.depositTxId = event.params.depositTxId
+  entity.depositSats = event.params.depositSats
+  entity.netSatsAfterFee = event.params.netSatsAfterFee
+  entity.recipient = event.params.recipient
+  entity.timestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  entity.vault = event.params.vault
+
+  log.debug('Found btc confirmation for deposit {}', [
+    event.params.depositTxId.toHexString(),
+  ])
+
+  entity.save()
+}

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/subgraph.yaml
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/subgraph.yaml
@@ -1,0 +1,27 @@
+specVersion: 1.0.0
+indexerHints:
+  prune: auto
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum
+    name: BitcoinTunnelManager
+    network: hemi
+    source:
+      address: '0xEAcA824F46c000fB89403846Bb57e6b913321081'
+      abi: BitcoinTunnelManager
+      startBlock: 1125154
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - DepositConfirmed
+      abis:
+        - name: BitcoinTunnelManager
+          file: ./abis/BitcoinTunnelManager.json
+      eventHandlers:
+        - event: DepositConfirmed(indexed address,indexed address,indexed
+            bytes32,uint256,uint256)
+          handler: handleDepositConfirmed
+      file: ./src/mappings/bitcoin-tunnel-manager.ts

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/tsconfig.json
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json",
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the definition for a subgraph that tracks all bitcoin deposits events - it tracks the `DepositConfirmed` event from `BitcoinTunnelManager`

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1330
Related to https://github.com/hemilabs/metrics-utilities/issues/3

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
