### PR TITLE
Use API cache to get the TVL

### DIFF
--- a/portal/hooks/useTvl.ts
+++ b/portal/hooks/useTvl.ts
@@ -2,44 +2,14 @@ import { useQuery } from '@tanstack/react-query'
 import fetch from 'fetch-plus-plus'
 import { isValidUrl } from 'utils/url'
 
-const tvlUrl = process.env.NEXT_PUBLIC_TVL_URL
-
-type Item = {
-  value: number
-}
-
-type Data = {
-  items: Array<Item>
-}
-
-type DsData = {
-  data: Array<Data>
-}
-
-type SampleData = {
-  id: number
-  dsData: Array<DsData>
-}
-
-type Sample = {
-  id: number
-  sampledata: SampleData
-}
+const apiCacheUrl = process.env.NEXT_PUBLIC_API_CACHE_URL
 
 export const useTvl = () =>
   useQuery({
     // If the URL is not set, tvl are not returned. Consumers of the hook
     // should consider this scenario
-    enabled: tvlUrl !== undefined && isValidUrl(tvlUrl),
-    async queryFn() {
-      const data = (await fetch(tvlUrl).then(
-        ({ samples }) => samples,
-      )) as Array<Sample>
-      const sampleData = data.find(x => x.id === 101171633).sampledata.dsData[0]
-        .data
-      const tvl = sampleData.reduce((sum, item) => sum + item.items[0].value, 0)
-      return tvl
-    },
+    enabled: apiCacheUrl !== undefined && isValidUrl(apiCacheUrl),
+    queryFn: () => fetch(`${apiCacheUrl}/tvl`).then(({ tvl }) => tvl),
     queryKey: ['tvl'],
     // refetch every 60 min
     refetchInterval: 60 * 60 * 1000,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

With #1337 merged and the service deployed, this PR changes `useTvl` to take advantage of the cache.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1336 