### PR TITLE
Improve EVM withdrawal polling and priority logics

### DIFF
--- a/portal/test/utils/watch/pollings/analyzeEvmWithdrawalPolling.test.ts
+++ b/portal/test/utils/watch/pollings/analyzeEvmWithdrawalPolling.test.ts
@@ -1,0 +1,86 @@
+import {
+  MessageDirection,
+  MessageStatus,
+  type ToEvmWithdrawOperation,
+} from 'types/tunnel'
+import { hemiSepolia, sepolia } from 'viem/chains'
+import { describe, expect, it } from 'vitest'
+import {
+  analyzeEvmWithdrawalPolling,
+  EvmWithdrawalPriority,
+} from 'workers/pollings/analyzeEvmWithdrawalPolling'
+
+const getSeconds = (seconds: number) => seconds * 1000
+const getMinutes = (minutes: number) => getSeconds(minutes * 60)
+
+const createWithdrawal = (
+  overrides: Partial<ToEvmWithdrawOperation> = {},
+): ToEvmWithdrawOperation =>
+  // @ts-expect-error Only adding the minimum required properties for testing
+  ({
+    claimTxHash: '0x456',
+    direction: MessageDirection.L2_TO_L1,
+    l1ChainId: sepolia.id,
+    l2ChainId: hemiSepolia.id,
+    proveTxHash: '0x123',
+    status: MessageStatus.RELAYED,
+    timestamp: 123456,
+    transactionHash: '0xabc',
+    ...overrides,
+  })
+
+describe('analyzeEvmWithdrawalPolling', function () {
+  it('returns MAX priority and 6s interval for focused withdrawal', function () {
+    const withdrawal = createWithdrawal()
+    const result = analyzeEvmWithdrawalPolling({
+      focusedWithdrawalHash: '0xabc',
+      withdrawal,
+    })
+    expect(result.priority).toBe(EvmWithdrawalPriority.MAX)
+    expect(result.interval).toBe(getSeconds(6))
+  })
+
+  it('returns HIGH priority and 8s interval if timestamp is missing', function () {
+    const withdrawal = createWithdrawal({ timestamp: undefined })
+    const result = analyzeEvmWithdrawalPolling({ withdrawal })
+    expect(result.priority).toBe(EvmWithdrawalPriority.HIGH)
+    expect(result.interval).toBe(getSeconds(8))
+  })
+
+  it('returns MEDIUM priority and 10s interval if proveTxHash is missing and status requires it', function () {
+    const withdrawal = createWithdrawal({
+      proveTxHash: undefined,
+      status: MessageStatus.READY_FOR_RELAY,
+    })
+    const result = analyzeEvmWithdrawalPolling({ withdrawal })
+    expect(result.priority).toBe(EvmWithdrawalPriority.MEDIUM)
+    expect(result.interval).toBe(getSeconds(10))
+  })
+
+  it('returns MEDIUM priority and 10s interval for READY_TO_PROVE status', function () {
+    const withdrawal = createWithdrawal({
+      status: MessageStatus.READY_TO_PROVE,
+    })
+    const result = analyzeEvmWithdrawalPolling({ withdrawal })
+    expect(result.priority).toBe(EvmWithdrawalPriority.MEDIUM)
+    expect(result.interval).toBe(getSeconds(10))
+  })
+
+  it('returns LOW priority and default mapped interval for unrelated status', function () {
+    const withdrawal = createWithdrawal({
+      status: MessageStatus.RELAYED,
+    })
+    const result = analyzeEvmWithdrawalPolling({ withdrawal })
+    expect(result.priority).toBe(EvmWithdrawalPriority.LOW)
+    expect(result.interval).toBe(getMinutes(3))
+  })
+
+  it('returns LOW priority and fallback interval if mapping is missing', function () {
+    const withdrawal = createWithdrawal({
+      l2ChainId: 99999, // unknown chain
+    })
+    const result = analyzeEvmWithdrawalPolling({ withdrawal })
+    expect(result.priority).toBe(EvmWithdrawalPriority.LOW)
+    expect(result.interval).toBe(getSeconds(12))
+  })
+})

--- a/portal/workers/pollings/analyzeEvmWithdrawalPolling.ts
+++ b/portal/workers/pollings/analyzeEvmWithdrawalPolling.ts
@@ -1,0 +1,94 @@
+import { hemiMainnet } from 'networks/hemiMainnet'
+import { hemiTestnet } from 'networks/hemiTestnet'
+import { MessageStatus, type ToEvmWithdrawOperation } from 'types/tunnel'
+import { isWithdrawalMissingInformation } from 'utils/tunnel'
+import { Hash } from 'viem'
+
+type Props = {
+  withdrawal: ToEvmWithdrawOperation
+  focusedWithdrawalHash?: Hash
+}
+
+const getSeconds = (seconds: number) => seconds * 1000
+const getMinutes = (minutes: number) => getSeconds(minutes * 60)
+
+// use different refetch intervals depending on the status and chain
+const refetchInterval = {
+  [hemiMainnet.id]: {
+    [MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE]: getSeconds(24),
+    [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: getMinutes(3),
+    [MessageStatus.STATE_ROOT_NOT_PUBLISHED]: getMinutes(1),
+    [MessageStatus.READY_TO_PROVE]: getMinutes(1),
+    [MessageStatus.IN_CHALLENGE_PERIOD]: getMinutes(3),
+    [MessageStatus.READY_FOR_RELAY]: getMinutes(3),
+    [MessageStatus.RELAYED]: getMinutes(3),
+  },
+  [hemiTestnet.id]: {
+    [MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE]: getSeconds(24),
+    [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: getMinutes(3),
+    [MessageStatus.STATE_ROOT_NOT_PUBLISHED]: getMinutes(1),
+    [MessageStatus.READY_TO_PROVE]: getMinutes(2),
+    [MessageStatus.IN_CHALLENGE_PERIOD]: getMinutes(2),
+    [MessageStatus.READY_FOR_RELAY]: getMinutes(2),
+    [MessageStatus.RELAYED]: getMinutes(3),
+  },
+} satisfies { [chainId: number]: { [status: number]: number | false } }
+
+export const EvmWithdrawalPriority = {
+  HIGH: 2, // Missing timestamp or status
+  LOW: 0, // Everything else
+  MAX: 3, // Focused withdrawal
+  MEDIUM: 1, // Missing info (like prove/claim tx) or specific statuses
+} as const
+
+// See https://www.npmjs.com/package/p-queue#priority
+export function analyzeEvmWithdrawalPolling({
+  focusedWithdrawalHash,
+  withdrawal,
+}: Props) {
+  const fallback = getSeconds(12)
+
+  // Focused withdrawal
+  if (
+    focusedWithdrawalHash &&
+    focusedWithdrawalHash.toLowerCase() ===
+      withdrawal.transactionHash.toLowerCase()
+  ) {
+    return {
+      interval: getSeconds(6),
+      priority: EvmWithdrawalPriority.MAX,
+    }
+  }
+
+  // Missing vital info
+  if (isWithdrawalMissingInformation(withdrawal)) {
+    if (!withdrawal.timestamp || withdrawal.status === undefined) {
+      return {
+        interval: getSeconds(8),
+        priority: EvmWithdrawalPriority.HIGH,
+      }
+    }
+    return {
+      interval: getSeconds(10),
+      priority: EvmWithdrawalPriority.MEDIUM,
+    }
+  }
+
+  if (
+    [MessageStatus.READY_TO_PROVE, MessageStatus.READY_FOR_RELAY].includes(
+      // @ts-expect-error status is of type MessageStatus
+      withdrawal.status,
+    )
+  ) {
+    return {
+      interval: getSeconds(10),
+      priority: EvmWithdrawalPriority.MEDIUM,
+    }
+  }
+
+  return {
+    interval:
+      refetchInterval[withdrawal.l2ChainId]?.[withdrawal.status] ?? fallback,
+    priority: EvmWithdrawalPriority.LOW,
+  }
+}


### PR DESCRIPTION
### Description

This PR extracts and unifies the logic for polling and priority based on:

- focusedWithdrawalHash, which gives max priority to withdrawals currently being viewed by the user (e.g., when the drawer is open).
- Missing withdrawal data (timestamp, status, prove/claim tx)
- Withdrawal message status
- Chain-specific fallback intervals

It also adds unit tests covering all combinations of priority and interval cases.

### Screenshots

No UI changes

### Related issue(s)

Related to #1318 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
