### PR TITLE
Change name from Ecosystem to Demos (temporary)

### DIFF
--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -87,7 +87,7 @@
       "heading": "DEMOS",
       "sub-heading": "Biometric verification solutions for Web3 applications."
     },
-    "heading": "Ecosystem",
+    "heading": "Demos",
     "hemihatchlings": {
       "heading": "Hemi Hatchlings",
       "sub-heading": "Learn how Ethereum & Bitcoin finality works"
@@ -96,7 +96,7 @@
       "heading": "Pure Finance",
       "sub-heading": "Utility and smart contract interaction built directly into the Hemi network"
     },
-    "sub-heading": "Learn and explore with Hemi developer ecosystem"
+    "sub-heading": "Learn and explore with Hemi developer demos"
   },
   "error-pages": {
     "not-found": {
@@ -193,7 +193,7 @@
       "title": "DEX"
     },
     "docs": "Documentation",
-    "ecosystem": "Ecosystem",
+    "ecosystem": "Demos",
     "explorer": "Explorer",
     "get-started": "Get Started",
     "help": {

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -87,7 +87,7 @@
       "heading": "DEMOS",
       "sub-heading": "Soluciones de verificación biométrica para aplicaciones Web3."
     },
-    "heading": "Ecosistema",
+    "heading": "Demos",
     "hemihatchlings": {
       "heading": "Hemi Hatchlings",
       "sub-heading": "Aprenda como funciona la finalidad de Ethereum y Bitcoin"
@@ -96,7 +96,7 @@
       "heading": "Pure Finance",
       "sub-heading": "Utilidad e interacciones de contratos inteligentes integrados directamente en la red Hemi"
     },
-    "sub-heading": "Aprenda y explore con el ecosistema para desarrolladores de Hemi"
+    "sub-heading": "Aprenda y explore con las demos de desarrolladores de Hemi"
   },
   "error-pages": {
     "not-found": {
@@ -193,7 +193,7 @@
       "title": "DEX"
     },
     "docs": "Documentación",
-    "ecosystem": "Ecosistema",
+    "ecosystem": "Demos",
     "explorer": "Explorador",
     "get-started": "Comenzar",
     "help": {

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -87,7 +87,7 @@
       "heading": "DEMOS",
       "sub-heading": "Soluções de verificação biométrica para aplicações Web3."
     },
-    "heading": "Ecosistema",
+    "heading": "Demonstrações",
     "hemihatchlings": {
       "heading": "Hemi Hatchlings",
       "sub-heading": "Saiba como funciona a finalidade de Ethereum e Bitcoin"
@@ -96,7 +96,7 @@
       "heading": "Pure Finance",
       "sub-heading": "Utilidade e interação com contratos inteligentes diretamente na rede Hemi"
     },
-    "sub-heading": "Aprenda e explore com o ecosistema para programadores Hemi"
+    "sub-heading": "Aprenda e explore com as demonstrações para programadores Hemi"
   },
   "error-pages": {
     "not-found": {
@@ -193,7 +193,7 @@
       "title": "DEX"
     },
     "docs": "Documentação",
-    "ecosystem": "Ecosistema",
+    "ecosystem": "Demonstrações",
     "explorer": "Explorador",
     "get-started": "Começar",
     "help": {


### PR DESCRIPTION
### Description

This PR updates the tab label from “Ecosystem” to “Demos” as a temporary solution, until the new Ecosystem update is ready. The translation keys were not changed, so we continue to use the existing ecosystem key to avoid unnecessary refactoring, since this is not the final naming.

Requested by @dvnahuel.

### Screenshots

No UI changes.

### Related issue(s)

Closes #1344 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
