### PR TITLE
Improve Btc deposit polling and priority logics

### DIFF
--- a/portal/test/utils/watch/pollings/analyzeBitcoinDepositPolling.test.ts
+++ b/portal/test/utils/watch/pollings/analyzeBitcoinDepositPolling.test.ts
@@ -1,0 +1,41 @@
+import { type BtcDepositOperation } from 'types/tunnel'
+import { zeroHash } from 'viem'
+import { describe, expect, it } from 'vitest'
+import {
+  analyzeBitcoinDepositPolling,
+  BitcoinDepositPriority,
+} from 'workers/pollings/analyzeBitcoinDepositPolling'
+
+const getSeconds = (seconds: number) => seconds * 1000
+
+const createDeposit = (
+  overrides: Partial<BtcDepositOperation> = {},
+): BtcDepositOperation =>
+  // @ts-expect-error Only required fields for testing
+  ({
+    status: 1,
+    timestamp: 123456,
+    transactionHash: zeroHash,
+    ...overrides,
+  })
+
+describe('analyzeBitcoinDepositPolling', function () {
+  it('returns HIGH priority and short interval for focused deposit', function () {
+    const deposit = createDeposit()
+    const result = analyzeBitcoinDepositPolling({
+      deposit,
+      focusedDepositHash: zeroHash,
+    })
+
+    expect(result.priority).toBe(BitcoinDepositPriority.HIGH)
+    expect(result.interval).toBe(getSeconds(14))
+  })
+
+  it('returns LOW priority and fallback interval when all data is present and not focused', function () {
+    const deposit = createDeposit()
+    const result = analyzeBitcoinDepositPolling({ deposit })
+
+    expect(result.priority).toBe(BitcoinDepositPriority.LOW)
+    expect(result.interval).toBe(getSeconds(28))
+  })
+})

--- a/portal/workers/pollings/analyzeBitcoinDepositPolling.ts
+++ b/portal/workers/pollings/analyzeBitcoinDepositPolling.ts
@@ -1,0 +1,37 @@
+import { BtcDepositOperation } from 'types/tunnel'
+import { Hash } from 'viem'
+
+type Props = {
+  deposit: BtcDepositOperation
+  focusedDepositHash?: Hash
+}
+
+const getSeconds = (seconds: number) => seconds * 1000
+
+export const BitcoinDepositPriority = {
+  HIGH: 1, // Focused deposit
+  LOW: 0, // Everything else
+} as const
+
+export function analyzeBitcoinDepositPolling({
+  deposit,
+  focusedDepositHash,
+}: Props) {
+  const fallback = getSeconds(28)
+
+  // Focused deposit
+  if (
+    focusedDepositHash &&
+    focusedDepositHash.toLowerCase() === deposit.transactionHash.toLowerCase()
+  ) {
+    return {
+      interval: getSeconds(14),
+      priority: BitcoinDepositPriority.HIGH,
+    }
+  }
+
+  return {
+    interval: fallback,
+    priority: BitcoinDepositPriority.LOW,
+  }
+}


### PR DESCRIPTION
### Description

Following the work on improving the workers, this PR extracts and unifies the logic for polling and priority based on:

- Focused deposit hash: prioritized with shorter interval (14s)
- All others: low priority with fallback interval of 28s

### Screenshots

No UI changes.

### Related issue(s)

Closes #1318

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
