### PR TITLE
Silent markdown rule from eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -101,6 +101,13 @@
         "markdownlint/md041": "warn",
         "markdownlint/md045": "warn"
       }
+    },
+    {
+      "extends": ["bloq/markdown"],
+      "files": [".github/pull_request_template.md"],
+      "rules": {
+        "markdownlint/md041": "off"
+      }
     }
   ],
   "root": true,

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable md041 -->
-
 ### Description
 
 <!-- Explain the changes included in this PR and why are relevant or what


### PR DESCRIPTION
<!-- markdownlint-disable md041 -->

### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

In https://github.com/hemilabs/ui-monorepo/pull/1359, we disabled one rule for the PR template, but this causes the following every time I open a PR:

![image](https://github.com/user-attachments/assets/fcb8b1a3-b695-4beb-9bcc-2af55cb8d6b4)

Although nothing gets rendered in the end, it's a bit annoying 😆  So this tiny PR silences the rule for this template file through the config

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
