### PR TITLE
Allow the token prices job to terminate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29237,7 +29237,7 @@
     },
     "portal-backend/cron/token-prices": {
       "name": "token-prices-cron",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "redis": "4.7.0",
         "safe-async-fn": "1.0.0",

--- a/portal-backend/cron/token-prices/package.json
+++ b/portal-backend/cron/token-prices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-prices-cron",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "dependencies": {
     "redis": "4.7.0",
     "safe-async-fn": "1.0.0",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

For the token prices cron to run as a cron (refreshes the prices and gracefully exits), the connection to Redis must be closed after the task is done. Otherwise, the open connection will prevent Node to exit.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1360

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
