### PR TITLE
Read Hemi token logos from Token list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1878,9 +1878,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@hemilabs/token-list": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hemilabs/token-list/-/token-list-2.0.1.tgz",
-      "integrity": "sha512-hcMwrHNk8gWa9kpzgXlzpSxwzKj9K7E79kcos6X+XIV/emlzmSK8oJ08o1s1WNQ4oOmrJ5Vj7NzoQB0oAQZorA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hemilabs/token-list/-/token-list-2.1.0.tgz",
+      "integrity": "sha512-0qOFTdxqHmkYWOv8D8Ny+o9Rq0oiAg0rjjAMC4gSGPm3BY9IHEpUHv2ijhy2tjYR6xRW+cIwfkVUQZklYKVmxA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -28917,7 +28917,7 @@
     "portal": {
       "version": "1.0.0",
       "dependencies": {
-        "@hemilabs/token-list": "2.0.1",
+        "@hemilabs/token-list": "2.1.0",
         "@rainbow-me/rainbowkit": "2.2.4",
         "@sentry/nextjs": "9.9.0",
         "@tanstack/react-query": "5.69.0",

--- a/patches/@hemilabs+token-list+2.1.0.patch
+++ b/patches/@hemilabs+token-list+2.1.0.patch
@@ -1,32 +1,29 @@
 diff --git a/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json b/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
-index 3fb81a8..17ff335 100644
+index 17c1715..9968812 100644
 --- a/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
 +++ b/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
-@@ -315,7 +315,12 @@
-       "chainId": 43111,
+@@ -340,6 +340,11 @@
        "decimals": 8,
        "extensions": {
--        "birthBlock": 1125154
-+        "birthBlock": 1125154,
+         "birthBlock": 1125154,
 +        "bridgeInfo": {
 +          "livenet": {
-+           "tokenAddress": "BTC"
++            "tokenAddress": "BTC"
 +          }
-+        }
++        },
+         "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hemibtc.svg"
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/hemibtc.svg",
-       "name": "Hemi Bitcoin",
-@@ -326,10 +331,15 @@
-       "chainId": 43111,
+@@ -352,10 +357,15 @@
        "decimals": 6,
        "extensions": {
--        "birthBlock": 623077
-+        "birthBlock": 623077,
+         "birthBlock": 623077,
 +        "bridgeInfo": {
 +          "1": {
 +            "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 +          }
-+        }
++        },
+         "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/usdc.svg"
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/usdc.svg",
 -      "name": "Bridged USDC (Stargate)",
@@ -34,31 +31,28 @@ index 3fb81a8..17ff335 100644
        "symbol": "USDC.e"
      },
      {
-@@ -364,7 +374,12 @@
-       "chainId": 43111,
+@@ -393,6 +403,11 @@
        "decimals": 6,
        "extensions": {
--        "birthBlock": 666946
-+        "birthBlock": 666946,
+         "birthBlock": 666946,
 +        "bridgeInfo": {
 +          "1": {
 +            "tokenAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
 +          }
-+        }
++        },
+         "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/usdt.svg"
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/usdt.svg",
-       "name": "USDT",
-@@ -500,11 +515,16 @@
-       "chainId": 743111,
+@@ -540,11 +555,16 @@
        "decimals": 8,
        "extensions": {
--        "birthBlock": 2165818
-+        "birthBlock": 2165818,
+         "birthBlock": 2165818,
 +        "bridgeInfo": {
 +          "testnet": {
 +            "tokenAddress": "tBTC"
 +          }
-+        }
++        },
+         "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hemibtc.svg"
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/hemibtc.svg",
 -      "name": "HemiBitcoin",
@@ -68,14 +62,14 @@ index 3fb81a8..17ff335 100644
      },
      {
        "address": "0x3Adf21A6cbc9ce6D5a3ea401E7Bae9499d391298",
-@@ -559,8 +579,8 @@
-       "chainId": 743111,
-       "decimals": 18,
+@@ -611,8 +631,8 @@
+         "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hdai.svg"
+       },
        "logoURI": "https://hemilabs.github.io/token-list/logos/hdai.svg",
 -      "name": "Hemi Tunneled DAI",
--      "symbol": "hDAI",
+-      "symbol": "hDAI"
 +      "name": "Dai Stablecoin",
-+      "symbol": "DAI",
-       "extensions": {
-         "birthBlock": 71589,
-         "bridgeInfo": {
++      "symbol": "DAI"
+     }
+   ]
+ }

--- a/portal/components/tokenLogo.tsx
+++ b/portal/components/tokenLogo.tsx
@@ -1,13 +1,11 @@
 import { useBitcoin } from 'hooks/useBitcoin'
 import { useNetworkType } from 'hooks/useNetworkType'
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
 import { Token } from 'types/token'
 import { isBtcNetworkId } from 'utils/chain'
 import { getNativeToken } from 'utils/nativeToken'
 
 import { CustomTokenLogo } from './customTokenLogo'
-import { HemiSubLogo } from './hemiSubLogo'
 import { BtcLogo } from './icons/btcLogo'
 
 const sizes = {
@@ -22,33 +20,11 @@ type Props = {
   token: Token
 }
 
-type ImageState = 'idle' | 'loaded' | 'error'
-
-const MaxRetries = 5
-
 // for hemi tokens, we add a hemi logo at the bottom right
 export function TokenLogo({ size, token }: Props) {
-  const [imageState, setImageState] = useState<ImageState>('idle')
-  const [retry, setRetry] = useState(0)
   const [networkType] = useNetworkType()
   const bitcoinChain = useBitcoin()
   const bitcoinToken = getNativeToken(bitcoinChain.id)
-
-  useEffect(
-    function retryImageEffect() {
-      let timer: NodeJS.Timeout | null = null
-      if (imageState === 'error' && retry <= MaxRetries) {
-        timer = setTimeout(function forceReload() {
-          setImageState('idle')
-          setRetry(r => r + 1)
-        }, 10 * 1000)
-      }
-      return function () {
-        if (timer) clearTimeout(timer)
-      }
-    },
-    [imageState, retry, setRetry, setImageState],
-  )
 
   // BTC and tBTC have special logo rendering.
   // On Hemi (mainnet), only BTC uses the preset logo because tBTC represents a different token.
@@ -67,19 +43,15 @@ export function TokenLogo({ size, token }: Props) {
     )
   }
 
-  return token.logoURI && imageState !== 'error' ? (
+  return token.logoURI ? (
     <div className={`relative ${sizes[size]}`}>
       <Image
         alt={`${token.symbol} Logo`}
         className="w-full"
         height={20}
-        onError={() => setImageState('error')}
-        onLoad={() => setImageState('loaded')}
-        src={`${token.logoURI}${retry === 0 ? '' : `?retry=${retry}`}`}
+        src={token.logoURI}
         width={20}
       />
-      {/* for custom tokens, it is already included in the component */}
-      <HemiSubLogo token={token} />
     </div>
   ) : (
     <div className={`relative ${sizes[size]}`}>

--- a/portal/next.config.js
+++ b/portal/next.config.js
@@ -21,11 +21,6 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
-        hostname: 'raw.githubusercontent.com',
-        pathname: '/hemilabs/token-list/**',
-        protocol: 'https',
-      },
-      {
         hostname: 'hemilabs.github.io',
         pathname: '/token-list/logos/**',
         protocol: 'https',

--- a/portal/package.json
+++ b/portal/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@hemilabs/token-list": "2.0.1",
+    "@hemilabs/token-list": "2.1.0",
     "@rainbow-me/rainbowkit": "2.2.4",
     "@sentry/nextjs": "9.9.0",
     "@tanstack/react-query": "5.69.0",

--- a/portal/scripts/generateServerConfig.js
+++ b/portal/scripts/generateServerConfig.js
@@ -78,7 +78,6 @@ customRpcOrigins.forEach(function (url) {
 // these are domains where we download images from
 const imageSrcUrls = [
   'https://hemi.xyz',
-  'https://raw.githubusercontent.com',
   'https://*.walletconnect.com',
   'https://hemilabs.github.io',
 ]

--- a/portal/tokenList/index.ts
+++ b/portal/tokenList/index.ts
@@ -45,6 +45,7 @@ export const getRemoteTokens = function (token: EvmToken) {
         },
       },
     },
+    logoURI: token.extensions!.l1LogoURI,
     name: token.name
       // Remove the ".e" suffix
       .replace('.e', '')

--- a/portal/tokenList/nativeTokens.ts
+++ b/portal/tokenList/nativeTokens.ts
@@ -17,8 +17,9 @@ import { type Address, type Chain } from 'viem'
 export const NativeTokenSpecialAddressOnL2 =
   '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000' as Address
 
-const ethLogoUri =
-  'https://raw.githubusercontent.com/hemilabs/token-list/master/src/logos/eth.svg'
+const ethLogoURI = 'https://hemilabs.github.io/token-list/l1Logos/eth.svg'
+
+const hemiEthLogoURI = 'https://hemilabs.github.io/token-list/logos/eth.svg'
 
 const nativeTokens: Token[] = [
   {
@@ -31,7 +32,7 @@ const nativeTokens: Token[] = [
         [hemiMainnet.id]: {},
       },
     },
-    logoURI: ethLogoUri,
+    logoURI: ethLogoURI,
     name: mainnet.nativeCurrency.name,
     symbol: mainnet.nativeCurrency.symbol,
   },
@@ -45,7 +46,7 @@ const nativeTokens: Token[] = [
         [hemiTestnet.id]: {},
       },
     },
-    logoURI: ethLogoUri,
+    logoURI: ethLogoURI,
     name: sepolia.nativeCurrency.name,
     symbol: sepolia.nativeCurrency.symbol,
   },
@@ -60,7 +61,7 @@ const nativeTokens: Token[] = [
         },
       },
     },
-    logoURI: ethLogoUri,
+    logoURI: hemiEthLogoURI,
     name: hemiMainnet.nativeCurrency.name,
     symbol: hemiMainnet.nativeCurrency.symbol,
   },
@@ -75,7 +76,7 @@ const nativeTokens: Token[] = [
         },
       },
     },
-    logoURI: ethLogoUri,
+    logoURI: hemiEthLogoURI,
     name: hemiTestnet.nativeCurrency.name,
     symbol: hemiTestnet.nativeCurrency.symbol,
   },

--- a/portal/types/token.ts
+++ b/portal/types/token.ts
@@ -5,6 +5,7 @@ type TunnelPartners = 'meson' | 'stargate'
 
 export type Extensions = {
   birthBlock?: number
+  l1LogoURI?: string
   bridgeInfo?: {
     [keyof: string]: {
       tokenAddress?: Address


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps the token list to show the L1 and L2 logos from it, instead of dynamically generate the L2 token logos.

- 56ea056c1a1bb2435e9c23fb36ca68b54858fb96 Bumps the package version and updates the patch
- 0106c186f3c9a4bd0d4042e87a985b93979e0c99 removes the retry mechanism added in https://github.com/hemilabs/ui-monorepo/pull/1212 as we're no longer loading images from `raw.githubusercontent.com`, but rather from Github Pages. For the same reason, these images were removed from the config and CSP headers.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->


https://github.com/user-attachments/assets/69d56be3-6503-4ec0-96b4-272afbe84b5f

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1379 and #876
It's needed to close both issues

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
