### PR TITLE
Add hemi small logo to hemiBTC

### DIFF
--- a/portal/components/customTokenLogo.tsx
+++ b/portal/components/customTokenLogo.tsx
@@ -2,8 +2,8 @@ import { HemiSubLogo } from 'components/hemiSubLogo'
 import { Token } from 'types/token'
 
 const sizes = {
-  medium: 'h-8 w-8 text-[8px]',
-  small: 'h-5 w-5 text-[6px]',
+  medium: 'size-8 text-[8px]',
+  small: 'size-5 text-[6px]',
 } as const
 
 type Size = keyof typeof sizes
@@ -21,6 +21,6 @@ export const CustomTokenLogo = ({ size, token }: Props) => (
     >
       {token.symbol}
     </div>
-    <HemiSubLogo token={token} />
+    <HemiSubLogo size={size} token={token} />
   </>
 )

--- a/portal/components/hemiSubLogo.tsx
+++ b/portal/components/hemiSubLogo.tsx
@@ -3,51 +3,42 @@
 import { useHemi } from 'hooks/useHemi'
 import { Token } from 'types/token'
 
-const HemiLogo = () => (
+const sizes = {
+  medium: 'size-4',
+  small: 'size-2.5',
+} as const
+
+type Props = {
+  size: keyof typeof sizes
+  token: Token
+}
+
+const HemiLogo = ({ size }: Pick<Props, 'size'>) => (
   <svg
-    className="h-full w-full"
+    className={sizes[size]}
     fill="none"
-    height={16}
-    viewBox="0 0 16 16"
-    width={16}
+    height="10"
+    viewBox="0 0 10 10"
+    width="10"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <rect
-      fill="#FFEBD4"
-      height={13.5}
-      rx={3.75}
-      width={13.5}
-      x={1.25}
-      y={1.25}
-    />
-    <rect
-      height={13.5}
-      rx={3.75}
-      stroke="#fff"
-      strokeWidth={1.5}
-      width={13.5}
-      x={1.25}
-      y={1.25}
-    />
+    <rect fill="#FFEBD4" height="9" rx="2.5" width="9" x="0.5" y="0.5" />
+    <rect height="9" rx="2.5" stroke="white" width="9" x="0.5" y="0.5" />
     <path
-      d="M8.72 4.251a.07.07 0 0 0-.08.058l-.466 2.689h-.348l-.465-2.69a.07.07 0 0 0-.082-.057c-1.653.326-2.92 1.76-3.024 3.512 0 .002-.005.076-.005.113V8c0 1.859 1.303 3.405 3.031 3.747a.07.07 0 0 0 .082-.057l.466-2.69h.347l.463 2.692a.07.07 0 0 0 .082.058c1.653-.328 2.918-1.762 3.024-3.514 0-.003.005-.077.005-.114V8c.002-1.859-1.301-3.406-3.03-3.748Z"
+      d="M5.57675 2.00091C5.54587 1.99536 5.5168 2.01571 5.51135 2.04715L5.13896 4.19821H4.86103L4.48865 2.04715C4.4832 2.01571 4.45413 1.99536 4.42325 2.00091C3.10082 2.2617 2.08719 3.40844 2.00363 4.81042C2.00363 4.81227 2 4.87145 2 4.90105C2 4.90475 2 4.90845 2 4.9103C2 4.92139 2 4.93249 2 4.94359C2 4.94729 2 4.95099 2 4.95654C2 4.97133 2 4.98428 2 4.99908C2 6.48614 3.04269 7.7235 4.42507 7.99724C4.45595 8.00279 4.48501 7.98244 4.49046 7.951L4.86285 5.79994H5.14078L5.51135 7.95285C5.5168 7.98429 5.54587 8.00464 5.57675 7.99909C6.89918 7.73645 7.91099 6.58971 7.99636 5.18773C7.99636 5.18588 8 5.1267 8 5.0971C8 5.0934 8 5.0897 8 5.08785C8 5.07676 8 5.06566 8 5.05456C8 5.05086 8 5.04716 8 5.04162C8 5.02682 8 5.01387 8 4.99908C8.00181 3.51202 6.95913 2.27465 5.57675 2.00091Z"
       fill="#FF6C15"
     />
   </svg>
 )
 
-type Props = {
-  token: Token
-}
-
-export const HemiSubLogo = function ({ token }: Props) {
+export const HemiSubLogo = function ({ size, token }: Props) {
   const hemi = useHemi()
   if (token.chainId !== hemi.id) {
     return null
   }
   return (
-    <div className="absolute -bottom-0.5 -right-0.5">
-      <HemiLogo />
+    <div className="absolute bottom-0 right-0">
+      <HemiLogo size={size} />
     </div>
   )
 }

--- a/portal/components/tokenLogo.tsx
+++ b/portal/components/tokenLogo.tsx
@@ -6,11 +6,12 @@ import { isBtcNetworkId } from 'utils/chain'
 import { getNativeToken } from 'utils/nativeToken'
 
 import { CustomTokenLogo } from './customTokenLogo'
+import { HemiSubLogo } from './hemiSubLogo'
 import { BtcLogo } from './icons/btcLogo'
 
 const sizes = {
-  medium: 'h-8 w-8',
-  small: 'h-5 w-5 [&>div:nth-child(2)]:h-2.5 [&>div:nth-child(2)]:w-2.5',
+  medium: 'size-8',
+  small: 'size-5',
 } as const
 
 type Size = keyof typeof sizes
@@ -36,9 +37,10 @@ export function TokenLogo({ size, token }: Props) {
   if (isBtcNetworkId(token.chainId) || (isTestnet && isHemiBtc)) {
     return (
       <div className={`relative ${sizes[size]}`}>
-        <div className="flex h-full w-full items-center justify-center">
-          <BtcLogo className="h-full w-full" />
+        <div className="flex size-full items-center justify-center">
+          <BtcLogo className="size-full" />
         </div>
+        {isTestnet && isHemiBtc && <HemiSubLogo size={size} token={token} />}
       </div>
     )
   }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Now that the token list's been updated, we can fix the hemiBTC logo for testnet. In this particular case, it does not use the logo from hemiBTC, but the BTC logo with the hemi sub logo on top of it. This small hemi logo was missing (See screenshots in the issue), but this PR fixes that.

I also replaced a few `h-* w-*` with `size-*` and cleaned up some styles that were no longer needed.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="601" height="586" alt="image" src="https://github.com/user-attachments/assets/68fa32c6-553f-4ced-86f2-f22c689238aa" />

<img width="465" height="416" alt="image" src="https://github.com/user-attachments/assets/8134339f-ff55-469b-aa27-a7994b0ad84b" />

<img width="1611" height="95" alt="image" src="https://github.com/user-attachments/assets/2d28988a-52e1-436b-9e65-f12c8fb0a955" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1379 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
