### PR TITLE
Add tokens to hemi wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27762,6 +27762,11 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/wallet-watch-asset": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/hemilabs/wallet-watch-asset.git#9ac4cef8ce57b90d350ebf029ad90b195257fc90",
+      "license": "MIT"
+    },
     "node_modules/watchpack": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
@@ -28954,7 +28959,8 @@
         "use-local-storage-state": "19.5.0",
         "viem": "2.22.10",
         "viem-erc20": "1.0.1",
-        "wagmi": "2.14.8"
+        "wagmi": "2.14.8",
+        "wallet-watch-asset": "github:hemilabs/wallet-watch-asset#v1.0.0"
       },
       "devDependencies": {
         "@types/big.js": "6.2.2",

--- a/patches/@hemilabs+token-list+2.1.0.patch
+++ b/patches/@hemilabs+token-list+2.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json b/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
-index 17c1715..9968812 100644
+index 17c1715..66662f8 100644
 --- a/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
 +++ b/node_modules/@hemilabs/token-list/src/hemi.tokenlist.json
 @@ -340,6 +340,11 @@
@@ -43,7 +43,7 @@ index 17c1715..9968812 100644
          "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/usdt.svg"
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/usdt.svg",
-@@ -540,11 +555,16 @@
+@@ -540,10 +555,15 @@
        "decimals": 8,
        "extensions": {
          "birthBlock": 2165818,
@@ -56,20 +56,16 @@ index 17c1715..9968812 100644
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/hemibtc.svg",
 -      "name": "HemiBitcoin",
--      "symbol": "hBTC"
 +      "name": "Testnet Bitcoin",
-+      "symbol": "tBTC"
+       "symbol": "hBTC"
      },
      {
-       "address": "0x3Adf21A6cbc9ce6D5a3ea401E7Bae9499d391298",
-@@ -611,8 +631,8 @@
+@@ -611,7 +631,7 @@
          "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hdai.svg"
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/hdai.svg",
 -      "name": "Hemi Tunneled DAI",
--      "symbol": "hDAI"
 +      "name": "Dai Stablecoin",
-+      "symbol": "DAI"
+       "symbol": "hDAI"
      }
    ]
- }

--- a/patches/wallet-watch-asset+1.0.0.patch
+++ b/patches/wallet-watch-asset+1.0.0.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/wallet-watch-asset/src/index.js b/node_modules/wallet-watch-asset/src/index.js
+index f719a4c..010f7c2 100644
+--- a/node_modules/wallet-watch-asset/src/index.js
++++ b/node_modules/wallet-watch-asset/src/index.js
+@@ -29,9 +29,11 @@ async function watchAsset(provider, account, token, storage) {
+   const { address, chainId, decimals, logoURI, symbol } = token;
+ 
+   // The only wallet known so far with EIP-747 support is MetaMask.
+-  if (!provider.isMetaMask) {
+-    throw new Error("Wallet not supported");
+-  }
++  // The portal uses Viem Transport's, so we must skip this check
++  // for this package to work
++  // if (!provider.isMetaMask) {
++  //   throw new Error("Wallet not supported");
++  // }
+ 
+   const storageKey = `watchedAssets:${account}`;
+   const watchedAssets = storage?.getItem(storageKey) || "";

--- a/portal/app/[locale]/stake/_components/manageStake/index.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/index.tsx
@@ -9,6 +9,7 @@ import { Drawer } from 'components/drawer'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { type StakeOperations, type StakeToken } from 'types/stake'
+import { getTokenSymbol } from 'utils/token'
 
 import { type DrawerModes } from '../../_hooks/useDrawerStakeQueryString'
 
@@ -45,8 +46,10 @@ export const ManageStake = function ({
       subheading: t('description-manage-stake'),
     },
     stake: {
-      heading: t('stake-token', { symbol: token.symbol }),
-      subheading: t('stake-and-earn-rewards', { symbol: token.symbol }),
+      heading: t('stake-token', { symbol: getTokenSymbol(token) }),
+      subheading: t('stake-and-earn-rewards', {
+        symbol: getTokenSymbol(token),
+      }),
     },
   }[mode]
 

--- a/portal/app/[locale]/stake/_components/manageStake/operation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/operation.tsx
@@ -3,7 +3,7 @@ import { ReviewOperation } from 'components/reviewOperation'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { ReactNode } from 'react'
 import { StakeToken } from 'types/stake'
-import { parseTokenUnits } from 'utils/token'
+import { getTokenSymbol, parseTokenUnits } from 'utils/token'
 
 import { Form } from './form'
 
@@ -54,6 +54,7 @@ export const Operation = ({
           amount={parseTokenUnits(amount, token).toString()}
           callToAction={callToAction}
           steps={steps}
+          symbolRenderer={getTokenSymbol}
           token={token}
         />
       </div>

--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -11,7 +11,7 @@ import { useTranslations } from 'next-intl'
 import { StakeOperations, StakeStatusEnum, type StakeToken } from 'types/stake'
 import { getNativeToken, isNativeToken } from 'utils/nativeToken'
 import { canSubmit } from 'utils/stake'
-import { parseTokenUnits } from 'utils/token'
+import { getTokenSymbol, parseTokenUnits } from 'utils/token'
 import { formatUnits } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -104,7 +104,9 @@ export const StakeOperation = function ({
     }
 
     return {
-      description: t('common.approving-token', { symbol: token.symbol }),
+      description: t('common.approving-token', {
+        symbol: getTokenSymbol(token),
+      }),
       explorerChainId: token.chainId,
       fees: showFees
         ? {
@@ -137,7 +139,9 @@ export const StakeOperation = function ({
     ].includes(stakeStatus)
 
     return {
-      description: t('stake-page.drawer.stake-token', { symbol: token.symbol }),
+      description: t('stake-page.drawer.stake-token', {
+        symbol: getTokenSymbol(token),
+      }),
       explorerChainId: token.chainId,
       fees: showFees
         ? {

--- a/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
@@ -12,7 +12,7 @@ import {
 } from 'types/stake'
 import { getNativeToken } from 'utils/nativeToken'
 import { canSubmit } from 'utils/stake'
-import { parseTokenUnits } from 'utils/token'
+import { getTokenSymbol, parseTokenUnits } from 'utils/token'
 import { formatUnits } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -97,7 +97,9 @@ export const UnstakeOperation = function ({
   }
 
   const unstakeStep: StepPropsWithoutPosition = {
-    description: t('stake-page.drawer.unstake-token', { symbol: token.symbol }),
+    description: t('stake-page.drawer.unstake-token', {
+      symbol: getTokenSymbol(token),
+    }),
     explorerChainId: token.chainId,
     fees:
       unstakeStatus === UnstakeStatusEnum.UNSTAKE_TX_PENDING

--- a/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -18,6 +18,7 @@ import { useTranslations } from 'next-intl'
 import { MouseEvent, useMemo } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { StakeToken } from 'types/stake'
+import { getTokenSymbol } from 'utils/token'
 
 import { useDrawerStakeQueryString } from '../../_hooks/useDrawerStakeQueryString'
 import { ProtocolImage } from '../protocolImage'
@@ -45,7 +46,7 @@ const columnsBuilder = (
     cell: ({ row }) => (
       <div className="flex items-center justify-center space-x-2">
         <TokenLogo size="small" token={row.original} />
-        <span className="text-neutral-950">{row.original.symbol}</span>
+        <span className="text-neutral-950">{getTokenSymbol(row.original)}</span>
       </div>
     ),
     header: () => <Header text={t('asset')} />,

--- a/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -22,6 +22,7 @@ import { MouseEvent, RefObject, useMemo, useRef } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { StakeToken } from 'types/stake'
 import { sortTokens } from 'utils/sortTokens'
+import { getTokenSymbol } from 'utils/token'
 import { queryStringObjectToString } from 'utils/url'
 
 import { ProtocolImage } from '../../../_components/protocolImage'
@@ -160,7 +161,7 @@ const columnsBuilder = (
     cell: ({ row }) => (
       <div className="flex items-center justify-center space-x-2">
         <TokenLogo size="small" token={row.original} />
-        <span className="text-neutral-950">{row.original.symbol}</span>
+        <span className="text-neutral-950">{getTokenSymbol(row.original)}</span>
       </div>
     ),
     header: () => <Header text={t('asset')} />,

--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -10,7 +10,7 @@ import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
 import { formatEvmAddress } from 'utils/format'
-import { parseTokenUnits } from 'utils/token'
+import { getTunnelTokenSymbol, parseTokenUnits } from 'utils/token'
 import { walletIsConnected } from 'utils/wallet'
 
 import { useMinDepositSats } from '../_hooks/useMinDepositSats'
@@ -141,7 +141,7 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
               tooltipText={t(
                 'tunnel-page.form.hemi-receiving-address-description',
                 {
-                  symbol: state.fromToken.symbol,
+                  symbol: getTunnelTokenSymbol(state.fromToken),
                 },
               )}
             />

--- a/portal/app/[locale]/tunnel/_components/form.tsx
+++ b/portal/app/[locale]/tunnel/_components/form.tsx
@@ -10,6 +10,7 @@ import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { FormEvent, ReactNode } from 'react'
 import { isEvmNetworkId } from 'utils/chain'
+import { getTunnelTokenSymbol } from 'utils/token'
 
 import { useTunnelState } from '../_hooks/useTunnelState'
 
@@ -110,7 +111,12 @@ export const FormContent = function ({
             label={t('form.receive')}
             onChange={updateFromInput}
             token={toToken}
-            tokenSelector={<TokenSelectorReadOnly token={toToken} />}
+            tokenSelector={
+              <TokenSelectorReadOnly
+                symbolRenderer={getTunnelTokenSymbol}
+                token={toToken}
+              />
+            }
             // Tunnelling goes 1:1, so output equals input
             value={fromInput}
           />

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/addTokenToWallet.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/addTokenToWallet.tsx
@@ -1,0 +1,97 @@
+import { useMutation } from '@tanstack/react-query'
+import { useHemi } from 'hooks/useHemi'
+import { useUmami } from 'hooks/useUmami'
+import { useWatchedAsset } from 'hooks/useWatchedAsset'
+import { useTranslations } from 'next-intl'
+import { ComponentProps } from 'react'
+import { EvmToken } from 'types/token'
+import { isNativeToken } from 'utils/nativeToken'
+import { type Address } from 'viem'
+import { useAccount, useSwitchChain, useWalletClient } from 'wagmi'
+import watchAsset from 'wallet-watch-asset'
+
+type Props = {
+  token: EvmToken
+}
+
+const PlusIcon = (props: ComponentProps<'svg'>) => (
+  <svg
+    fill="none"
+    height="16"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      clipRule="evenodd"
+      d="M8 15C9.85652 15 11.637 14.2625 12.9497 12.9497C14.2625 11.637 15 9.85652 15 8C15 6.14348 14.2625 4.36301 12.9497 3.05025C11.637 1.7375 9.85652 1 8 1C6.14348 1 4.36301 1.7375 3.05025 3.05025C1.7375 4.36301 1 6.14348 1 8C1 9.85652 1.7375 11.637 3.05025 12.9497C4.36301 14.2625 6.14348 15 8 15ZM8.75 4.75V7.25H11.25C11.4489 7.25 11.6397 7.32902 11.7803 7.46967C11.921 7.61032 12 7.80109 12 8C12 8.19891 11.921 8.38968 11.7803 8.53033C11.6397 8.67098 11.4489 8.75 11.25 8.75H8.75V11.25C8.75 11.4489 8.67098 11.6397 8.53033 11.7803C8.38968 11.921 8.19891 12 8 12C7.80109 12 7.61032 11.921 7.46967 11.7803C7.32902 11.6397 7.25 11.4489 7.25 11.25V8.75H4.75C4.55109 8.75 4.36032 8.67098 4.21967 8.53033C4.07902 8.38968 4 8.19891 4 8C4 7.80109 4.07902 7.61032 4.21967 7.46967C4.36032 7.32902 4.55109 7.25 4.75 7.25H7.25V4.75C7.25 4.55109 7.32902 4.36032 7.46967 4.21967C7.61032 4.07902 7.80109 4 8 4C8.19891 4 8.38968 4.07902 8.53033 4.21967C8.67098 4.36032 8.75 4.55109 8.75 4.75Z"
+      fill="#FF6C15"
+      fillRule="evenodd"
+    />
+  </svg>
+)
+
+export const AddTokenToWallet = function ({ token }: Props) {
+  const { address, chainId } = useAccount()
+  const hemi = useHemi()
+  const { switchChainAsync } = useSwitchChain()
+  const t = useTranslations('tunnel-page.review-deposit')
+  const { track } = useUmami()
+  const { data: walletClient } = useWalletClient()
+  const isTokenAdded = useWatchedAsset(token.address)
+
+  const { mutate, status } = useMutation({
+    async mutationFn() {
+      // users must be connected to hemi to add tokens.
+      if (chainId !== hemi.id) {
+        await switchChainAsync({ chainId: hemi.id })
+      }
+      track?.('save token wallet - init', { address: token.address })
+      return watchAsset(
+        walletClient,
+        address,
+        {
+          ...token,
+          address: token.address as Address,
+          // token logos include the small Hemi logo, but wallets crop it.
+          // Besides, many wallets add the chain logo anyways, so we're safe to
+          // use the L1 logo version
+          logoURI: token.extensions.l1LogoURI,
+        },
+        localStorage,
+      )
+    },
+    onError: () =>
+      track?.('save token wallet - error', { address: token.address }),
+    onSuccess: () =>
+      track?.('save token wallet - ok', { address: token.address }),
+  })
+
+  // only show the button if the token is an ERC20, and if it wasn't previously added.
+  // Note that if it was just added, status is "success", thus preventing to hide the
+  // success message.
+  if (isNativeToken(token) || (isTokenAdded && status === 'idle')) {
+    return null
+  }
+
+  const canAdd = !['pending', 'success'].includes(status)
+
+  function addToken() {
+    if (canAdd) {
+      mutate()
+    }
+  }
+
+  return (
+    <button
+      className="group/add-token mx-auto flex w-full cursor-pointer items-center justify-center gap-x-2 pt-4 text-sm font-medium text-orange-500 hover:text-orange-700"
+      disabled={!canAdd}
+      onClick={addToken}
+      type="button"
+    >
+      <PlusIcon className="group-hover/add-token:[&>path]:fill-orange-700" />
+      <span>{t(`add-token-to-wallet-${status}`)}</span>
+    </button>
+  )
+}

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/operation.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/operation.tsx
@@ -3,6 +3,7 @@ import { ReviewOperation } from 'components/reviewOperation'
 import { Amount } from 'components/reviewOperation/amount'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { ComponentProps, ReactNode } from 'react'
+import { getTunnelTokenSymbol } from 'utils/token'
 
 type Props = {
   callToAction?: ReactNode
@@ -35,6 +36,7 @@ export const Operation = ({
       bottomSection={bottomSection}
       callToAction={callToAction}
       steps={steps}
+      symbolRenderer={getTunnelTokenSymbol}
       token={token}
     />
   </>

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
@@ -20,6 +20,7 @@ import { formatUnits } from 'viem'
 import { useEstimateDepositFees } from '../../_hooks/useEstimateDepositFees'
 import { RetryEvmDeposit } from '../retryEvmDeposit'
 
+import { AddTokenToWallet } from './addTokenToWallet'
 import { ChainIcon } from './chainIcon'
 import { ChainLabel } from './chainLabel'
 import { Operation } from './operation'
@@ -181,9 +182,24 @@ const ReviewContent = function ({
   steps.push(getDepositStep())
   steps.push(getFundsHemiStep())
 
+  const addToken = function () {
+    // Only show the option to add the token if the deposit is either completed,
+    // or the user is waiting for the tokens to be minted on Hemi.
+    if (
+      ![
+        EvmDepositStatus.DEPOSIT_TX_CONFIRMED,
+        EvmDepositStatus.DEPOSIT_RELAYED,
+      ].includes(depositStatus)
+    ) {
+      return null
+    }
+    return <AddTokenToWallet token={toToken} />
+  }
+
   return (
     <Operation
       amount={deposit.amount}
+      bottomSection={addToken()}
       callToAction={getCallToAction(deposit)}
       heading={t('review-deposit')}
       onClose={onClose}

--- a/portal/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/withdraw.tsx
@@ -16,7 +16,11 @@ import Skeleton from 'react-loading-skeleton'
 import { isEvmNetwork } from 'utils/chain'
 import { formatBtcAddress } from 'utils/format'
 import { getNativeToken, isNativeToken } from 'utils/nativeToken'
-import { parseTokenUnits, tunnelsThroughPartners } from 'utils/token'
+import {
+  getTunnelTokenSymbol,
+  parseTokenUnits,
+  tunnelsThroughPartners,
+} from 'utils/token'
 import { walletIsConnected } from 'utils/wallet'
 import { formatUnits } from 'viem'
 import { useAccount } from 'wagmi'
@@ -196,7 +200,7 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
             tooltipText={t(
               'tunnel-page.form.bitcoin-receiving-address-description',
               {
-                symbol: toToken.symbol,
+                symbol: getTunnelTokenSymbol(toToken),
               },
             )}
           />

--- a/portal/app/[locale]/tunnel/_utils/index.ts
+++ b/portal/app/[locale]/tunnel/_utils/index.ts
@@ -2,7 +2,7 @@ import Big from 'big.js'
 import { validateInput } from 'components/tokenInput/utils'
 import { RemoteChain } from 'types/chain'
 import { Token } from 'types/token'
-import { parseTokenUnits } from 'utils/token'
+import { getTunnelTokenSymbol, parseTokenUnits } from 'utils/token'
 import { formatUnits } from 'viem'
 
 type CanSubmit = Parameters<typeof validateInput>[0] & {
@@ -25,6 +25,7 @@ export const validateSubmit = function ({
     balance,
     minAmount,
     operation,
+    symbolRenderer: getTunnelTokenSymbol,
     t,
     token,
   })

--- a/portal/app/[locale]/tunnel/transaction-history/_components/amount.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/amount.tsx
@@ -3,6 +3,7 @@ import { TokenLogo } from 'components/tokenLogo'
 import { useToken } from 'hooks/useToken'
 import Skeleton from 'react-loading-skeleton'
 import { TunnelOperation } from 'types/tunnel'
+import { getTunnelTokenSymbol } from 'utils/token'
 import { isDeposit } from 'utils/tunnel'
 import { formatUnits } from 'viem'
 
@@ -38,6 +39,7 @@ export const Amount = function ({ operation }: Props) {
       <DisplayAmount
         amount={formatUnits(BigInt(amount), token.decimals)}
         showSymbol={false}
+        symbolRenderer={getTunnelTokenSymbol}
         token={token}
       />
     </div>

--- a/portal/app/analyticsEvents.ts
+++ b/portal/app/analyticsEvents.ts
@@ -134,6 +134,10 @@ const analyticsEvents = [
   'custom erc20 - cancel',
   'custom erc20 - open modal',
   'custom erc20 - save token',
+  // save tokens in user's wallet
+  'save token wallet - error',
+  'save token wallet - init',
+  'save token wallet - ok',
 ] as const
 
 type AnalyticsEvents = typeof analyticsEvents
@@ -150,12 +154,15 @@ type AnalyticsEventsWithWallet = Extract<
   | 'evm disconnected'
 >
 
-// These events require a custom ERC20 address
-type AnalyticsEventsWithCustomERC20 = Extract<
+// These events require an ERC20 address
+type AnalyticsEventsWithERC20 = Extract<
   AnalyticsEvent,
   | 'custom erc20 - cancel'
   | 'custom erc20 - open modal'
   | 'custom erc20 - save token'
+  | 'save token wallet - error'
+  | 'save token wallet - init'
+  | 'save token wallet - ok'
 >
 
 // this event requires a partner name
@@ -172,7 +179,7 @@ type PartnerBridgeData = { partner: string }
 type EventDataMap = {
   [K in AnalyticsEvent]: K extends AnalyticsEventsWithWallet
     ? WalletChainData
-    : K extends AnalyticsEventsWithCustomERC20
+    : K extends AnalyticsEventsWithERC20
       ? CustomERC20Data
       : K extends AnalyticsEventsWithPartnerBridge
         ? PartnerBridgeData

--- a/portal/components/customTunnelsThroughPartners/index.tsx
+++ b/portal/components/customTunnelsThroughPartners/index.tsx
@@ -2,6 +2,7 @@ import { Drawer, DrawerParagraph, DrawerTopSection } from 'components/drawer'
 import { WarningBox } from 'components/warningBox'
 import { useTranslations } from 'next-intl'
 import { Token } from 'types/token'
+import { getTunnelTokenSymbol } from 'utils/token'
 
 import { Meson } from './meson'
 import { Stargate } from './stargate'
@@ -25,12 +26,16 @@ export const CustomTunnelsThroughPartners = function ({
     <Drawer onClose={onClose}>
       <div className="drawer-content max-md:pb-16 md:h-full">
         <DrawerTopSection
-          heading={t(`${operation}.heading`, { symbol: fromToken.symbol })}
+          heading={t(`${operation}.heading`, {
+            symbol: getTunnelTokenSymbol(fromToken),
+          })}
           onClose={onClose}
         />
         <div className="mb-3">
           <DrawerParagraph>
-            {t(`${operation}.subheading`, { symbol: fromToken.symbol })}
+            {t(`${operation}.subheading`, {
+              symbol: getTunnelTokenSymbol(fromToken),
+            })}
           </DrawerParagraph>
         </div>
         <div className="mb-3 space-y-4">

--- a/portal/components/displayAmount.tsx
+++ b/portal/components/displayAmount.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from 'components/tooltip'
 import { ComponentType, Fragment, ReactNode } from 'react'
 import { Token } from 'types/token'
 import { formatNumber } from 'utils/format'
+import { getTokenSymbol } from 'utils/token'
 
 type CustomContainer = ComponentType<{
   children?: ReactNode
@@ -20,6 +21,7 @@ type Props = {
   symbolContainer?: CustomContainer
   showSymbol?: boolean
   showTokenLogo?: boolean
+  symbolRenderer?: (token: Token) => string
   token: Token
 }
 
@@ -30,6 +32,7 @@ export const DisplayAmount = function ({
   showSymbol = true,
   showTokenLogo = true,
   symbolContainer: SymbolContainer = DefaultTextContainer,
+  symbolRenderer = getTokenSymbol,
   token,
 }: Props) {
   const formattedAmount = formatNumber(amount)
@@ -40,7 +43,7 @@ export const DisplayAmount = function ({
   const showDots = bigAmount.lt(1) && notZero && formattedAmount !== amount
   return (
     <Tooltip
-      id={`amount-tooltip-${token.symbol}`}
+      id={`amount-tooltip-${token.name}`}
       overlay={
         notZero ? (
           <div className="flex items-center gap-x-1 px-2 py-1 text-sm font-medium text-white">
@@ -51,7 +54,7 @@ export const DisplayAmount = function ({
             }).format(
               // @ts-expect-error NumberFormat.format accept strings, typings are wrong. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#parameters
               amount,
-            )} ${token.symbol}`}</span>
+            )} ${symbolRenderer(token)}`}</span>
           </div>
         ) : null
       }
@@ -61,7 +64,7 @@ export const DisplayAmount = function ({
           showDots ? '...' : ''
         }`}</AmountContainer>
         {showSymbol ? (
-          <SymbolContainer>{` ${token.symbol}`}</SymbolContainer>
+          <SymbolContainer>{` ${symbolRenderer(token)}`}</SymbolContainer>
         ) : null}
       </Container>
     </Tooltip>

--- a/portal/components/reviewOperation/amount.tsx
+++ b/portal/components/reviewOperation/amount.tsx
@@ -6,11 +6,12 @@ import { Token } from 'types/token'
 import { formatUnits } from 'viem'
 
 type Props = {
+  symbolRenderer?: (token: Token) => string
   token?: Token
   value: string
 }
 
-export const Amount = function ({ token, value }: Props) {
+export const Amount = function ({ symbolRenderer, token, value }: Props) {
   const t = useTranslations('common')
   return (
     <div className="flex items-center justify-between text-sm font-medium">
@@ -18,6 +19,7 @@ export const Amount = function ({ token, value }: Props) {
       <div className="text-neutral-950">
         <DisplayAmount
           amount={formatUnits(BigInt(value), token?.decimals ?? 18)}
+          symbolRenderer={symbolRenderer}
           token={token}
         />
       </div>

--- a/portal/components/reviewOperation/index.tsx
+++ b/portal/components/reviewOperation/index.tsx
@@ -1,5 +1,6 @@
 import { DrawerSection } from 'components/drawer'
 import { ComponentProps, ReactNode } from 'react'
+import { Token } from 'types/token'
 
 import { Amount } from './amount'
 import { CallToActionContainer } from './callToActionContainer'
@@ -9,6 +10,7 @@ type Props = {
   bottomSection?: ReactNode
   callToAction?: ReactNode
   steps: StepPropsWithoutPosition[]
+  symbolRenderer?: (token: Token) => string
 } & Omit<ComponentProps<typeof Amount>, 'value'> & {
     // rename value to amount
     amount: ComponentProps<typeof Amount>['value']
@@ -19,12 +21,13 @@ export const ReviewOperation = ({
   bottomSection,
   callToAction,
   steps,
+  symbolRenderer,
   token,
 }: Props) => (
   <>
     <div className="skip-parent-padding-x mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto">
       <DrawerSection>
-        <Amount token={token} value={amount} />
+        <Amount symbolRenderer={symbolRenderer} token={token} value={amount} />
         <div
           className="mt-4 flex flex-col gap-y-8"
           // use this to prevent layout shift for the gray container

--- a/portal/components/tokenLogo.tsx
+++ b/portal/components/tokenLogo.tsx
@@ -48,7 +48,7 @@ export function TokenLogo({ size, token }: Props) {
   return token.logoURI ? (
     <div className={`relative ${sizes[size]}`}>
       <Image
-        alt={`${token.symbol} Logo`}
+        alt={`${token.name} Logo`}
         className="w-full"
         height={20}
         src={token.logoURI}

--- a/portal/components/tokenSelector/index.tsx
+++ b/portal/components/tokenSelector/index.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { RemoteChain } from 'types/chain'
 import { Token } from 'types/token'
+import { getTunnelTokenSymbol } from 'utils/token'
 
 import { Chevron } from '../icons/chevron'
 import { TokenLogo } from '../tokenLogo'
@@ -66,7 +67,9 @@ export const TokenSelector = function ({
         type="button"
       >
         <TokenLogo size="small" token={selectedToken} />
-        <span className="text-neutral-950">{selectedToken.symbol}</span>
+        <span className="text-neutral-950">
+          {getTunnelTokenSymbol(selectedToken)}
+        </span>
         {tokens.length > 1 && (
           <Chevron.Bottom className="ml-auto flex-shrink-0 [&>path]:fill-neutral-500 [&>path]:group-hover/token-selector:fill-neutral-950" />
         )}

--- a/portal/components/tokenSelector/readonly.tsx
+++ b/portal/components/tokenSelector/readonly.tsx
@@ -1,13 +1,20 @@
 import { TokenLogo } from 'components/tokenLogo'
 import { Token } from 'types/token'
+import { getTokenSymbol } from 'utils/token'
 
 type Props = {
+  symbolRenderer?: (token: Token) => string
   token: Token
 }
 
-export const TokenSelectorReadOnly = ({ token }: Props) => (
+export const TokenSelectorReadOnly = ({
+  symbolRenderer = getTokenSymbol,
+  token,
+}: Props) => (
   <div className="flex items-center justify-between gap-x-2">
     <TokenLogo size="small" token={token} />
-    <span className="font-medium text-neutral-950">{token.symbol}</span>
+    <span className="font-medium text-neutral-950">
+      {symbolRenderer(token)}
+    </span>
   </div>
 )

--- a/portal/components/tokenSelector/token.tsx
+++ b/portal/components/tokenSelector/token.tsx
@@ -2,6 +2,7 @@ import { CustomTokenLogo } from 'components/customTokenLogo'
 import Skeleton from 'react-loading-skeleton'
 import { Token as TokenType } from 'types/token'
 import { formatEvmAddress } from 'utils/format'
+import { getTunnelTokenSymbol } from 'utils/token'
 
 import { Balance } from '../cryptoBalance'
 import { FiatBalance } from '../fiatBalance'
@@ -53,7 +54,7 @@ export const Token = ({ token }: { token: TokenType }) => (
         <Balance token={token} />
       </div>
       <div className="flex items-center justify-between text-neutral-500">
-        <span>{token.symbol}</span>
+        <span>{getTunnelTokenSymbol(token)}</span>
         <div className="flex items-center gap-x-1 font-normal">
           <span>$</span>
           <FiatBalance token={token} />

--- a/portal/components/tokenSelector/tokenList.tsx
+++ b/portal/components/tokenSelector/tokenList.tsx
@@ -13,6 +13,7 @@ import partition from 'lodash/partition'
 import { useTranslations } from 'next-intl'
 import { type JSX, useRef, useState } from 'react'
 import { Token as TokenType } from 'types/token'
+import { getTunnelTokenSymbol } from 'utils/token'
 import { type Chain, isAddress, isAddressEqual } from 'viem'
 
 import { NoTokensMatch } from './noTokensMatch'
@@ -117,7 +118,7 @@ const List = function ({
 }
 
 const bySymbol = (a: TokenType, b: TokenType) =>
-  a.symbol.localeCompare(b.symbol)
+  getTunnelTokenSymbol(a).localeCompare(getTunnelTokenSymbol(b))
 
 export const TokenList = function ({
   chainId,
@@ -136,7 +137,9 @@ export const TokenList = function ({
   const tokensToList = tokens.filter(
     token =>
       token.name.toLowerCase().includes(debouncedSearchText.toLowerCase()) ||
-      token.symbol.toLowerCase().includes(debouncedSearchText.toLowerCase()) ||
+      getTunnelTokenSymbol(token)
+        .toLowerCase()
+        .includes(debouncedSearchText.toLowerCase()) ||
       // allow only exact match for addresses. In most cases, they will be pasted, rather than typed
       // so no user will partially type an address
       (userTypedAddress &&

--- a/portal/hooks/useStakeTokens.ts
+++ b/portal/hooks/useStakeTokens.ts
@@ -1,17 +1,10 @@
 import { useMemo } from 'react'
 import { tokenList } from 'tokenList'
-import { StakeToken } from 'types/stake'
 import { isStakeEnabledOnTestnet } from 'utils/stake'
 import { isStakeToken } from 'utils/token'
 
 import { useHemi } from './useHemi'
 import { useNetworkType } from './useNetworkType'
-
-// Some tokens use a custom token symbol only for the stake. Replace that here.
-const replaceSymbol = (token: StakeToken) =>
-  token.extensions?.stakeSymbol
-    ? { ...token, symbol: token.extensions.stakeSymbol }
-    : token
 
 export const useStakeTokens = function () {
   const [networkType] = useNetworkType()
@@ -23,8 +16,7 @@ export const useStakeTokens = function () {
     () =>
       tokenList.tokens
         .filter(isStakeToken)
-        .filter(t => t.chainId === id && (!testnet || stakeEnabledTestnet))
-        .map(replaceSymbol),
+        .filter(t => t.chainId === id && (!testnet || stakeEnabledTestnet)),
     [id, stakeEnabledTestnet, testnet],
   )
 }

--- a/portal/hooks/useTunnelTokens.ts
+++ b/portal/hooks/useTunnelTokens.ts
@@ -1,16 +1,9 @@
 import { useMemo } from 'react'
 import { tokenList } from 'tokenList'
 import { RemoteChain } from 'types/chain'
-import { Token } from 'types/token'
 import { isTunnelToken } from 'utils/token'
 
 import { useUserTokenList } from './useUserTokenList'
-
-// Some tokens use a custom token symbol only for the tunnel. Replace that here.
-const replaceSymbol = (token: Token) =>
-  token.extensions?.tunnelSymbol
-    ? { ...token, symbol: token.extensions.tunnelSymbol }
-    : token
 
 export const useTunnelTokens = function (chainId?: RemoteChain['id']) {
   const { userTokenList } = useUserTokenList()
@@ -18,7 +11,6 @@ export const useTunnelTokens = function (chainId?: RemoteChain['id']) {
     () =>
       tokenList.tokens
         .filter(isTunnelToken)
-        .map(replaceSymbol)
         // custom user list is added through the tunnel, so by definition all tokens can be tunneled.
         .concat(userTokenList)
         .filter(t => !chainId || t.chainId === chainId),

--- a/portal/hooks/useWatchedAsset.ts
+++ b/portal/hooks/useWatchedAsset.ts
@@ -1,0 +1,22 @@
+import { EvmToken } from 'types/token'
+import useLocalStorageState from 'use-local-storage-state'
+import { useAccount } from 'wagmi'
+
+import { useHemi } from './useHemi'
+
+// See https://github.com/hemilabs/wallet-watch-asset/blob/9ac4cef8ce57b90d350ebf029ad90b195257fc90/src/index.js#L36
+export const useWatchedAsset = function (tokenAddress: EvmToken['address']) {
+  const { address } = useAccount()
+  const hemi = useHemi()
+  const [storedKeys] = useLocalStorageState<string | undefined>(
+    `watchedAssets:${address}`,
+    {
+      serializer: {
+        parse: value => value,
+        // Not really needed, but required to comply with the types.
+        stringify: (value: string) => value,
+      },
+    },
+  )
+  return !!storedKeys && storedKeys.includes(`${hemi.id}:${tokenAddress}`)
+}

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -323,6 +323,10 @@
       "to-network": "To Network"
     },
     "review-deposit": {
+      "add-token-to-wallet-error": "Failed to add the token contract to your wallet",
+      "add-token-to-wallet-idle": "Add token contract to your wallet",
+      "add-token-to-wallet-pending": "Adding token contract to your wallet...",
+      "add-token-to-wallet-success": "Token contract added to your wallet",
       "approve-confirmed": "Approve confirmed",
       "approve-initiated": "Approve initiated",
       "btc-deposit-come-back-delay-note": "If you do not receive your deposit after {hours} hours return to this page to manually claim.",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -323,6 +323,10 @@
       "to-network": "Hacia la Red"
     },
     "review-deposit": {
+      "add-token-to-wallet-error": "No se pudo agregar el contrato del token a su billetera",
+      "add-token-to-wallet-idle": "Agregar contrato del token a su billetera",
+      "add-token-to-wallet-pending": "Agregando contrato del token a su billetera...",
+      "add-token-to-wallet-success": "El contrato del token fue agregado a su billetera",
       "approve-confirmed": "Aprobación confirmada",
       "approve-initiated": "Aprobación iniciada",
       "btc-deposit-come-back-delay-note": "Si usted no recibe su depósito después de {hours} horas regrese a esta pagina para reclamarlo manualmente.",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -323,6 +323,10 @@
       "to-network": "Para a Rede"
     },
     "review-deposit": {
+      "add-token-to-wallet-error": "Falha ao adicionar o contrato do token à sua carteira",
+      "add-token-to-wallet-idle": "Adicionar contrato do token à sua carteira",
+      "add-token-to-wallet-pending": "A adicionar contrato do token à sua carteira...",
+      "add-token-to-wallet-success": "Contrato do token adicionado à sua carteira",
       "approve-confirmed": "Aprovação confirmada",
       "approve-initiated": "Aprovação iniciada",
       "btc-deposit-come-back-delay-note": "Se não receber o seu depósito após {hours} horas, regresse a esta página para reclamar manualmente.",

--- a/portal/package.json
+++ b/portal/package.json
@@ -50,7 +50,8 @@
     "use-local-storage-state": "19.5.0",
     "viem": "2.22.10",
     "viem-erc20": "1.0.1",
-    "wagmi": "2.14.8"
+    "wagmi": "2.14.8",
+    "wallet-watch-asset": "github:hemilabs/wallet-watch-asset#v1.0.0"
   },
   "devDependencies": {
     "@types/big.js": "6.2.2",

--- a/portal/test/utils/token.test.ts
+++ b/portal/test/utils/token.test.ts
@@ -5,6 +5,8 @@ import {
   isEvmToken,
   tunnelsThroughPartners,
   parseTokenUnits,
+  getTokenSymbol,
+  getTunnelTokenSymbol,
 } from 'utils/token'
 import { parseUnits as viemParseUnits } from 'viem'
 import { describe, expect, it } from 'vitest'
@@ -168,6 +170,36 @@ describe('utils/token', function () {
         token.decimals,
       )
       expect(parseTokenUnits(largeDecimalAmount, token)).toEqual(expected)
+    })
+  })
+
+  describe('getTokenSymbol', function () {
+    it('should return customSymbol if it exists in the token extensions', function () {
+      const token = {
+        ...baseToken,
+        extensions: { customSymbol: 'cBTC' },
+        symbol: 'BTC',
+      }
+      expect(getTokenSymbol(token)).toBe(token.extensions.customSymbol)
+    })
+
+    it('should return the token symbol if customSymbol does not exist in extensions', function () {
+      expect(getTokenSymbol(baseToken)).toBe(baseToken.symbol)
+    })
+  })
+
+  describe('getTunnelTokenSymbol', function () {
+    it('should return tunnelSymbol if it exists in the token extensions', function () {
+      const token = {
+        ...baseToken,
+        extensions: { customSymbol: 'cBTC', tunnelSymbol: 'tBTC' },
+        symbol: 'BTC',
+      }
+      expect(getTunnelTokenSymbol(token)).toBe(token.extensions.tunnelSymbol)
+    })
+
+    it('should fall back to getTokenSymbol when no tunnel exist', function () {
+      expect(getTunnelTokenSymbol(baseToken)).toBe(getTokenSymbol(baseToken))
     })
   })
 })

--- a/portal/tokenList/customSymbols.ts
+++ b/portal/tokenList/customSymbols.ts
@@ -1,0 +1,40 @@
+import { hemi, hemiSepolia } from 'hemi-viem'
+import { Extensions } from 'types/token'
+import { Chain } from 'viem'
+
+export const customSymbolsList: Partial<
+  Record<Chain['id'], Record<string, Pick<Extensions, 'customSymbol'>>>
+> = {
+  // Prefer ordering by symbol in comments, instead of by address, which makes it harder
+  // to search for a specific token.
+  /* eslint-disable sort-keys */
+  [hemi.id]: {
+    // brBTC
+    '0x93919784C523f39CACaa98Ee0a9d96c3F32b593e': {
+      customSymbol: 'brBTC',
+    },
+    // egETH
+    '0x027a9d301FB747cd972CFB29A63f3BDA551DFc5c': {
+      customSymbol: 'egETH',
+    },
+    // MBTC - Liquid Staked BTC
+    '0x0Af3EC6F9592C193196bEf220BC0Ce4D9311527D': {
+      customSymbol: 'mBTC',
+    },
+    // USDT
+    '0xbB0D083fb1be0A9f6157ec484b6C79E0A4e31C2e': {
+      customSymbol: 'USDT',
+    },
+  },
+  [hemiSepolia.id]: {
+    // DAI
+    '0xec46E0EFB2EA8152da0327a5Eb3FF9a43956F13e': {
+      customSymbol: 'DAI',
+    },
+    // hemiBTC
+    '0x36Ab5Dba83d5d470F670BC4c06d7Da685d9afAe7': {
+      customSymbol: 'tBTC',
+    },
+  },
+  /* eslint-disable sort-keys */
+}

--- a/portal/tokenList/customTunnelPartnersWhitelist.ts
+++ b/portal/tokenList/customTunnelPartnersWhitelist.ts
@@ -29,7 +29,6 @@ export const customTunnelPartnersWhitelist: Partial<
     // USDT
     '0xbB0D083fb1be0A9f6157ec484b6C79E0A4e31C2e': {
       tunnelPartners: ['meson', 'stargate'],
-      tunnelSymbol: 'USDT',
     },
   },
 }

--- a/portal/tokenList/index.ts
+++ b/portal/tokenList/index.ts
@@ -5,6 +5,7 @@ import { type RemoteChain } from 'types/chain'
 import { type EvmToken, type Token } from 'types/token'
 import { type Address } from 'viem'
 
+import { customSymbolsList } from './customSymbols'
 import { customTunnelPartnersWhitelist } from './customTunnelPartnersWhitelist'
 import { nativeTokens } from './nativeTokens'
 import { priceWhiteList } from './priceTokens'
@@ -70,6 +71,7 @@ export const tokenList = {
   timestamp: hemilabsTokenList.timestamp,
   tokens: tokens
     .concat(nativeTokens)
+    .map(extendWithWhiteList(customSymbolsList))
     .map(extendWithWhiteList(customTunnelPartnersWhitelist))
     .map(extendWithWhiteList(priceWhiteList))
     .map(extendWithWhiteList(stakeWhiteList))

--- a/portal/tokenList/stakeTokens.ts
+++ b/portal/tokenList/stakeTokens.ts
@@ -14,7 +14,6 @@ export const stakeWhiteList: Partial<
     '0x93919784C523f39CACaa98Ee0a9d96c3F32b593e': {
       protocol: 'bedRock',
       rewards: ['hemi', 'bedrock'],
-      stakeSymbol: 'brBTC',
       website: 'https://www.bedrock.technology',
     },
     // DAI
@@ -27,7 +26,6 @@ export const stakeWhiteList: Partial<
     '0x027a9d301FB747cd972CFB29A63f3BDA551DFc5c': {
       protocol: 'egEth',
       rewards: ['hemi2x', 'eigenpie'],
-      stakeSymbol: 'egETH',
       website: 'https://www.eigenlayer.magpiexyz.io/restake',
     },
     // enzoBTC
@@ -58,7 +56,6 @@ export const stakeWhiteList: Partial<
     '0x0Af3EC6F9592C193196bEf220BC0Ce4D9311527D': {
       protocol: 'babypie',
       rewards: ['hemi2x', 'babypie'],
-      stakeSymbol: 'mBTC',
       website: 'https://www.babylon.magpiexyz.io/stake',
     },
     // M-BTC

--- a/portal/types/token.ts
+++ b/portal/types/token.ts
@@ -5,19 +5,19 @@ type TunnelPartners = 'meson' | 'stargate'
 
 export type Extensions = {
   birthBlock?: number
-  l1LogoURI?: string
   bridgeInfo?: {
     [keyof: string]: {
       tokenAddress?: Address
     }
   }
+  // use this to replace the symbol across the entire UI
+  customSymbol?: string
+  l1LogoURI?: string
   protocol?: string
   // Use this to map which symbol should be used to map prices
   priceSymbol?: string
-  // Custom token symbol to show in the Stake
-  stakeSymbol?: string
   tunnel?: boolean
-  // Custom token symbol to show in the Tunnel
+  // Custom token symbol to show in the Tunnel page only
   tunnelSymbol?: string
   tunnelPartners?: TunnelPartners[]
 }

--- a/portal/utils/sortTokens.ts
+++ b/portal/utils/sortTokens.ts
@@ -1,6 +1,6 @@
 import Big from 'big.js'
 import { StakeToken } from 'types/stake'
-import { getTokenPrice } from 'utils/token'
+import { getTokenPrice, getTokenSymbol } from 'utils/token'
 import { formatUnits } from 'viem'
 
 const hasBalance = (token: StakeToken): boolean =>
@@ -60,6 +60,6 @@ export const sortTokens = function (
       return bUsdValue - aUsdValue
     }
 
-    return a.symbol.localeCompare(b.symbol)
+    return getTokenSymbol(a).localeCompare(getTokenSymbol(b))
   })
 }

--- a/portal/utils/token.ts
+++ b/portal/utils/token.ts
@@ -138,3 +138,16 @@ export const parseTokenUnits = function (amount: string, token: Token) {
     : whole
   return viemParseUnits(normalizedAmount, token.decimals)
 }
+
+export const getTokenSymbol = function (token: Token) {
+  const { extensions = {}, symbol } = token
+  if (extensions.customSymbol) {
+    return extensions.customSymbol
+  }
+  return symbol
+}
+
+export const getTunnelTokenSymbol = (token: Token) =>
+  token.extensions?.tunnelSymbol
+    ? token.extensions.tunnelSymbol
+    : getTokenSymbol(token)


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the functionality to save hemi tokens into the user's wallet.  Changes:

- a89c13b193bfcade44cbb93be6f63c6333db1099 Adding a token to the wallet requires that the symbol and decimals match what the contract says. However, we were patching some symbols in the tokens definition to show a better symbol in the app (For example, in testnet, `DAI` is `hDAI` in the contract). This commit makes changes so the symbol change does not take place on the token definition, but on the UI that needs to be rendered. This required propagating the change to many places, both in the tunnel and in stake. This also meant reverting some of the changes that were patching the `@hemilabs/token-list`. Also note that particularly `USDC` is shown as `USDC` in the tunnel but as `USDC.e` in stake (as required from Matt Lam time ago), so this made it a little bit more complex to maintain.
- aad2d404821d6284986818d081057cf90ce009d1 With the previous change applied, this commit adds the logic to save Hemi tokens into the user wallet after depositing (from Ethereum or from Bitcoin) is completed.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/3e1da921-91ed-4285-a568-9428d9fc9ffd


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #876 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
