### PR TITLE
Fix bad CORS glob-to-regexp code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28988,7 +28988,7 @@
     },
     "portal-backend/api": {
       "name": "portal-backend",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "cors": "2.8.5",
         "esplora-client": "1.2.0",

--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "dependencies": {
     "cors": "2.8.5",
     "esplora-client": "1.2.0",

--- a/portal-backend/api/server.js
+++ b/portal-backend/api/server.js
@@ -18,7 +18,7 @@ const app = express()
 const origin = config
   .get('origins')
   .split(',')
-  .map(o => (/\*/.test(o) ? globToRegExp : o))
+  .map(o => (/\*/.test(o) ? globToRegExp(o) : o))
 
 app.use(cors({ origin }))
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The code that parsed the origins to get the CORS config was returning the `globToRegex` function instead of the result of applying it to the given origin. 🤦🏼‍♂️ 

This PR fixes that.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Fixes #1387 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
