### PR TITLE
Limit permissions on gh actions

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -8,6 +8,9 @@ on:
       - 'portal-backend/**'
       - 'subgraph-api/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-checks.yml
+++ b/.github/workflows/docker-checks.yml
@@ -10,6 +10,9 @@ on:
       - 'portal-backend/**'
       - 'subgraph-api/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true

--- a/.github/workflows/hostinger-deployment.yml
+++ b/.github/workflows/hostinger-deployment.yml
@@ -8,6 +8,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: false


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR limits permissions on the workflows to read only (after all, none of these require permission to update the repo). This should solve the security improvements in the [code-scanning section](https://github.com/hemilabs/ui-monorepo/security/code-scanning)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
