### PR TITLE
Split stake toast from toast component

### DIFF
--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -2,11 +2,13 @@ import { DrawerParagraph } from 'components/drawer'
 import { ProgressStatus } from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { Spinner } from 'components/spinner'
+import { ToastLoader } from 'components/toast/toastLoader'
 import { stakeManagerAddresses } from 'hemi-viem-stake-actions'
 import { useAllowance } from 'hooks/useAllowance'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useHemi } from 'hooks/useHemi'
+import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { StakeOperations, StakeStatusEnum, type StakeToken } from 'types/stake'
 import { getNativeToken, isNativeToken } from 'utils/nativeToken'
@@ -18,7 +20,14 @@ import { useAccount } from 'wagmi'
 import { useAmount } from '../../_hooks/useAmount'
 import { useEstimateStakeFees } from '../../_hooks/useEstimateStakeFees'
 import { useStake } from '../../_hooks/useStake'
-import { StakeToast } from '../stakeToast'
+
+const StakeToast = dynamic(
+  () => import('../stakeToast').then(mod => mod.StakeToast),
+  {
+    loading: () => <ToastLoader />,
+    ssr: false,
+  },
+)
 
 import { Fees } from './fees'
 import { StakeMaxBalance } from './maxBalance'

--- a/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
@@ -1,6 +1,7 @@
 import { ProgressStatus } from 'components/reviewOperation/progressStatus'
 import { StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { Spinner } from 'components/spinner'
+import { ToastLoader } from 'components/toast/toastLoader'
 import { useHemi } from 'hooks/useHemi'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
@@ -20,7 +21,14 @@ import { useAmount } from '../../_hooks/useAmount'
 import { useEstimateUnstakeFees } from '../../_hooks/useEstimateUnstakeFees'
 import { useStakedBalance } from '../../_hooks/useStakedBalance'
 import { useUnstake } from '../../_hooks/useUnstake'
-import { StakeToast } from '../stakeToast'
+
+const StakeToast = dynamic(
+  () => import('../stakeToast').then(mod => mod.StakeToast),
+  {
+    loading: () => <ToastLoader />,
+    ssr: false,
+  },
+)
 
 import { Fees } from './fees'
 import { UnstakeMaxBalance } from './maxBalance'

--- a/portal/app/[locale]/stake/_components/stakeToast.tsx
+++ b/portal/app/[locale]/stake/_components/stakeToast.tsx
@@ -18,26 +18,33 @@ export const StakeToast = function ({ chainId, txHash, type }: Props) {
 
   const t = useTranslations('stake-page.toast')
 
+  const tx = {
+    href: `${blockExplorer.url}/tx/${txHash}`,
+    label: formatEvmHash(txHash),
+  }
+
+  if (type === 'stake') {
+    return (
+      <Toast
+        description={t('here-your-stake-tx', {
+          type: t('staking'),
+        })}
+        goTo={{
+          href: '/stake/dashboard',
+          label: t('go-staking-dashboard'),
+        }}
+        title={t('staking-successful')}
+        tx={tx}
+      />
+    )
+  }
   return (
     <Toast
       description={t('here-your-stake-tx', {
-        type: t(type === 'stake' ? 'staking' : 'unstaking'),
+        type: t('unstaking'),
       })}
-      goTo={
-        type === 'stake'
-          ? {
-              href: '/stake/dashboard',
-              label: t('go-staking-dashboard'),
-            }
-          : undefined
-      }
-      title={
-        type === 'stake' ? t('staking-successful') : t('unstaking-successful')
-      }
-      tx={{
-        href: `${blockExplorer.url}/tx/${txHash}`,
-        label: formatEvmHash(txHash),
-      }}
+      title={t('unstaking-successful')}
+      tx={tx}
     />
   )
 }

--- a/portal/app/[locale]/stake/_components/stakeToast.tsx
+++ b/portal/app/[locale]/stake/_components/stakeToast.tsx
@@ -1,10 +1,6 @@
-import { ExternalLink } from 'components/externalLink'
-import { CheckMark } from 'components/icons/checkMark'
-import { CloseIcon } from 'components/icons/closeIcon'
-import { Link } from 'components/link'
+import { Toast } from 'components/toast'
 import { useChain } from 'hooks/useChain'
 import { useTranslations } from 'next-intl'
-import { useEffect, useState } from 'react'
 import { RemoteChain } from 'types/chain'
 import { formatEvmHash } from 'utils/format'
 import { type Hash } from 'viem'
@@ -12,78 +8,36 @@ import { type Hash } from 'viem'
 type ToastType = 'stake' | 'unstake'
 
 type Props = {
-  autoCloseMs?: number
   chainId: RemoteChain['id']
   txHash: Hash
   type: ToastType
 }
 
-export const StakeToast = function ({
-  autoCloseMs = 5000,
-  chainId,
-  txHash,
-  type,
-}: Props) {
-  const [closedToast, setClosedToast] = useState(false)
+export const StakeToast = function ({ chainId, txHash, type }: Props) {
   const blockExplorer = useChain(chainId).blockExplorers.default
 
   const t = useTranslations('stake-page.toast')
 
-  useEffect(
-    function autoCloseToast() {
-      if (autoCloseMs) {
-        const timer = setTimeout(function closeToastAfterDelay() {
-          setClosedToast(true)
-        }, autoCloseMs)
-
-        return () => clearTimeout(timer)
-      }
-      return undefined
-    },
-    [autoCloseMs],
-  )
-
-  if (closedToast) {
-    return null
-  }
-
   return (
-    <div
-      className="shadow-soft fixed bottom-20 left-4 right-4 z-40 flex justify-between
-      gap-x-3 rounded-xl border border-solid border-black/85 bg-neutral-800 p-3.5
-    text-sm font-medium text-white md:bottom-auto md:left-auto md:right-8 md:top-20"
-    >
-      <div className="mt-1.5">
-        <CheckMark className="[&>path]:stroke-emerald-500" />
-      </div>
-      <div className="flex flex-col items-start gap-y-1.5">
-        <h5 className="text-base">
-          {type === 'stake'
-            ? t('staking-successful')
-            : t('unstaking-successful')}
-        </h5>
-        <p className="text-neutral-400 md:max-w-96">
-          {t('here-your-stake-tx', {
-            type: t(type === 'stake' ? 'staking' : 'unstaking'),
-          })}
-          <ExternalLink href={`${blockExplorer.url}/tx/${txHash}`}>
-            <span className="ml-1 text-orange-500 hover:text-orange-700">
-              {formatEvmHash(txHash)}
-            </span>
-          </ExternalLink>
-        </p>
-        {type === 'stake' && (
-          <Link
-            className="mt-1.5 cursor-pointer underline hover:text-neutral-200 hover:opacity-80"
-            href="/stake/dashboard"
-          >
-            {t('go-staking-dashboard')}
-          </Link>
-        )}
-      </div>
-      <button className="h-5 w-5" onClick={() => setClosedToast(true)}>
-        <CloseIcon className="h-full w-full [&>path]:hover:stroke-white" />
-      </button>
-    </div>
+    <Toast
+      description={t('here-your-stake-tx', {
+        type: t(type === 'stake' ? 'staking' : 'unstaking'),
+      })}
+      goTo={
+        type === 'stake'
+          ? {
+              href: '/stake/dashboard',
+              label: t('go-staking-dashboard'),
+            }
+          : undefined
+      }
+      title={
+        type === 'stake' ? t('staking-successful') : t('unstaking-successful')
+      }
+      tx={{
+        href: `${blockExplorer.url}/tx/${txHash}`,
+        label: formatEvmHash(txHash),
+      }}
+    />
   )
 }

--- a/portal/components/toast/index.tsx
+++ b/portal/components/toast/index.tsx
@@ -49,7 +49,7 @@ export const Toast = function ({
 
   return (
     <div
-      className="shadow-soft fixed bottom-20 left-4 right-4 z-40 flex justify-between
+      className="shadow-soft fixed inset-x-4 bottom-20 z-40 flex justify-between
       gap-x-3 rounded-xl border border-solid border-black/85 bg-neutral-800 p-3.5
     text-sm font-medium text-white md:bottom-auto md:left-auto md:right-8 md:top-20"
     >
@@ -75,8 +75,8 @@ export const Toast = function ({
           </Link>
         )}
       </div>
-      <button className="h-5 w-5" onClick={() => setClosedToast(true)}>
-        <CloseIcon className="h-full w-full [&>path]:hover:stroke-white" />
+      <button className="size-5" onClick={() => setClosedToast(true)}>
+        <CloseIcon className="size-full [&>path]:hover:stroke-white" />
       </button>
     </div>
   )

--- a/portal/components/toast/index.tsx
+++ b/portal/components/toast/index.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { ExternalLink } from 'components/externalLink'
+import { CheckMark } from 'components/icons/checkMark'
+import { CloseIcon } from 'components/icons/closeIcon'
+import { Link } from 'components/link'
+import { type ComponentProps, useEffect, useState } from 'react'
+
+type Props = {
+  autoCloseMs?: number
+  description: string
+  goTo?: {
+    href: ComponentProps<typeof ExternalLink>['href']
+    label: string
+  }
+  tx: {
+    href: ComponentProps<typeof ExternalLink>['href']
+    label: string
+  }
+  title: string
+}
+
+export const Toast = function ({
+  autoCloseMs = 5000,
+  description,
+  goTo,
+  title,
+  tx,
+}: Props) {
+  const [closedToast, setClosedToast] = useState(false)
+
+  useEffect(
+    function autoCloseToast() {
+      if (autoCloseMs) {
+        const timer = setTimeout(function closeToastAfterDelay() {
+          setClosedToast(true)
+        }, autoCloseMs)
+
+        return () => clearTimeout(timer)
+      }
+      return undefined
+    },
+    [autoCloseMs],
+  )
+
+  if (closedToast) {
+    return null
+  }
+
+  return (
+    <div
+      className="shadow-soft fixed bottom-20 left-4 right-4 z-40 flex justify-between
+      gap-x-3 rounded-xl border border-solid border-black/85 bg-neutral-800 p-3.5
+    text-sm font-medium text-white md:bottom-auto md:left-auto md:right-8 md:top-20"
+    >
+      <div className="mt-1.5">
+        <CheckMark className="[&>path]:stroke-emerald-500" />
+      </div>
+      <div className="flex flex-col items-start gap-y-1.5">
+        <h5 className="text-base">{title}</h5>
+        <p className="text-neutral-400 md:max-w-96">
+          {description}
+          <ExternalLink href={tx.href}>
+            <span className="ml-1 text-orange-500 hover:text-orange-700">
+              {tx.label}
+            </span>
+          </ExternalLink>
+        </p>
+        {goTo !== undefined && (
+          <Link
+            className="mt-1.5 cursor-pointer underline hover:text-neutral-200 hover:opacity-80"
+            href={goTo.href}
+          >
+            {goTo.label}
+          </Link>
+        )}
+      </div>
+      <button className="h-5 w-5" onClick={() => setClosedToast(true)}>
+        <CloseIcon className="h-full w-full [&>path]:hover:stroke-white" />
+      </button>
+    </div>
+  )
+}

--- a/portal/components/toast/toastLoader.tsx
+++ b/portal/components/toast/toastLoader.tsx
@@ -3,6 +3,6 @@ import Skeleton from 'react-loading-skeleton'
 export const ToastLoader = () => (
   <Skeleton
     className="shadow-soft h-26 w-full rounded-xl md:w-96"
-    containerClassName="fixed bottom-20 left-4 right-4 z-40 md:bottom-auto md:left-auto md:right-8 md:top-20 "
+    containerClassName="fixed bottom-20 inset-x-4 z-40 md:bottom-auto md:left-auto md:right-8 md:top-20"
   />
 )

--- a/portal/components/toast/toastLoader.tsx
+++ b/portal/components/toast/toastLoader.tsx
@@ -1,0 +1,8 @@
+import Skeleton from 'react-loading-skeleton'
+
+export const ToastLoader = () => (
+  <Skeleton
+    className="shadow-soft h-26 w-full rounded-xl md:w-96"
+    containerClassName="fixed bottom-20 left-4 right-4 z-40 md:bottom-auto md:left-auto md:right-8 md:top-20 "
+  />
+)


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

We will need the toast component _somewhere else_ (_wink wink_), and we had a toast component used exclusively for the Stake page. This PR splits that component into 2: A generic component that accepts the props, and updates the Stake component to use it.

In addition to this, I updated the toast to be loaded dynamically as it won't be shown after user interaction.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Other than the lazy loading, there are no visible changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to _mystery issue_ (?)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
