### PR TITLE
Make ArrowDownLeftIcon orange on hover

### DIFF
--- a/portal/app/[locale]/get-started/_components/fundWallet.tsx
+++ b/portal/app/[locale]/get-started/_components/fundWallet.tsx
@@ -49,7 +49,7 @@ const FundMethod = function ({
           ? t('get-testnet-tokens')
           : t('buy-sell-swap')}
       </span>
-      <ArrowDownLeftIcon className="group-hover/link:text-orange-70 [&>path]:fill-orange-500" />
+      <ArrowDownLeftIcon className="[&>path]:fill-orange-500 group-hover/link:[&>path]:fill-orange-700" />
     </ExternalLink>
   )
 }


### PR DESCRIPTION
### Description

This PR updates the ArrowDownLeftIcon used in the funding method links so that the arrow icon is initially orange by default (orange-500), and becomes a darker orange (orange-700) on hover. Previously, the icon was neutral grey unless hovered, which caused inconsistency with the primary brand color of the action buttons. This change improves visual consistency and feedback for users interacting with wallet funding actions.
### Screenshots
before hovering
<img width="1727" height="647" alt="Screenshot 2025-07-29 200604" src="https://github.com/user-attachments/assets/f2ba814c-6f2e-49ff-b8c3-08f91a1763b1" />
and now after hovering (cursor not displaying just coz i did a window capture on pc)
<img width="1604" height="596" alt="Screenshot 2025-07-29 200613" src="https://github.com/user-attachments/assets/cf982e43-45c8-499d-81b0-d0b43efabc9e" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Fixes #1413 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
