### PR TITLE
Fix wrong validation for extraInfo field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16162,15 +16162,6 @@
       "resolved": "subgraphs/hemi-tunnel-withdrawals-subgraph",
       "link": true
     },
-    "node_modules/hemi-viem": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.4.2.tgz",
-      "integrity": "sha512-VjzUL2gN+kRUg95K1vONqthfaDxpDU/rTva4aOMDwBGP8BM7F0Sm8cTeCGPcI7UzipE2KRQnYwudnXagpikysg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "viem": "^2.x"
-      }
-    },
     "node_modules/hemi-viem-stake-actions": {
       "resolved": "packages/hemi-viem-stake-actions",
       "link": true
@@ -28624,7 +28615,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "hemi-viem": "2.4.2",
+        "hemi-viem": "2.6.1",
         "viem-erc20": "1.0.1"
       },
       "devDependencies": {
@@ -28742,6 +28733,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "packages/hemi-tunnel-actions/node_modules/hemi-viem": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.6.1.tgz",
+      "integrity": "sha512-XuNAX2p8/lpk+CWks+kCgi761qxhwMkL3zpf4/8l4G1kYejOTe2IJVY1qZ/ri1T1kRp5S1r5ZG1RtJfwf0Twgw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "viem": "^2.x"
       }
     },
     "packages/hemi-tunnel-actions/node_modules/ms": {
@@ -28908,13 +28908,22 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "hemi-viem": "2.4.2"
+        "hemi-viem": "2.6.1"
       },
       "devDependencies": {
         "@tsconfig/node20": "20.1.5",
         "typescript": "5.8.3",
         "viem": "2.22.10"
       },
+      "peerDependencies": {
+        "viem": "^2.x"
+      }
+    },
+    "packages/hemi-viem-stake-actions/node_modules/hemi-viem": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.6.1.tgz",
+      "integrity": "sha512-XuNAX2p8/lpk+CWks+kCgi761qxhwMkL3zpf4/8l4G1kYejOTe2IJVY1qZ/ri1T1kRp5S1r5ZG1RtJfwf0Twgw==",
+      "license": "MIT",
       "peerDependencies": {
         "viem": "^2.x"
       }
@@ -28939,7 +28948,7 @@
         "fetch-plus-plus": "1.0.0",
         "hemi-socials": "1.0.0",
         "hemi-tunnel-actions": "1.0.0",
-        "hemi-viem": "2.4.2",
+        "hemi-viem": "2.6.1",
         "hemi-viem-stake-actions": "1.0.0",
         "lodash": "4.17.21",
         "next": "14.2.16",
@@ -28998,7 +29007,7 @@
       "dependencies": {
         "cors": "2.8.5",
         "esplora-client": "1.2.0",
-        "hemi-viem": "2.5.0",
+        "hemi-viem": "2.6.1",
         "not-express": "4.1.0",
         "promise-limit-one": "1.1.0",
         "promise-mem": "1.0.4",
@@ -29111,9 +29120,9 @@
       }
     },
     "portal-backend/api/node_modules/hemi-viem": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.5.0.tgz",
-      "integrity": "sha512-p1GLhbbFcO6Fb06cF7aCpBzuqXN64rcX7Bnig9JzyAZY0L05H2+7/Oiq+5DaAiangiose7ZyAkDJ0WJZaYF23g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.6.1.tgz",
+      "integrity": "sha512-XuNAX2p8/lpk+CWks+kCgi761qxhwMkL3zpf4/8l4G1kYejOTe2IJVY1qZ/ri1T1kRp5S1r5ZG1RtJfwf0Twgw==",
       "license": "MIT",
       "peerDependencies": {
         "viem": "^2.x"
@@ -29400,6 +29409,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "portal/node_modules/hemi-viem": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hemi-viem/-/hemi-viem-2.6.1.tgz",
+      "integrity": "sha512-XuNAX2p8/lpk+CWks+kCgi761qxhwMkL3zpf4/8l4G1kYejOTe2IJVY1qZ/ri1T1kRp5S1r5ZG1RtJfwf0Twgw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "viem": "^2.x"
       }
     },
     "portal/node_modules/map-obj": {

--- a/packages/hemi-tunnel-actions/package.json
+++ b/packages/hemi-tunnel-actions/package.json
@@ -19,7 +19,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.4.2",
+    "hemi-viem": "2.6.1",
     "viem-erc20": "1.0.1"
   },
   "devDependencies": {

--- a/packages/hemi-viem-stake-actions/package.json
+++ b/packages/hemi-viem-stake-actions/package.json
@@ -19,7 +19,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.4.2"
+    "hemi-viem": "2.6.1"
   },
   "devDependencies": {
     "@tsconfig/node20": "20.1.5",

--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "cors": "2.8.5",
     "esplora-client": "1.2.0",
-    "hemi-viem": "2.5.0",
+    "hemi-viem": "2.6.1",
     "not-express": "4.1.0",
     "promise-limit-one": "1.1.0",
     "promise-mem": "1.0.4",

--- a/portal/package.json
+++ b/portal/package.json
@@ -30,7 +30,7 @@
     "fetch-plus-plus": "1.0.0",
     "hemi-socials": "1.0.0",
     "hemi-tunnel-actions": "1.0.0",
-    "hemi-viem": "2.4.2",
+    "hemi-viem": "2.6.1",
     "hemi-viem-stake-actions": "1.0.0",
     "lodash": "4.17.21",
     "next": "14.2.16",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps the version for `hemi-viem` bringing the following fix https://github.com/hemilabs/hemi-viem/pull/56
This fix will allow users again to confirm btc deposits manually

I updated all packages to use the same version of `hemi-viem` for consistency; however, it's not needed to publish the portal-api for this (There are no relevant changes)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
