### PR TITLE
Use z-0 instead of z-10 to avoid stacking issues

### DIFF
--- a/portal/components/button.tsx
+++ b/portal/components/button.tsx
@@ -20,20 +20,20 @@ const withBeforeTransition = `
 
 const variants = {
   primary: `
-    relative z-10 overflow-hidden text-white bg-button-primary
+    relative z-0 overflow-hidden text-white bg-button-primary
     border border-button-primary-custom shadow-button-primary
     disabled:bg-button-primary-disabled disabled:shadow-button-primary-disabled
     focus-visible:shadow-button-primary-focused
     ${withBeforeTransition} before:bg-button-primary-hovered
   `,
   secondary: `
-    relative z-10 overflow-hidden text-neutral-950 bg-white
+    relative z-0 overflow-hidden text-neutral-950 bg-white
     shadow-button-secondary focus-visible:shadow-button-secondary-focused
     disabled:bg-neutral-50 disabled:shadow-button-secondary-disabled
     ${withBeforeTransition} before:bg-neutral-50
   `,
   tertiary: `
-    relative z-10 overflow-hidden text-neutral-950 bg-transparent
+    relative z-0 overflow-hidden text-neutral-950 bg-transparent
     focus:bg-neutral-100 focus-visible:shadow-button-tertiary-focused
     ${withBeforeTransition} before:bg-neutral-100
   `,


### PR DESCRIPTION
### Description

This PR replaces z-10 with z-0. Using z-10 was causing the button to appear above the Header component in the staking table. The transaction history was not affected. z-0 is sufficient to preserve the hover effect while avoiding this layering issue.

### Screenshots

https://github.com/user-attachments/assets/f29a2687-84ef-41a3-83db-1c00bb42ed0a

### Related issue(s)

Closes #1418
Fixes #1418 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
