### PR TITLE
Replace Inter Display with Inter Variable

### DIFF
--- a/portal/styles/globals.css
+++ b/portal/styles/globals.css
@@ -36,10 +36,13 @@ like "next/router" or "next/navigation" inside the error pages.
   @apply font-inter-variable;
 }
 
+h3,
+h4 {
+  @apply font-inter-variable;
+}
+
 h1,
 h2,
-h3,
-h4,
 h5,
 h6 {
   @apply font-inter-display;


### PR DESCRIPTION
### Description

This commit applies Inter Variable to h3 and h4; other headings will remain in Inter Display.

### Screenshots

<img width="358" height="231" alt="Captura de pantalla 2025-08-01 a la(s) 4 58 01 p  m" src="https://github.com/user-attachments/assets/4096d8a0-3dd3-4e97-8ba4-084a448b40cd" />

<img width="363" height="258" alt="Captura de pantalla 2025-08-01 a la(s) 4 57 44 p  m" src="https://github.com/user-attachments/assets/13b00c32-0a5a-4563-9a85-1678b20ebe2e" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1384

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
