### PR TITLE
Get the right balance from Binance BTC wallet

### DIFF
--- a/packages/btc-wallet/connectors/unisat.ts
+++ b/packages/btc-wallet/connectors/unisat.ts
@@ -25,7 +25,18 @@ const unisatWalletConnector = {
   },
   getBalance() {
     assertInstalled()
-    return window.unisat.getBalance()
+    return window.unisat.getBalance().then(function (res) {
+      if (typeof res === 'number') {
+        // The Binance BTC injected provider returns the total balance instead
+        // of the whole object!
+        return {
+          confirmed: res,
+          total: res,
+          unconfirmed: 0,
+        }
+      }
+      return res
+    })
   },
   getNetwork() {
     assertInstalled()

--- a/packages/btc-wallet/unisat.ts
+++ b/packages/btc-wallet/unisat.ts
@@ -18,7 +18,7 @@ interface EventMap {
 export interface Unisat {
   disconnect(): Promise<void>
   getAccounts(): Promise<Account[]>
-  getBalance(): Promise<Balance>
+  getBalance(): Promise<Balance | Satoshis>
   getNetwork(): Promise<BtcSupportedNetworks>
   requestAccounts(): Promise<Account[]>
   on<Event extends keyof EventMap>(event: Event, handler: EventMap[Event]): void


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The implementation of the Bitcoin injected provider by Binance is partially compatible with Unisat. In particular, `getBalance` returns the total balance instead of the balance object regardless [what the documentation says](https://developers.binance.com/docs/binance-w3w/bitcoin-provider#getbalance).

Note that his change will only allow the portal to properly read the balance from the injected BTC provider but is not enough to use it as it does not implement `sendBitcoin`, which is required by the portal. Further changes are required, most probably the use of `signPsbt` instead.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
