### PR TITLE
Whitelist Binance URLs

### DIFF
--- a/portal/scripts/generateServerConfig.js
+++ b/portal/scripts/generateServerConfig.js
@@ -45,10 +45,17 @@ const fetchDomains = new Set([
   'https://*.walletconnect.org',
   // cookie3
   'https://a.markfi.xyz',
-  // coinbase wallet
+  // Coinbase wallet
   'https://chain-proxy.wallet.coinbase.com',
   'https://keys.coinbase.com',
   'wss://www.walletlink.org/rpc',
+  // Binance W3W wallet
+  'https://binance.nodereal.io',
+  'https://bsc-dataseed2.ninicoin.io',
+  'https://bscrpc.com',
+  'https://rpc.ankr.com/bsc',
+  'wss://nbstream.binance.click',
+  'wss://nbstream.binance.com',
 ])
 
 if (process.env.NEXT_PUBLIC_PORTAL_API_URL) {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

After #1431, the some Binance-related URLs had to be whitelisted. Otherwise, CSP errors would appear and the connection would fail.

With this change, both the desktop and mobile versions of the portal can connect to the Binance wallet. The desktop does so through WalletConnect while the mobile uses the injected connector in the Binance mobile app.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
