### PR TITLE
Fix future time display

### DIFF
--- a/portal/utils/format.ts
+++ b/portal/utils/format.ts
@@ -73,7 +73,7 @@ export const formatPastTime = (secondsFromNow: number, locale: string) =>
 export const formatFutureTime = (seconds: number, locale: string) =>
   formatRelativeTime({
     locale,
-    rounder: Math.round,
+    rounder: Math.floor,
     seconds,
   })
 


### PR DESCRIPTION
### Description

This PR fixes the `formatFutureTime` function that was incorrectly rounding time periods up, causing durations like 187 days to display as 7 months instead of 6 months.

### Screenshots

<img width="455" height="160" alt="Captura de Tela 2025-09-02 às 08 38 03" src="https://github.com/user-attachments/assets/c7b9e97f-eda5-4449-93b0-a64540d17d37" />

### Related issue(s)

Closes #1459 
Fixes #1459 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
