### PR TITLE
Fix lockTime normalization in Deposit event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31206,7 +31206,7 @@
       }
     },
     "subgraphs/ve-hemi-subgraph": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@graphprotocol/graph-cli": "0.95.0",
         "@graphprotocol/graph-ts": "0.36.0"

--- a/subgraphs/ve-hemi-subgraph/package.json
+++ b/subgraphs/ve-hemi-subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ve-hemi-subgraph",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "build": "graph build",
     "build:hemi": "npm run build -- --network hemi",

--- a/subgraphs/ve-hemi-subgraph/src/mappings/ve-hemi.ts
+++ b/subgraphs/ve-hemi-subgraph/src/mappings/ve-hemi.ts
@@ -25,9 +25,14 @@ export function handleDepositEvent(event: DepositEvent): void {
   // if the amount was updated, the increased amount is set, if not, zero is send
   // So we can just add it up
   lockedPosition.amount = lockedPosition.amount.plus(event.params.amount)
-  // if the lock time was increased, the new value is emitted. If not, the existing previous one is
-  // emitted in the event. So we can just set the event one.
-  lockedPosition.lockTime = event.params.lockTime
+
+  // Normalize lockTime: the Deposit event gives us the absolute unlock timestamp,
+  // but we want to keep consistency with the Lock event where lockTime is stored as a duration.
+  // So here we convert it back to a duration by subtracting the original start timestamp
+  const end = event.params.lockTime
+  const start = lockedPosition.timestamp
+  lockedPosition.lockTime = end.minus(start)
+
   log.info('Updating locked position: {}', [lockedPosition.id])
   lockedPosition.save()
 }


### PR DESCRIPTION
### Description

This PR fixes how lockTime is handled in the subgraph when processing the Deposit event.
Previously, we were directly storing the absolute unlock timestamp emitted by the contract. That caused inconsistencies because the Lock event uses a duration format.

### Screenshots

No UI changes.

### Related issue(s)

Closes #1467 
Fixes #1467 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
