### PR TITLE
Add a workflow to deploy the subgraphs

### DIFF
--- a/.github/workflows/subgraph-deployment.yml
+++ b/.github/workflows/subgraph-deployment.yml
@@ -44,7 +44,7 @@ jobs:
       - if: steps.version-check.outputs.VERSION_CHANGED == 'true'
         run: npm run deploy
         working-directory: subgraphs/${{ matrix.subgraph }}
-        continue-on-error: true
+        continue-on-error: false
       - if: ${{ !cancelled() }}
         uses: bloq/actions/notify-deploy-to-slack@v1
         with:

--- a/.github/workflows/subgraph-deployment.yml
+++ b/.github/workflows/subgraph-deployment.yml
@@ -1,0 +1,65 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'subgraphs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-subgraph:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bloq/actions/notify-deploy-to-slack@v1
+        with:
+          app-name: Hemi Portal Subgraphs
+          environment: staging
+          reference: ${{ github.event.head_commit.message }}
+          slack-mention: ${{ vars.SLACK_MENTION }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: 'started :stopwatch:'
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: hemilabs/actions/setup-node-env@v1
+      - run: npx --yes graph auth "$GRAPH_API_KEY"
+        env:
+          GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
+      - id: version-check
+        run: |
+          git fetch origin main
+          SUBGRAPH_NAME="${{ matrix.subgraph }}"
+          PREVIOUS_VERSION=$(git show origin/main:subgraphs/${SUBGRAPH_NAME}/package.json | jq -r .version 2>/dev/null || echo "none")
+          CURRENT_VERSION=$(jq -r .version subgraphs/${SUBGRAPH_NAME}/package.json)
+          if [ "$PREVIOUS_VERSION" = "none" || "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "VERSION_CHANGED=true" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION_CHANGED=false" >> $GITHUB_OUTPUT
+          fi
+      - if: steps.version-check.outputs.VERSION_CHANGED == 'true'
+        run: npm run deploy
+        working-directory: subgraphs/${{ matrix.subgraph }}
+        continue-on-error: true
+      - if: ${{ !cancelled() }}
+        uses: bloq/actions/notify-deploy-to-slack@v1
+        with:
+          app-name: Hemi Portal Subgraphs
+          environment: staging
+          slack-mention: ${{ vars.SLACK_MENTION }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status == 'failure' && 'failed :boom:' || 'finished :ok:' }}
+    strategy:
+      matrix:
+        subgraph:
+          - hemi-stake-operations-subgraph
+          - hemi-token-merkle-claims-subgraph
+          - hemi-tunnel-btc-deposits-subgraph
+          - hemi-tunnel-deposits-subgraph
+          - hemi-tunnel-withdrawals-proof-claim-subgraph
+          - hemi-tunnel-withdrawals-subgraph
+          - ve-hemi-subgraph

--- a/subgraphs/hemi-stake-operations-subgraph/package.json
+++ b/subgraphs/hemi-stake-operations-subgraph/package.json
@@ -7,6 +7,7 @@
     "build:hemi-sepolia": "npm run build -- --network hemi-sepolia",
     "codegen": "graph codegen",
     "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy": "npm run deploy-studio:hemi && npm run deploy-studio:hemi-sepolia",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
     "deploy-local:hemi": "npm run deploy-local -- --network hemi",
     "deploy-local:hemi-sepolia": "npm run deploy-local -- --network hemi-sepolia",

--- a/subgraphs/hemi-token-merkle-claims-subgraph/package.json
+++ b/subgraphs/hemi-token-merkle-claims-subgraph/package.json
@@ -7,6 +7,7 @@
     "build:hemi-sepolia": "npm run build -- --network hemi-sepolia",
     "codegen": "graph codegen",
     "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy": "npm run deploy-studio:hemi && npm run deploy-studio:hemi-sepolia",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
     "deploy-local:hemi": "npm run deploy-local -- --network hemi",
     "deploy-local:hemi-sepolia": "npm run deploy-local -- --network hemi-sepolia",

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/package.json
@@ -7,6 +7,7 @@
     "build:hemi-sepolia": "npm run build -- --network hemi-sepolia",
     "codegen": "graph codegen",
     "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy": "npm run deploy-studio:hemi && npm run deploy-studio:hemi-sepolia",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
     "deploy-local:hemi": "npm run deploy-local -- --network hemi",
     "deploy-local:hemi-sepolia": "npm run deploy-local -- --network hemi-sepolia",

--- a/subgraphs/hemi-tunnel-deposits-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-deposits-subgraph/package.json
@@ -7,6 +7,7 @@
     "build:sepolia": "npm run build -- --network sepolia",
     "codegen": "graph codegen",
     "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy": "npm run deploy-studio:mainnet && npm run deploy-studio:sepolia",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
     "deploy-local:mainnet": "npm run deploy-local -- --network mainnet",
     "deploy-local:sepolia": "npm run deploy-local -- --network sepolia",

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/package.json
@@ -7,6 +7,7 @@
     "build:sepolia": "npm run build -- --network sepolia",
     "codegen": "graph codegen",
     "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy": "npm run deploy-studio:mainnet && npm run deploy-studio:sepolia",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
     "deploy-local:mainnet": "npm run deploy-local -- --network mainnet",
     "deploy-local:sepolia": "npm run deploy-local -- --network sepolia",

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/package.json
@@ -7,6 +7,7 @@
     "build:hemi-sepolia": "npm run build -- --network hemi-sepolia",
     "codegen": "graph codegen",
     "create-local": "graph create --node http://localhost:8020/ $(jq -r .name package.json)",
+    "deploy": "npm run deploy-studio:hemi && npm run deploy-studio:hemi-sepolia",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $(jq -r .name package.json) --version-label $(jq -r .version package.json)",
     "deploy-local:hemi": "npm run deploy-local -- --network hemi",
     "deploy-local:hemi-sepolia": "npm run deploy-local -- --network hemi-sepolia",

--- a/subgraphs/ve-hemi-subgraph/package.json
+++ b/subgraphs/ve-hemi-subgraph/package.json
@@ -7,6 +7,7 @@
     "build:hemi-sepolia": "npm run build -- --network hemi-sepolia",
     "codegen": "graph codegen",
     "create-local": "graph create --node http://localhost:8020/ $npm_package_name",
+    "deploy": "npm run deploy-studio:hemi && npm run deploy-studio:hemi-sepolia",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $npm_package_name --version-label $npm_package_version",
     "deploy-local:hemi": "npm run deploy-local -- --network hemi",
     "deploy-local:hemi-sepolia": "npm run deploy-local -- --network hemi-sepolia",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds a workflow so any subgraph that changes (version must change in its package.json), is automatically deployed.

If/when this workflow works, it could be updated to query the deployed versions from the Graph API using the subgraph ids, instead of relying on version in the package.json files.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
