### PR TITLE
Fix min lock duration to match contract rule

### DIFF
--- a/packages/ve-hemi-actions/constants.ts
+++ b/packages/ve-hemi-actions/constants.ts
@@ -12,9 +12,8 @@ export const SupportedChains: number[] = [hemi.id, hemiSepolia.id]
 // Maximum lock duration is 4 years (a year is defined in the contract as 365.25 days)
 export const MaxLockDurationSeconds = 4 * 365.25 * 24 * 60 * 60
 
-// Minimum lock duration in seconds (≈ 12 days)
-// In the contract: YEAR = 365.25 days, so 1 day = 86400 seconds
-// SIX_DAYS = YEAR / (12 * 5) = 1,051,920 seconds
+// In the contract: YEAR = 365.25 days, SIX_DAYS = YEAR / (12 * 5)
+// If 1 day is 86,400 seconds, 12 days are 1,051,920 seconds
 export const MinLockDurationSeconds = 1_051_920
 
 export const getVeHemiContractAddress = function (chainId: number) {

--- a/packages/ve-hemi-actions/constants.ts
+++ b/packages/ve-hemi-actions/constants.ts
@@ -12,8 +12,10 @@ export const SupportedChains: number[] = [hemi.id, hemiSepolia.id]
 // Maximum lock duration is 4 years (a year is defined in the contract as 365.25 days)
 export const MaxLockDurationSeconds = 4 * 365.25 * 24 * 60 * 60
 
-// Minimum lock duration (12 days in seconds)
-export const MinLockDurationSeconds = 12 * 24 * 60 * 60
+// Minimum lock duration in seconds (≈ 12 days)
+// In the contract: YEAR = 365.25 days, so 1 day = 86400 seconds
+// SIX_DAYS = YEAR / (12 * 5) = 1,051,920 seconds
+export const MinLockDurationSeconds = 1_051_920
 
 export const getVeHemiContractAddress = function (chainId: number) {
   const address = VE_HEMI_CONTRACT_ADDRESSES[chainId]

--- a/portal/app/[locale]/staking-dashboard/_utils/lockCreationTimes.ts
+++ b/portal/app/[locale]/staking-dashboard/_utils/lockCreationTimes.ts
@@ -8,11 +8,15 @@ export const step = 6
 
 export const twoYears = 732
 
+// To ensure the lock duration is at least the minimum, we clamp the value after calculation
+const clampMin = <T extends number | bigint>(value: T, min: T): T =>
+  value < min ? min : value
+
 export function daysToSeconds(days: number): number
 export function daysToSeconds(days: bigint): bigint
 export function daysToSeconds(days: number | bigint): number | bigint {
   if (typeof days === 'bigint') {
-    return days * BigInt(daySeconds)
+    return clampMin(days * BigInt(daySeconds), BigInt(MinLockDurationSeconds))
   }
-  return days * daySeconds
+  return clampMin(days * daySeconds, MinLockDurationSeconds)
 }


### PR DESCRIPTION
### Description

This PR changes the minimum lock duration to 1,051,920 seconds (~12 days) to align with the smart contract’s internal rule.

### Screenshots

No UI changes.

### Related issue(s)

Closes #1479 
Fixes #1479 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
