### PR TITLE
Apply get-started improvements

### DIFF
--- a/portal/app/[locale]/get-started/_components/learnMore.tsx
+++ b/portal/app/[locale]/get-started/_components/learnMore.tsx
@@ -181,7 +181,9 @@ export const LearnMore = function () {
                     }}
                     selected={selectedTab === 'wallet'}
                   >
-                    {t('learn-more-tutorials.wallet-setup')}
+                    <span className="whitespace-nowrap">
+                      {t('learn-more-tutorials.wallet-setup')}
+                    </span>
                   </Tab>
                   <Tab
                     onClick={function () {
@@ -190,7 +192,9 @@ export const LearnMore = function () {
                     }}
                     selected={selectedTab === 'dev-tooling'}
                   >
-                    {t('learn-more-tutorials.developer-tooling')}
+                    <span className="whitespace-nowrap">
+                      {t('learn-more-tutorials.developer-tooling')}
+                    </span>
                   </Tab>
                   <Tab
                     onClick={function () {
@@ -199,7 +203,9 @@ export const LearnMore = function () {
                     }}
                     selected={selectedTab === 'PoP-miner'}
                   >
-                    {t('learn-more-tutorials.pop-miner')}
+                    <span className="whitespace-nowrap">
+                      {t('learn-more-tutorials.pop-miner')}
+                    </span>
                   </Tab>
                 </Tabs>
               </div>

--- a/portal/components/tabs.tsx
+++ b/portal/components/tabs.tsx
@@ -42,6 +42,7 @@ export const Tab = function ({
     >
       {(!isLink || disabled) && (
         <button
+          className="w-full"
           disabled={disabled || selected}
           onClick={!isLink && !disabled ? props.onClick : undefined}
           type="button"


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR makes some small improvements in the tabs in the `/get-started` page

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

| Before  | Now |
| ------------- | ------------- |
| <img width="816" height="455" alt="image" src="https://github.com/user-attachments/assets/64a2ffcf-729d-4fe7-952d-c5586e56ec8d" /> | <img width="496" height="307" alt="image" src="https://github.com/user-attachments/assets/ce524b26-e0d0-42bd-9a15-af3bedcd888f" /> |
| <img width="447" height="242" alt="image" src="https://github.com/user-attachments/assets/6bccd5f4-42c0-49b2-ac23-200fc417a8f3" /> | <img width="414" height="294" alt="image" src="https://github.com/user-attachments/assets/26ce15da-ae69-4b9a-a6cf-29bda075d4ef" /> |

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1341

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
