### PR TITLE
Fix loading wallet balance for boost stake

### DIFF
--- a/portal/app/[locale]/stake/_hooks/useWalletBalances.ts
+++ b/portal/app/[locale]/stake/_hooks/useWalletBalances.ts
@@ -6,7 +6,7 @@ import { getTokenBalance } from 'utils/getTokenBalance'
 import { useAccount } from 'wagmi'
 
 export const useWalletBalances = function () {
-  const { address: account, isConnected } = useAccount()
+  const { address: account } = useAccount()
   const hemiClient = useHemiClient()
   const stakeTokens = useStakeTokens()
 
@@ -21,12 +21,10 @@ export const useWalletBalances = function () {
         .map(({ data }) => data),
     }),
     queries: stakeTokens.map(token => ({
-      enabled: !!hemiClient && !!account,
       queryFn: () =>
         getTokenBalance({
           account: account!,
           client: hemiClient,
-          isConnected,
           token,
         }),
       queryKey: ['wallet-token-balance', token.chainId, token.address],

--- a/portal/app/[locale]/stake/_hooks/useWalletBalances.ts
+++ b/portal/app/[locale]/stake/_hooks/useWalletBalances.ts
@@ -23,7 +23,7 @@ export const useWalletBalances = function () {
     queries: stakeTokens.map(token => ({
       queryFn: () =>
         getTokenBalance({
-          account: account!,
+          account,
           client: hemiClient,
           token,
         }),

--- a/portal/hooks/useTopTokensToHighlight.ts
+++ b/portal/hooks/useTopTokensToHighlight.ts
@@ -79,12 +79,10 @@ export function useTopTokensToHighlight({ tokens }: Props) {
         : getEvmL1PublicClient(chainId)
 
       return {
-        enabled: !!account,
         queryFn: () =>
           getTokenBalance({
-            account: account!,
+            account,
             client,
-            isConnected,
             token,
           }),
         queryKey: ['top-token-balance', token.chainId, token.address],

--- a/portal/test/utils/getTokenBalance.test.ts
+++ b/portal/test/utils/getTokenBalance.test.ts
@@ -42,9 +42,8 @@ describe('getTokenBalance', function () {
 
   it('should return 0 if not connected', async function () {
     const result = await getTokenBalance({
-      account,
+      account: undefined,
       client: {} as PublicClient,
-      isConnected: false,
       token: mockNativeToken,
     })
 
@@ -57,7 +56,6 @@ describe('getTokenBalance', function () {
     const result = await getTokenBalance({
       account,
       client: {} as PublicClient,
-      isConnected: true,
       token: mockNativeToken,
     })
 
@@ -71,7 +69,6 @@ describe('getTokenBalance', function () {
     const result = await getTokenBalance({
       account,
       client,
-      isConnected: true,
       token: mockErc20Token,
     })
 
@@ -84,7 +81,6 @@ describe('getTokenBalance', function () {
     const result = await getTokenBalance({
       account,
       client: {} as PublicClient,
-      isConnected: true,
       token: mockNativeToken,
     })
 
@@ -98,7 +94,6 @@ describe('getTokenBalance', function () {
     const result = await getTokenBalance({
       account,
       client,
-      isConnected: true,
       token: mockErc20Token,
     })
 

--- a/portal/utils/getTokenBalance.ts
+++ b/portal/utils/getTokenBalance.ts
@@ -5,19 +5,13 @@ import { getBalance } from 'viem/actions'
 import { getErc20TokenBalance } from 'viem-erc20/actions'
 
 type Props = {
-  account: Address
+  account: Address | undefined
   client: PublicClient
-  isConnected: boolean
   token: Token
 }
 
-export async function getTokenBalance({
-  account,
-  client,
-  isConnected,
-  token,
-}: Props) {
-  if (!isConnected) {
+export async function getTokenBalance({ account, client, token }: Props) {
+  if (!account) {
     return BigInt(0)
   }
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR fixes a bug accidentally introduced in #1482 

It caused the Boost Stake page to crash when the user was disconnected. The issue was like this: By enabling `strict: true`, the `account` type was defined as required. In that PR, I disabled the useQuery with (`enabled: false`) if the user was disconnected. But in reality, that `useQuery` already handled the user being disconnected, returning wallet balances as zero. The table expected that to render all the stake tokens (with their balance being zero).   
The fix was to allow `account` to be `undefined`, therefore removing the `enabled` property that was added. I also removed the redundant `isConnected` property as it was no longer needed - I just need a defined address.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

This was staging (this has not reached prod)

<img width="1918" height="876" alt="image" src="https://github.com/user-attachments/assets/a0068c70-e7ca-49ae-ba0e-0e209fb65277" />

This is how it now looks after the fix

<img width="1917" height="857" alt="image" src="https://github.com/user-attachments/assets/1f0bdd4e-055c-4f76-b5f6-39fed1fd7ca5" />

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
