### PR TITLE
Fix possible error with const enums in drawer

### DIFF
--- a/portal/app/[locale]/genesis-drop/_components/claimDrawer.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/claimDrawer.tsx
@@ -2,7 +2,10 @@ import { MutationStatus } from '@tanstack/react-query'
 import { Button } from 'components/button'
 import { Drawer } from 'components/drawer'
 import { Operation } from 'components/reviewOperation/operation'
-import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { SubmitWhenConnectedToChain } from 'components/submitWhenConnectedToChain'
 import { LockupMonths, type EligibilityData } from 'genesis-drop-actions'
@@ -73,7 +76,7 @@ export const ClaimDrawer = function ({
       </form>
     ) : null
 
-  const statusMap: Partial<Record<MutationStatus, ProgressStatus>> = {
+  const statusMap: Partial<Record<MutationStatus, ProgressStatusType>> = {
     error: ProgressStatus.FAILED,
     pending: ProgressStatus.PROGRESS,
     success: ProgressStatus.COMPLETED,

--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -1,5 +1,8 @@
 import { DrawerParagraph } from 'components/drawer'
-import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { Spinner } from 'components/spinner'
 import { ToastLoader } from 'components/toast/toastLoader'
@@ -110,7 +113,7 @@ export const StakeOperation = function ({
         return ProgressStatus.COMPLETED
       }
 
-      const statusMap: Partial<Record<StakeStatusEnum, ProgressStatus>> = {
+      const statusMap: Partial<Record<StakeStatusEnum, ProgressStatusType>> = {
         [StakeStatusEnum.APPROVAL_TX_FAILED]: ProgressStatus.FAILED,
         [StakeStatusEnum.APPROVAL_TX_PENDING]: ProgressStatus.PROGRESS,
       }
@@ -147,7 +150,7 @@ export const StakeOperation = function ({
       if (stakeStatus === undefined) {
         return ProgressStatus.NOT_READY
       }
-      const statusMap: Record<StakeStatusEnum, ProgressStatus> = {
+      const statusMap: Record<StakeStatusEnum, ProgressStatusType> = {
         [StakeStatusEnum.APPROVAL_TX_PENDING]: ProgressStatus.NOT_READY,
         [StakeStatusEnum.APPROVAL_TX_FAILED]: ProgressStatus.NOT_READY,
         [StakeStatusEnum.APPROVAL_TX_COMPLETED]: ProgressStatus.READY,

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/review.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/review.tsx
@@ -2,7 +2,10 @@
 
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import { Operation } from 'components/reviewOperation/operation'
-import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useHemi } from 'hooks/useHemi'
@@ -87,7 +90,9 @@ export const Review = function ({ onClose }: Props) {
       StakingDashboardStatus.APPROVAL_TX_PENDING,
     ].includes(stakingStatus)
 
-    const statusMap: Partial<Record<StakingDashboardStatus, ProgressStatus>> = {
+    const statusMap: Partial<
+      Record<StakingDashboardStatus, ProgressStatusType>
+    > = {
       [StakingDashboardStatus.APPROVAL_TX_FAILED]: ProgressStatus.FAILED,
       [StakingDashboardStatus.APPROVAL_TX_PENDING]: ProgressStatus.PROGRESS,
     }
@@ -119,7 +124,7 @@ export const Review = function ({ onClose }: Props) {
   }
 
   const addStakingStep = function (): StepPropsWithoutPosition {
-    const statusMap: Record<StakingDashboardStatus, ProgressStatus> = {
+    const statusMap: Record<StakingDashboardStatus, ProgressStatusType> = {
       [StakingDashboardStatus.APPROVAL_TX_PENDING]: ProgressStatus.NOT_READY,
       [StakingDashboardStatus.APPROVAL_TX_FAILED]: ProgressStatus.NOT_READY,
       [StakingDashboardStatus.APPROVAL_TX_COMPLETED]: ProgressStatus.READY,

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcDeposit.tsx
@@ -1,6 +1,9 @@
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import { Operation } from 'components/reviewOperation/operation'
-import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { WarningBox } from 'components/warningBox'
 import { useBitcoin } from 'hooks/useBitcoin'
@@ -86,13 +89,13 @@ const ReviewContent = function ({
   const steps: StepPropsWithoutPosition[] = []
 
   const getDepositStep = function (): StepPropsWithoutPosition {
-    const statusMap: Partial<Record<BtcDepositStatus, ProgressStatus>> = {
+    const statusMap: Partial<Record<BtcDepositStatus, ProgressStatusType>> = {
       [BtcDepositStatus.BTC_TX_PENDING]: ProgressStatus.PROGRESS,
       [BtcDepositStatus.BTC_TX_FAILED]: ProgressStatus.FAILED,
     }
 
     const postActionStatusMap: Partial<
-      Record<BtcDepositStatus, ProgressStatus>
+      Record<BtcDepositStatus, ProgressStatusType>
     > = {
       [BtcDepositStatus.BTC_TX_PENDING]: ProgressStatus.NOT_READY,
       [BtcDepositStatus.BTC_TX_CONFIRMED]: ProgressStatus.PROGRESS,
@@ -134,7 +137,7 @@ const ReviewContent = function ({
   }
 
   const getDepositFinalizedStep = function (): StepPropsWithoutPosition {
-    const statusMap: Partial<Record<BtcDepositStatus, ProgressStatus>> = {
+    const statusMap: Partial<Record<BtcDepositStatus, ProgressStatusType>> = {
       [BtcDepositStatus.READY_TO_MANUAL_CONFIRM]: ProgressStatus.FAILED,
       [BtcDepositStatus.DEPOSIT_MANUAL_CONFIRMING]: ProgressStatus.FAILED,
       [BtcDepositStatus.DEPOSIT_MANUAL_CONFIRMATION_TX_FAILED]:
@@ -163,7 +166,7 @@ const ReviewContent = function ({
       if (deposit.status === BtcDepositStatus.BTC_DEPOSITED_MANUALLY) {
         return ProgressStatus.COMPLETED
       }
-      const map: Partial<Record<BtcDepositStatus, ProgressStatus>> = {
+      const map: Partial<Record<BtcDepositStatus, ProgressStatusType>> = {
         [BtcDepositStatus.READY_TO_MANUAL_CONFIRM]: ProgressStatus.READY,
         [BtcDepositStatus.DEPOSIT_MANUAL_CONFIRMING]: ProgressStatus.PROGRESS,
         [BtcDepositStatus.DEPOSIT_MANUAL_CONFIRMATION_TX_FAILED]:

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcWithdrawal.tsx
@@ -3,7 +3,10 @@
 import { useAccount as useBtcAccount } from 'btc-wallet/hooks/useAccount'
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import { Operation } from 'components/reviewOperation/operation'
-import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { WarningBox } from 'components/warningBox'
 import { useChain } from 'hooks/useChain'
@@ -99,18 +102,18 @@ const ReviewContent = function ({
   const steps: StepPropsWithoutPosition[] = []
 
   const addWithdrawStep = function (): StepPropsWithoutPosition {
-    const statusMap: Partial<Record<BtcWithdrawStatus, ProgressStatus>> = {
+    const statusMap: Partial<Record<BtcWithdrawStatus, ProgressStatusType>> = {
       [BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING]: ProgressStatus.PROGRESS,
       [BtcWithdrawStatus.WITHDRAWAL_FAILED]: ProgressStatus.FAILED,
     }
 
-    const postActionStatus: Partial<Record<BtcWithdrawStatus, ProgressStatus>> =
-      {
-        [BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED]:
-          ProgressStatus.PROGRESS,
-        [BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING]: ProgressStatus.NOT_READY,
-        [BtcWithdrawStatus.WITHDRAWAL_FAILED]: ProgressStatus.NOT_READY,
-      }
+    const postActionStatus: Partial<
+      Record<BtcWithdrawStatus, ProgressStatusType>
+    > = {
+      [BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED]: ProgressStatus.PROGRESS,
+      [BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING]: ProgressStatus.NOT_READY,
+      [BtcWithdrawStatus.WITHDRAWAL_FAILED]: ProgressStatus.NOT_READY,
+    }
 
     return {
       description: (

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
@@ -3,7 +3,10 @@
 import { ChainIcon } from 'components/reviewOperation/chainIcon'
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import { Operation } from 'components/reviewOperation/operation'
-import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { useChain } from 'hooks/useChain'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
@@ -108,7 +111,7 @@ const ReviewContent = function ({
   })
 
   const getDepositStep = function (): StepPropsWithoutPosition {
-    const statusMap: Partial<Record<EvmDepositStatus, ProgressStatus>> = {
+    const statusMap: Partial<Record<EvmDepositStatus, ProgressStatusType>> = {
       [EvmDepositStatus.APPROVAL_TX_COMPLETED]: ProgressStatus.READY,
       [EvmDepositStatus.APPROVAL_TX_PENDING]: ProgressStatus.NOT_READY,
       [EvmDepositStatus.DEPOSIT_TX_CONFIRMED]: ProgressStatus.COMPLETED,
@@ -117,10 +120,11 @@ const ReviewContent = function ({
       [EvmDepositStatus.DEPOSIT_RELAYED]: ProgressStatus.COMPLETED,
     }
 
-    const postStatusMap: Partial<Record<EvmDepositStatus, ProgressStatus>> = {
-      [EvmDepositStatus.DEPOSIT_TX_CONFIRMED]: ProgressStatus.PROGRESS,
-      [EvmDepositStatus.DEPOSIT_RELAYED]: ProgressStatus.COMPLETED,
-    }
+    const postStatusMap: Partial<Record<EvmDepositStatus, ProgressStatusType>> =
+      {
+        [EvmDepositStatus.DEPOSIT_TX_CONFIRMED]: ProgressStatus.PROGRESS,
+        [EvmDepositStatus.DEPOSIT_RELAYED]: ProgressStatus.COMPLETED,
+      }
     return {
       description: (
         <ChainLabel

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmWithdrawal.tsx
@@ -1,6 +1,9 @@
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import { Operation } from 'components/reviewOperation/operation'
-import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { useChain } from 'hooks/useChain'
 import { useToken } from 'hooks/useToken'
@@ -87,7 +90,7 @@ const ReviewContent = function ({
     })
 
   const getWithdrawalStatus = function () {
-    const map: Partial<Record<MessageStatusType, ProgressStatus>> = {
+    const map: Partial<Record<MessageStatusType, ProgressStatusType>> = {
       [MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE]: ProgressStatus.NOT_READY,
       [MessageStatus.STATE_ROOT_NOT_PUBLISHED]: ProgressStatus.PROGRESS,
       [MessageStatus.FAILED_L1_TO_L2_MESSAGE]: ProgressStatus.FAILED,
@@ -140,12 +143,13 @@ const ReviewContent = function ({
       return ProgressStatus.NOT_READY
     }
 
-    const map: Partial<Record<ToEvmWithdrawOperationStatuses, ProgressStatus>> =
-      {
-        claiming: ProgressStatus.PROGRESS,
-        failed: ProgressStatus.FAILED,
-        rejected: ProgressStatus.REJECTED,
-      }
+    const map: Partial<
+      Record<ToEvmWithdrawOperationStatuses, ProgressStatusType>
+    > = {
+      claiming: ProgressStatus.PROGRESS,
+      failed: ProgressStatus.FAILED,
+      rejected: ProgressStatus.REJECTED,
+    }
     return map[operationStatus] ?? ProgressStatus.READY
   }
 
@@ -156,12 +160,13 @@ const ReviewContent = function ({
     if (withdrawal.status >= MessageStatus.IN_CHALLENGE_PERIOD) {
       return ProgressStatus.COMPLETED
     }
-    const map: Partial<Record<ToEvmWithdrawOperationStatuses, ProgressStatus>> =
-      {
-        failed: ProgressStatus.FAILED,
-        proving: ProgressStatus.PROGRESS,
-        rejected: ProgressStatus.REJECTED,
-      }
+    const map: Partial<
+      Record<ToEvmWithdrawOperationStatuses, ProgressStatusType>
+    > = {
+      failed: ProgressStatus.FAILED,
+      proving: ProgressStatus.PROGRESS,
+      rejected: ProgressStatus.REJECTED,
+    }
     return map[operationStatus] ?? ProgressStatus.READY
   }
 

--- a/portal/components/reviewOperation/positionStatus.tsx
+++ b/portal/components/reviewOperation/positionStatus.tsx
@@ -3,11 +3,11 @@ import Image from 'next/image'
 
 import { ErrorIcon } from './_icons/errorIcon'
 import gradientLoadingImg from './_images/gradient_loading.png'
-import { ProgressStatus } from './progressStatus'
+import { ProgressStatus, type ProgressStatusType } from './progressStatus'
 
 type Props = {
   position: number
-  status: ProgressStatus
+  status: ProgressStatusType
 }
 
 export const PositionStatus = function ({ position, status }: Props) {

--- a/portal/components/reviewOperation/progressStatus.ts
+++ b/portal/components/reviewOperation/progressStatus.ts
@@ -1,8 +1,14 @@
-export const enum ProgressStatus {
-  NOT_READY = 0,
-  READY = 1,
-  PROGRESS = 2,
-  COMPLETED = 3,
-  FAILED = 4,
-  REJECTED = 5,
-}
+// Prefer ordering these by value rather than by key
+/* eslint-disable sort-keys */
+export const ProgressStatus = {
+  NOT_READY: 0,
+  READY: 1,
+  PROGRESS: 2,
+  COMPLETED: 3,
+  FAILED: 4,
+  REJECTED: 5,
+} as const
+/* eslint-enable sort-keys */
+
+export type ProgressStatusType =
+  (typeof ProgressStatus)[keyof typeof ProgressStatus]

--- a/portal/components/reviewOperation/step.tsx
+++ b/portal/components/reviewOperation/step.tsx
@@ -8,7 +8,7 @@ import { Token } from 'types/token'
 import { FeesIcon } from './_icons/feesIcon'
 import { OneRowBox, TwoRowBox } from './box'
 import { PositionStatus } from './positionStatus'
-import { ProgressStatus } from './progressStatus'
+import { ProgressStatus, type ProgressStatusType } from './progressStatus'
 import { SeeOnExplorer } from './seeOnExplorer'
 import { Separator } from './separator'
 import { SubStep } from './subStep'
@@ -26,7 +26,7 @@ type Props = {
   position: number
   postAction?: {
     description: ReactNode
-    status: ProgressStatus
+    status: ProgressStatusType
   }
   separator?: boolean
   txHash?: string
@@ -252,7 +252,7 @@ const statusMap = {
 export const Step = function ({
   status,
   ...props
-}: Props & { status: ProgressStatus }) {
+}: Props & { status: ProgressStatusType }) {
   const StatusStep = statusMap[status]
   return (
     <>

--- a/portal/components/reviewOperation/subStep.tsx
+++ b/portal/components/reviewOperation/subStep.tsx
@@ -4,11 +4,11 @@ import { ReactNode } from 'react'
 
 import { ClockIcon } from './_icons/clockIcon'
 import gradientLoadingImg from './_images/gradient_loading.png'
-import { ProgressStatus } from './progressStatus'
+import { ProgressStatus, type ProgressStatusType } from './progressStatus'
 
 type Props = {
   description: ReactNode
-  status: ProgressStatus
+  status: ProgressStatusType
 }
 
 export function SubStep({ description, status }: Props) {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

There's an error on Sentry that I've seen many time,s but I was never able to reproduce. If you see the error, it says

> Cannot read properties of undefined (reading 'NOT_READY')

and the stack trace where this fails is like this:

```js
const statusMap = {
  [ProgressStatus.NOT_READY]: NotReady,
  [ProgressStatus.READY]: Ready,
  [ProgressStatus.PROGRESS]: Progress,
  [ProgressStatus.COMPLETED]: Completed,
  [ProgressStatus.FAILED]: Failed,
  [ProgressStatus.REJECTED]: Rejected
```

which is very weird because `ProgressStatus` is a static enum defined. And there's no circular reference when importing it. I was never able to reproduce this error; however, Typescript has long been trying to discourage enum usages - it even has [a feature to remove them](https://www.totaltypescript.com/erasable-syntax-only). They are a quirk of Typescript and not really a JavaScript feature; so on build time, they are inlined in the final bundle. In general, Typescript code can be just "removed" and the runtime should continue to work, but this is not the case with Enums.

I am unsure where the issue lies - I suspect there's some weird behaviour in the bundle when inlining the enum. Because of this, I removed the `ProgressStatus`, replacing it with the recommended approach - a cost object. It's, after all, a plain JavaScript object. The fact that it uses `as const` is just to have a narrow, stricter type. Hopefully, with this, the bug will disappear. We'll see!

As enums were used both as objects and types, this PR replaces them with a const object and adds the Type as a separate entity.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1486

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
