### PR TITLE
Hide another Sentry error

### DIFF
--- a/portal/instrumentation-client.ts
+++ b/portal/instrumentation-client.ts
@@ -5,7 +5,7 @@ const enabled = !!process.env.NEXT_PUBLIC_SENTRY_DSN
 const unsupportedWalletErrors = [
   '@polkadot/keyring requires direct dependencies',
   "Backpack couldn't override `window.ethereum`.",
-  'message: Cannot redefine property: ethereum',
+  'Cannot redefine property: ethereum',
   // Nightly wallet
   'Cannot set property ethereum of #<Window> which has only a getter',
   'sendRequest() -> core.crypto.encode()',


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

There's an error in Sentry that is like this.

> TypeError Cannot redefine property: ethereum

We already had a very similar error blocklisted -  bug prefixed with `message` . By removing this prefix, we should be able to silent both

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1229

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
