### PR TITLE
Fix subgraph deploy condition

### DIFF
--- a/.github/workflows/subgraph-deployment.yml
+++ b/.github/workflows/subgraph-deployment.yml
@@ -36,7 +36,7 @@ jobs:
           SUBGRAPH_NAME="${{ matrix.subgraph }}"
           PREVIOUS_VERSION=$(git show origin/main:subgraphs/${SUBGRAPH_NAME}/package.json | jq -r .version 2>/dev/null || echo "none")
           CURRENT_VERSION=$(jq -r .version subgraphs/${SUBGRAPH_NAME}/package.json)
-          if [ "$PREVIOUS_VERSION" = "none" || "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+          if [ "$PREVIOUS_VERSION" = "none" ] || [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
             echo "VERSION_CHANGED=true" >> $GITHUB_OUTPUT
           else
             echo "VERSION_CHANGED=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

It was wrong and the workflow failed with this error:

```
line 5: [: missing `]'
line 5: 1.0.1: command not found
```

Ref: https://github.com/hemilabs/ui-monorepo/actions/runs/17657641887/job/50184203445#step:6:15

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
