### PR TITLE
Show all claim groups for users, even not eligible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33012,7 +33012,7 @@
     },
     "portal-backend/api": {
       "name": "portal-backend",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@sentry/node": "10.5.0",
         "config": "4.1.0",

--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "dependencies": {
     "@sentry/node": "10.5.0",
     "config": "4.1.0",

--- a/portal-backend/api/src/claims.js
+++ b/portal-backend/api/src/claims.js
@@ -39,16 +39,16 @@ module.exports = function () {
    * @param {Address} address
    * @returns {Promise<ClaimData[]>}
    */
-  async function getAllUserClaimData(chainId, address) {
-    const userData = /** @type {ClaimData[]} */ ([])
-    Object.values(localData[chainId] || {}).forEach(function (claimGroup) {
+  const getAllUserClaimData = async (chainId, address) =>
+    Object.entries(localData[chainId] || {}).map(function ([
+      claimGroupId,
+      claimGroup,
+    ]) {
       const data = claimGroup[address]
-      if (data) {
-        userData.push(data)
-      }
+      return data
+        ? data
+        : { amount: '0', claimGroupId: Number(claimGroupId), proof: [] }
     })
-    return userData
-  }
 
   /**
    * Return only the first claim data for retro-compatibility.

--- a/portal/app/[locale]/genesis-drop/_components/genesisDropTabs.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/genesisDropTabs.tsx
@@ -44,7 +44,7 @@ const GenesisDropTabsImpl = function () {
             key={claimGroupId}
             selected={selectedClaimGroup === claimGroupId}
           >
-            <span className="flex justify-center">
+            <span className="flex justify-center truncate">
               <ClaimGroupName claimGroupId={claimGroupId} />
             </span>
           </Tab>

--- a/portal/app/[locale]/genesis-drop/page.tsx
+++ b/portal/app/[locale]/genesis-drop/page.tsx
@@ -2,15 +2,25 @@
 
 import { HemiSymbolWhite } from 'components/icons/hemiSymbolWhite'
 import { Spinner } from 'components/spinner'
+import { type EligibilityData } from 'genesis-drop-actions'
 import { useTranslations } from 'next-intl'
+import Skeleton from 'react-loading-skeleton'
 import { walletIsConnected } from 'utils/wallet'
 import { useAccount } from 'wagmi'
 
+import { ClaimGroupName } from './_components/claimGroupsName'
 import { DisconnectedState } from './_components/disconnectedState'
 import { Eligible } from './_components/eligible'
 import { NotEligible } from './_components/notEligible'
 import { useAllEligibleForTokens } from './_hooks/useAllEligibleForTokens'
 import { useSelectedClaimGroup } from './_hooks/useSelectedClaimGroup'
+
+const hasAllocation = (
+  allEligibility: EligibilityData[],
+  selectedClaimGroup: number,
+) =>
+  (allEligibility.find(item => item.claimGroupId === selectedClaimGroup)
+    ?.amount ?? BigInt(0)) > BigInt(0)
 
 export default function Page() {
   const { status } = useAccount()
@@ -37,11 +47,18 @@ export default function Page() {
       </div>
     )
 
-    if (!walletIsConnected(status) || allEligibility === undefined) {
+    if (
+      !walletIsConnected(status) ||
+      allEligibility === undefined ||
+      selectedClaimGroup === null
+    ) {
       return spinner
     }
 
-    if (allEligibility.length === 0) {
+    if (
+      allEligibility.length === 0 ||
+      !hasAllocation(allEligibility, selectedClaimGroup)
+    ) {
       return <NotEligible />
     }
 
@@ -67,7 +84,11 @@ export default function Page() {
           {t('title')}
         </p>
         <p className="text-center text-4xl font-semibold text-neutral-950">
-          {t('subheading')}
+          {selectedClaimGroup !== null ? (
+            <ClaimGroupName claimGroupId={selectedClaimGroup!} />
+          ) : (
+            <Skeleton className="h-10 w-72" />
+          )}
         </p>
         {getMainSection()}
       </div>

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -112,7 +112,7 @@
     "claim-and-stake-successful": "Claim and Stake successful",
     "claim-details": "Claim details",
     "claim-groups": {
-      "genesis-drop": "Genesis Drop",
+      "genesis-drop": "Hemi Genesis Drop",
       "spectra-and-dodo": "Spectra + Dodo",
       "other-drop": "Other Drop"
     },
@@ -154,7 +154,6 @@
     "rewards-multiplier": "Rewards multiplier",
     "staked-for-months": "{amount} for {months} months",
     "stake-hemi": "Stake {symbol}",
-    "subheading": "Hemi Genesis Drop",
     "switch-to-start-claiming": "You can switch networks to start claiming your HEMI.",
     "terms-and-conditions": {
       "title": "Hemi Genesis Drop Terms and Conditions"

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -112,7 +112,7 @@
     "claim-and-stake-successful": "Reclamo y Stake exitoso",
     "claim-details": "Detalles del reclamo",
     "claim-groups": {
-      "genesis-drop": "Lanzamiento Génesis",
+      "genesis-drop": "Lanzamiento Génesis de Hemi",
       "spectra-and-dodo": "Spectra + Dodo",
       "other-drop": "Otro Lanzamiento"
     },
@@ -154,7 +154,6 @@
     "rewards-multiplier": "Multiplicador de recompensas",
     "staked-for-months": "{amount} por {months} meses",
     "stake-hemi": "Hacer Stake de {symbol}",
-    "subheading": "Lanzamiento Génesis de Hemi",
     "switch-to-start-claiming": "Puede cambiar de red para comenzar a reclamar su HEMI.",
     "terms-and-conditions": {
       "title": "Términos y Condiciones del programa Lanzamiento Génesis de Hemi"

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -112,7 +112,7 @@
     "claim-and-stake-successful": "Reivindicação e Stake bem-sucedidos",
     "claim-details": "Detalhes da reivindicação",
     "claim-groups": {
-      "genesis-drop": "Lançamento Gênesis",
+      "genesis-drop": "Lançamento Gênesis do Hemi",
       "spectra-and-dodo": "Spectra + Dodo",
       "other-drop": "Outro Lançamento"
     },
@@ -154,7 +154,6 @@
     "rewards-multiplier": "Multiplicador de recompensas",
     "staked-for-months": "{amount} por {months} meses",
     "stake-hemi": "Faça stake de {symbol}",
-    "subheading": "Lançamento Génesis do Hemi",
     "switch-to-start-claiming": "Pode mudar de rede para começar a reivindicar o seu HEMI.",
     "terms-and-conditions": {
       "title": "Termos e condições do Lançamento Genesis Hemi"


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR shows all the claim group tabs in the Genesis drop page - this way, users will see those claims where they weren't eligible, instead of being "hidden". This makes it clearer to them that they were not eligible

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/159cfd13-585b-4987-a98f-792370514daf

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1506

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
