### PR TITLE
Show default text for disconnected user

### DIFF
--- a/portal/app/[locale]/genesis-drop/page.tsx
+++ b/portal/app/[locale]/genesis-drop/page.tsx
@@ -80,6 +80,19 @@ export default function Page() {
     )
   }
 
+  const getSubheading = function () {
+    // use the default claim group if the user is disconnected
+    if (status === 'disconnected') {
+      return t('claim-groups.genesis-drop')
+    }
+
+    if (selectedClaimGroup !== null) {
+      return <ClaimGroupName claimGroupId={selectedClaimGroup} />
+    }
+
+    return <Skeleton className="h-10 w-72" />
+  }
+
   return (
     <>
       <div className="flex w-full flex-col items-center gap-y-2">
@@ -90,11 +103,7 @@ export default function Page() {
           {t('title')}
         </p>
         <p className="text-center text-4xl font-semibold text-neutral-950">
-          {selectedClaimGroup !== null ? (
-            <ClaimGroupName claimGroupId={selectedClaimGroup} />
-          ) : (
-            <Skeleton className="h-10 w-72" />
-          )}
+          {getSubheading()}
         </p>
         {getMainSection()}
       </div>


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

After #1507  a bug was introduced where the claim group name wasn't shown if the user was disconnected. This PR adds the Hemi Genesis Drop text as the default for that scenario

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/b8dd0d5b-15cd-4e66-ae8a-476adc489751

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
