### PR TITLE
Move code that sets claimGroupId to page

### DIFF
--- a/portal/app/[locale]/genesis-drop/_hooks/useAllEligibleForTokens.ts
+++ b/portal/app/[locale]/genesis-drop/_hooks/useAllEligibleForTokens.ts
@@ -8,8 +8,6 @@ import { useAccount } from 'wagmi'
 
 import { filterExclusiveGroups } from '../_utils'
 
-import { useSelectedClaimGroup } from './useSelectedClaimGroup'
-
 const portalApiUrl = process.env.NEXT_PUBLIC_PORTAL_API_URL
 
 const byClaimGroupId = (a: EligibilityData, b: EligibilityData) =>
@@ -19,7 +17,6 @@ export const useAllEligibleForTokens = function ({
   enabled = true,
 }: { enabled?: boolean } = {}) {
   const { address } = useAccount()
-  const [selectedClaimGroup, setSelectedClaimGroup] = useSelectedClaimGroup()
   const hemi = useHemi()
 
   return useQuery({
@@ -56,14 +53,6 @@ export const useAllEligibleForTokens = function ({
       const filteredResponse = (
         hemi.id === hemiMainnet.id ? filterExclusiveGroups(response) : response
       ).sort(byClaimGroupId)
-
-      if (
-        selectedClaimGroup === undefined ||
-        !filteredResponse.some(e => e.claimGroupId === selectedClaimGroup)
-      ) {
-        // select the first one by default, if not set already, unless the one set is not in the response
-        setSelectedClaimGroup(filteredResponse[0].claimGroupId)
-      }
 
       return filteredResponse
     },

--- a/portal/app/[locale]/genesis-drop/page.tsx
+++ b/portal/app/[locale]/genesis-drop/page.tsx
@@ -4,6 +4,7 @@ import { HemiSymbolWhite } from 'components/icons/hemiSymbolWhite'
 import { Spinner } from 'components/spinner'
 import { type EligibilityData } from 'genesis-drop-actions'
 import { useTranslations } from 'next-intl'
+import { useEffect } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { walletIsConnected } from 'utils/wallet'
 import { useAccount } from 'wagmi'
@@ -32,8 +33,25 @@ export default function Page() {
   const { status } = useAccount()
 
   const { data: allEligibility } = useAllEligibleForTokens()
-  const [selectedClaimGroup] = useSelectedClaimGroup()
+  const [selectedClaimGroup, setSelectedClaimGroup] = useSelectedClaimGroup()
   const t = useTranslations('genesis-drop')
+
+  useEffect(
+    function autoSelectClaimGroup() {
+      if (allEligibility === undefined || allEligibility.length === 0) {
+        // do nothing - still loading or claim groups not available
+        return
+      }
+      const claimGroupIdFound = allEligibility.some(
+        e => e.claimGroupId === selectedClaimGroup,
+      )
+      if (selectedClaimGroup === undefined || !claimGroupIdFound) {
+        // select the first one by default, if not set already, unless the one set is not in the response
+        setSelectedClaimGroup(allEligibility[0].claimGroupId)
+      }
+    },
+    [allEligibility, selectedClaimGroup, setSelectedClaimGroup],
+  )
 
   const getMainSection = function () {
     if (status === 'disconnected') {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR moves the code that sets the `claimGroupId` query string to the page component instead of doing so in the fetch code. This way, it will run when entering the page and if the data is already cached (which causes the fetch not to run)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/69a14d1e-d4c5-4462-8c78-ca67b6a5d5bc

Now users don't get stuck in the "Loading" page

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1512

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
