### PR TITLE
Bump @graphprotocol dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,37 +1903,37 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli": {
-      "version": "0.95.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.95.0.tgz",
-      "integrity": "sha512-UcIWBl0iIuE36B5WBDjsnnSUb5PiXQtfE30tStrypWCqJpLrJtEBaBYDqU7BfR+7JnfexQTXD5H/97R5iXfc7g==",
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.97.1.tgz",
+      "integrity": "sha512-j5dc2Tl694jMZmVQu8SSl5Yt3VURiBPgglQEpx30aW6UJ89eLR/x46Nn7S6eflV69fmB5IHAuAACnuTzo8MD0Q==",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@float-capital/float-subgraph-uncrashable": "0.0.0-internal-testing.5",
-        "@oclif/core": "4.0.34",
+        "@oclif/core": "4.3.0",
         "@oclif/plugin-autocomplete": "^3.2.11",
         "@oclif/plugin-not-found": "^3.2.29",
         "@oclif/plugin-warn-if-update-available": "^3.1.24",
         "@pinax/graph-networks-registry": "^0.6.5",
         "@whatwg-node/fetch": "^0.10.1",
         "assemblyscript": "0.19.23",
-        "chokidar": "4.0.1",
-        "debug": "4.3.7",
-        "docker-compose": "1.1.0",
-        "fs-extra": "11.2.0",
-        "glob": "11.0.0",
+        "chokidar": "4.0.3",
+        "debug": "4.4.1",
+        "docker-compose": "1.2.0",
+        "fs-extra": "11.3.0",
+        "glob": "11.0.2",
         "gluegun": "5.2.0",
-        "graphql": "16.9.0",
-        "immutable": "5.0.3",
-        "jayson": "4.1.3",
+        "graphql": "16.11.0",
+        "immutable": "5.1.2",
+        "jayson": "4.2.0",
         "js-yaml": "4.1.0",
         "kubo-rpc-client": "^5.0.2",
-        "open": "10.1.0",
-        "prettier": "3.4.2",
-        "semver": "7.6.3",
+        "open": "10.1.2",
+        "prettier": "3.5.3",
+        "semver": "7.7.2",
         "tmp-promise": "3.0.3",
-        "undici": "7.2.3",
+        "undici": "7.9.0",
         "web3-eth-abi": "4.4.1",
-        "yaml": "2.6.1"
+        "yaml": "2.8.0"
       },
       "bin": {
         "graph": "bin/run.js"
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -1958,9 +1958,9 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2001,9 +2001,9 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/glob": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+      "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -2087,9 +2087,9 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/open": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
@@ -2121,9 +2121,9 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -2148,50 +2148,42 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@graphprotocol/graph-cli/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@graphprotocol/graph-cli/node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/@graphprotocol/graph-ts": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.36.0.tgz",
-      "integrity": "sha512-yJNQK5YZWEThuawSboQQ+U4Fb2C78KBjmaoeOK7Nn0CFoChmHc+woRvW3yj+IKVSPc7JNHt4JSUHxVDJfUZbTA==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.38.1.tgz",
+      "integrity": "sha512-CEE2mJugPuukPugMY4bJRW8t8lOqdNa6Y3Oc0x8xc0EwidjF1LRBcfbuC5Ep5gfvWILNC/IQTT1p+QYW8cz4Hw==",
       "dependencies": {
-        "assemblyscript": "0.19.10"
+        "assemblyscript": "0.27.31"
       }
     },
     "node_modules/@graphprotocol/graph-ts/node_modules/assemblyscript": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.10.tgz",
-      "integrity": "sha512-HavcUBXB3mBTRGJcpvaQjmnmaqKHBGREjSPNsIvnAk2f9dj78y4BkMaSSdvBQYWcDDzsHQjyUC8stICFkD1Odg==",
+      "version": "0.27.31",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.27.31.tgz",
+      "integrity": "sha512-Ra8kiGhgJQGZcBxjtMcyVRxOEJZX64kd+XGpjWzjcjgxWJVv+CAQO0aDBk4GQVhjYbOkATarC83mHjAVGtwPBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "binaryen": "101.0.0-nightly.20210723",
-        "long": "^4.0.0"
+        "binaryen": "116.0.0-nightly.20240114",
+        "long": "^5.2.1"
       },
       "bin": {
-        "asc": "bin/asc",
-        "asinit": "bin/asinit"
+        "asc": "bin/asc.js",
+        "asinit": "bin/asinit.js"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=7"
       },
       "funding": {
         "type": "opencollective",
@@ -2199,19 +2191,14 @@
       }
     },
     "node_modules/@graphprotocol/graph-ts/node_modules/binaryen": {
-      "version": "101.0.0-nightly.20210723",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-101.0.0-nightly.20210723.tgz",
-      "integrity": "sha512-eioJNqhHlkguVSbblHOtLqlhtC882SOEPKmNFZaDuz1hzQjolxZ+eu3/kaS10n3sGPONsIZsO7R9fR00UyhEUA==",
+      "version": "116.0.0-nightly.20240114",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-116.0.0-nightly.20240114.tgz",
+      "integrity": "sha512-0GZrojJnuhoe+hiwji7QFaL3tBlJoA+KFUN7ouYSDGZLSo9CKM8swQX8n/UcbR0d1VuZKU+nhogNzv423JEu5A==",
       "license": "Apache-2.0",
       "bin": {
-        "wasm-opt": "bin/wasm-opt"
+        "wasm-opt": "bin/wasm-opt",
+        "wasm2js": "bin/wasm2js"
       }
-    },
-    "node_modules/@graphprotocol/graph-ts/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
     },
     "node_modules/@hemilabs/token-list": {
       "version": "2.5.0",
@@ -4981,22 +4968,22 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.0.34",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.0.34.tgz",
-      "integrity": "sha512-jHww7lIqyifamynDSjDNNjNOwFTQdKYeOSYaxUaoWhqXnRwacZ+pfUN4Y0L9lqSN4MQtlWM9mwnBD7FvlT9kPw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.3.0.tgz",
+      "integrity": "sha512-lIzHY+JMP6evrS5E/sGijNnwrCoNtGy8703jWXcMuPOYKiFhWoAqnIm1BGgoRgmxczkbSfRsHUL/lwsSgh74Lw==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
-        "ansis": "^3.3.2",
+        "ansis": "^3.17.0",
         "clean-stack": "^3.0.1",
         "cli-spinners": "^2.9.2",
-        "debug": "^4.3.7",
+        "debug": "^4.4.0",
         "ejs": "^3.1.10",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
-        "lilconfig": "^3.1.2",
+        "lilconfig": "^3.1.3",
         "minimatch": "^9.0.5",
         "semver": "^7.6.3",
         "string-width": "^4.2.3",
@@ -17144,9 +17131,9 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.1.0.tgz",
-      "integrity": "sha512-VrkQJNafPQ5d6bGULW0P6KqcxSkv3ZU5Wn2wQA19oB71o7+55vQ9ogFe2MMeNbK+jc9rrKVy280DnHO5JLMWOQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.2.0.tgz",
+      "integrity": "sha512-wIU1eHk3Op7dFgELRdmOYlPYS4gP8HhH1ZmZa13QZF59y0fblzFDFmKPhyc05phCy2hze9OEvNZAsoljrs+72w==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.2.2"
@@ -21039,9 +21026,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
-      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -21529,9 +21516,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.2.tgz",
+      "integrity": "sha512-qHKXW1q6liAk1Oys6umoaZbDRqjcjgSrbnrifHsfsttza7zcvRAsL7mMV6xWcyhwQy7Xj5v4hhbr6b+iDYwlmQ==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -22765,9 +22752,9 @@
       }
     },
     "node_modules/jayson": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
-      "integrity": "sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.2.0.tgz",
+      "integrity": "sha512-VfJ9t1YLwacIubLhONk0KFeosUBwstRWQ0IRT1KDjEjnVnSOVHC3uwugyV7L0c7R9lpVyrUGT2XWiBA1UTtpyg==",
       "license": "MIT",
       "dependencies": {
         "@types/connect": "^3.4.33",
@@ -22779,7 +22766,7 @@
         "eyes": "^0.1.8",
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
-        "JSONStream": "^1.3.5",
+        "stream-json": "^1.9.1",
         "uuid": "^8.3.2",
         "ws": "^7.5.10"
       },
@@ -23127,6 +23114,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -23136,6 +23124,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "jsonparse": "^1.2.0",
@@ -31522,6 +31511,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
@@ -32316,6 +32320,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -33099,9 +33104,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.2.3.tgz",
-      "integrity": "sha512-2oSLHaDalSt2/O/wHA9M+/ZPAOcU2yrSP/cdBYJ+YxZskiPYDSqHbysLSlD7gq3JMqOoJI5O31RVU3BxX/MnAA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.9.0.tgz",
+      "integrity": "sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -36082,50 +36087,50 @@
     "subgraphs/hemi-stake-operations-subgraph": {
       "version": "1.0.0",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.95.0",
-        "@graphprotocol/graph-ts": "0.36.0"
+        "@graphprotocol/graph-cli": "0.97.1",
+        "@graphprotocol/graph-ts": "0.38.1"
       }
     },
     "subgraphs/hemi-token-merkle-claims-subgraph": {
       "version": "1.0.1",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.95.0",
-        "@graphprotocol/graph-ts": "0.36.0"
+        "@graphprotocol/graph-cli": "0.97.1",
+        "@graphprotocol/graph-ts": "0.38.1"
       }
     },
     "subgraphs/hemi-tunnel-btc-deposits-subgraph": {
       "version": "1.0.0",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.95.0",
-        "@graphprotocol/graph-ts": "0.36.0"
+        "@graphprotocol/graph-cli": "0.97.1",
+        "@graphprotocol/graph-ts": "0.38.1"
       }
     },
     "subgraphs/hemi-tunnel-deposits-subgraph": {
       "version": "1.0.0",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.95.0",
-        "@graphprotocol/graph-ts": "0.36.0"
+        "@graphprotocol/graph-cli": "0.97.1",
+        "@graphprotocol/graph-ts": "0.38.1"
       }
     },
     "subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph": {
       "version": "1.0.0",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.95.0",
-        "@graphprotocol/graph-ts": "0.36.0"
+        "@graphprotocol/graph-cli": "0.97.1",
+        "@graphprotocol/graph-ts": "0.38.1"
       }
     },
     "subgraphs/hemi-tunnel-withdrawals-subgraph": {
       "version": "1.0.0",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.95.0",
-        "@graphprotocol/graph-ts": "0.36.0"
+        "@graphprotocol/graph-cli": "0.97.1",
+        "@graphprotocol/graph-ts": "0.38.1"
       }
     },
     "subgraphs/ve-hemi-subgraph": {
       "version": "1.0.1",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.95.0",
-        "@graphprotocol/graph-ts": "0.36.0"
+        "@graphprotocol/graph-cli": "0.97.1",
+        "@graphprotocol/graph-ts": "0.38.1"
       }
     }
   }

--- a/subgraphs/hemi-stake-operations-subgraph/package.json
+++ b/subgraphs/hemi-stake-operations-subgraph/package.json
@@ -18,7 +18,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.36.0"
+    "@graphprotocol/graph-cli": "0.97.1",
+    "@graphprotocol/graph-ts": "0.38.1"
   }
 }

--- a/subgraphs/hemi-stake-operations-subgraph/schema.graphql
+++ b/subgraphs/hemi-stake-operations-subgraph/schema.graphql
@@ -20,7 +20,7 @@ type Withdraw @entity(immutable: true) {
   transactionHash: Bytes!
 }
 
-type TokenStakeBalance @entity {
+type TokenStakeBalance @entity(immutable: false) {
   id: Bytes! # token address
   totalStaked: BigInt!
 }

--- a/subgraphs/hemi-token-merkle-claims-subgraph/package.json
+++ b/subgraphs/hemi-token-merkle-claims-subgraph/package.json
@@ -18,7 +18,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.36.0"
+    "@graphprotocol/graph-cli": "0.97.1",
+    "@graphprotocol/graph-ts": "0.38.1"
   }
 }

--- a/subgraphs/hemi-tunnel-btc-deposits-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-btc-deposits-subgraph/package.json
@@ -18,7 +18,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.36.0"
+    "@graphprotocol/graph-cli": "0.97.1",
+    "@graphprotocol/graph-ts": "0.38.1"
   }
 }

--- a/subgraphs/hemi-tunnel-deposits-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-deposits-subgraph/package.json
@@ -18,7 +18,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.36.0"
+    "@graphprotocol/graph-cli": "0.97.1",
+    "@graphprotocol/graph-ts": "0.38.1"
   }
 }

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/package.json
@@ -18,7 +18,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.36.0"
+    "@graphprotocol/graph-cli": "0.97.1",
+    "@graphprotocol/graph-ts": "0.38.1"
   }
 }

--- a/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/schema.graphql
+++ b/subgraphs/hemi-tunnel-withdrawals-proof-claim-subgraph/schema.graphql
@@ -1,4 +1,4 @@
-type Withdrawal @entity {
+type Withdrawal @entity(immutable: false) {
   id: Bytes!
   claimTxHash: Bytes
   proveTxHash: Bytes

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/package.json
@@ -18,7 +18,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ $(jq -r .name package.json)"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.36.0"
+    "@graphprotocol/graph-cli": "0.97.1",
+    "@graphprotocol/graph-ts": "0.38.1"
   }
 }

--- a/subgraphs/ve-hemi-subgraph/package.json
+++ b/subgraphs/ve-hemi-subgraph/package.json
@@ -18,7 +18,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ $npm_package_name"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.36.0"
+    "@graphprotocol/graph-cli": "0.97.1",
+    "@graphprotocol/graph-ts": "0.38.1"
   }
 }

--- a/subgraphs/ve-hemi-subgraph/schema.graphql
+++ b/subgraphs/ve-hemi-subgraph/schema.graphql
@@ -1,4 +1,4 @@
-type LockedPosition @entity {
+type LockedPosition @entity(immutable: false) {
   amount: BigInt!
   blockNumber: BigInt!
   blockTimestamp: BigInt!


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps the `@graphprotocol` dependencies to solve the job failures in #1527 

The deps updated had a breaking change where `graphql` entities were required to indicate if they were immutable or not. This PR solves that, adding the `immutable: false` for those that were mutable (The immutable ones were already marked as such)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
