### PR TITLE
Add EVM withdrawal warning for mainnet

### DIFF
--- a/portal/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/withdraw.tsx
@@ -3,6 +3,7 @@
 import { DrawerLoader } from 'components/drawer/drawerLoader'
 import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { FeesContainer } from 'components/feesContainer'
+import { WarningIcon } from 'components/icons/warningIcon'
 import { useAccounts } from 'hooks/useAccounts'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import { useWithdrawBitcoin } from 'hooks/useBtcTunnel'
@@ -366,7 +367,9 @@ const EvmWithdraw = function ({ state }: EvmWithdrawProps) {
   const balanceLoaded = nativeTokenBalanceLoaded || tokenBalanceLoaded
 
   function RenderBelowForm() {
-    if (!canWithdraw) return null
+    if (!canWithdraw) {
+      return null
+    }
 
     return (
       <FeesContainer>
@@ -379,8 +382,23 @@ const EvmWithdraw = function ({ state }: EvmWithdrawProps) {
     )
   }
 
+  function RenderBottomSection() {
+    if (!isMainnet || providerType !== 'native') {
+      return null
+    }
+
+    return (
+      <span className="mt-1 flex items-center justify-center gap-x-2 text-center text-sm font-medium text-neutral-500">
+        <WarningIcon className="shrink-0 text-neutral-400" />
+        {t('tunnel-page.form.withdrawing-funds-time-warning')}
+      </span>
+    )
+  }
+
   function RenderTunnelProviderToggle() {
-    if (!isMainnet) return null
+    if (!isMainnet) {
+      return null
+    }
 
     return (
       <TunnelProviderToggle
@@ -393,7 +411,9 @@ const EvmWithdraw = function ({ state }: EvmWithdrawProps) {
   }
 
   function RenderSubmitButton() {
-    if (providerType !== 'native') return null
+    if (providerType !== 'native') {
+      return null
+    }
 
     return (
       <SubmitEvmWithdrawal
@@ -410,6 +430,7 @@ const EvmWithdraw = function ({ state }: EvmWithdrawProps) {
     <>
       <TunnelForm
         belowForm={<RenderBelowForm />}
+        bottomSection={<RenderBottomSection />}
         formContent={
           <FormContent
             errorKey={

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -435,7 +435,8 @@
       "receive": "Receive",
       "send": "Send",
       "third-party-bridge": "3rd party bridge",
-      "to-network": "To Network"
+      "to-network": "To Network",
+      "withdrawing-funds-time-warning": "Withdrawing funds can take up to 24 hours to complete."
     },
     "review-deposit": {
       "add-token-to-wallet-error": "Failed to add the token contract to your wallet",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -435,7 +435,8 @@
       "receive": "Recibir",
       "send": "Enviar",
       "third-party-bridge": "Puente de terceros",
-      "to-network": "Hacia la Red"
+      "to-network": "Hacia la Red",
+      "withdrawing-funds-time-warning": "El retiro de fondos puede llevar hasta 24 horas para completarse."
     },
     "review-deposit": {
       "add-token-to-wallet-error": "No se pudo agregar el contrato del token a su billetera",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -435,7 +435,8 @@
       "receive": "Receber",
       "send": "Enviar",
       "third-party-bridge": "Ponte de terceiros",
-      "to-network": "Para a Rede"
+      "to-network": "Para a Rede",
+      "withdrawing-funds-time-warning": "A retirada de fundos pode levar até 24 horas para ser concluída."
     },
     "review-deposit": {
       "add-token-to-wallet-error": "Falha ao adicionar o contrato do token à sua carteira",


### PR DESCRIPTION
### Description

This PR implements a conditional warning message for EVM withdrawal operations when using the native provider on mainnet. The warning informs users that withdrawing funds can take up to 24 hours to complete.

### Screenshots

https://github.com/user-attachments/assets/d556e590-e01d-46a1-a350-c1e23ccf3e82

### Related issue(s)

Closes #1533 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
