### PR TITLE
Add staking position filter tabs

### DIFF
--- a/portal/app/[locale]/staking-dashboard/_components/form.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/form.tsx
@@ -73,7 +73,7 @@ export const StakingForm = ({
         }}
       >
         <div className="flex flex-col gap-y-3">{formContent}</div>
-        <div className="mt-10 w-full [&>*]:w-full">{submitButton}</div>
+        <div className="mt-12 w-full [&>*]:w-full">{submitButton}</div>
         {bottomSection}
       </form>
     </Card>

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
@@ -140,7 +140,7 @@ export function StakeTable({ data, loading }: Props) {
 
   return (
     <div className="w-full rounded-xl bg-neutral-100 text-sm font-medium">
-      <div className="md:min-h-128 h-[53dvh] overflow-hidden">
+      <div className="md:min-h-120 h-[49dvh] overflow-hidden">
         {getContent()}
       </div>
     </div>

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/linearProgress.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/linearProgress.tsx
@@ -9,7 +9,7 @@ export function LinearProgress({ percentage, unlockTime }: Props) {
   const width = `${Math.min(100, Math.max(0, percentage))}%`
 
   return (
-    <div className="relative flex h-7 w-28 items-center justify-center overflow-hidden rounded-md bg-neutral-100 px-2 py-1.5">
+    <div className="relative flex h-7 min-w-28 items-center justify-center overflow-hidden rounded-md bg-neutral-100 px-2 py-1.5">
       <div
         className="bg-linear-progress-bar absolute inset-y-0 left-0 transition-all duration-300 ease-out"
         style={{

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/stakeTableFilter.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/stakeTableFilter.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { Tab, Tabs } from 'components/tabs'
+import { useUmami } from 'hooks/useUmami'
+import { useTranslations } from 'next-intl'
+import { StakingPositionStatus } from 'types/stakingDashboard'
+
+export type StakeTableFilterOptions = StakingPositionStatus
+
+type Props = {
+  filter: StakeTableFilterOptions
+  onFilter: (filter: StakeTableFilterOptions) => void
+}
+
+export function StakeTableFilter({ filter, onFilter }: Props) {
+  const t = useTranslations('staking-dashboard.table')
+  const { track } = useUmami()
+
+  return (
+    <Tabs>
+      <Tab
+        onClick={function () {
+          onFilter('active')
+          track?.('staking dashboard - filter active')
+        }}
+        selected={filter === 'active'}
+      >
+        {t('active')}
+      </Tab>
+      <Tab
+        onClick={function () {
+          onFilter('withdrawn')
+          track?.('staking dashboard - filter burned')
+        }}
+        selected={filter === 'withdrawn'}
+      >
+        {t('burned')}
+      </Tab>
+    </Tabs>
+  )
+}

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/timeRemaining.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/timeRemaining.tsx
@@ -33,6 +33,7 @@ export function TimeRemaining({ operation }: Props) {
           status,
           tokenId,
         }}
+        unlockDate={unlockDate}
       />
     )
   }

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/unlock.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/unlock.tsx
@@ -1,8 +1,9 @@
 import { Button } from 'components/button'
 import { useHemiToken } from 'hooks/useHemiToken'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { StakingPosition, StakingPositionStatus } from 'types/stakingDashboard'
+import { formatDate } from 'utils/format'
 
 import { useStakingDashboard } from '../../_context/stakingDashboardContext'
 import { useUnlock } from '../../_hooks/useUnlock'
@@ -20,12 +21,14 @@ const CheckIcon = () => (
 
 type Props = {
   operation: Pick<StakingPosition, 'amount' | 'status' | 'tokenId'>
+  unlockDate: Date
 }
 
 export type OperationRunning = 'idle' | 'unlocking' | 'failed'
 
-export function Unlock({ operation }: Props) {
+export function Unlock({ operation, unlockDate }: Props) {
   const t = useTranslations('staking-dashboard')
+  const locale = useLocale()
   const token = useHemiToken()
   const { amount, tokenId } = operation
   const [operationRunning, setOperationRunning] =
@@ -53,10 +56,17 @@ export function Unlock({ operation }: Props) {
 
   if (operation.status === StakingPositionStatus.WITHDRAWN) {
     return (
-      <div className="flex items-center gap-x-1.5">
-        <CheckIcon />
-        <span className="text-sm font-medium text-neutral-500">
-          {t('table.unlocked')}
+      <div className="flex flex-col items-start">
+        <div className="flex items-center">
+          <CheckIcon />
+          <span className="text-sm font-medium text-emerald-600">
+            {t('table.burned')}
+          </span>
+        </div>
+        <span className="text-xs font-normal text-neutral-500">
+          {t('table.on', {
+            date: formatDate(unlockDate, locale),
+          })}
         </span>
       </div>
     )

--- a/portal/app/[locale]/staking-dashboard/page.tsx
+++ b/portal/app/[locale]/staking-dashboard/page.tsx
@@ -4,9 +4,14 @@ import { PageLayout } from 'components/pageLayout'
 import { useHemiToken } from 'hooks/useHemiToken'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useTranslations } from 'next-intl'
+import { useMemo, useState } from 'react'
 
 import { StakeForm } from './_components/stakeForm'
 import { StakeTable } from './_components/stakeTable'
+import {
+  StakeTableFilter,
+  type StakeTableFilterOptions,
+} from './_components/stakeTable/stakeTableFilter'
 import { StakingDashboardDisabledTestnet } from './_components/stakingDashboardDisabledTestnet'
 import { StakingDashboardProvider } from './_context/stakingDashboardContext'
 import { useStakingPositions } from './_hooks/useStakingPositions'
@@ -15,11 +20,25 @@ import { isStakingDashboardEnabledOnTestnet } from './_utils/isStakingDashboardE
 function StakingContent() {
   const { data, isLoading } = useStakingPositions()
 
+  const [filter, setFilter] = useState<StakeTableFilterOptions>('active')
+
+  function handleFilter(newFilter: StakeTableFilterOptions) {
+    setFilter(newFilter)
+  }
+
+  const filteredData = useMemo(
+    () => data?.filter(position => position.status === filter),
+    [data, filter],
+  )
+
   return (
     <StakingDashboardProvider>
       <div className="mt-8 flex flex-col-reverse gap-6 lg:flex-row">
         <div className="w-full lg:w-1/2 lg:flex-initial 2xl:w-full">
-          <StakeTable data={data} loading={isLoading} />
+          <div className="mb-4 ml-1 flex flex-row md:w-fit">
+            <StakeTableFilter filter={filter} onFilter={handleFilter} />
+          </div>
+          <StakeTable data={filteredData} loading={isLoading} />
         </div>
         <div className="w-full lg:w-fit lg:flex-auto lg:flex-shrink-0 lg:basis-1/2 2xl:w-fit 2xl:flex-none">
           <StakeForm />

--- a/portal/app/analyticsEvents.ts
+++ b/portal/app/analyticsEvents.ts
@@ -84,6 +84,8 @@ const analyticsEvents = [
   'stake - unstake success',
   // /staking-dashboard
   'staking dashboard - approve reverted',
+  'staking dashboard - filter active',
+  'staking dashboard - filter burned',
   'staking dashboard - lock creation reverted',
   'staking dashboard - lock creation success',
   'staking dashboard - signed lock creation',

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -271,10 +271,13 @@
     "stake-successful": "Stake successful",
     "switch-to-start-staking": "You can switch networks to start staking your HEMI.",
     "table": {
+      "active": "Active",
+      "burned": "Burned",
       "connect-to-hemi": "Connect to {network} to view your stake positions.",
       "connect-to-stake": "Connect your wallet to view your {symbol} staked.",
       "get-started": "Get started by staking your {symbol}",
       "no-hemi-staked": "No {symbol} staked",
+      "on": "On {date}",
       "time-remaining": "Time remaining",
       "tx": "Tx",
       "unlock": "Unlock",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -271,10 +271,13 @@
     "stake-successful": "Stake exitoso",
     "switch-to-start-staking": "Puede cambiar de red para comenzar a hacer staking de su HEMI.",
     "table": {
+      "active": "Activo",
+      "burned": "Quemado",
       "connect-to-hemi": "Conéctese a {network} para ver sus posiciones de stake.",
       "connect-to-stake": "Conecte su billetera para ver su {symbol} en stake.",
       "get-started": "Comience haciendo staking de sus {symbol}",
       "no-hemi-staked": "No hay {symbol} en stake",
+      "on": "En {date}",
       "time-remaining": "Tiempo restante",
       "tx": "Tx",
       "unlock": "Desbloquear",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -271,10 +271,13 @@
     "stake-successful": "Stake bem-sucedido",
     "switch-to-start-staking": "Você pode mudar de rede para começar a fazer staking do seu HEMI.",
     "table": {
+      "active": "Ativo",
+      "burned": "Queimado",
       "connect-to-hemi": "Conecte à {network} para ver as suas posições de stake.",
       "connect-to-stake": "Conecte a sua carteira para ver o seu {symbol} em stake.",
       "get-started": "Comece a fazer stake com seu {symbol}",
       "no-hemi-staked": "Sem {symbol} staked",
+      "on": "Em {date}",
       "time-remaining": "Tempo restante",
       "tx": "Tx",
       "unlock": "Desbloquear",


### PR DESCRIPTION
### Description

This PR adds the filter tabs to switch between Active and Burned staking positions. It also updates time remaining column to show burned status with date.

### Screenshots

https://github.com/user-attachments/assets/faa71f2e-dcbf-4c61-bf1b-22c39e14d903

### Related issue(s)

Related to #1505 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
