### PR TITLE
Allow adding custom token without checksum val

### DIFF
--- a/portal/components/customTokenDrawer/index.tsx
+++ b/portal/components/customTokenDrawer/index.tsx
@@ -18,7 +18,7 @@ import { isL2Network } from 'utils/chain'
 import {
   type Address,
   type Chain,
-  checksumAddress,
+  getAddress,
   isAddress,
   isAddressEqual,
 } from 'viem'
@@ -47,7 +47,7 @@ const canSubmit = ({
   acknowledged &&
   !!l1CustomToken &&
   !!l2customToken &&
-  isAddress(l1CustomToken.address) &&
+  isAddress(l1CustomToken.address, { strict: false }) &&
   isAddressEqual(l2customToken.l1Token, l1CustomToken.address)
 
 const getL1AddressValidity = (l1CustomToken: Token | undefined) =>
@@ -140,16 +140,18 @@ export const CustomTokenDrawer = function ({
     }
 
     // canSubmit ensures l2CustomToken is defined
-    const { l1Token, ...tokenData } = l2customToken!
+    const { address, l1Token, ...tokenData } = l2customToken!
     // the token list is saved with chainId from Hemi, and then the opposite is generated
     // from the tunnel info. See https://github.com/hemilabs/token-list/blob/master/src/hemi.tokenlist.json
     // for examples
+
     const l2TokenAdded = {
       ...tokenData,
+      address: getAddress(address),
       extensions: {
         bridgeInfo: {
           [l1ChainId]: {
-            tokenAddress: checksumAddress(l1Token, l1ChainId),
+            tokenAddress: getAddress(l1Token),
           },
         },
       },


### PR DESCRIPTION
### Description

This PR removes the strict checksum validation (isAddress(..., { strict: true })) when adding a custom token, allowing users to input lowercase addresses. At the same time, all addresses are normalized using getAddress before being saved, ensuring they are stored consistently in checksummed (EIP-55) format.

### Screenshots

https://github.com/user-attachments/assets/720650f4-1af3-4821-a350-7f9a2d6e833b

### Related issue(s)

Related to https://github.com/hemilabs/token-list/issues/88

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
