### PR TITLE
Standardize shadows across most of the app

### DIFF
--- a/portal/app/[locale]/_components/appLayout.tsx
+++ b/portal/app/[locale]/_components/appLayout.tsx
@@ -90,7 +90,7 @@ export const AppLayout = function ({ children }: Props) {
         <>
           <Backdrop onClick={() => setIsNavbarOpen(false)} />
           <div
-            className="shadow-navbar z-30 ml-2 mt-2 hidden  h-[calc(100dvh-16px)] rounded-xl bg-white p-1 md:absolute md:block lg:hidden"
+            className="z-30 ml-2 mt-2 hidden h-[calc(100dvh-16px)] rounded-xl bg-white p-1 shadow-xl md:absolute md:block lg:hidden"
             ref={ref}
           >
             <Navbar />

--- a/portal/app/[locale]/_components/appLayoutContainer.tsx
+++ b/portal/app/[locale]/_components/appLayoutContainer.tsx
@@ -11,14 +11,14 @@ const UI = ({
 }: Props & { networkType: NetworkType }) => (
   <div
     className={`
-      shadow-hemi-layout backdrop-blur-20 relative flex h-full
+      backdrop-blur-20 relative flex h-full
       w-3/4 flex-1 flex-col self-stretch overflow-y-hidden bg-neutral-50 lg:h-[calc(100dvh-16px)]
       ${
         networkType === 'testnet'
           ? 'md:border-2 md:border-orange-500'
           : 'border-neutral-300/55 lg:border'
       }
-      md:my-0 md:mr-0 md:w-[calc(75%-8px)] lg:my-2 lg:mr-2 lg:rounded-2xl`}
+      md:my-0 md:mr-0 md:w-[calc(75%-8px)] lg:my-2 lg:mr-3 lg:rounded-2xl`}
     id="app-layout-container"
   >
     {children}

--- a/portal/app/[locale]/_components/earnCard/earnRewards.tsx
+++ b/portal/app/[locale]/_components/earnCard/earnRewards.tsx
@@ -57,7 +57,7 @@ export const EarnRewards = function ({ onClose }: { onClose: VoidFunction }) {
   const image = imageMap[locale]
 
   return (
-    <div className="group/card-image shadow-theme-md hover:shadow-theme-lg rounded-xl border border-solid border-neutral-300/55 bg-white">
+    <div className="group/card-image rounded-xl bg-white shadow-md hover:shadow-lg">
       <div className="p-1.5">
         <div className="relative overflow-hidden rounded-lg">
           <Image

--- a/portal/app/[locale]/_components/header/index.tsx
+++ b/portal/app/[locale]/_components/header/index.tsx
@@ -35,13 +35,13 @@ export const Header = ({ isMenuOpen, setIsNavbarOpen, toggleMenu }: Props) => (
       <Badge />
     </div>
     <div className="size-13 hidden items-center justify-center border-r border-neutral-300/55 md:flex lg:hidden">
-      <div
-        className="shadow-soft hidden size-7 cursor-pointer items-center
-          justify-center rounded-lg border border-neutral-300/55 bg-white md:flex"
+      <ButtonIcon
         onClick={() => setIsNavbarOpen(true)}
+        size="xSmall"
+        variant="secondary"
       >
         <HamburgerIcon />
-      </div>
+      </ButtonIcon>
     </div>
     <div className="hidden pl-6 md:block">
       <StakeTabs />

--- a/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
@@ -209,11 +209,11 @@ const DexImpl = function () {
 
       {isOpen && (
         <div
-          className="shadow-help-menu md:translate-y-30 absolute bottom-0
-          left-0 z-30 flex
-          w-full flex-col items-start
-          rounded-t-2xl border border-neutral-300/55 bg-white
-          p-4 md:top-0 md:h-fit md:w-64
+          className="md:translate-y-30 absolute bottom-0 left-0
+          z-30 flex w-full
+          flex-col items-start rounded-t-2xl
+          bg-white p-4
+          shadow-lg md:top-0 md:h-fit md:w-64
           md:translate-x-56 md:rounded-lg
           md:p-1"
         >

--- a/portal/app/[locale]/_components/navbar/_components/getStarted/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/getStarted/index.tsx
@@ -35,7 +35,7 @@ const UI = ({ active, href, onClick, t }: Props) => (
       href={href}
       onClick={onClick}
     >
-      <div className="shadow-get-started-card relative h-full w-52 rounded-lg bg-white">
+      <div className="relative h-full w-52 rounded-lg bg-white shadow-sm">
         <Background
           className={`rounded-lg 
             ${

--- a/portal/app/[locale]/_components/navbar/_components/help/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/index.tsx
@@ -156,11 +156,10 @@ const LanguageMenu = function ({ active }: LanguageProps) {
 
   return (
     <div
-      className="shadow-help-menu absolute bottom-0 right-0 z-40
-    flex h-fit w-52 -translate-x-8
-    -translate-y-32 flex-col
-    items-start justify-center rounded-lg border
-    border-neutral-300/55 bg-white p-2
+      className="absolute bottom-0 right-0 z-40 flex
+    h-fit w-52 -translate-x-8 -translate-y-32
+    flex-col items-start
+    justify-center rounded-lg bg-white p-2 shadow-lg
     md:top-0 md:translate-x-48 md:translate-y-1 md:p-1"
     >
       {locales.map(locale => (
@@ -186,11 +185,10 @@ const LanguageMenu = function ({ active }: LanguageProps) {
 
 const LegalAndPrivacy = () => (
   <div
-    className="-translate-y-18 shadow-help-menu absolute bottom-0 right-0
-        z-20 flex w-64 -translate-x-8
-        flex-col items-start
-        gap-x-2 rounded-lg border
-        border-neutral-300/55 bg-white p-4
+    className="-translate-y-18 absolute bottom-0 right-0 z-20
+        flex w-64 -translate-x-8 flex-col
+        items-start gap-x-2
+        rounded-lg bg-white p-4 shadow-lg
         md:translate-x-60 md:translate-y-7"
   >
     <TermsAndConditions />
@@ -225,10 +223,9 @@ export const Help = function () {
 
       {isOpen && (
         <div
-          className="shadow-help-menu absolute bottom-0 left-0
-          z-30 flex h-36 w-full
-          flex-col items-start rounded-t-2xl
-          border border-neutral-300/55 bg-white p-4
+          className="absolute bottom-0 left-0 z-30
+          flex h-36 w-full flex-col
+          items-start rounded-t-2xl bg-white p-4 shadow-lg
           md:top-0 md:h-fit md:w-64 md:translate-x-52
           md:translate-y-16 md:rounded-lg md:p-1"
         >

--- a/portal/app/[locale]/_components/navbar/_components/tvl/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/tvl/index.tsx
@@ -36,7 +36,7 @@ const TvlImpl = function () {
   return (
     isNotTestnet && (
       <section
-        className="shadow-soft h-22 bg-sky-450 relative mx-0.5 mb-4 flex flex-col gap-y-3 rounded-lg 
+        className="h-22 bg-sky-450 relative mx-0.5 mb-4 flex flex-col gap-y-3 rounded-lg 
         p-4 md:mb-0 md:mt-3"
       >
         <div className="flex w-full items-center justify-between">
@@ -54,7 +54,7 @@ export const Tvl = () => (
     fallback={
       // Statically render a skeleton as TVL is only shown and mainnet, but in addition to this,
       // the position changes on the navbar.
-      <Skeleton className="h-22 shadow-soft mb-4 w-full rounded-lg md:mb-0 md:mt-4" />
+      <Skeleton className="h-22 mb-4 w-full rounded-lg md:mb-0 md:mt-4" />
     }
   >
     <TvlImpl />

--- a/portal/app/[locale]/genesis-drop/_components/strategy.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/strategy.tsx
@@ -17,9 +17,9 @@ import { RecommendedBadge } from './recommendedBadge'
 // I prefer to sort these in priority-based order
 /* eslint-disable sort-keys */
 const boxShadows: Record<RecommendationLevel, string> = {
-  low: 'shadow-claim-page-soft',
-  medium: 'shadow-claim-page-high',
-  high: 'shadow-claim-page-high',
+  low: 'shadow-bs',
+  medium: 'shadow-md',
+  high: 'shadow-md',
 }
 /* eslint-enable sort-keys */
 

--- a/portal/app/[locale]/genesis-drop/_components/termsAndConditions.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/termsAndConditions.tsx
@@ -83,7 +83,7 @@ export const TermsAndConditions = function ({ onAccept, onClose }: Props) {
   return (
     <Modal onClose={onClose}>
       <div className="max-w-120 relative w-full bg-neutral-50">
-        <div className="shadow-claim-page-high relative z-10 rounded-lg bg-white">
+        <div className="relative z-10 rounded-lg bg-white shadow-sm">
           <h3 className="px-6 py-4 text-lg font-semibold  text-neutral-950">
             {t('genesis-drop.terms-and-conditions.title')}
           </h3>

--- a/portal/app/[locale]/stake/_components/manageStake/preview.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/preview.tsx
@@ -56,7 +56,7 @@ export const Preview = function ({
         )}
         <DrawerSection>
           <div className="flex flex-col gap-y-4">
-            <div className="[&>*]:hover:shadow-large [&>*]:border-neutral-300/55 [&>*]:bg-white">
+            <div className="[&>*]:shadow-bs [&>*]:bg-white [&>*]:hover:shadow-sm">
               <TokenInput
                 balanceComponent={balanceComponent}
                 disabled={isOperating}

--- a/portal/app/[locale]/stake/_components/stakeDisabledTestnet.tsx
+++ b/portal/app/[locale]/stake/_components/stakeDisabledTestnet.tsx
@@ -6,8 +6,8 @@ import { StakeAndEarn } from './stakeAndEarn'
 
 export const StakeDisabledTestnet = () => (
   <div
-    className="shadow-large flex flex-col items-center rounded-2xl border border-solid border-neutral-300/55 px-5
-    pt-12 md:mt-12 lg:h-[60dvh] lg:flex-row lg:justify-evenly lg:gap-x-12 lg:py-12 2xl:gap-x-24"
+    className="flex flex-col items-center rounded-xl px-5 pt-12
+    shadow-md md:mt-12 lg:h-[60dvh] lg:flex-row lg:justify-evenly lg:gap-x-12 lg:py-12 2xl:gap-x-24"
     style={{
       background:
         'radial-gradient(100% 100% at 50% 0%, rgba(253, 239, 232, 0.16) 14.12%, rgba(255, 108, 21, 0.16) 32.29%, rgba(255, 24, 20, 0.03) 98.87%), #FFF',

--- a/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/welcomeStake.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/welcomeStake.tsx
@@ -5,8 +5,8 @@ import { StakeLink } from './stakeLink'
 
 export const WelcomeStake = () => (
   <div
-    className="shadow-large mb-12 flex flex-col items-center rounded-2xl border border-solid border-neutral-300/55
-    px-5 pt-12 lg:mt-12 lg:h-[50dvh] lg:flex-row lg:justify-evenly lg:gap-x-44 lg:py-12 xl:gap-x-16"
+    className="mb-12 flex flex-col items-center rounded-xl px-5
+    pt-12 shadow-md lg:mt-12 lg:h-[50dvh] lg:flex-row lg:justify-evenly lg:gap-x-44 lg:py-12 xl:gap-x-16"
     style={{
       background:
         'radial-gradient(100% 100% at 50% 0%, rgba(253, 239, 232, 0.16) 14.12%, rgba(255, 108, 21, 0.16) 32.29%, rgba(255, 24, 20, 0.03) 98.87%), #FFF',

--- a/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
@@ -38,7 +38,7 @@ const Points = ({
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div className="h-24 w-full [&>div]:overflow-hidden">
-    <Card shadow="shadow-soft">
+    <Card>
       <div className="relative">{children}</div>
     </Card>
   </div>

--- a/portal/app/[locale]/staking-dashboard/_components/stakingDashboardDisabledTestnet.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakingDashboardDisabledTestnet.tsx
@@ -11,7 +11,7 @@ export const StakingDashboardDisabledTestnet = function () {
   const tCommon = useTranslations('common')
 
   return (
-    <div className="shadow-live-mainnet-card mt-8 flex flex-col items-center justify-center gap-y-1 rounded-xl bg-white py-48">
+    <div className="mt-8 flex flex-col items-center justify-center gap-y-1 rounded-xl bg-white py-48 shadow-md">
       <LiveIcon />
       <h2 className="text-lg font-semibold text-neutral-950">
         {tCommon('only-live-on-mainnet')}

--- a/portal/app/[locale]/tunnel/_components/tunnelProviderToggle.tsx
+++ b/portal/app/[locale]/tunnel/_components/tunnelProviderToggle.tsx
@@ -63,7 +63,7 @@ export const TunnelProviderToggle = function ({
         <button
           className={`flex-1 rounded-md p-1 text-sm font-medium transition ${
             providerType === 'native'
-              ? 'border border-neutral-300/55 bg-white text-neutral-950 shadow-sm'
+              ? 'bg-white text-neutral-950 shadow-sm'
               : 'text-neutral-600 hover:text-neutral-950'
           }`}
           onClick={toggleNativeProvider}
@@ -74,7 +74,7 @@ export const TunnelProviderToggle = function ({
         <button
           className={`flex-1 rounded-md p-1 text-sm font-medium transition ${
             providerType === 'thirdParty'
-              ? 'border border-neutral-300/55 bg-white text-neutral-950 shadow-sm'
+              ? 'bg-white text-neutral-950 shadow-sm'
               : 'text-neutral-600 hover:text-neutral-950'
           }`}
           onClick={toggleThirdPartyProvider}

--- a/portal/components/card.tsx
+++ b/portal/components/card.tsx
@@ -1,12 +1,7 @@
 import { ComponentProps } from 'react'
 
-type Props = ComponentProps<'div'> & {
-  shadow?: 'shadow-soft' | 'shadow-large'
-}
+type Props = ComponentProps<'div'>
 
-export const Card = ({ shadow = 'shadow-large', ...props }: Props) => (
-  <div
-    className={`card-container rounded-2xl border border-solid border-neutral-300/55 bg-white ${shadow}`}
-    {...props}
-  />
+export const Card = (props: Props) => (
+  <div className="card-container rounded-xl bg-white shadow-md" {...props} />
 )

--- a/portal/components/connectWallets/box.tsx
+++ b/portal/components/connectWallets/box.tsx
@@ -30,7 +30,7 @@ export const Box = function ({
           })}
         </span>
       </div>
-      <div className="rounded-xl border border-solid border-neutral-300/55 bg-white p-2 shadow-sm">
+      <div className="rounded-xl bg-white p-2 shadow-md">
         <div className="flex w-full items-center justify-between rounded-md border border-solid bg-neutral-300/55 bg-neutral-50 px-2 py-1">
           {topContent}
         </div>

--- a/portal/components/connectWallets/connectWalletsDrawer.tsx
+++ b/portal/components/connectWallets/connectWalletsDrawer.tsx
@@ -55,8 +55,8 @@ export const ConnectWalletsDrawer = function ({ closeDrawer }: Props) {
           <div className="flex flex-col items-center gap-y-3 rounded-2xl bg-neutral-50 px-1 pb-3 pt-1">
             <BtcWallet />
             <div
-              className="shadow-soft mt-1 flex size-6 items-center justify-center rounded-full border
-          border-solid border-rose-100 bg-rose-50"
+              className="mt-1 flex size-6 items-center justify-center rounded-full border border-solid
+          border-rose-100 bg-rose-50 shadow-sm"
             >
               <WarningIcon />
             </div>

--- a/portal/components/connectWallets/wallets.tsx
+++ b/portal/components/connectWallets/wallets.tsx
@@ -48,8 +48,8 @@ const ConnectWalletButton = function ({
   const { track } = useUmami()
   return (
     <button
-      className={`group flex w-full cursor-pointer items-center gap-x-2 rounded-xl border
-       border-solid border-neutral-200 bg-white p-3 shadow-sm ${hoverClassName}`}
+      className={`group flex w-full cursor-pointer items-center gap-x-2 
+        rounded-xl bg-white p-3 shadow-sm ${hoverClassName}`}
       onClick={function () {
         track?.(event)
         onClick?.()
@@ -99,7 +99,7 @@ export const BtcWallet = function () {
     return (
       <ConnectWalletButton
         event="btc connect"
-        hoverClassName="hover:bg-orange-50 hover:border-orange-300/55"
+        hoverClassName="hover:bg-orange-50"
         icon={<BtcLogo />}
         onClick={() => connect(unisat.wallet)}
         rightIcon={
@@ -188,7 +188,7 @@ export const EvmWallet = function () {
     return (
       <ConnectWalletButton
         event="evm connect"
-        hoverClassName="hover:bg-blue-50 hover:border-blue-300/55"
+        hoverClassName="hover:bg-blue-50"
         icon={<EthLogo />}
         onClick={openConnectModal}
         text={t('connect-evm-wallet')}

--- a/portal/components/customTokenDrawer/acknowledge.tsx
+++ b/portal/components/customTokenDrawer/acknowledge.tsx
@@ -16,8 +16,8 @@ export const Acknowledge = function ({ acknowledged, onChange }: Props) {
     >
       <input
         checked={acknowledged}
-        className="shadow-soft checkbox h-4 w-4 cursor-pointer appearance-none rounded border border-solid border-neutral-300/55 bg-white
-              transition-all checked:border-0 checked:bg-orange-500 focus:ring-2 focus:ring-orange-500"
+        className="checkbox h-4 w-4 cursor-pointer appearance-none rounded bg-white shadow-sm
+              transition-all checked:bg-orange-500 focus:ring-2 focus:ring-orange-500"
         id="custom-token-acknowledged"
         onChange={e => onChange(e.target.checked)}
         type="checkbox"

--- a/portal/components/customTunnelsThroughPartners/partnerLink.tsx
+++ b/portal/components/customTunnelsThroughPartners/partnerLink.tsx
@@ -18,8 +18,8 @@ export const PartnerLink = function ({
   const { enabled, track } = useUmami()
   return (
     <ExternalLink
-      className="group/link flex w-full items-center gap-x-1 rounded-xl border border-solid border-neutral-300/55 bg-white
-        p-3 text-base font-medium text-neutral-950 shadow-sm transition-all duration-200 hover:bg-neutral-50 hover:shadow"
+      className="group/link flex w-full items-center gap-x-1 rounded-xl bg-white p-3
+        text-base font-medium text-neutral-950 shadow-sm transition-all duration-200 hover:bg-neutral-50 hover:shadow-md"
       href={url}
       onClick={enabled ? () => track('partner bridge', { partner }) : undefined}
     >

--- a/portal/components/menu.tsx
+++ b/portal/components/menu.tsx
@@ -3,7 +3,7 @@ type Props = {
 }
 
 export const Menu = ({ items }: Props) => (
-  <div className="rounded-lg border border-solid border-neutral-300/55 bg-white p-1 text-sm shadow-md">
+  <div className="rounded-lg bg-white p-1 text-sm shadow-lg">
     <ul className="flex flex-col gap-y-1">
       {items.map(({ content, id }) => (
         <li

--- a/portal/components/modal.tsx
+++ b/portal/components/modal.tsx
@@ -43,7 +43,7 @@ export const Modal = function ({
     <>
       <OverlayComponent />
       <dialog
-        className={`pointer-event-auto shadow-large fixed inset-0 z-50 flex min-h-screen justify-center overflow-y-auto overflow-x-hidden rounded-2xl bg-transparent outline-none focus:outline-none md:min-h-0 ${
+        className={`pointer-event-auto fixed inset-0 z-50 flex min-h-screen justify-center overflow-y-auto overflow-x-hidden rounded-2xl bg-transparent shadow-xl outline-none focus:outline-none md:min-h-0 ${
           verticalAlign === 'top' ? 'pt-13 m-0 items-start' : 'items-center'
         }`}
         onTouchStart={e => e.stopPropagation()}

--- a/portal/components/table/index.tsx
+++ b/portal/components/table/index.tsx
@@ -91,7 +91,7 @@ function TableBody<TData>({
 
   return (
     <div
-      className="shadow-table -mt-1.5 mb-1 min-h-0 flex-1 overflow-y-auto rounded-xl bg-white"
+      className="-mt-1.5 mb-1 min-h-0 flex-1 overflow-y-auto rounded-xl bg-white shadow-md"
       onScroll={e => fetchMoreOnBottomReached(e.currentTarget)}
       ref={scrollContainerRef}
       style={{

--- a/portal/components/tabs.tsx
+++ b/portal/components/tabs.tsx
@@ -44,7 +44,7 @@ export const Tab = function ({
       } flex-1 items-center py-1 font-medium transition-colors duration-300 md:flex-auto [&>a]:w-full
       ${
         selected
-          ? 'shadow-tab-active bg-white text-neutral-950'
+          ? 'bg-white text-neutral-950 shadow-sm'
           : 'cursor-pointer bg-neutral-100 text-neutral-700 hover:text-neutral-950'
       }
     `}

--- a/portal/components/toast/index.tsx
+++ b/portal/components/toast/index.tsx
@@ -49,7 +49,7 @@ export const Toast = function ({
 
   return (
     <div
-      className="shadow-soft fixed inset-x-4 bottom-20 z-40 flex justify-between
+      className="fixed inset-x-4 bottom-20 z-40 flex justify-between
       gap-x-3 rounded-xl border border-solid border-black/85 bg-neutral-800 p-3.5
     text-sm font-medium text-white md:bottom-auto md:left-auto md:right-8 md:top-20"
     >

--- a/portal/components/toast/toastLoader.tsx
+++ b/portal/components/toast/toastLoader.tsx
@@ -2,7 +2,7 @@ import Skeleton from 'react-loading-skeleton'
 
 export const ToastLoader = () => (
   <Skeleton
-    className="shadow-soft h-26 w-full rounded-xl md:w-96"
+    className="h-26 w-full rounded-xl md:w-96"
     containerClassName="fixed bottom-20 inset-x-4 z-40 md:bottom-auto md:left-auto md:right-8 md:top-20"
   />
 )

--- a/portal/components/tokenInput/index.tsx
+++ b/portal/components/tokenInput/index.tsx
@@ -59,8 +59,8 @@ export const TokenInput = function <T extends Token>({
   const BalanceComponent = balanceComponent ?? Balance
   return (
     <div
-      className="h-[120px] rounded-lg border border-solid border-transparent bg-neutral-50
-      p-4 font-medium text-neutral-500 hover:border-neutral-300/55"
+      className="hover:shadow-bs h-[120px] rounded-lg border border-solid border-transparent bg-neutral-50
+      p-4 font-medium text-neutral-500"
     >
       <div className="flex h-full items-center justify-between">
         <div className="flex h-full flex-shrink flex-grow flex-col items-start">

--- a/portal/components/tokenSelector/list.tsx
+++ b/portal/components/tokenSelector/list.tsx
@@ -255,7 +255,7 @@ export const List = function ({
   return (
     <div
       className={`skip-parent-padding-x flex-1 overflow-y-auto bg-white transition-shadow duration-200 ${
-        hasScrolled ? 'shadow-top-token-selector' : ''
+        hasScrolled ? 'shadow-md' : ''
       }`}
       onScroll={onScroll}
       ref={parentRef}

--- a/portal/components/tokenSelector/tokenList.tsx
+++ b/portal/components/tokenSelector/tokenList.tsx
@@ -192,7 +192,9 @@ export const TokenList = function ({
 
   return (
     <Modal onClose={closeModal} verticalAlign={width < 768 ? 'top' : 'center'}>
-      <Card className="overflow-hidden rounded-2xl bg-white">{content}</Card>
+      <Card>
+        <div className="overflow-hidden bg-white">{content}</div>
+      </Card>
     </Modal>
   )
 }

--- a/portal/components/tokenSelector/tokenQuickSelect.tsx
+++ b/portal/components/tokenSelector/tokenQuickSelect.tsx
@@ -23,7 +23,7 @@ export const TokenQuickSelect = ({ onSelect, tokens }: Props) => (
   <div className="flex gap-x-3">
     {tokens.map(token => (
       <div
-        className="shadow-token-selector group relative flex-1 rounded-lg bg-white"
+        className="group relative flex-1 rounded-lg bg-white shadow-sm"
         key={token.address}
       >
         {/* Inner hover background */}

--- a/portal/tailwind.config.ts
+++ b/portal/tailwind.config.ts
@@ -8,6 +8,17 @@ const config: Config = {
   ],
   plugins: [],
   theme: {
+    boxShadow: {
+      // Sorting by increasing size of shadow
+      /* eslint-disable sort-keys */
+      // Base
+      bs: '0 0 0 1px rgba(0, 0, 0, 0.05)',
+      sm: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.08), 0 7px 11px -6px rgba(0, 0, 0, 0.08)',
+      md: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 5px 16px -2px rgba(0, 0, 0, 0.08), 0 7px 11px -6px rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.02)',
+      lg: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 12px 28px -8px rgba(0, 0, 0, 0.16), 0 5px 16px -2px rgba(0, 0, 0, 0.06)',
+      xl: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 5px 16px -2px rgba(0, 0, 0, 0.06), 0 15px 35px -5px rgba(0, 0, 0, 0.20)',
+      /* eslint-enable sort-keys */
+    },
     extend: {
       animation: {
         'withdraw-progress': 'withdraw-progress 2s infinite',
@@ -53,45 +64,13 @@ const config: Config = {
         'button-secondary-focused':
           '0 0 0 1px rgba(10, 10, 10, 0.08), 0 0 0 4px #E5E5E5, 0 1px 3px 0 rgba(10, 10, 10, 0.15), 0 7px 11px -5px rgba(10, 10, 10, 0.11)',
         'button-tertiary-focused': '0 0 0 4px #E5E5E5',
-        'claim-page-high':
-          '0 0 0 1px rgba(10, 10, 10, 0.08), 0 3px 12px 0 rgba(0, 0, 0, 0.04), 0 7px 16px -5px rgba(10, 10, 10, 0.08)',
-        'claim-page-soft': '0 0 0 1px rgba(10, 10, 10, 0.08)',
-        'get-started-card':
-          '0 0 0 1px rgba(10, 10, 10, 0.08), 0 1px 3px 0 rgba(10, 10, 10, 0.15), 0 7px 11px -5px rgba(10, 10, 10, 0.11)',
-        'help-icon':
-          '0px 1px 2px 0px rgba(10 10 10 0.04), 0px 1px 4px 0px #rgba(10 10 10 0.02)',
-        'help-menu':
-          '0px 4px 12px 0px rgba(10 10 10 0.06), 0px 4px 6px 0px rgba(10 10 10 0.02), 0px 0px 0px 1px rgba(10 10 10 0.06)',
-        'hemi-layout':
-          '0px 2px 2px 0px rgba(10, 10, 10, 0.04), 0px 8px 16px -4px rgba(10, 10, 10, 0.04)',
-        'large':
-          '0px 2px 4px 0px rgba(0, 2, 2, 0.04), 0px 8px 24px -4px rgba(0, 2, 2, 0.04)',
-        'live-mainnet-card':
-          '0 0 2px 0 rgba(10, 10, 10, 0.10), 0 8px 12px -4px rgba(10, 10, 10, 0.08), 0 1px 2px 0 rgba(10, 10, 10, 0.10)',
         'lockup-input-default':
           '0 0 0 1px rgba(10, 10, 10, 0.08), 0 1px 3px 0 rgba(10, 10, 10, 0.08), 0 1px 2px -1px rgba(10, 10, 10, 0.08)',
         'lockup-input-error':
           '0 0 0 1px rgba(244, 63, 94, 0.88), 0 1px 3px 0 rgba(10, 10, 10, 0.08), 0 1px 2px -1px rgba(10, 10, 10, 0.08)',
         'lockup-input-hover':
           '0 0 0 1px rgba(10, 10, 10, 0.14), 0 1px 3px 0 rgba(10, 10, 10, 0.08), 0 1px 2px -1px rgba(10, 10, 10, 0.08)',
-        'navbar':
-          '0px 0px 0px 1px rgba(212, 212, 216, 0.56), 12px 0px 24px -8px rgba(10, 10, 10, 0.06), 0px 10px 24px -8px rgba(10, 10, 10, 0.08), 0px 4px 6px -2px rgba(10, 10, 10, 0.04)',
         'soft': '0px 1px 2px 0px rgba(10, 10, 10, 0.04)',
-        'tab-active':
-          '0 0 0 1px rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.08), 0 7px 11px -6px rgba(0, 0, 0, 0.08)',
-        'table':
-          '0 0 2px 0 rgba(10, 10, 10, 0.10), 0 8px 12px -4px rgba(10, 10, 10, 0.08), 0 1px 2px 0 rgba(10, 10, 10, 0.10)',
-        'token-selector':
-          '0px 0px 0px 1px rgba(10,10,10,0.08), 0px 1px 3px 0px rgba(10,10,10,0.08), 0px 1px 2px -1px rgba(10,10,10,0.08)',
-        'top-token-selector': 'inset 0 4px 4px -2px rgba(0,0,0,0.03)',
-        // These shadows "theme-md" and "theme-lg" will be part of the Shadows Design system
-        // once https://github.com/hemilabs/ui-monorepo/issues/1526 is implemented
-        /* eslint-disable sort-keys */
-        'theme-md':
-          '0 0 0 1px rgba(0, 0, 0, 0.05), 0 5px 16px -2px rgba(0, 0, 0, 0.08), 0 7px 11px -6px rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.02)',
-        'theme-lg':
-          '0 0 0 1px rgba(0, 0, 0, 0.05), 0 12px 28px -8px rgba(0, 0, 0, 0.16), 0 5px 16px -2px rgba(0, 0, 0, 0.06)',
-        /* eslint-enable sort-keys */
       },
       // See https://www.figma.com/design/4fVd9wneclsvYDYD95ApZ9/Hemi-Portal?node-id=3685-11596&node-type=FRAME&m=dev
       colors: {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR removes many (but not all) custom shadows and defines the set of standard shadows defined in Figma. There are a few places where I haven't changed this yet, because doing so would break the current UI without applying the changes in #1526 , #1525 and #1541 - so it's better to update the shadows there when we do those items.

For the most part, I removed standard shadows, I replaced them with the new shadows (removing defaults from Tailwind too), and for those elements with shadows, I removed the borders (so the borders are generated by the shadows).

Notably, I also removed the custom `className` for the `Card` component as that was a non-standard solution that could easily be solved another way.

I also made small fixes we came accross with Nahuel when I was sharing the changes with him.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

It's too many subtle changes on shadows 😆 

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1526

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
