### PR TITLE
Add voting power

### DIFF
--- a/portal/app/[locale]/staking-dashboard/_components/amount.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/amount.tsx
@@ -1,5 +1,6 @@
 import { DisplayAmount } from 'components/displayAmount'
 import { TokenLogo } from 'components/tokenLogo'
+import { TxLink } from 'components/txLink'
 import { useHemiToken } from 'hooks/useHemiToken'
 import { StakingPosition } from 'types/stakingDashboard'
 import { formatUnits } from 'viem'
@@ -14,15 +15,26 @@ export const Amount = function ({ operation }: Props) {
   const token = useHemiToken()
 
   return (
-    <div className="flex items-center gap-x-1.5 text-neutral-950">
-      <TokenLogo size="small" token={token} version="L1" />
-      <DisplayAmount
-        amount={formatUnits(BigInt(amount), token.decimals)}
-        logoVersion="L1"
-        showSymbol={false}
-        token={token}
-      />
-      <span className="text-sm">{`${token.symbol}`}</span>
+    <div className="flex items-center gap-x-5 text-neutral-950">
+      <TokenLogo size="medium" token={token} version="L1" />
+      <div className="flex flex-col">
+        <div className="flex items-center gap-x-1.5">
+          <DisplayAmount
+            amount={formatUnits(BigInt(amount), token.decimals)}
+            logoVersion="L1"
+            showSymbol={false}
+            token={token}
+          />
+          <span className="text-sm">{token.symbol}</span>
+        </div>
+        <span className="text-xs font-normal text-neutral-500">
+          <TxLink
+            chainId={token.chainId}
+            textColor="neutral-500"
+            txHash={operation.transactionHash}
+          />
+        </span>
+      </div>
     </div>
   )
 }

--- a/portal/app/[locale]/staking-dashboard/_components/form.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/form.tsx
@@ -51,6 +51,7 @@ export const FormContent = function ({
         value={input}
       />
       <Lockup
+        input={input}
         inputDays={inputDays}
         lockupDays={lockupDays}
         updateInputDays={updateInputDays}

--- a/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
@@ -57,7 +57,7 @@ export const StakeForm = function () {
   if (!hemiToken) {
     return (
       <Skeleton
-        className="min-h-128 rounded-2xl"
+        className="min-h-136 rounded-2xl"
         containerClassName="flex justify-center"
       />
     )

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseUnlockTime/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseUnlockTime/index.tsx
@@ -43,7 +43,7 @@ export const ReviewIncreaseUnlockTime = function ({ onClose }: Props) {
     useState<StakingOperationRunning>('idle')
 
   // stakingDashboardOperation and stakingPosition will always be defined here
-  const { inputDays, lockupDays, stakingPosition, transactionHash } =
+  const { input, inputDays, lockupDays, stakingPosition, transactionHash } =
     stakingDashboardOperation!
   const { tokenId } = stakingPosition!
 
@@ -215,6 +215,7 @@ export const ReviewIncreaseUnlockTime = function ({ onClose }: Props) {
       <Preview
         callToAction={getCallToAction(stakingDashboardStatus)}
         gas={getGas()}
+        input={input!}
         inputDays={inputDays!}
         isRunningOperation={isRunningOperation}
         isValid={isValid}

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseUnlockTime/preview.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseUnlockTime/preview.tsx
@@ -19,6 +19,7 @@ type PreviewProps = {
     label: string
     token: Token
   }
+  input: string
   inputDays: string
   isRunningOperation: boolean
   isValid: boolean
@@ -34,6 +35,7 @@ type PreviewProps = {
 export function Preview({
   callToAction,
   gas,
+  input,
   inputDays,
   isRunningOperation,
   isValid,
@@ -64,6 +66,7 @@ export function Preview({
         >
           <div className="flex flex-1 flex-col gap-y-3 overflow-y-auto p-4 md:p-6">
             <Lockup
+              input={input}
               inputDays={inputDays}
               lockupDays={lockupDays}
               updateInputDays={onUpdateInputDays}

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/actionCell.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/actionCell.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { type StakingPosition } from 'types/stakingDashboard'
+import { formatUnits } from 'viem'
 
 import { useStakingDashboard } from '../../_context/stakingDashboardContext'
 import { useDrawerStakingQueryString } from '../../_hooks/useDrawerStakingQueryString'
@@ -38,7 +39,7 @@ type Props = {
 
 export function ActionCell({ openRowId, row, setOpenRowId }: Props) {
   const t = useTranslations('staking-dashboard.table')
-  const { symbol } = useHemiToken()
+  const { decimals, symbol } = useHemiToken()
   const buttonRef = useRef<HTMLDivElement>(null)
   const menuRef = useOnClickOutside<HTMLDivElement>(() => setOpenRowId(null))
   const [menuPosition, setMenuPosition] = useState({ left: 0, top: 0 })
@@ -128,6 +129,7 @@ export function ActionCell({ openRowId, row, setOpenRowId }: Props) {
 
   function handleIncreaseUnlockTime() {
     updateStakingDashboardOperation({
+      input: formatUnits(amount, decimals),
       inputDays: minDays.toString(),
       lockupDays: minDays,
       stakingPosition: {

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
@@ -5,7 +5,6 @@ import { Card } from 'components/card'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { Table } from 'components/table'
 import { Header } from 'components/table/_components/header'
-import { TxLink } from 'components/txLink'
 import { useHemi } from 'hooks/useHemi'
 import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
 import { useTranslations } from 'next-intl'
@@ -15,6 +14,7 @@ import { type StakingPosition } from 'types/stakingDashboard'
 import { walletIsConnected } from 'utils/wallet'
 import { useAccount } from 'wagmi'
 
+import { calculateVotingPower } from '../../_utils/lockCreationTimes'
 import { Amount } from '../amount'
 
 import { ActionCell } from './actionCell'
@@ -23,6 +23,7 @@ import { LockupTime } from './lockupTime'
 import { NoPositionStaked } from './noPositionStaked'
 import { TimeRemaining } from './timeRemaining'
 import { UnsupportedChain } from './unsupportedChain'
+import { VotingPower } from './votingPower'
 
 type StakingColumnsProps = {
   t: ReturnType<typeof useTranslations<'staking-dashboard'>>
@@ -45,22 +46,30 @@ const stakingColumns = ({
         </ErrorBoundary>
       </div>
     ),
-    header: () => <Header text={t('amount')} />,
-    id: 'amount',
-    meta: { width: '150px' },
+    header: () => <Header text={t('table.locked-amount')} />,
+    id: 'locked-amount',
+    meta: { width: '170px' },
   },
   {
-    cell: function ExplorerLink({ row }) {
-      const hemi = useHemi()
+    cell({ row }) {
+      const { amount, lockTime, timestamp } = row.original
+      const { percentageOfMax, votingPower } = calculateVotingPower({
+        amount,
+        lockTime,
+        timestamp,
+      })
       return (
-        <div className="flex items-center">
-          <TxLink chainId={hemi.id} txHash={row.original.transactionHash} />
+        <div className="flex items-center justify-center gap-x-2">
+          <VotingPower
+            percentageOfMax={percentageOfMax}
+            votingPower={votingPower}
+          />
         </div>
       )
     },
-    header: () => <Header text={t('table.tx')} />,
-    id: 'tx',
-    meta: { width: '120px' },
+    header: () => <Header text={t('voting-power')} />,
+    id: 'voting-power',
+    meta: { width: '150px' },
   },
   {
     cell: ({ row }) => (
@@ -70,8 +79,8 @@ const stakingColumns = ({
         <LockupTime lockupTime={row.original.lockTime} />
       </ErrorBoundary>
     ),
-    header: () => <Header text={t('lockup-period')} />,
-    id: 'lockup-period',
+    header: () => <Header text={t('table.lockup')} />,
+    id: 'lockup',
     meta: { width: '200px' },
   },
   {
@@ -165,7 +174,7 @@ export function StakeTable({ data, loading }: Props) {
 
   return (
     <div className="w-full rounded-xl bg-neutral-100 text-sm font-medium">
-      <div className="md:min-h-120 h-[49dvh] overflow-hidden">
+      <div className="md:min-h-136 h-[56dvh] overflow-hidden">
         {getContent()}
       </div>
     </div>

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/votingPower.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/votingPower.tsx
@@ -1,0 +1,37 @@
+import { useHemiToken } from 'hooks/useHemiToken'
+import { useLocale } from 'next-intl'
+import { formatUnits } from 'viem'
+
+type Props = {
+  decimals?: number
+  percentageOfMax: number
+  votingPower: bigint
+}
+
+export const VotingPower = function ({
+  decimals = 18,
+  percentageOfMax,
+  votingPower,
+}: Props) {
+  const token = useHemiToken()
+  const locale = useLocale()
+  const formattedPower = formatUnits(votingPower, decimals)
+
+  const numberFormatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 3, // Show up to 3 decimal places
+  })
+
+  const displayPower = numberFormatter.format(Number(formattedPower))
+  const clampedPercentage = Math.min(100, Math.max(0, percentageOfMax))
+
+  return (
+    <div className="flex flex-col">
+      <span className="text-sm font-medium text-neutral-950">
+        {`${displayPower} ve${token.symbol}`}
+      </span>
+      <span className="text-xs font-normal text-neutral-500">
+        {clampedPercentage.toFixed(0)}%
+      </span>
+    </div>
+  )
+}

--- a/portal/app/[locale]/staking-dashboard/_utils/lockCreationTimes.ts
+++ b/portal/app/[locale]/staking-dashboard/_utils/lockCreationTimes.ts
@@ -1,6 +1,7 @@
+import { StakingPosition } from 'types/stakingDashboard'
 import { MaxLockDurationSeconds, MinLockDurationSeconds } from 've-hemi-actions'
 
-const daySeconds = 86_400
+export const daySeconds = 86_400
 
 export const minDays = Math.floor(MinLockDurationSeconds / daySeconds)
 export const maxDays = Math.floor(MaxLockDurationSeconds / daySeconds)
@@ -45,5 +46,36 @@ export function getUnlockInfo({ lockTime, timestamp }: GetUnlockInfoProps) {
     totalLockTimeSeconds: lockTimeNum,
     unlockDate,
     unlockTime,
+  }
+}
+
+type CalculateVotingPowerProps = Pick<
+  StakingPosition,
+  'amount' | 'timestamp' | 'lockTime'
+>
+
+export function calculateVotingPower({
+  amount,
+  lockTime,
+  timestamp,
+}: CalculateVotingPowerProps) {
+  const maxTimeSeconds = BigInt(maxDays * daySeconds)
+  const now = BigInt(Math.floor(Date.now() / 1000))
+
+  const end = timestamp + lockTime
+  const timeRemaining = end > now ? end - now : BigInt(0)
+
+  // Calculate voting power (decays linearly)
+  const votingPower = (amount * timeRemaining) / maxTimeSeconds
+
+  // Calculate percentage: (votingPower / lockedAmount) * 100
+  const percentageOfMax =
+    amount > BigInt(0)
+      ? Math.min(100, Number((votingPower * BigInt(10000)) / amount) / 100)
+      : 0
+
+  return {
+    percentageOfMax,
+    votingPower,
   }
 }

--- a/portal/components/customTokenLogo.tsx
+++ b/portal/components/customTokenLogo.tsx
@@ -1,10 +1,14 @@
 import { HemiSubLogo } from 'components/hemiSubLogo'
 import { Token } from 'types/token'
 
+// Prefer ordering these by value rather than by key
+/* eslint-disable sort-keys */
 const sizes = {
-  medium: 'size-8 text-[8px]',
   small: 'size-5 text-[6px]',
+  medium: 'size-6 text-[7px]',
+  large: 'size-8 text-[8px]',
 } as const
+/* eslint-enable sort-keys */
 
 type Size = keyof typeof sizes
 

--- a/portal/components/hemiSubLogo.tsx
+++ b/portal/components/hemiSubLogo.tsx
@@ -3,10 +3,14 @@
 import { useHemi } from 'hooks/useHemi'
 import { Token } from 'types/token'
 
+// Prefer ordering these by value rather than by key
+/* eslint-disable sort-keys */
 const sizes = {
-  medium: 'size-4',
   small: 'size-2.5',
+  medium: 'size-3',
+  large: 'size-4',
 } as const
+/* eslint-enable sort-keys */
 
 type Props = {
   size: keyof typeof sizes

--- a/portal/components/tokenLogo.tsx
+++ b/portal/components/tokenLogo.tsx
@@ -9,10 +9,14 @@ import { CustomTokenLogo } from './customTokenLogo'
 import { HemiSubLogo } from './hemiSubLogo'
 import { BtcLogo } from './icons/btcLogo'
 
+// Prefer ordering these by value rather than by key
+/* eslint-disable sort-keys */
 const sizes = {
-  medium: 'size-8',
   small: 'size-5',
+  medium: 'size-6',
+  large: 'size-8',
 } as const
+/* eslint-enable sort-keys */
 
 type Size = keyof typeof sizes
 

--- a/portal/components/tokenSelector/token.tsx
+++ b/portal/components/tokenSelector/token.tsx
@@ -45,7 +45,7 @@ export const CustomToken = ({ token }: { token: TokenType | undefined }) => (
 export const Token = ({ token }: { token: TokenType }) => (
   <div className="flex items-center gap-x-3 p-3 text-sm font-medium text-neutral-950">
     <div className="flex-shrink-0 flex-grow-0">
-      <TokenLogo size="medium" token={token} />
+      <TokenLogo size="large" token={token} />
     </div>
     <div className="flex w-full flex-col">
       <div className="flex items-center justify-between">

--- a/portal/components/txLink.tsx
+++ b/portal/components/txLink.tsx
@@ -7,16 +7,21 @@ import { type Hash } from 'viem'
 
 type Props = {
   chainId: RemoteChain['id']
+  textColor?: 'neutral-500' | 'neutral-600'
   txHash: BtcTransaction | Hash
 }
-export const TxLink = function ({ chainId, txHash }: Props) {
+export const TxLink = function ({
+  chainId,
+  textColor = 'neutral-600',
+  txHash,
+}: Props) {
   const chain = useChain(chainId)
   const hash = `${txHash.slice(0, 6)}...${txHash.slice(-4)}`
   const href = `${chain?.blockExplorers?.default.url}/tx/${txHash}`
   return (
     <div className="group/txhash-link flex w-full items-center gap-x-2">
       <ExternalLink
-        className="cursor-pointer text-neutral-600 hover:text-neutral-950"
+        className={`cursor-pointer text-${textColor} hover:text-neutral-950`}
         href={href}
         // needed as there's event delegation in the row
         onClick={e => e.stopPropagation()}

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -288,6 +288,8 @@
       "connect-to-hemi": "Connect to {network} to view your stake positions.",
       "connect-to-stake": "Connect your wallet to view your {symbol} staked.",
       "get-started": "Get started by staking your {symbol}",
+      "locked-amount": "Locked Amount",
+      "lockup": "Lockup",
       "no-hemi-staked": "No {symbol} staked",
       "on": "On {date}",
       "time-remaining": "Time remaining",
@@ -296,7 +298,8 @@
       "unlocked": "Unlocked",
       "unlocks-on": "Unlocks on {date}"
     },
-    "unlock-successful": "Unlock successful"
+    "unlock-successful": "Unlock successful",
+    "voting-power": "Voting Power"
   },
   "metadata": {
     "title": "Hemi Portal"

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -288,6 +288,8 @@
       "connect-to-hemi": "Conéctese a {network} para ver sus posiciones de stake.",
       "connect-to-stake": "Conecte su billetera para ver su {symbol} en stake.",
       "get-started": "Comience haciendo staking de sus {symbol}",
+      "locked-amount": "Cantidad bloqueada",
+      "lockup": "Bloqueo",
       "no-hemi-staked": "No hay {symbol} en stake",
       "on": "En {date}",
       "time-remaining": "Tiempo restante",
@@ -296,7 +298,8 @@
       "unlocked": "Desbloqueado",
       "unlocks-on": "Desbloquea el {date}"
     },
-    "unlock-successful": "Desbloqueo exitoso"
+    "unlock-successful": "Desbloqueo exitoso",
+    "voting-power": "Poder de Voto"
   },
   "metadata": {
     "title": "Portal de Hemi"

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -288,6 +288,8 @@
       "connect-to-hemi": "Conecte à {network} para ver as suas posições de stake.",
       "connect-to-stake": "Conecte a sua carteira para ver o seu {symbol} em stake.",
       "get-started": "Comece a fazer stake com seu {symbol}",
+      "locked-amount": "Quantidade Bloqueada",
+      "lockup": "Bloqueio",
       "no-hemi-staked": "Sem {symbol} staked",
       "on": "Em {date}",
       "time-remaining": "Tempo restante",
@@ -296,7 +298,8 @@
       "unlocked": "Desbloqueado",
       "unlocks-on": "Desbloqueia em {date}"
     },
-    "unlock-successful": "Desbloqueio bem-sucedido"
+    "unlock-successful": "Desbloqueio bem-sucedido",
+    "voting-power": "Poder de Voto"
   },
   "metadata": {
     "title": "Portal Hemi"

--- a/portal/tailwind.config.ts
+++ b/portal/tailwind.config.ts
@@ -270,7 +270,7 @@ const config: Config = {
         '85vh': '85vh',
       },
       minHeight: {
-        '128': '32rem',
+        '136': '34rem',
       },
       opacity: {
         '88': '.88',

--- a/portal/test/[locale]/staking-dashboard/_utils/calculateVotingPower.test.ts
+++ b/portal/test/[locale]/staking-dashboard/_utils/calculateVotingPower.test.ts
@@ -1,0 +1,102 @@
+import {
+  calculateVotingPower,
+  daySeconds,
+  maxDays,
+} from 'app/[locale]/staking-dashboard/_utils/lockCreationTimes'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('calculateVotingPower', function () {
+  const mockNow = 1000000000 // Fixed timestamp for tests
+
+  beforeEach(function () {
+    vi.useFakeTimers()
+    vi.setSystemTime(mockNow * 1000)
+  })
+
+  afterEach(function () {
+    vi.useRealTimers()
+  })
+
+  it('should return 100% voting power at lock creation with max duration', function () {
+    const amount = BigInt(1000e18) // 1000 HEMI
+    const timestamp = BigInt(mockNow)
+    const lockTime = BigInt(maxDays * daySeconds)
+
+    const result = calculateVotingPower({ amount, lockTime, timestamp })
+
+    expect(result.votingPower).toBe(amount)
+    expect(result.percentageOfMax).toBe(100)
+  })
+
+  it('should return 50% voting power at half time remaining', function () {
+    const amount = BigInt(1000e18)
+    const maxTime = BigInt(maxDays * daySeconds)
+    const timestamp = BigInt(mockNow - Number(maxTime) / 2) // Started half time ago
+    const lockTime = maxTime
+
+    const result = calculateVotingPower({ amount, lockTime, timestamp })
+
+    expect(result.votingPower).toBe(amount / BigInt(2))
+    expect(result.percentageOfMax).toBe(50)
+  })
+
+  it('should return 0% voting power after lock expires', function () {
+    const amount = BigInt(1000e18)
+    const timestamp = BigInt(mockNow - maxDays * daySeconds - 1000) // Expired
+    const lockTime = BigInt(maxDays * daySeconds)
+
+    const result = calculateVotingPower({ amount, lockTime, timestamp })
+
+    expect(result.votingPower).toBe(BigInt(0))
+    expect(result.percentageOfMax).toBe(0)
+  })
+
+  it('should handle zero amount', function () {
+    const amount = BigInt(0)
+    const timestamp = BigInt(mockNow)
+    const lockTime = BigInt(maxDays * daySeconds)
+
+    const result = calculateVotingPower({ amount, lockTime, timestamp })
+
+    expect(result.votingPower).toBe(BigInt(0))
+    expect(result.percentageOfMax).toBe(0)
+  })
+
+  it('should decay linearly over time', function () {
+    const amount = BigInt(1000e18)
+    const maxTime = BigInt(maxDays * daySeconds)
+
+    // At 75% time remaining
+    const timestamp75 = BigInt(mockNow - Number(maxTime) / 4)
+    const result75 = calculateVotingPower({
+      amount,
+      lockTime: maxTime,
+      timestamp: timestamp75,
+    })
+
+    // At 25% time remaining
+    const timestamp25 = BigInt(mockNow - (Number(maxTime) * 3) / 4)
+    const result25 = calculateVotingPower({
+      amount,
+      lockTime: maxTime,
+      timestamp: timestamp25,
+    })
+
+    expect(result75.percentageOfMax).toBeCloseTo(75, 0)
+    expect(result25.percentageOfMax).toBeCloseTo(25, 0)
+  })
+
+  it('should handle 2 year lock (50% of max)', function () {
+    const amount = BigInt(1000e18)
+    const twoYears = BigInt(730 * daySeconds) // ~2 years
+    const timestamp = BigInt(mockNow)
+
+    const result = calculateVotingPower({
+      amount,
+      lockTime: twoYears,
+      timestamp,
+    })
+
+    expect(result.percentageOfMax).toBeCloseTo(50, 0)
+  })
+})


### PR DESCRIPTION
### Description

This PR adds voting power display for `veHEMI` positions. The implementation replicates the logic from the contract's `_balanceOfNFTAt` method, calculating voting power based on locked amount and time remaining, with linear decay from 100% at lock creation to 0% at unlock. 

### Screenshots

https://github.com/user-attachments/assets/2f2dd83a-f112-4312-b16e-09b580c87e8c

### Related issue(s)

Related to #1505

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
