### PR TITLE
Aligne time in reviwing a BTC withdrawal

### DIFF
--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcWithdrawal.tsx
@@ -141,8 +141,8 @@ const ReviewContent = function ({
           hours: () =>
             isLoadingVaultGracePeriod ? (
               <Skeleton
-                className="h-full w-12"
-                containerClassName="h-5 inline-table"
+                className="mx-1 inline-block h-3.5 w-12 align-text-top"
+                containerClassName="h-3.5 inline-table"
               />
             ) : (
               tCommon('hours', {


### PR DESCRIPTION
### Description

This commit fixes the alignment of the time wait in Withdrawals.

### Screenshots
<img width="856" height="438" alt="Captura de pantalla 2025-10-15 a la(s) 3 15 21 p  m" src="https://github.com/user-attachments/assets/93e0f8b8-d2e9-4689-93da-dc637f68031a" />



### Related issue(s)

Closes #1492
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
