### PR TITLE
Add address of the rewards contract Hemi mainnet

### DIFF
--- a/packages/ve-hemi-rewards/constants.ts
+++ b/packages/ve-hemi-rewards/constants.ts
@@ -1,9 +1,9 @@
 import { hemi, hemiSepolia } from 'hemi-viem'
-import { zeroAddress, type Address } from 'viem'
+import { type Address } from 'viem'
 
 // TODO : Add contract addresses when available
 const VE_HEMI_REWARDS_CONTRACT_ADDRESSES: Record<number, Address> = {
-  [hemi.id]: zeroAddress,
+  [hemi.id]: '0x0d85B6676d499c05FE06fcB6A3b620334Eb8012F',
   [hemiSepolia.id]: '0xa6c5DE7512521Cb8d4c6bBA45dF9bbb280aB276d',
 } as const
 


### PR DESCRIPTION
### Description

As the title says, this PR adds the address of the rewards contract Hemi mainnet.

### Screenshots

No UI changes.

### Related issue(s)

Related to #1596 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
