### PR TITLE
Remove custom subgraph URL support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35798,7 +35798,7 @@
       "license": "MIT"
     },
     "subgraph-api": {
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "@tsconfig/node22": "22.0.2",
         "config": "3.3.12",

--- a/subgraph-api/config/custom-environment-variables.json
+++ b/subgraph-api/config/custom-environment-variables.json
@@ -13,8 +13,7 @@
     "apiUrl": "SUBGRAPH_API_URL",
     "origin": "SUBGRAPH_ORIGIN",
     "veHemi": {
-      "testnet": "SUBGRAPH_VE_HEMI_TESTNET",
-      "testnetCustomUrl": "SUBGRAPH_HEMI_VE_REWARDS_TESTNET_CUSTOM_URL"
+      "testnet": "SUBGRAPH_VE_HEMI_TESTNET"
     }
   }
 }

--- a/subgraph-api/package.json
+++ b/subgraph-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subgraph-api",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "scripts": {
     "build": "tsc",
     "start": "tsx server.ts"

--- a/subgraph-api/src/subgraph.ts
+++ b/subgraph-api/src/subgraph.ts
@@ -652,17 +652,10 @@ export const getLockedPositions = function ({
     [hemiSepolia.id]: subgraphConfig.veHemi.testnet,
   }
 
-  // Allow overriding the subgraph URL for Hemi Sepolia via config
-  // This is temporarily needed while we test the veHemiRewards subgraph
-  // Should be removed once the subgraph is fully deployed and stable
-  const customUrl = config.get<string | undefined>(
-    'subgraph.veHemi.testnetCustomUrl',
-  )
-
-  const subgraphUrl =
-    chainId === hemiSepolia.id && customUrl
-      ? customUrl
-      : getSubgraphUrl({ chainId, subgraphIds })
+  const subgraphUrl = getSubgraphUrl({
+    chainId,
+    subgraphIds,
+  })
 
   const schema = {
     query: `


### PR DESCRIPTION
### Description

Now that we have the hemi-sepolia subgraph deployed, we can remove this custom subgraph support.

### Screenshots

No UI changes.

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
