### PR TITLE
Revert ve-hemi contract to original deployment on Hemi-Sepolia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36612,7 +36612,7 @@
       }
     },
     "subgraphs/ve-hemi-subgraph": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@graphprotocol/graph-cli": "0.97.1",
         "@graphprotocol/graph-ts": "0.38.1"

--- a/packages/ve-hemi-actions/constants.ts
+++ b/packages/ve-hemi-actions/constants.ts
@@ -3,7 +3,7 @@ import type { Address } from 'viem'
 
 const VE_HEMI_CONTRACT_ADDRESSES: Record<number, Address> = {
   [hemi.id]: '0x371d3718D5b7F75EAb050FAe6Da7DF3092031c89',
-  [hemiSepolia.id]: '0xd137b7B3510b23E98b6A9aC2acB5C8bb668AC82d',
+  [hemiSepolia.id]: '0x54e24e64653F97477872D320c4d116D03a201493',
 } as const
 
 export const SupportedChains: number[] = [hemi.id, hemiSepolia.id]

--- a/subgraphs/ve-hemi-subgraph/networks.json
+++ b/subgraphs/ve-hemi-subgraph/networks.json
@@ -7,8 +7,8 @@
   },
   "hemi-sepolia": {
     "VeHemi": {
-      "address": "0xd137b7B3510b23E98b6A9aC2acB5C8bb668AC82d",
-      "startBlock": 4456930
+      "address": "0x54e24e64653F97477872D320c4d116D03a201493",
+      "startBlock": 3819082
     }
   }
 }

--- a/subgraphs/ve-hemi-subgraph/package.json
+++ b/subgraphs/ve-hemi-subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ve-hemi-subgraph",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "build": "graph build",
     "build:hemi": "npm run build -- --network hemi",


### PR DESCRIPTION
### Description

As the title says, this PR reverts the ve-hemi contract on the Hemi-Sepolia network back to the original deployment.
The temporary contract currently in use was only needed for testing reward claims, which is no longer required.

### Screenshots

No UI changes

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
