### PR TITLE
Remove deprecated Image prop in Integrations.tsx

### DIFF
--- a/portal/app/[locale]/bitcoin-yield/_components/integrations.tsx
+++ b/portal/app/[locale]/bitcoin-yield/_components/integrations.tsx
@@ -28,8 +28,8 @@ const Integration = ({
             alt={`${name} logo`}
             className="px-2.5"
             fill
-            objectFit="contain"
             src={logo}
+            style={{ objectFit: 'contain' }}
           />
         </div>
         <p className="body-text-caption mt-5 text-orange-500">{category}</p>


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

When running locally, there's a warning

> Image with src "/_next/static/media/spectra.00a3637c.svg" has legacy prop "objectFit". Did you forget to run the codemod?
> Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13

If you check that link, you'll see it recommends 

> Removes objectFit prop in favor of style or className

I accidentally used a deprecated prop. This PR fixes that

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
