### PR TITLE
Fix styles when loading pool deposits

### DIFF
--- a/portal/app/[locale]/bitcoin-yield/_components/poolDeposits.tsx
+++ b/portal/app/[locale]/bitcoin-yield/_components/poolDeposits.tsx
@@ -18,7 +18,7 @@ export const PoolDeposits = function () {
     <CardInfo
       data={poolDeposits}
       formatValue={value => (
-        <>
+        <div className="flex items-center">
           <span className="mr-1">$</span>
           <RenderFiatBalance
             balance={value}
@@ -27,7 +27,7 @@ export const PoolDeposits = function () {
             queryStatus="success"
             token={poolToken}
           />
-        </>
+        </div>
       )}
       icon={poolDepositIcon}
       isError={isError}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR fixes the "Loading" skeleton for Pool deposits in the HemiBTC page

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Before

<img width="411" height="140" alt="image" src="https://github.com/user-attachments/assets/680734f4-b3c3-43a8-a175-95df317aec3b" />


Now

<img width="830" height="276" alt="image" src="https://github.com/user-attachments/assets/591fedd4-a78e-4e25-8076-3df6ab0e30ac" />

Once loaded, it renders as usual

<img width="804" height="256" alt="image" src="https://github.com/user-attachments/assets/cc0963ab-53c3-4edf-a860-cd4ed048d41a" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1619 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
