### PR TITLE
Use hemi.xyz from hemi-socials

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/termsAndConditions.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/termsAndConditions.tsx
@@ -1,7 +1,10 @@
 import { ExternalLink } from 'components/externalLink'
+import hemiSocials from 'hemi-socials'
 import { useTranslations } from 'next-intl'
 
 const cssLink = 'text-orange-500 hover:text-orange-700'
+
+const { website } = hemiSocials
 
 export const TermsAndConditions = function () {
   const t = useTranslations('navbar')
@@ -9,18 +12,12 @@ export const TermsAndConditions = function () {
     <p className="font-base mx-auto w-full pb-2 text-left text-xs text-neutral-400">
       {t.rich('agree-to-terms-and-policy', {
         policy: chunk => (
-          <ExternalLink
-            className={cssLink}
-            href="https://hemi.xyz/privacy-policy/"
-          >
+          <ExternalLink className={cssLink} href={`${website}/privacy-policy/`}>
             {chunk}
           </ExternalLink>
         ),
         terms: chunk => (
-          <ExternalLink
-            className={cssLink}
-            href="https://hemi.xyz/terms-of-service"
-          >
+          <ExternalLink className={cssLink} href={`${website}/terms`}>
             {chunk}
           </ExternalLink>
         ),

--- a/portal/app/[locale]/genesis-drop/_components/termsAndConditions.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/termsAndConditions.tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 import { Button } from 'components/button'
 import { ExternalLink } from 'components/externalLink'
 import { Modal } from 'components/modal'
+import hemiSocials from 'hemi-socials'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
@@ -10,13 +11,17 @@ import { FormEvent } from 'react'
 import { Hash } from 'viem'
 import { useAccount, useSwitchChain } from 'wagmi'
 
+const { website } = hemiSocials
+
 // This text is a legal one so we can't translate it
 const termsAndConditions = `By clicking "Accept" below, you agree to the {termsAndConditions} of all Hemi websites and represent and warrant that (i) you are not a citizen of, resident in, or formed or qualified to transact business in, the United States or the Peoples Republic of China, (ii) in connection with claiming any Hemi Token you are in compliance with all applicable laws of the jurisdiction in which you reside or are located and of the United States and the Peoples Republic of China, and (iii) neither you nor, to your knowledge, any of your affiliates or direct beneficial owners, (A) appears on any governmental sanctions or similar list,  nor are they otherwise a party with which the Hemi is prohibited to deal under the laws of the United States, (B) is a person identified as a terrorist organization on any other relevant lists maintained by governmental authorities, nor is a senior foreign political figure, or any immediate family member or close associate of a senior foreign political figure, and (C) by claiming Hemi tokens will not be in violation of applicable U.S. federal or state or non-U.S. laws or regulations, including, without limitation, anti-money laundering, economic sanctions, anti-bribery or anti-boycott laws or regulations.`
 
 // The signing message needs to be a plain string...
 const SigningMessage = termsAndConditions.replace(
   '{termsAndConditions}',
-  'Terms & Conditions (https://hemi.xyz/terms-of-service)',
+  // Although the url is /terms, the signing message in the contract requires this url.
+  // There's a redirection from here to /terms, so nothing is broken.
+  `Terms & Conditions (${website}/terms-of-service)`,
 )
 // but the UI needs to display the link to the T&C
 const LegalText = function () {
@@ -33,8 +38,9 @@ const LegalText = function () {
       {before}
       <ExternalLink
         className="text-orange-500 hover:text-orange-700"
-        href="https://hemi.xyz/terms-of-service"
+        href={`${website}/terms-of-service`}
       >
+        {/* Part of a legal text that is on English - so we can't translate it */}
         Terms & Conditions
       </ExternalLink>
       {after}

--- a/portal/scripts/generateServerConfig.js
+++ b/portal/scripts/generateServerConfig.js
@@ -2,6 +2,7 @@
 
 require('dotenv').config({ override: true, path: ['.env', '.env.local'] })
 const { writeFile } = require('fs/promises')
+const { website } = require('hemi-socials')
 const path = require('path')
 const { hemi, hemiSepolia, mainnet, sepolia } = require('viem/chains')
 
@@ -90,7 +91,7 @@ customRpcOrigins.forEach(function (url) {
 
 // these are domains where we download images from
 const imageSrcUrls = [
-  'https://hemi.xyz',
+  website,
   'https://*.walletconnect.com',
   'https://hemilabs.github.io',
 ]


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR:

- Replaces `hemi.xyz` from the variable coming from `hemi-socials`
- Fixes the `/terms-of-service` link to the new page `/terms`... except for the genesis-drop page that requires signing with the old url

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users, the links now work

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1689 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
