### PR TITLE
Add netSatsAfterFee field to BTC withdrawal query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36645,7 +36645,7 @@
       "license": "MIT"
     },
     "subgraph-api": {
-      "version": "1.8.0",
+      "version": "1.9.0",
       "dependencies": {
         "@tsconfig/node22": "22.0.2",
         "config": "3.3.12",

--- a/subgraph-api/package.json
+++ b/subgraph-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subgraph-api",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "scripts": {
     "build": "tsc",
     "start": "tsx server.ts"

--- a/subgraph-api/src/subgraph.ts
+++ b/subgraph-api/src/subgraph.ts
@@ -177,6 +177,7 @@ export const getBtcWithdrawals = function ({
         l1Token,
         l2ChainId,
         l2Token,
+        netSatsAfterFee,
         timestamp,
         to,
         transactionHash,

--- a/subgraph-api/types/tunnel.ts
+++ b/subgraph-api/types/tunnel.ts
@@ -56,6 +56,7 @@ export type ToBtcWithdrawOperation = CommonOperation &
   } & {
     challengeTxHash?: Hash
     uuid?: string // bigint can't be serialized into local storage
+    netSatsAfterFee: string
   }
 
 export type BtcDepositOperation = {


### PR DESCRIPTION
### Description

This PR adds the `netSatsAfterFee` field to the `getBtcWithdrawals` query in the subgraph API. This field contains the net withdrawal amount after vault fees are deducted, matching the data structure from the hemi-tunnel-withdrawals subgraph.

Note: `hemi-tunnel-withdrawals-subgraph` `v1.1.0` was already deployed for `Hemi` and `Hemi-sepolia` networks.

### Screenshots

No UI changes.

### Related issue(s)

Related to #1309

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
