### PR TITLE
Make tokenId of StakingPosition as bigint

### DIFF
--- a/portal/app/[locale]/staking-dashboard/_components/rewardsDisplay.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/rewardsDisplay.tsx
@@ -6,14 +6,14 @@ import { useCalculateRewards } from '../_hooks/useCalculateRewards'
 import { useRewardTokens } from '../_hooks/useRewardTokens'
 
 type Props = {
-  tokenId: string
+  tokenId: bigint
 }
 
-function RewardRow({ token, tokenId }: { token: EvmToken; tokenId: string }) {
+function RewardRow({ token, tokenId }: { token: EvmToken; tokenId: bigint }) {
   const { data, isLoading } = useCalculateRewards({
     rewardToken: token.address,
     token,
-    tokenId: BigInt(tokenId),
+    tokenId,
   })
 
   const formattedAmount =

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
@@ -71,7 +71,7 @@ const stakingColumns = ({
       const { amount, tokenId } = row.original
       return (
         <div className="flex items-center justify-center gap-x-2">
-          <VotingPower amount={amount} tokenId={BigInt(tokenId)} />
+          <VotingPower amount={amount} tokenId={tokenId} />
         </div>
       )
     },

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/lockupTime.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/lockupTime.tsx
@@ -9,7 +9,7 @@ import { useCalculateApr } from '../../_hooks/useCalculateApr'
 type Props = {
   lockupTime: bigint
   status: StakingPositionStatus
-  tokenId: string
+  tokenId: bigint
 }
 
 export const LockupTime = function ({ lockupTime, status, tokenId }: Props) {
@@ -19,7 +19,7 @@ export const LockupTime = function ({ lockupTime, status, tokenId }: Props) {
 
   const { data: apr, error: error } = useCalculateApr({
     enabled: isActive,
-    tokenId: BigInt(tokenId),
+    tokenId,
   })
 
   const renderApr = function () {

--- a/portal/app/[locale]/staking-dashboard/_hooks/useCollectAllRewards.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useCollectAllRewards.ts
@@ -19,7 +19,7 @@ import { useRewardTokens } from './useRewardTokens'
 
 type UseCollectRewards = {
   on?: (emitter: EventEmitter<CollectAllRewardsEvents>) => void
-  tokenId: string
+  tokenId: bigint
   updateCollectRewardsDashboardOperation: (
     payload?: CollectAllRewardsDashboardOperation,
   ) => void
@@ -56,7 +56,7 @@ export const useCollectRewards = function ({
       const { emitter, promise } = collectAllRewards({
         account: address,
         addToPositionBPS: BigInt(0),
-        tokenId: BigInt(tokenId),
+        tokenId,
         walletClient: hemiWalletClient!,
       })
 
@@ -90,7 +90,7 @@ export const useCollectRewards = function ({
             const queryKey = getCalculateRewardsQueryKey({
               chainId: hemi.id,
               rewardToken: rewardsAddress,
-              tokenId: BigInt(tokenId),
+              tokenId,
             })
             queryClient.setQueryData(queryKey, () => BigInt(0))
           })
@@ -125,7 +125,7 @@ export const useCollectRewards = function ({
         const queryKey = getCalculateRewardsQueryKey({
           chainId: hemi.id,
           rewardToken: rewardsAddress,
-          tokenId: BigInt(tokenId),
+          tokenId,
         })
         queryClient.invalidateQueries({ queryKey })
       })

--- a/portal/app/[locale]/staking-dashboard/_hooks/useHasRewards.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useHasRewards.ts
@@ -4,7 +4,7 @@ import { useHemiToken } from 'hooks/useHemiToken'
 import { getCalculateRewardsQueryKey } from './useCalculateRewards'
 import { useRewardTokens } from './useRewardTokens'
 
-export function useHasRewards(tokenId: string) {
+export function useHasRewards(tokenId: bigint) {
   const queryClient = useQueryClient()
   const token = useHemiToken()
   const { isLoading, tokens: rewardTokens } = useRewardTokens()
@@ -13,7 +13,7 @@ export function useHasRewards(tokenId: string) {
     const queryKey = getCalculateRewardsQueryKey({
       chainId: token.chainId,
       rewardToken: address,
-      tokenId: BigInt(tokenId),
+      tokenId,
     })
 
     const data = queryClient.getQueryData<bigint>(queryKey)

--- a/portal/app/[locale]/staking-dashboard/_hooks/useIncreaseAmount.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useIncreaseAmount.ts
@@ -24,7 +24,7 @@ type UseIncreaseAmount = {
   input: string
   on?: (emitter: EventEmitter<IncreaseAmountEvents>) => void
   token: StakingDashboardToken
-  tokenId: string
+  tokenId: bigint
   updateStakingDashboardOperation: (payload?: StakingDashboardOperation) => void
 }
 
@@ -76,7 +76,7 @@ export const useIncreaseAmount = function ({
         account: address,
         additionalAmount: amount,
         approvalAdditionalAmount: amount,
-        tokenId: BigInt(tokenId),
+        tokenId,
         walletClient: hemiWalletClient!,
       })
 
@@ -154,7 +154,7 @@ export const useIncreaseAmount = function ({
         queryClient.invalidateQueries({
           queryKey: getCalculateAprQueryKey({
             chainId: token.chainId,
-            tokenId: BigInt(tokenId),
+            tokenId,
           }),
         })
 
@@ -162,7 +162,7 @@ export const useIncreaseAmount = function ({
         queryClient.invalidateQueries({
           queryKey: getPositionVotingPowerQueryKey({
             chainId: token.chainId,
-            tokenId: BigInt(tokenId),
+            tokenId,
           }),
         })
 

--- a/portal/app/[locale]/staking-dashboard/_hooks/useIncreaseUnlockTime.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useIncreaseUnlockTime.ts
@@ -25,7 +25,7 @@ type UseIncreaseUnlockTime = {
   lockupDays: number
   on?: (emitter: EventEmitter<IncreaseUnlockTimeEvents>) => void
   token: StakingDashboardToken
-  tokenId: string
+  tokenId: bigint
   updateStakingDashboardOperation: (payload?: StakingDashboardOperation) => void
 }
 
@@ -63,7 +63,7 @@ export const useIncreaseUnlockTime = function ({
       const { emitter, promise } = increaseUnlockTime({
         account: address,
         lockDurationInSeconds: daysToSeconds(lockupDays),
-        tokenId: BigInt(tokenId),
+        tokenId,
         walletClient: hemiWalletClient!,
       })
 
@@ -127,7 +127,7 @@ export const useIncreaseUnlockTime = function ({
           queryClient.invalidateQueries({
             queryKey: getCalculateAprQueryKey({
               chainId: token.chainId,
-              tokenId: BigInt(tokenId),
+              tokenId,
             }),
           })
 
@@ -135,7 +135,7 @@ export const useIncreaseUnlockTime = function ({
           queryClient.invalidateQueries({
             queryKey: getPositionVotingPowerQueryKey({
               chainId: token.chainId,
-              tokenId: BigInt(tokenId),
+              tokenId,
             }),
           })
 

--- a/portal/app/[locale]/staking-dashboard/_hooks/useStake.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useStake.ts
@@ -150,7 +150,7 @@ export const useStake = function ({
           pastOwners: [],
           status: 'active',
           timestamp: ts,
-          tokenId: tokenId.toString(),
+          tokenId,
           transactionHash,
           transferable: true,
         }

--- a/portal/app/[locale]/staking-dashboard/_hooks/useStakingPositions.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useStakingPositions.ts
@@ -6,13 +6,19 @@ import { useAccount } from 'wagmi'
 
 type ApiPosition = Omit<
   StakingPosition,
-  'amount' | 'blockNumber' | 'blockTimestamp' | 'lockTime' | 'timestamp'
+  | 'amount'
+  | 'blockNumber'
+  | 'blockTimestamp'
+  | 'lockTime'
+  | 'timestamp'
+  | 'tokenId'
 > & {
   amount: string
   blockNumber: string
   blockTimestamp: string
   lockTime: string
   timestamp: string
+  tokenId: string
 }
 
 type ApiResponse = {
@@ -57,6 +63,7 @@ export const useStakingPositions = function (
             blockTimestamp: BigInt(position.blockTimestamp),
             lockTime: BigInt(position.lockTime),
             timestamp: BigInt(position.timestamp),
+            tokenId: BigInt(position.tokenId),
           }) as StakingPosition,
       )
 

--- a/portal/app/[locale]/staking-dashboard/_hooks/useUnlock.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useUnlock.ts
@@ -22,7 +22,7 @@ type UseUnlock = {
   amount: bigint
   on?: (emitter: EventEmitter<WithdrawEvents>) => void
   token: StakingDashboardToken
-  tokenId: string
+  tokenId: bigint
   updateUnlockingDashboardOperation: (
     payload?: UnlockingDashboardOperation,
   ) => void
@@ -66,7 +66,7 @@ export const useUnlock = function ({
       }
       const { emitter, promise } = withdraw({
         account: address,
-        tokenId: BigInt(tokenId),
+        tokenId,
         walletClient: hemiWalletClient!,
       })
 

--- a/portal/types/stakingDashboard.ts
+++ b/portal/types/stakingDashboard.ts
@@ -43,7 +43,7 @@ export type StakingPosition = {
   pastOwners: string[]
   status: StakingPositionStatus
   timestamp: bigint
-  tokenId: string
+  tokenId: bigint
   transactionHash: Hash
   transferable: boolean
 }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR solves some tech debt and uses `tokenId` from the `StakingPosition` as type `bigint` instead of `string`.
As it comes from the BE as a string (because `bigint` can't be serialized), the code first converts it from `string` to `bigint` and then uses `bigint` everywhere.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1646 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
