### PR TITLE
Only load the get-started video for large devices

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/videoAsset.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/videoAsset.tsx
@@ -1,16 +1,33 @@
-export const VideoAsset = () => (
-  <div className="w-54 h-30 -translate-y-22 absolute scale-150 overflow-x-hidden">
-    <div className="flex h-full w-[270px]">
-      <video autoPlay className="h-auto w-full" loop muted preload="none">
-        <source src="/navbarVideo.mp4" type="video/mp4" />
-      </video>
+import { useWindowSize } from 'hooks/useWindowSize'
+import { Suspense } from 'react'
+import { screenBreakpoints } from 'styles'
+
+const VideoAssetImpl = function () {
+  const { width } = useWindowSize()
+
+  if (width < screenBreakpoints.md) {
+    return null
+  }
+
+  return (
+    <div className="w-54 h-30 -translate-y-22 absolute scale-150 overflow-x-hidden">
+      <div className="flex h-full w-[270px]">
+        <video autoPlay className="h-auto w-full" loop muted preload="none">
+          <source src="/navbarVideo.mp4" type="video/mp4" />
+        </video>
+      </div>
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'linear-gradient(180deg, #FFF 0%, rgba(255, 255, 255, 0.00) 49.52%, #FFF 100%)',
+        }}
+      />
     </div>
-    <div
-      className="pointer-events-none absolute inset-0"
-      style={{
-        background:
-          'linear-gradient(180deg, #FFF 0%, rgba(255, 255, 255, 0.00) 49.52%, #FFF 100%)',
-      }}
-    />
-  </div>
+  )
+}
+export const VideoAsset = () => (
+  <Suspense>
+    <VideoAssetImpl />
+  </Suspense>
 )


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

We were loading the "Get Started" video of the navbar for all users, regardless the device size, but it was only rendered to tablet and larger sizes. On mobile, some "auto-play" issue caused the video to go full screen and reproduce on the browser upon users entering the page. I wasn't able to consistenly reproduce it.

This PR just removes the video when it's not needed.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1741 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
