### PR TITLE
Enable tablet navbar menu on larger viewports

### DIFF
--- a/portal/app/[locale]/_components/appLayoutContainer.tsx
+++ b/portal/app/[locale]/_components/appLayoutContainer.tsx
@@ -12,11 +12,11 @@ const UI = ({
   <div
     className={`
       backdrop-blur-20 relative flex h-full w-3/4 flex-1 flex-col self-stretch overflow-y-hidden
-    bg-neutral-50/55 md:w-[calc(75%-8px)] lg:rounded-l-xl
+    bg-neutral-50/55 md:w-[calc(75%-8px)] xl:rounded-l-xl
       ${
         networkType === 'testnet'
           ? 'md:border-2 md:border-orange-600'
-          : 'border-neutral-300/55 lg:border'
+          : 'border-neutral-300/55 xl:border'
       }
       `}
     id="app-layout-container"

--- a/portal/app/[locale]/_components/header/index.tsx
+++ b/portal/app/[locale]/_components/header/index.tsx
@@ -34,7 +34,7 @@ export const Header = ({ isMenuOpen, setIsNavbarOpen, toggleMenu }: Props) => (
       <HomeLink />
       <Badge />
     </div>
-    <div className="size-13 hidden items-center justify-center border-r border-neutral-300/55 md:flex lg:hidden">
+    <div className="size-13 hidden items-center justify-center border-r border-neutral-300/55 md:flex xl:hidden">
       <ButtonIcon
         onClick={() => setIsNavbarOpen(true)}
         size="xSmall"

--- a/portal/app/[locale]/_components/navbar/navbarResponsive.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarResponsive.tsx
@@ -14,7 +14,7 @@ type Props = {
 // The tablet navbar is the desktop one contained in a Drawer
 export const NavbarResponsive = function ({ onClose }: Props) {
   const { width } = useWindowSize()
-  if (width >= screenBreakpoints.lg) {
+  if (width >= screenBreakpoints.xl) {
     // as of lg breakpoint in tailwind, it should not render anything
     // Can't use CSS because the drawer works as a Portal in React.
     return null

--- a/portal/app/[locale]/layout.tsx
+++ b/portal/app/[locale]/layout.tsx
@@ -79,7 +79,7 @@ export default async function RootLayout({
                   <Analytics>
                     <TunnelHistoryProvider>
                       <div className="flex h-dvh flex-nowrap justify-stretch bg-white">
-                        <div className="max-lg:hidden">
+                        <div className="max-xl:hidden">
                           <NavbarDesktop />
                         </div>
                         <AppLayout>

--- a/portal/components/pageLayout.tsx
+++ b/portal/components/pageLayout.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 const variants = {
   center: 'max-w-5xl px-4',
   genesisDrop: 'px-2 md:px-4 xl:px-0 xl:pb-6 2xl:px-6',
-  wide: 'xl:px-12 xl:pb-12 px-4',
+  wide: 'lg:px-12 lg:pb-12 px-4',
   superWide: 'px-2 md:px-4 xl:px-6 xl:pb-6',
 } as const
 /* eslint-enable sort-keys */


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds some adjustments for the viewports requested by Nahuel: Now the "tablet mode" extends up to 1280px (it was 1024px before)

The x-axis padding was also increased in the btc-yield page for that range

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Now the "full desktop" mode appears on 1280px

https://github.com/user-attachments/assets/34c2f32f-5b5e-46fe-a77e-2d16f939a8d5

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1584 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
