### PR TITLE
Add external link mobile arrow visible default

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
@@ -136,7 +136,7 @@ const DexImpl = function () {
       <Row>
         <IconContainer selected={isOpen}>{<DexIcon />}</IconContainer>
         <ItemText selected={isOpen} text={t('title')} />
-        <Chevron.Right className="group ml-auto hidden group-hover/nav:block group-hover/item:flex max-md:hidden [&>path]:fill-neutral-500" />
+        <Chevron.Right className="group ml-auto hidden max-md:hidden md:group-hover/nav:block [&>path]:fill-neutral-500" />
       </Row>
 
       {isOpen &&

--- a/portal/app/[locale]/_components/navbar/_components/externalLink.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/externalLink.tsx
@@ -24,7 +24,7 @@ export const ExternalLinkUI = ({
       <RowComponent>
         {icon && <IconContainer>{icon}</IconContainer>}
         <ItemText text={text} />
-        <div className="ml-auto hidden size-4 items-center group-hover/item:flex">
+        <div className="ml-auto size-4 items-center max-md:flex md:hidden md:group-hover/item:flex">
           <ArrowDownLeftIcon />
         </div>
       </RowComponent>

--- a/portal/app/[locale]/_components/navbar/navbarMobile.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarMobile.tsx
@@ -77,11 +77,7 @@ export const NavbarMobile = function () {
           <EcosystemLink />
         </SmallBox>
         <FullItem>
-          <BitcoinKitLink
-            iconContainer={IconContainer}
-            itemContainer={CustomContainer}
-            row={RowContainer}
-          />
+          <BitcoinKitLink itemContainer={CustomContainer} row={RowContainer} />
         </FullItem>
         <FullItem>
           <DocsLink


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why they are relevant or what
problem they solve. -->

This commit makes the “external link” arrow visible in the default state and fixes a hover issue in DEXs items.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img alt="Captura de pantalla 2026-01-14 a la(s) 3 46 14 p  m" src="https://github.com/user-attachments/assets/5fc8402d-b7c3-4223-af4d-5a18f4ef4f58" />



### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1745
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
