### PR TITLE
Fix misaligned social icons

### DIFF
--- a/portal/app/[locale]/_components/navbar/navbarMobile.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarMobile.tsx
@@ -77,7 +77,11 @@ export const NavbarMobile = function () {
           <EcosystemLink />
         </SmallBox>
         <FullItem>
-          <BitcoinKitLink itemContainer={CustomContainer} row={RowContainer} />
+          <BitcoinKitLink
+            iconContainer={IconContainer}
+            itemContainer={CustomContainer}
+            row={RowContainer}
+          />
         </FullItem>
         <FullItem>
           <DocsLink
@@ -125,7 +129,7 @@ export const NavbarMobile = function () {
                 </div>
               </IconContainer>
               <ItemText text={t('follow-us')} />
-              <div className="ml-auto flex gap-x-3">
+              <div className="ml-auto flex flex-wrap items-end gap-x-3">
                 <SocialLinks />
               </div>
             </RowContainer>

--- a/portal/components/icons/linkedinIcon.tsx
+++ b/portal/components/icons/linkedinIcon.tsx
@@ -3,8 +3,8 @@ import { ComponentProps } from 'react'
 export const LinkedinIcon = (props: ComponentProps<'svg'>) => (
   <svg
     fill="none"
-    height={15}
-    width={16}
+    height={18}
+    width={20}
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This commit fixes the misalignment by aligning the social icons with the container.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Before
<img  alt="Captura de pantalla 2026-01-16 a la(s) 10 33 02 a  m" src="https://github.com/user-attachments/assets/449b03a7-6eea-42a3-8636-662ec704d8eb" />

After
<img width="655" height="55" alt="Captura de pantalla 2026-01-16 a la(s) 10 28 57 a  m" src="https://github.com/user-attachments/assets/7268a263-ee7f-4532-8e34-0264c39bf270" />


Context 
<img  alt="Screenshot 2026-01-16 at 9 45 16 AM (1)" src="https://github.com/user-attachments/assets/de4fe82c-c135-45c8-89e3-0bb81d62155e" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1746
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
