### PR TITLE
Delete bg-color stake navbar.

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/navItem.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/navItem.tsx
@@ -95,7 +95,7 @@ export const AccordionIconContainer = ({
       group-hover/nav:[&>svg>path]:fill-neutral-950 ${
         selected
           ? '[&>svg>path]:fill-neutral-950'
-          : 'bg-neutral-100 [&>svg>path]:fill-neutral-400'
+          : '[&>svg>path]:fill-neutral-400'
       }`}
   >
     {children}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The Stake navbar item had a background color. It has been removed.

### Screenshots
<img alt="Captura de pantalla 2026-01-21 a la(s) 3 21 25 p  m" src="https://github.com/user-attachments/assets/3350f900-af0f-46a7-81a3-5baf6d42613e" />

<img alt="Captura de pantalla 2026-01-21 a la(s) 3 19 38 p  m" src="https://github.com/user-attachments/assets/882f646a-598d-443c-b3cf-c7860242bd3b" />

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1754 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
