### PR TITLE
Fix social links hidden by video on testnet navbar

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/videoAsset.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/videoAsset.tsx
@@ -1,16 +1,23 @@
+import { useNetworkType } from 'hooks/useNetworkType'
 import { useWindowSize } from 'hooks/useWindowSize'
 import { Suspense } from 'react'
 import { screenBreakpoints } from 'styles'
 
 const VideoAssetImpl = function () {
   const { width } = useWindowSize()
+  const [networkType] = useNetworkType()
+  const isNotTestnet = networkType !== 'testnet'
 
   if (width < screenBreakpoints.md) {
     return null
   }
 
   return (
-    <div className="w-54 h-30 -translate-y-22 absolute scale-150 overflow-x-hidden">
+    <div
+      className={`w-54 h-30 absolute scale-150 overflow-x-hidden ${
+        isNotTestnet ? '-translate-y-22' : '-translate-y-30'
+      }`}
+    >
       <div className="flex h-full w-[270px]">
         <video autoPlay className="h-auto w-full" loop muted preload="none">
           <source src="/navbarVideo.mp4" type="video/mp4" />


### PR DESCRIPTION
### Description

This PR fixes navbar social links not visible when switching to testnet. The `VideoAsset` component used a fixed `-translate-y-22` that overlapped the social links area when the TVL section was hidden on testnet.

### Screenshots

https://github.com/user-attachments/assets/f98322a5-8b0f-4bea-aa5f-907d0932a30f

### Related issue(s)

Closes #1790 
Fixes #1790

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
