### PR TITLE
Simplify useNativeTokenBalance hook

### DIFF
--- a/portal/hooks/useBalance.ts
+++ b/portal/hooks/useBalance.ts
@@ -1,23 +1,17 @@
 import { EvmToken } from 'types/token'
 import { isNativeAddress } from 'utils/nativeToken'
-import { type Address, erc20Abi, isAddress } from 'viem'
+import { type Address, type Chain, erc20Abi, isAddress } from 'viem'
 import {
   useAccount,
   useBalance as useWagmiBalance,
   useReadContract,
 } from 'wagmi'
 
-export const useNativeTokenBalance = function (
-  chainId: EvmToken['chainId'],
-  enabled: boolean = true,
-) {
-  const { address, isConnected } = useAccount()
+export const useNativeTokenBalance = function (chainId: Chain['id']) {
+  const { address } = useAccount()
   return useWagmiBalance({
     address,
     chainId,
-    query: {
-      enabled: isConnected && enabled,
-    },
   })
 }
 


### PR DESCRIPTION
### Description

Simplifies the `useNativeTokenBalance` hook by removing unused code and improving type clarity:

- **Remove unused `enabled` parameter**: This parameter was never passed by any of the 24 callers across the codebase
- **Remove redundant `isConnected` check**: wagmi's `useBalance` automatically handles disconnected states when `address` is undefined, making our explicit check unnecessary
- **Replace `EvmToken['chainId']` with `Chain['id']`**: Both types resolve to `number`, but using `Chain['id']` is more semantically clear

**No breaking changes**: All existing usages continue to work as before since they only pass the `chainId` parameter.

### Screenshots

N/A - Internal hook refactoring with no UI changes.

### Related issue(s)

N/A - Code cleanup improvement.

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.