### PR TITLE
Pin Help and Get Started buttons to mobile navbar

### DIFF
--- a/portal/app/[locale]/_components/navbar/navbarMobile.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarMobile.tsx
@@ -56,95 +56,97 @@ const CustomContainer = (props: ComponentProps<typeof ItemContainer>) => (
 export const NavbarMobile = function () {
   const t = useTranslations('navbar')
   return (
-    <div className="h-90dvh overflow-y-auto bg-white px-5 py-6">
-      <ul className="flex h-fit flex-wrap justify-start gap-2">
-        <SmallBox>
-          <BitcoinYield />
-        </SmallBox>
-        <SmallBox>
-          <TunnelLink />
-        </SmallBox>
-        <SmallBox>
-          <Dex />
-        </SmallBox>
-        <SmallBox>
-          <GenesisDrop />
-        </SmallBox>
-        <SmallBox>
-          <StakeMobile />
-        </SmallBox>
-        <SmallBox>
-          <EcosystemLink />
-        </SmallBox>
-        <FullItem>
-          <BitcoinKitLink
-            iconContainer={IconContainer}
-            itemContainer={CustomContainer}
-            row={RowContainer}
-          />
-        </FullItem>
-        <FullItem>
-          <DocsLink
-            iconContainer={IconContainer}
-            itemContainer={CustomContainer}
-            row={RowContainer}
-          />
-        </FullItem>
-        <FullItem>
-          <HemiExplorerLink
-            iconContainer={IconContainer}
-            itemContainer={CustomContainer}
-            row={RowContainer}
-          />
-        </FullItem>
-        <FullItem>
-          <HemiStatusLink
-            iconContainer={IconContainer}
-            itemContainer={CustomContainer}
-            row={RowContainer}
-          />
-        </FullItem>
-        <FullItem>
-          <NetworkSwitch
-            iconContainer={IconContainer}
-            itemContainer={CustomContainer}
-            row={RowContainer}
-          />
-        </FullItem>
-        <FullItem>
-          <CustomContainer>
-            <RowContainer>
-              <IconContainer>
-                <div className="size-4">
-                  <svg
-                    fill="none"
-                    viewBox="0 0 15 15"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8.625 1.125C8.625 0.826631 8.50647 0.540483 8.29549 0.329505C8.08452 0.118526 7.79837 0 7.5 0C7.20163 0 6.91548 0.118526 6.7045 0.329505C6.49353 0.540483 6.375 0.826631 6.375 1.125V6.375H1.125C0.826631 6.375 0.540483 6.49353 0.329505 6.7045C0.118526 6.91548 0 7.20163 0 7.5C0 7.79837 0.118526 8.08452 0.329505 8.29549C0.540483 8.50647 0.826631 8.625 1.125 8.625H6.375V13.875C6.375 14.1734 6.49353 14.4595 6.7045 14.6705C6.91548 14.8815 7.20163 15 7.5 15C7.79837 15 8.08452 14.8815 8.29549 14.6705C8.50647 14.4595 8.625 14.1734 8.625 13.875V8.625H13.875C14.1734 8.625 14.4595 8.50647 14.6705 8.29549C14.8815 8.08452 15 7.79837 15 7.5C15 7.20163 14.8815 6.91548 14.6705 6.7045C14.4595 6.49353 14.1734 6.375 13.875 6.375H8.625V1.125Z"
-                      fill="#A3A3A3"
-                    />
-                  </svg>
+    <div className="h-90dvh flex flex-col bg-white">
+      <div className="flex-1 overflow-y-auto px-5 py-6">
+        <ul className="flex h-fit flex-wrap justify-start gap-2">
+          <SmallBox>
+            <BitcoinYield />
+          </SmallBox>
+          <SmallBox>
+            <TunnelLink />
+          </SmallBox>
+          <SmallBox>
+            <Dex />
+          </SmallBox>
+          <SmallBox>
+            <GenesisDrop />
+          </SmallBox>
+          <SmallBox>
+            <StakeMobile />
+          </SmallBox>
+          <SmallBox>
+            <EcosystemLink />
+          </SmallBox>
+          <FullItem>
+            <BitcoinKitLink
+              iconContainer={IconContainer}
+              itemContainer={CustomContainer}
+              row={RowContainer}
+            />
+          </FullItem>
+          <FullItem>
+            <DocsLink
+              iconContainer={IconContainer}
+              itemContainer={CustomContainer}
+              row={RowContainer}
+            />
+          </FullItem>
+          <FullItem>
+            <HemiExplorerLink
+              iconContainer={IconContainer}
+              itemContainer={CustomContainer}
+              row={RowContainer}
+            />
+          </FullItem>
+          <FullItem>
+            <HemiStatusLink
+              iconContainer={IconContainer}
+              itemContainer={CustomContainer}
+              row={RowContainer}
+            />
+          </FullItem>
+          <FullItem>
+            <NetworkSwitch
+              iconContainer={IconContainer}
+              itemContainer={CustomContainer}
+              row={RowContainer}
+            />
+          </FullItem>
+          <FullItem>
+            <CustomContainer>
+              <RowContainer>
+                <IconContainer>
+                  <div className="size-4">
+                    <svg
+                      fill="none"
+                      viewBox="0 0 15 15"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.625 1.125C8.625 0.826631 8.50647 0.540483 8.29549 0.329505C8.08452 0.118526 7.79837 0 7.5 0C7.20163 0 6.91548 0.118526 6.7045 0.329505C6.49353 0.540483 6.375 0.826631 6.375 1.125V6.375H1.125C0.826631 6.375 0.540483 6.49353 0.329505 6.7045C0.118526 6.91548 0 7.20163 0 7.5C0 7.79837 0.118526 8.08452 0.329505 8.29549C0.540483 8.50647 0.826631 8.625 1.125 8.625H6.375V13.875C6.375 14.1734 6.49353 14.4595 6.7045 14.6705C6.91548 14.8815 7.20163 15 7.5 15C7.79837 15 8.08452 14.8815 8.29549 14.6705C8.50647 14.4595 8.625 14.1734 8.625 13.875V8.625H13.875C14.1734 8.625 14.4595 8.50647 14.6705 8.29549C14.8815 8.08452 15 7.79837 15 7.5C15 7.20163 14.8815 6.91548 14.6705 6.7045C14.4595 6.49353 14.1734 6.375 13.875 6.375H8.625V1.125Z"
+                        fill="#A3A3A3"
+                      />
+                    </svg>
+                  </div>
+                </IconContainer>
+                <ItemText text={t('follow-us')} />
+                <div className="ml-auto flex flex-wrap items-end gap-x-3">
+                  <SocialLinks />
                 </div>
-              </IconContainer>
-              <ItemText text={t('follow-us')} />
-              <div className="ml-auto flex flex-wrap items-end gap-x-3">
-                <SocialLinks />
-              </div>
-            </RowContainer>
-          </CustomContainer>
-        </FullItem>
-        <FullItem>
-          <div className="mt-5">
-            <Tvl />
-          </div>
-        </FullItem>
-        <li className="flex h-11 w-full items-center gap-x-3 [&_a]:size-full [&_button]:size-11">
-          <Help />
-          <GetStarted />
-        </li>
-      </ul>
+              </RowContainer>
+            </CustomContainer>
+          </FullItem>
+          <FullItem>
+            <div className="mt-5">
+              <Tvl />
+            </div>
+          </FullItem>
+        </ul>
+      </div>
+      <div className="flex w-full shrink-0 items-center gap-x-3 bg-white p-5 [&_a]:size-full [&_button]:size-11">
+        <Help />
+        <GetStarted />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
### Description

Fix mobile navbar to keep Help and Get Started buttons fixed at the bottom while allowing menu content to scroll independently on smaller screens.

### Screenshots

Before

https://github.com/user-attachments/assets/2a95053f-7ef2-4eba-b1fb-3022082a67c4


After

https://github.com/user-attachments/assets/567ed97b-0ce0-448c-b648-493d3aa7679f


### Related issue(s)

Closes #1749 
Fixes #1749 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
