### PR TITLE
Fix calculation of unlock time

### DIFF
--- a/packages/ve-hemi-actions/constants.ts
+++ b/packages/ve-hemi-actions/constants.ts
@@ -8,13 +8,15 @@ const VE_HEMI_CONTRACT_ADDRESSES: Record<number, Address> = {
 
 export const SupportedChains: number[] = [hemi.id, hemiSepolia.id]
 
+// In the contract: YEAR = 365.25 days, SIX_DAYS = YEAR / (12 * 5) = 525,960 seconds
+export const SixDaysSeconds = 525_960
+
 // See https://docs.soliditylang.org/en/latest/units-and-global-variables.html#time-units
 // Maximum lock duration is 4 years (a year is defined in the contract as 365.25 days)
 export const MaxLockDurationSeconds = 4 * 365.25 * 24 * 60 * 60
 
-// In the contract: YEAR = 365.25 days, SIX_DAYS = YEAR / (12 * 5)
-// If 1 day is 86,400 seconds, 12 days are 1,051,920 seconds
-export const MinLockDurationSeconds = 1_051_920
+// MinLockDuration = 2 * SIX_DAYS = 1,051,920 seconds
+export const MinLockDurationSeconds = SixDaysSeconds * 2
 
 export const getVeHemiContractAddress = function (chainId: number) {
   const address = VE_HEMI_CONTRACT_ADDRESSES[chainId]

--- a/packages/ve-hemi-actions/index.ts
+++ b/packages/ve-hemi-actions/index.ts
@@ -9,6 +9,7 @@ export {
   getVeHemiContractAddress,
   MaxLockDurationSeconds,
   MinLockDurationSeconds,
+  SixDaysSeconds,
 } from './constants'
 
 export { getLockEvent, validateCreateLockInputs } from './utils'

--- a/portal/app/[locale]/staking-dashboard/_hooks/useIncreaseUnlockTime.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useIncreaseUnlockTime.ts
@@ -13,10 +13,11 @@ import {
 } from 'types/stakingDashboard'
 import { unixNowTimestamp } from 'utils/time'
 import { IncreaseUnlockTimeEvents } from 've-hemi-actions'
+import { SixDaysSeconds } from 've-hemi-actions'
 import { increaseUnlockTime } from 've-hemi-actions/actions'
 import { useAccount } from 'wagmi'
 
-import { daysToSeconds, step } from '../_utils/lockCreationTimes'
+import { daysToSeconds } from '../_utils/lockCreationTimes'
 
 import { getCalculateAprQueryKey } from './useCalculateApr'
 import { getPositionVotingPowerQueryKey } from './usePositionVotingPower'
@@ -111,8 +112,8 @@ export const useIncreaseUnlockTime = function ({
                 // Calculate new unlock time (current time + chosen duration, rounded)
                 const rawUnlockTime =
                   unixNowTimestamp() + daysToSeconds(BigInt(lockupDays))
-                const newUnlockTime =
-                  (rawUnlockTime / BigInt(step)) * BigInt(step)
+                const sixDays = BigInt(SixDaysSeconds)
+                const newUnlockTime = (rawUnlockTime / sixDays) * sixDays
 
                 // New lockTime is duration from original start to new end
                 const newLockTime = newUnlockTime - BigInt(position.timestamp)

--- a/portal/app/[locale]/staking-dashboard/_utils/aprCalculations.ts
+++ b/portal/app/[locale]/staking-dashboard/_utils/aprCalculations.ts
@@ -1,7 +1,8 @@
 import { EvmToken } from 'types/token'
 import { parseTokenUnits } from 'utils/token'
+import { SixDaysSeconds } from 've-hemi-actions'
 
-import { epochsPerYear, secondsPerEpoch } from './lockCreationTimes'
+import { epochsPerYear } from './lockCreationTimes'
 
 /**
  * Calculates reward weight decay over 61 epochs (366 days)
@@ -45,7 +46,7 @@ export function calculateRewardWeightDecay({
 
   // Calculate how many epochs until unlock
   const timeUntilUnlock = lockEndTimestamp - currentTimestamp
-  const epochsUntilUnlock = Math.ceil(Number(timeUntilUnlock) / secondsPerEpoch)
+  const epochsUntilUnlock = Math.ceil(Number(timeUntilUnlock) / SixDaysSeconds)
 
   for (let epoch = 0; epoch < epochsPerYear; epoch++) {
     if (epoch >= epochsUntilUnlock || epochsUntilUnlock <= 0) {

--- a/portal/app/[locale]/staking-dashboard/_utils/lockCreationTimes.ts
+++ b/portal/app/[locale]/staking-dashboard/_utils/lockCreationTimes.ts
@@ -1,6 +1,10 @@
 import { StakingPosition } from 'types/stakingDashboard'
 import { unixNowTimestamp } from 'utils/time'
-import { MaxLockDurationSeconds, MinLockDurationSeconds } from 've-hemi-actions'
+import {
+  MaxLockDurationSeconds,
+  MinLockDurationSeconds,
+  SixDaysSeconds,
+} from 've-hemi-actions'
 
 export const daySeconds = 86_400
 
@@ -11,7 +15,6 @@ export const step = 6
 export const twoYears = 732
 
 export const epochsPerYear = 61 // 61 epochs × 6 days = 366 days
-export const secondsPerEpoch = step * daySeconds
 
 // To ensure the lock duration is at least the minimum, we clamp the value after calculation
 const clampMin = <T extends number | bigint>(value: T, min: T): T =>
@@ -38,7 +41,8 @@ export function getUnlockInfo({ lockTime, timestamp }: GetUnlockInfoProps) {
   const timestampNum = Number(timestamp)
   const lockTimeNum = Number(lockTime)
 
-  const unlockTime = timestampNum + lockTimeNum
+  const unlockTime =
+    Math.floor((timestampNum + lockTimeNum) / SixDaysSeconds) * SixDaysSeconds
   const timeRemainingSeconds = unlockTime - currentTimeInSeconds
 
   // Calculate unlock date in UTC

--- a/portal/test/[locale]/staking-dashboard/_utils/aprCalculations.test.ts
+++ b/portal/test/[locale]/staking-dashboard/_utils/aprCalculations.test.ts
@@ -2,8 +2,8 @@ import {
   calculateApr,
   calculateRewardWeightDecay,
 } from 'app/[locale]/staking-dashboard/_utils/aprCalculations'
-import { secondsPerEpoch } from 'app/[locale]/staking-dashboard/_utils/lockCreationTimes'
 import { EvmToken } from 'types/token'
+import { SixDaysSeconds } from 've-hemi-actions'
 import { zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
 
@@ -14,7 +14,7 @@ describe('calculateRewardWeightDecay', function () {
     const result = calculateRewardWeightDecay({
       currentBalance: BigInt('100000000000000000000'), // 100 veHEMI
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(1731772800 + 30 * secondsPerEpoch), // 30 epochs from now
+      lockEndTimestamp: BigInt(1731772800 + 30 * SixDaysSeconds), // 30 epochs from now
     })
 
     expect(result).toHaveLength(61)
@@ -26,7 +26,7 @@ describe('calculateRewardWeightDecay', function () {
     const result = calculateRewardWeightDecay({
       currentBalance,
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(1731772800 + 30 * secondsPerEpoch),
+      lockEndTimestamp: BigInt(1731772800 + 30 * SixDaysSeconds),
     })
 
     // First epoch should equal current balance
@@ -40,9 +40,7 @@ describe('calculateRewardWeightDecay', function () {
     const result = calculateRewardWeightDecay({
       currentBalance,
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(
-        1731772800 + epochsUntilUnlock * secondsPerEpoch,
-      ),
+      lockEndTimestamp: BigInt(1731772800 + epochsUntilUnlock * SixDaysSeconds),
     })
 
     // Check linear decay
@@ -59,9 +57,7 @@ describe('calculateRewardWeightDecay', function () {
     const result = calculateRewardWeightDecay({
       currentBalance: BigInt('100000000000000000000'),
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(
-        1731772800 + epochsUntilUnlock * secondsPerEpoch,
-      ),
+      lockEndTimestamp: BigInt(1731772800 + epochsUntilUnlock * SixDaysSeconds),
     })
 
     // All epochs from unlock onwards should be zero
@@ -76,9 +72,7 @@ describe('calculateRewardWeightDecay', function () {
     const result = calculateRewardWeightDecay({
       currentBalance: BigInt('50000000000000000000'), // 50 veHEMI
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(
-        1731772800 + epochsUntilUnlock * secondsPerEpoch,
-      ),
+      lockEndTimestamp: BigInt(1731772800 + epochsUntilUnlock * SixDaysSeconds),
     })
 
     // Should have values for epochs 0-14, zeros for 15-60
@@ -98,9 +92,7 @@ describe('calculateRewardWeightDecay', function () {
     const result = calculateRewardWeightDecay({
       currentBalance: BigInt('100000000000000000000'),
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(
-        1731772800 + epochsUntilUnlock * secondsPerEpoch,
-      ),
+      lockEndTimestamp: BigInt(1731772800 + epochsUntilUnlock * SixDaysSeconds),
     })
 
     // All 61 epochs should have positive reward weight
@@ -133,7 +125,7 @@ describe('calculateRewardWeightDecay', function () {
     const result = calculateRewardWeightDecay({
       currentBalance: smallBalance,
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(1731772800 + 30 * secondsPerEpoch),
+      lockEndTimestamp: BigInt(1731772800 + 30 * SixDaysSeconds),
     })
 
     // Should still calculate values (not all zeros due to rounding)
@@ -147,9 +139,7 @@ describe('calculateRewardWeightDecay', function () {
     const result = calculateRewardWeightDecay({
       currentBalance: BigInt('100000000000000000000'),
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(
-        1731772800 + epochsUntilUnlock * secondsPerEpoch,
-      ), // Exactly 10 epochs
+      lockEndTimestamp: BigInt(1731772800 + epochsUntilUnlock * SixDaysSeconds), // Exactly 10 epochs
     })
 
     // Epoch 9 should have value, epoch 10 should be zero
@@ -185,9 +175,7 @@ describe('calculateApr', function () {
     const rewardWeightDecay = calculateRewardWeightDecay({
       currentBalance,
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(
-        1731772800 + epochsUntilUnlock * secondsPerEpoch,
-      ),
+      lockEndTimestamp: BigInt(1731772800 + epochsUntilUnlock * SixDaysSeconds),
     })
 
     const apr = calculateApr({
@@ -209,9 +197,7 @@ describe('calculateApr', function () {
     const rewardWeightDecay = calculateRewardWeightDecay({
       currentBalance,
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(
-        1731772800 + epochsUntilUnlock * secondsPerEpoch,
-      ),
+      lockEndTimestamp: BigInt(1731772800 + epochsUntilUnlock * SixDaysSeconds),
     })
 
     const apr = calculateApr({
@@ -286,7 +272,7 @@ describe('calculateApr', function () {
     const rewardWeightDecay = calculateRewardWeightDecay({
       currentBalance,
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(1731772800 + 100 * secondsPerEpoch),
+      lockEndTimestamp: BigInt(1731772800 + 100 * SixDaysSeconds),
     })
 
     const apr = calculateApr({
@@ -325,7 +311,7 @@ describe('calculateApr', function () {
     const rewardWeightDecay = calculateRewardWeightDecay({
       currentBalance: smallBalance,
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(1731772800 + 30 * secondsPerEpoch),
+      lockEndTimestamp: BigInt(1731772800 + 30 * SixDaysSeconds),
     })
 
     const apr = calculateApr({
@@ -348,9 +334,7 @@ describe('calculateApr', function () {
     const rewardWeightDecay = calculateRewardWeightDecay({
       currentBalance,
       currentTimestamp: BigInt(1731772800),
-      lockEndTimestamp: BigInt(
-        1731772800 + epochsUntilUnlock * secondsPerEpoch,
-      ),
+      lockEndTimestamp: BigInt(1731772800 + epochsUntilUnlock * SixDaysSeconds),
     })
 
     const apr = calculateApr({

--- a/portal/test/[locale]/staking-dashboard/_utils/lockCreationTimes.test.ts
+++ b/portal/test/[locale]/staking-dashboard/_utils/lockCreationTimes.test.ts
@@ -1,5 +1,44 @@
-import { predictVotingPower } from 'app/[locale]/staking-dashboard/_utils/lockCreationTimes'
+import {
+  getUnlockInfo,
+  predictVotingPower,
+} from 'app/[locale]/staking-dashboard/_utils/lockCreationTimes'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+describe('getUnlockInfo', function () {
+  const mockNow = BigInt(1756500000)
+
+  beforeEach(function () {
+    vi.useFakeTimers()
+    vi.setSystemTime(Number(mockNow) * 1000)
+  })
+
+  afterEach(function () {
+    vi.useRealTimers()
+  })
+
+  it('should round unlock time down to nearest SIX_DAYS boundary matching the contract', function () {
+    // Real on-chain values: start = 1756428611, lockTime = 15778800
+    // Contract computes: unlockTime = ((1756428611 + 15778800) / 525960) * 525960 = 1771959240
+    const result = getUnlockInfo({ lockTime: 15778800, timestamp: 1756428611 })
+    expect(result.unlockTime).toBe(1771959240)
+  })
+
+  it('should not round when sum is already on a SIX_DAYS boundary', function () {
+    // 525960 * 3370 = 1772484200 is exactly on boundary
+    const exactBoundary = 525960 * 3370
+    const timestamp = 1000000
+    const lockTime = exactBoundary - timestamp
+
+    const result = getUnlockInfo({ lockTime, timestamp })
+    expect(result.unlockTime).toBe(exactBoundary)
+  })
+
+  it('should compute correct time remaining', function () {
+    const result = getUnlockInfo({ lockTime: 15778800, timestamp: 1756428611 })
+    // unlockTime (1771959240) - mockNow (1756500000) = 15459240
+    expect(result.timeRemainingSeconds).toBe(1771959240 - Number(mockNow))
+  })
+})
 
 describe('predictVotingPower', function () {
   const mockNow = BigInt(1700000000) // fixed timestamp for testing


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

There was a miscalculation of the "Unlock Time" in the staking governance table.

[The contract](https://github.com/hemilabs/veHEMI/blob/dfa5c7532c3a6ff0afc3fe697d133a1bbd7bda68/src/VeHemi.sol#L557) applies a rounding every 6 days, which over the lock time (in the test case, 6 months) it compounds to ~2 hours every 6 days. This causes that the unlock time takes place 2/3 days before what we were actually showing.

This PR adds this rounding issue so users will be able to now unlock

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Production:

<img width="229" height="150" alt="image" src="https://github.com/user-attachments/assets/3c426632-b7c9-4b8a-8af7-bf0d84dc1316" />

Now with this fix ,I can unlock:

<img width="331" height="176" alt="image" src="https://github.com/user-attachments/assets/2130117a-bff9-4cd7-830b-3dc0e49dc4df" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1821

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
