### PR TITLE
Migrates to call useAllowance lib

### DIFF
--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -1,3 +1,5 @@
+import { useAllowance } from '@hemilabs/react-hooks/useAllowance'
+import { type UseQueryOptions } from '@tanstack/react-query'
 import { DrawerParagraph } from 'components/drawer'
 import { HemiFees } from 'components/hemiFees'
 import {
@@ -8,7 +10,6 @@ import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { Spinner } from 'components/spinner'
 import { ToastLoader } from 'components/toast/toastLoader'
 import { stakeManagerAddresses } from 'hemi-viem-stake-actions'
-import { useAllowance } from 'hooks/useAllowance'
 import { useAmount } from 'hooks/useAmount'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
@@ -24,7 +25,7 @@ import {
 import { getNativeToken, isNativeToken } from 'utils/nativeToken'
 import { canSubmit } from 'utils/stake'
 import { parseTokenUnits } from 'utils/token'
-import { formatUnits } from 'viem'
+import { type Address, formatUnits } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { useEstimateStakeFees } from '../../_hooks/useEstimateStakeFees'
@@ -44,6 +45,11 @@ import { Preview } from './preview'
 import { StakeCallToAction } from './stakeCallToAction'
 import { StrategyDetails } from './strategyDetails'
 import { SubmitButton } from './submitButton'
+
+type AllowanceQuery = Omit<
+  UseQueryOptions<bigint, Error, bigint>,
+  'queryFn' | 'queryKey' | 'enabled'
+> & { enabled?: boolean }
 
 type Props = {
   closeDrawer: () => void
@@ -74,16 +80,14 @@ export const StakeOperation = function ({
   const operatesNativeToken = isNativeToken(token)
   const spender = stakeManagerAddresses[token.chainId]
 
-  const { data: allowance = BigInt(0), isPending } = useAllowance(
-    token.address,
-    {
-      args: {
-        owner: address,
-        spender,
-      },
-      chainId: token.chainId,
-    },
-  )
+  const { data: allowance = BigInt(0), isPending } = useAllowance<bigint>({
+    owner: address,
+    query: {
+      enabled: !operatesNativeToken,
+    } satisfies AllowanceQuery as AllowanceQuery,
+    spender,
+    token: { address: token.address as Address, chainId: token.chainId },
+  })
 
   const amount = parseTokenUnits(amountInput, token)
 

--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -25,7 +25,7 @@ import {
 import { getNativeToken, isNativeToken } from 'utils/nativeToken'
 import { canSubmit } from 'utils/stake'
 import { parseTokenUnits } from 'utils/token'
-import { type Address, formatUnits } from 'viem'
+import { type Address, formatUnits, isAddress, zeroAddress } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { useEstimateStakeFees } from '../../_hooks/useEstimateStakeFees'
@@ -79,6 +79,9 @@ export const StakeOperation = function ({
   const [amountInput, setAmountInput] = useAmount()
   const operatesNativeToken = isNativeToken(token)
   const spender = stakeManagerAddresses[token.chainId]
+  const erc20Address: Address = isAddress(token.address)
+    ? token.address
+    : zeroAddress
 
   const { data: allowance = BigInt(0), isPending } = useAllowance<bigint>({
     owner: address,
@@ -86,7 +89,7 @@ export const StakeOperation = function ({
       enabled: !operatesNativeToken,
     } satisfies AllowanceQuery as AllowanceQuery,
     spender,
-    token: { address: token.address as Address, chainId: token.chainId },
+    token: { address: erc20Address, chainId: token.chainId },
   })
 
   const amount = parseTokenUnits(amountInput, token)


### PR DESCRIPTION
### Description

Migrates `stakeOperation.tsx` to call `@hemilabs/react-hooks/useAllowance` directly, removing the dependency on the local wrapper `hooks/useAllowance`.

### Scope

This PR is intentionally limited to **one file only**:

- `portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx`

### What changed

- Replaced `import { useAllowance } from 'hooks/useAllowance'` with `@hemilabs/react-hooks/useAllowance` (lib direct call).
- The native-token guard, previously implicit inside the wrapper, is now explicit at the call site via `query: { enabled: !operatesNativeToken }`.
- `AllowanceQuery` type defined locally to handle the `enabled` field, which the lib omits from its query type signature but supports at runtime.
- `UseQueryOptions` and `Address` imported as `type` only — no runtime impact.

### What did not change

- `StakeOperation` component public API is unchanged.
- `allowance` and `isPending` fields preserve the same semantics for consumers.
- Runtime behavior is identical.

### Architecture notes

- `AllowanceQuery` is duplicated between this file and `hooks/useAllowance.ts`. This is intentional and temporary — the local wrapper will be removed in PR 4.4 once all callers are migrated.
- No new runtime dependencies introduced. `@tanstack/react-query` was already a project dependency.

### Validation

- Lint passes (no errors, no warnings).
- `portal` build and type-check passes.
- No tests exist for this component. N/A.

### Related issue(s)

Related to #1843

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A. (N/A)
- [x] Documentation updated, or N/A. (N/A)
- [x] Environment variables set in CI, or N/A. (N/A)