### PR TITLE
Replace useAllowance with allowanceQueryKey

### DIFF
--- a/portal/app/[locale]/stake/_hooks/useStake.ts
+++ b/portal/app/[locale]/stake/_hooks/useStake.ts
@@ -1,7 +1,7 @@
+import { allowanceQueryKey } from '@hemilabs/react-hooks/useAllowance'
 import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { stakeManagerAddresses } from 'hemi-viem-stake-actions'
-import { useAllowance } from 'hooks/useAllowance'
 import { useNativeTokenBalance, useTokenBalance } from 'hooks/useBalance'
 import { useHemiClient, useHemiWalletClient } from 'hooks/useHemiClient'
 import { useNetworkType } from 'hooks/useNetworkType'
@@ -16,7 +16,7 @@ import {
 import { isNativeToken } from 'utils/nativeToken'
 import { stake } from 'utils/stake'
 import { parseTokenUnits } from 'utils/token'
-import { Hash } from 'viem'
+import { type Address, type Hash, isAddress, zeroAddress } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { getStakedBalanceQueryKey } from './useStakedBalance'
@@ -25,9 +25,13 @@ export const useStake = function (token: StakeToken) {
   const operatesNativeToken = isNativeToken(token)
   const { address } = useAccount()
   const ensureConnectedTo = useEnsureConnectedTo()
-  const { queryKey: allowanceQueryKey } = useAllowance(token.address, {
-    args: { owner: address, spender: stakeManagerAddresses[token.chainId] },
-    chainId: token.chainId,
+  const erc20Address: Address = isAddress(token.address)
+    ? token.address
+    : zeroAddress
+  const allowanceKey = allowanceQueryKey({
+    owner: address,
+    spender: stakeManagerAddresses[token.chainId],
+    token: { address: erc20Address, chainId: token.chainId },
   })
   const [networkType] = useNetworkType()
   const hemiPublicClient = useHemiClient()
@@ -108,7 +112,7 @@ export const useStake = function (token: StakeToken) {
           setStakeStatus(StakeStatusEnum.APPROVAL_TX_COMPLETED)
           if (!operatesNativeToken) {
             // invalidate allowance after an erc20 approval took place
-            queryClient.invalidateQueries({ queryKey: allowanceQueryKey })
+            queryClient.invalidateQueries({ queryKey: allowanceKey })
           }
         },
         onTokenApprove: () =>


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Migrate `useStake.ts` to use the lib's `allowanceQueryKey` function directly, removing the dependency on the local `hooks/useAllowance` wrapper.


### Scope
This PR is intentionally limited to **one file only**:
- `portal/app/[locale]/stake/_hooks/useStake.ts`

### What changed
- Replaced `import { useAllowance } from 'hooks/useAllowance'` with `import { allowanceQueryKey } from '@hemilabs/react-hooks/useAllowance'`.
- The previous code called the `useAllowance` hook only to destructure `queryKey` for cache invalidation. This was unnecessary — `allowanceQueryKey()` is a pure function that produces the same key without executing a hook.
- Token address narrowed via `isAddress()` type guard with `zeroAddress` fallback — no `as Address` casts.

### What did not change

- `useStake` return shape is identical.
- Cache invalidation behavior is identical (same query key shape).
- Runtime behavior is unchanged.

### Architecture notes
- This change reduces coupling: `useStake` no longer depends on the local wrapper and no longer triggers an unnecessary `useQuery` subscription just to get a static key.
- No `AllowanceQuery` type needed here since we don't call the hook.

### Validation
- Lint passes (no errors, no warnings).
- `portal` build and type-check passes.
- No tests exist for this hook. N/A.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Fixes #
Related to #1807 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
