### PR TITLE
Add Hemi Earn tabbed table

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/apyWithTooltip.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/apyWithTooltip.tsx
@@ -1,0 +1,37 @@
+import { InfoIcon } from 'components/icons/infoIcon'
+import { Tooltip } from 'components/tooltip'
+import { useTranslations } from 'next-intl'
+
+import { formatApyDisplay } from '../_utils'
+
+type Props = {
+  apy: { base: number; incentivized: number; total: number }
+}
+
+export const ApyWithTooltip = function ({ apy }: Props) {
+  const t = useTranslations('hemi-earn.table')
+
+  const tooltipContent = (
+    <span className="flex w-44 flex-col">
+      <span className="flex items-center justify-between">
+        <span>{t('apy-base')}</span>
+        <span>{formatApyDisplay(apy.base)}</span>
+      </span>
+      <span className="flex items-center justify-between">
+        <span>{t('apy-incentivized')}</span>
+        <span>{formatApyDisplay(apy.incentivized)}</span>
+      </span>
+    </span>
+  )
+
+  return (
+    <div className="flex items-center gap-x-1">
+      <span className="text-orange-600">{formatApyDisplay(apy.total)}</span>
+      <Tooltip text={tooltipContent} variant="simple">
+        <div className="group">
+          <InfoIcon className="size-4 [&_path]:fill-neutral-400 [&_path]:transition-colors [&_path]:duration-300 group-hover:[&_path]:fill-neutral-950" />
+        </div>
+      </Tooltip>
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/earnTable.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnTable.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { Tab, Tabs } from 'components/tabs'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+
+import { MyPositionsTable } from './myPositionsTable'
+import { PoolsTable } from './poolsTable'
+
+type TabKey = 'pools' | 'positions'
+
+export const EarnTable = function () {
+  const t = useTranslations('hemi-earn.table')
+  const [activeTab, setActiveTab] = useState<TabKey>('pools')
+
+  return (
+    <div className="mt-10 w-full">
+      <div className="w-full md:w-fit">
+        <Tabs>
+          <Tab
+            onClick={() => setActiveTab('pools')}
+            selected={activeTab === 'pools'}
+          >
+            {t('pools')}
+          </Tab>
+          <Tab
+            onClick={() => setActiveTab('positions')}
+            selected={activeTab === 'positions'}
+          >
+            {t('my-positions')}
+          </Tab>
+        </Tabs>
+      </div>
+      <div className="mt-4">
+        {activeTab === 'pools' ? <PoolsTable /> : <MyPositionsTable />}
+      </div>
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/exposureTokens.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/exposureTokens.tsx
@@ -1,9 +1,9 @@
-import { type Chain } from 'viem'
+import { type Address, type Chain } from 'viem'
 
 import { TokenDisplay } from './tokenDisplay'
 
 type ExposureToken = {
-  address: string
+  address: Address
   chainId: Chain['id']
 }
 
@@ -31,7 +31,7 @@ export const ExposureTokens = function ({ tokens }: Props) {
                 }`
               : '-ml-2 rounded-full border border-white transition-all duration-200 group-hover:ml-0.5'
           }
-          key={token.address}
+          key={`${token.chainId}:${token.address}`}
         >
           <TokenDisplay
             address={token.address}

--- a/portal/app/[locale]/hemi-earn/_components/exposureTokens.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/exposureTokens.tsx
@@ -1,0 +1,45 @@
+import { type Chain } from 'viem'
+
+import { TokenDisplay } from './tokenDisplay'
+
+type ExposureToken = {
+  address: string
+  chainId: Chain['id']
+}
+
+type Props = {
+  tokens: ExposureToken[]
+}
+
+export const ExposureTokens = function ({ tokens }: Props) {
+  if (tokens.length === 0) {
+    return null
+  }
+
+  const hasMultiple = tokens.length > 1
+
+  return (
+    <div className={`flex items-center ${hasMultiple ? 'group' : ''}`}>
+      {tokens.map((token, index) => (
+        <div
+          className={
+            index === 0
+              ? `z-10 ${
+                  hasMultiple
+                    ? 'transition-transform duration-200 group-hover:-translate-x-0.5'
+                    : ''
+                }`
+              : '-ml-2 rounded-full border border-white transition-all duration-200 group-hover:ml-0.5'
+          }
+          key={token.address}
+        >
+          <TokenDisplay
+            address={token.address}
+            chainId={token.chainId}
+            size="small"
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/myPositionsTable/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/myPositionsTable/columns.tsx
@@ -1,0 +1,106 @@
+import { type ColumnDef } from '@tanstack/react-table'
+import { Button } from 'components/button'
+import { ErrorBoundary } from 'components/errorBoundary'
+import { RenderFiatBalance } from 'components/fiatBalance'
+import { Header } from 'components/table/_components/header'
+import { useTranslations } from 'next-intl'
+import { useMemo } from 'react'
+import { formatFiatNumber } from 'utils/format'
+import { formatUnits } from 'viem'
+
+import { type EarnPosition } from '../../types'
+import { ApyWithTooltip } from '../apyWithTooltip'
+import { PoolData } from '../poolData'
+
+const Fallback = () => <span className="text-sm text-neutral-950">-</span>
+
+export const useGetPositionsColumns = function () {
+  const t = useTranslations('hemi-earn')
+
+  return useMemo(
+    () =>
+      [
+        {
+          cell: ({ row }) => (
+            <ErrorBoundary fallback={<Fallback />}>
+              <PoolData
+                token={row.original.token}
+                vaultAddress={row.original.vaultAddress}
+              />
+            </ErrorBoundary>
+          ),
+          header: () => <Header text={t('table.pool')} />,
+          id: 'pool',
+          meta: { width: '200px' },
+        },
+        {
+          cell: ({ row }) => (
+            <ErrorBoundary fallback={<Fallback />}>
+              <div className="flex flex-col">
+                <span className="body-text-medium text-neutral-950">
+                  <RenderFiatBalance
+                    balance={row.original.yourDeposit}
+                    customFormatter={usd => `$${formatFiatNumber(usd)}`}
+                    queryStatus="success"
+                    token={row.original.token}
+                  />
+                </span>
+                <span className="body-text-normal flex gap-x-1 text-neutral-500">
+                  <span>
+                    {formatUnits(
+                      row.original.yourDeposit,
+                      row.original.token.decimals,
+                    )}
+                  </span>
+                  <span>{row.original.token.symbol}</span>
+                </span>
+              </div>
+            </ErrorBoundary>
+          ),
+          header: () => <Header text={t('table.your-deposit')} />,
+          id: 'your-deposit',
+          meta: { width: '200px' },
+        },
+        {
+          cell: ({ row }) => (
+            <ErrorBoundary fallback={<Fallback />}>
+              <ApyWithTooltip apy={row.original.apy} />
+            </ErrorBoundary>
+          ),
+          header: () => <Header text={t('table.apy')} />,
+          id: 'apy',
+          meta: { width: '120px' },
+        },
+        {
+          cell: ({ row }) => (
+            <ErrorBoundary fallback={<Fallback />}>
+              <span className="body-text-medium text-neutral-950">
+                {row.original.yieldEarned}
+              </span>
+            </ErrorBoundary>
+          ),
+          header: () => <Header text={t('table.yield-earned')} />,
+          id: 'yield-earned',
+          meta: { width: '150px' },
+        },
+        {
+          cell: () => (
+            <div className="flex w-full justify-start lg:justify-end">
+              {/* TODO: open manage drawer — to be implemented in a future PR */}
+              <Button size="xSmall" type="button" variant="secondary">
+                {t('table.manage')}
+              </Button>
+            </div>
+          ),
+          header: () => (
+            <div className="w-full max-lg:pl-4 lg:pr-4 *:lg:text-right">
+              <Header text={t('table.actions')} />
+            </div>
+          ),
+          id: 'actions',
+          meta: { width: '100px' },
+        },
+      ] satisfies ColumnDef<EarnPosition>[],
+    [t],
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/myPositionsTable/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/myPositionsTable/index.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { Column } from 'components/table/_components/column'
+import { ColumnHeader } from 'components/table/_components/columnHeader'
+import { getNewColumnOrder } from 'components/table/_utils'
+import { useTranslations } from 'next-intl'
+import { screenBreakpoints } from 'styles'
+
+import { useEarnPositions } from '../../_hooks/useEarnPositions'
+import { TotalYieldEarnedIcon } from '../../_icons/totalYieldEarnedIcon'
+
+import { useGetPositionsColumns } from './columns'
+
+const NoPositionsEmptyState = function () {
+  const t = useTranslations('hemi-earn.table')
+
+  return (
+    <div className="flex min-h-40 w-full flex-col items-center justify-center gap-y-2">
+      <div className="flex size-8 items-center justify-center rounded-full border border-orange-100 bg-orange-50">
+        <TotalYieldEarnedIcon />
+      </div>
+      <div className="flex flex-col items-center gap-y-1 text-center">
+        <p className="text-mid-md font-semibold tracking-tight text-neutral-950">
+          {t('no-positions-title')}
+        </p>
+        <p className="text-sm text-neutral-500">{t('no-positions-subtitle')}</p>
+      </div>
+    </div>
+  )
+}
+
+export const MyPositionsTable = function () {
+  const columns = useGetPositionsColumns()
+  const positions = useEarnPositions()
+  const { width } = useWindowSize()
+
+  const table = useReactTable({
+    columns,
+    data: positions,
+    getCoreRowModel: getCoreRowModel(),
+    state: {
+      columnOrder: getNewColumnOrder({
+        breakpoint: screenBreakpoints.lg,
+        columns,
+        priorityColumnIds: ['actions'],
+        width,
+      }),
+    },
+  })
+
+  const tableHead = (
+    <thead className="sticky top-0 z-10">
+      {table.getHeaderGroups().map(headerGroup => (
+        <tr className="flex w-full items-center" key={headerGroup.id}>
+          {headerGroup.headers.map(header => (
+            <ColumnHeader
+              key={header.id}
+              style={{
+                width: header.column.columnDef.meta?.width,
+              }}
+            >
+              {flexRender(header.column.columnDef.header, header.getContext())}
+            </ColumnHeader>
+          ))}
+        </tr>
+      ))}
+    </thead>
+  )
+
+  if (positions.length === 0) {
+    return (
+      <div className="w-full overflow-hidden rounded-xl bg-neutral-100 text-sm font-medium">
+        <table className="w-full border-separate border-spacing-0 px-1">
+          {tableHead}
+        </table>
+        <div className="mx-1 -mt-1.5 mb-1 rounded-xl bg-white shadow-md">
+          <NoPositionsEmptyState />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="w-full overflow-x-auto rounded-xl bg-neutral-100 text-sm font-medium"
+      style={{
+        scrollbarColor: '#d4d4d4 transparent',
+        scrollbarWidth: 'thin',
+      }}
+    >
+      <table className="w-full border-separate border-spacing-0 whitespace-nowrap px-1">
+        {tableHead}
+        <tbody className="-mt-1.5 mb-1 flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden rounded-xl bg-white shadow-md">
+          {table.getRowModel().rows.map(row => (
+            <tr className="group/row flex w-full items-center" key={row.id}>
+              {row.getVisibleCells().map(cell => (
+                <Column
+                  key={cell.id}
+                  style={{
+                    width: cell.column.columnDef.meta?.width,
+                  }}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </Column>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/poolData.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolData.tsx
@@ -1,0 +1,35 @@
+import { ExternalLink } from 'components/externalLink'
+import { TokenLogo } from 'components/tokenLogo'
+import { useHemi } from 'hooks/useHemi'
+import { type Token } from 'types/token'
+import { formatEvmAddress } from 'utils/format'
+import { type Address } from 'viem'
+
+type Props = {
+  token: Token
+  vaultAddress: Address
+}
+
+export const PoolData = function ({ token, vaultAddress }: Props) {
+  const hemi = useHemi()
+
+  return (
+    <div className="flex items-center gap-x-3">
+      <div className="flex size-10 shrink-0 items-center justify-center overflow-clip rounded-lg bg-neutral-50">
+        <TokenLogo size="medium" token={token} version="L1" />
+      </div>
+      <div className="flex flex-col">
+        <span className="body-text-medium text-neutral-950">
+          {token.symbol}
+        </span>
+        <span className="body-text-normal text-neutral-500 hover:text-neutral-950">
+          <ExternalLink
+            href={`${hemi.blockExplorers!.default.url}/address/${vaultAddress}`}
+          >
+            {formatEvmAddress(vaultAddress)}
+          </ExternalLink>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/poolsTable/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsTable/columns.tsx
@@ -1,0 +1,105 @@
+import { type ColumnDef } from '@tanstack/react-table'
+import { Button } from 'components/button'
+import { ErrorBoundary } from 'components/errorBoundary'
+import { RenderFiatBalance } from 'components/fiatBalance'
+import { Header } from 'components/table/_components/header'
+import { useTranslations } from 'next-intl'
+import { useMemo } from 'react'
+import { formatFiatNumber } from 'utils/format'
+import { formatUnits } from 'viem'
+
+import { type EarnPool } from '../../types'
+import { ApyWithTooltip } from '../apyWithTooltip'
+import { ExposureTokens } from '../exposureTokens'
+import { PoolData } from '../poolData'
+
+const Fallback = () => <span className="text-sm text-neutral-950">-</span>
+
+export const useGetPoolsColumns = function () {
+  const t = useTranslations('hemi-earn')
+
+  return useMemo(
+    () =>
+      [
+        {
+          cell: ({ row }) => (
+            <ErrorBoundary fallback={<Fallback />}>
+              <PoolData
+                token={row.original.token}
+                vaultAddress={row.original.vaultAddress}
+              />
+            </ErrorBoundary>
+          ),
+          header: () => <Header text={t('table.pool')} />,
+          id: 'pool',
+          meta: { width: '200px' },
+        },
+        {
+          cell: ({ row }) => (
+            <ErrorBoundary fallback={<Fallback />}>
+              <div className="flex flex-col">
+                <span className="body-text-medium text-neutral-950">
+                  <RenderFiatBalance
+                    balance={row.original.totalDeposits}
+                    customFormatter={usd => `$${formatFiatNumber(usd)}`}
+                    queryStatus="success"
+                    token={row.original.token}
+                  />
+                </span>
+                <span className="body-text-normal flex gap-x-1 text-neutral-500">
+                  <span>
+                    {formatUnits(
+                      row.original.totalDeposits,
+                      row.original.token.decimals,
+                    )}
+                  </span>
+                  <span>{row.original.token.symbol}</span>
+                </span>
+              </div>
+            </ErrorBoundary>
+          ),
+          header: () => <Header text={t('table.total-deposits')} />,
+          id: 'total-deposits',
+          meta: { width: '200px' },
+        },
+        {
+          cell: ({ row }) => (
+            <ErrorBoundary fallback={<Fallback />}>
+              <ApyWithTooltip apy={row.original.apy} />
+            </ErrorBoundary>
+          ),
+          header: () => <Header text={t('table.apy')} />,
+          id: 'apy',
+          meta: { width: '120px' },
+        },
+        {
+          cell: ({ row }) => (
+            <ErrorBoundary fallback={<Fallback />}>
+              <ExposureTokens tokens={row.original.exposureTokens} />
+            </ErrorBoundary>
+          ),
+          header: () => <Header text={t('table.exposure')} />,
+          id: 'exposure',
+          meta: { width: '120px' },
+        },
+        {
+          cell: () => (
+            <div className="flex w-full justify-start lg:justify-end">
+              {/* TODO: open deposit drawer — to be implemented in a future PR */}
+              <Button size="xSmall" type="button" variant="primary">
+                {t('table.deposit-and-earn-yield')}
+              </Button>
+            </div>
+          ),
+          header: () => (
+            <div className="w-full max-lg:pl-4 lg:pr-4 *:lg:text-right">
+              <Header text={t('table.actions')} />
+            </div>
+          ),
+          id: 'actions',
+          meta: { width: '260px' },
+        },
+      ] satisfies ColumnDef<EarnPool>[],
+    [t],
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/poolsTable/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsTable/index.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { Column } from 'components/table/_components/column'
+import { ColumnHeader } from 'components/table/_components/columnHeader'
+import { getNewColumnOrder } from 'components/table/_utils'
+import { screenBreakpoints } from 'styles'
+
+import { useEarnPools } from '../../_hooks/useEarnPools'
+
+import { useGetPoolsColumns } from './columns'
+
+export const PoolsTable = function () {
+  const columns = useGetPoolsColumns()
+  const { data: pools = [] } = useEarnPools()
+  const { width } = useWindowSize()
+
+  const table = useReactTable({
+    columns,
+    data: pools,
+    getCoreRowModel: getCoreRowModel(),
+    state: {
+      columnOrder: getNewColumnOrder({
+        breakpoint: screenBreakpoints.lg,
+        columns,
+        priorityColumnIds: ['actions'],
+        width,
+      }),
+    },
+  })
+
+  return (
+    <div
+      className="w-full overflow-x-auto rounded-xl bg-neutral-100 text-sm font-medium"
+      style={{
+        scrollbarColor: '#d4d4d4 transparent',
+        scrollbarWidth: 'thin',
+      }}
+    >
+      <table className="w-full border-separate border-spacing-0 whitespace-nowrap px-1">
+        <thead className="sticky top-0 z-10">
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr className="flex w-full items-center" key={headerGroup.id}>
+              {headerGroup.headers.map(header => (
+                <ColumnHeader
+                  key={header.id}
+                  style={{
+                    width: header.column.columnDef.meta?.width,
+                  }}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+                </ColumnHeader>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody className="-mt-1.5 mb-1 flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden rounded-xl bg-white shadow-md">
+          {table.getRowModel().rows.map(row => (
+            <tr className="group/row flex w-full items-center" key={row.id}>
+              {row.getVisibleCells().map(cell => (
+                <Column
+                  key={cell.id}
+                  style={{
+                    width: cell.column.columnDef.meta?.width,
+                  }}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </Column>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -1,0 +1,68 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { getEarnVaultAddresses } from 'hemi-earn-actions'
+import { useHemi } from 'hooks/useHemi'
+import { useHemiClient } from 'hooks/useHemiClient'
+import { useMemo } from 'react'
+import { type Chain, zeroAddress } from 'viem'
+import { totalAssets } from 'viem-erc4626/actions'
+
+import { type EarnPool } from '../types'
+
+import { useHemiEarnTokens } from './useHemiEarnTokens'
+
+export const useEarnPools = function () {
+  const { id: chainId } = useHemi()
+  const hemiClient = useHemiClient()
+  const tokens = useHemiEarnTokens()
+
+  const vaultTokens = useMemo(
+    function () {
+      const vaultAddresses = getEarnVaultAddresses(chainId)
+
+      return tokens.map((token, index) => ({
+        token,
+        vaultAddress: vaultAddresses[index] ?? zeroAddress,
+      }))
+    },
+    [tokens, chainId],
+  )
+
+  return useQuery<EarnPool[]>({
+    enabled: vaultTokens.length > 0,
+    async queryFn() {
+      const deposits = await Promise.all(
+        vaultTokens.map(({ vaultAddress }) =>
+          vaultAddress !== zeroAddress
+            ? totalAssets(hemiClient, { address: vaultAddress })
+            : Promise.resolve(BigInt(0)),
+        ),
+      )
+
+      // TODO: apy requires off-chain data once available
+      // TODO: exposure tokens are not finalized — using pool token + counterpart as placeholder
+      return vaultTokens.map(({ token, vaultAddress }, index) => ({
+        apy: { base: 0, incentivized: 0, total: 0 },
+        exposureTokens: (vaultTokens[(index + 1) % vaultTokens.length]?.token
+          .address !== token.address
+          ? [
+              { address: token.address, chainId: token.chainId as Chain['id'] },
+              {
+                address:
+                  vaultTokens[(index + 1) % vaultTokens.length].token.address,
+                chainId: vaultTokens[(index + 1) % vaultTokens.length].token
+                  .chainId as Chain['id'],
+              },
+            ]
+          : [
+              { address: token.address, chainId: token.chainId as Chain['id'] },
+            ]) satisfies EarnPool['exposureTokens'],
+        token,
+        totalDeposits: deposits[index],
+        vaultAddress,
+      }))
+    },
+    queryKey: ['hemi-earn', 'pools', chainId],
+  })
+}

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -5,7 +5,8 @@ import { getEarnVaultAddresses } from 'hemi-earn-actions'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiClient } from 'hooks/useHemiClient'
 import { useMemo } from 'react'
-import { type Chain, zeroAddress } from 'viem'
+import { type EvmToken } from 'types/token'
+import { type Address, zeroAddress } from 'viem'
 import { totalAssets } from 'viem-erc4626/actions'
 
 import { type EarnPool } from '../types'
@@ -17,10 +18,9 @@ export const useEarnPools = function () {
   const hemiClient = useHemiClient()
   const tokens = useHemiEarnTokens()
 
-  const vaultTokens = useMemo(
+  const vaultTokens = useMemo<{ token: EvmToken; vaultAddress: Address }[]>(
     function () {
       const vaultAddresses = getEarnVaultAddresses(chainId)
-
       return tokens.map((token, index) => ({
         token,
         vaultAddress: vaultAddresses[index] ?? zeroAddress,
@@ -47,19 +47,19 @@ export const useEarnPools = function () {
         exposureTokens: (vaultTokens[(index + 1) % vaultTokens.length]?.token
           .address !== token.address
           ? [
-              { address: token.address, chainId: token.chainId as Chain['id'] },
+              { address: token.address as Address, chainId: token.chainId },
               {
-                address:
-                  vaultTokens[(index + 1) % vaultTokens.length].token.address,
-                chainId: vaultTokens[(index + 1) % vaultTokens.length].token
-                  .chainId as Chain['id'],
+                address: vaultTokens[(index + 1) % vaultTokens.length].token
+                  .address as Address,
+                chainId:
+                  vaultTokens[(index + 1) % vaultTokens.length].token.chainId,
               },
             ]
           : [
-              { address: token.address, chainId: token.chainId as Chain['id'] },
+              { address: token.address as Address, chainId: token.chainId },
             ]) satisfies EarnPool['exposureTokens'],
         token,
-        totalDeposits: deposits[index],
+        totalDeposits: deposits[index] ?? BigInt(0),
         vaultAddress,
       }))
     },

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { getEarnVaultAddresses } from 'hemi-earn-actions'
+import { useHemi } from 'hooks/useHemi'
+import { useMemo } from 'react'
+import { zeroAddress } from 'viem'
+
+import { type EarnPosition } from '../types'
+
+import { useHemiEarnTokens } from './useHemiEarnTokens'
+
+export const useEarnPositions = function (): EarnPosition[] {
+  const { id: chainId } = useHemi()
+  const tokens = useHemiEarnTokens()
+
+  return useMemo(
+    function () {
+      const vaultAddresses = getEarnVaultAddresses(chainId)
+      // TODO: remove mock positions and fetch real user positions once vaults are deployed
+      return tokens.slice(0, 2).map((token, index) => ({
+        apy: { base: 1, incentivized: 3.32, total: 4.32 },
+        token,
+        vaultAddress: vaultAddresses[index] ?? zeroAddress,
+        yieldEarned: '$12.34',
+        yourDeposit: BigInt(100000),
+      }))
+    },
+    [tokens, chainId],
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
@@ -4,7 +4,9 @@ import { hemi, hemiSepolia } from 'hemi-viem'
 import { useHemi } from 'hooks/useHemi'
 import { useMemo } from 'react'
 import { tokenList } from 'tokenList'
+import { type EvmToken } from 'types/token'
 import { toChecksumAddress } from 'utils/address'
+import { isEvmToken } from 'utils/token'
 
 // TODO: replace with vault.asset() calls when earn vaults are deployed
 const EARN_TOKEN_ADDRESSES: Partial<Record<number, string[]>> = {
@@ -23,7 +25,8 @@ export const useHemiEarnTokens = function () {
   return useMemo(
     () =>
       tokenList.tokens.filter(
-        t =>
+        (t): t is EvmToken =>
+          isEvmToken(t) &&
           t.chainId === id &&
           (EARN_TOKEN_ADDRESSES[id] ?? []).includes(t.address),
       ),

--- a/portal/app/[locale]/hemi-earn/page.tsx
+++ b/portal/app/[locale]/hemi-earn/page.tsx
@@ -1,10 +1,35 @@
 'use client'
 
 import { PageLayout } from 'components/pageLayout'
+import dynamic from 'next/dynamic'
+import Skeleton from 'react-loading-skeleton'
 
-import { EarnTable } from './_components/earnTable'
 import { InfoCards } from './_components/infoCards'
 import { TopSection } from './_components/topSection'
+
+const EarnTableSkeleton = () => (
+  <div className="mt-10 w-full">
+    <div className="flex w-full gap-x-2 md:w-fit">
+      <div className="flex-1 md:w-16 md:flex-none">
+        <Skeleton className="h-7 w-full rounded-md" />
+      </div>
+      <div className="flex-1 md:w-28 md:flex-none">
+        <Skeleton className="h-7 w-full rounded-md" />
+      </div>
+    </div>
+    <Skeleton className="h-17 mt-4 w-full rounded-xl" />
+  </div>
+)
+
+// Dynamically load the table because the column order depends on viewport size
+// so, if we don't do this, there will be a very visible layout shift
+const EarnTable = dynamic(
+  () => import('./_components/earnTable').then(mod => mod.EarnTable),
+  {
+    loading: () => <EarnTableSkeleton />,
+    ssr: false,
+  },
+)
 
 export default function Page() {
   return (

--- a/portal/app/[locale]/hemi-earn/page.tsx
+++ b/portal/app/[locale]/hemi-earn/page.tsx
@@ -2,6 +2,7 @@
 
 import { PageLayout } from 'components/pageLayout'
 
+import { EarnTable } from './_components/earnTable'
 import { InfoCards } from './_components/infoCards'
 import { TopSection } from './_components/topSection'
 
@@ -10,6 +11,7 @@ export default function Page() {
     <PageLayout variant="wide">
       <TopSection />
       <InfoCards />
+      <EarnTable />
     </PageLayout>
   )
 }

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -14,17 +14,17 @@ export type EarnCardData = {
 }
 
 export type EarnPool = {
-  vaultAddress: Address
-  token: EvmToken
   apy: { base: number; incentivized: number; total: number }
-  totalDeposits: bigint
   exposureTokens: { address: Address; chainId: EvmToken['chainId'] }[]
+  token: EvmToken
+  totalDeposits: bigint
+  vaultAddress: Address
 }
 
 export type EarnPosition = {
-  vaultAddress: Address
-  token: EvmToken
   apy: { base: number; incentivized: number; total: number }
-  yourDeposit: bigint
+  token: EvmToken
+  vaultAddress: Address
   yieldEarned: string
+  yourDeposit: bigint
 }

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -1,11 +1,30 @@
+import { type Token } from 'types/token'
+import { type Address, type Chain } from 'viem'
+
 export type VaultBreakdown = {
   name: string
   tokenAddress: string
-  tokenChainId: number
+  tokenChainId: Chain['id']
   value: string
 }
 
 export type EarnCardData = {
   vaultBreakdown: VaultBreakdown[]
   vaultCount: number
+}
+
+export type EarnPool = {
+  vaultAddress: Address
+  token: Token
+  apy: { base: number; incentivized: number; total: number }
+  totalDeposits: bigint
+  exposureTokens: { address: string; chainId: Chain['id'] }[]
+}
+
+export type EarnPosition = {
+  vaultAddress: Address
+  token: Token
+  apy: { base: number; incentivized: number; total: number }
+  yourDeposit: bigint
+  yieldEarned: string
 }

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -1,10 +1,10 @@
-import { type Token } from 'types/token'
-import { type Address, type Chain } from 'viem'
+import { type EvmToken } from 'types/token'
+import { type Address } from 'viem'
 
 export type VaultBreakdown = {
   name: string
   tokenAddress: string
-  tokenChainId: Chain['id']
+  tokenChainId: EvmToken['chainId']
   value: string
 }
 
@@ -15,15 +15,15 @@ export type EarnCardData = {
 
 export type EarnPool = {
   vaultAddress: Address
-  token: Token
+  token: EvmToken
   apy: { base: number; incentivized: number; total: number }
   totalDeposits: bigint
-  exposureTokens: { address: string; chainId: Chain['id'] }[]
+  exposureTokens: { address: Address; chainId: EvmToken['chainId'] }[]
 }
 
 export type EarnPosition = {
   vaultAddress: Address
-  token: Token
+  token: EvmToken
   apy: { base: number; incentivized: number; total: number }
   yourDeposit: bigint
   yieldEarned: string

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -10,7 +10,24 @@
       "total-yield": "Total yield earned",
       "total-yield-tooltip": "Total yield you have earned across all vaults"
     },
-    "subheading": "One click earn for your assets"
+    "subheading": "One click earn for your assets",
+    "table": {
+      "actions": "Actions",
+      "apy": "APY",
+      "apy-base": "Base",
+      "apy-incentivized": "Incentivized",
+      "deposit-and-earn-yield": "Deposit and earn yield",
+      "exposure": "Exposure",
+      "manage": "Manage",
+      "my-positions": "My positions",
+      "no-positions-subtitle": "Deposit into a vault to start earning yield.",
+      "no-positions-title": "No active positions",
+      "pool": "Pool",
+      "pools": "Pools",
+      "total-deposits": "Total deposits",
+      "yield-earned": "Yield earned",
+      "your-deposit": "Your deposit"
+    }
   },
   "bitcoin-yield": {
     "bridge-btc-and-receive": "Bridge your BTC through the tunnel and receive {symbol}",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -16,7 +16,7 @@
       "apy": "TEA",
       "apy-base": "Base",
       "apy-incentivized": "Incentivada",
-      "deposit-and-earn-yield": "Depositar y ganar rendimiento",
+      "deposit-and-earn-yield": "Deposite y gane rendimiento",
       "exposure": "Exposición",
       "manage": "Gestionar",
       "my-positions": "Mis posiciones",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -10,7 +10,24 @@
       "total-yield": "Rendimiento total ganado",
       "total-yield-tooltip": "Rendimiento total que ha ganado en todos los vaults"
     },
-    "subheading": "Gane rendimiento con sus activos en un solo clic"
+    "subheading": "Gane rendimiento con sus activos en un solo clic",
+    "table": {
+      "actions": "Acciones",
+      "apy": "TEA",
+      "apy-base": "Base",
+      "apy-incentivized": "Incentivada",
+      "deposit-and-earn-yield": "Depositar y ganar rendimiento",
+      "exposure": "Exposición",
+      "manage": "Gestionar",
+      "my-positions": "Mis posiciones",
+      "no-positions-subtitle": "Deposite en un vault para empezar a ganar rendimiento.",
+      "no-positions-title": "Sin posiciones activas",
+      "pool": "Pool",
+      "pools": "Pools",
+      "total-deposits": "Depósitos totales",
+      "yield-earned": "Rendimiento ganado",
+      "your-deposit": "Su depósito"
+    }
   },
   "bitcoin-yield": {
     "bridge-btc-and-receive": "Transfiera su BTC a través del túnel y reciba {symbol}",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -10,7 +10,24 @@
       "total-yield": "Rendimento total ganho",
       "total-yield-tooltip": "Rendimento total que você ganhou em todos os vaults"
     },
-    "subheading": "Ganhe rendimento com seus ativos em um clique"
+    "subheading": "Ganhe rendimento com seus ativos em um clique",
+    "table": {
+      "actions": "Ações",
+      "apy": "TEA",
+      "apy-base": "Base",
+      "apy-incentivized": "Incentivada",
+      "deposit-and-earn-yield": "Depositar e ganhar rendimento",
+      "exposure": "Exposição",
+      "manage": "Gerenciar",
+      "my-positions": "Minhas posições",
+      "no-positions-subtitle": "Deposite em um vault para começar a ganhar rendimento.",
+      "no-positions-title": "Nenhuma posição ativa",
+      "pool": "Pool",
+      "pools": "Pools",
+      "total-deposits": "Depósitos totais",
+      "yield-earned": "Rendimento ganho",
+      "your-deposit": "Seu depósito"
+    }
   },
   "bitcoin-yield": {
     "bridge-btc-and-receive": "Transfira seu BTC através do túnel e receba {symbol}",

--- a/portal/package.json
+++ b/portal/package.json
@@ -35,6 +35,7 @@
     "fetch-plus-plus": "1.0.0",
     "genesis-drop-actions": "1.0.0",
     "hemi-btc-staking-actions": "1.0.0",
+    "hemi-earn-actions": "1.0.0",
     "hemi-socials": "2.1.0",
     "hemi-tunnel-actions": "1.0.0",
     "hemi-viem": "2.7.0",


### PR DESCRIPTION
### Description

This PR adds a two-tab table (Pools / My positions) below the info cards on the /hemi-earn page. Pools tab shows each vault's token, total deposits, APY breakdown tooltip, exposure tokens with hover-spread animation, and a deposit CTA button. My positions tab shows user deposits, APY, yield earned, and a manage button, with an empty state when no positions exist. Hooks are returning mocked data for now. CTAs will be implemented in upcoming PRs.

### Screenshots

https://github.com/user-attachments/assets/13eee334-8511-4537-a8a8-e15fea215ab9

<img width="854" height="972" alt="Captura de Tela 2026-04-02 às 14 50 06" src="https://github.com/user-attachments/assets/cfbdf3c2-415c-4e76-ab0d-09dca73070be" />


### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
