### PR TITLE
Add vault detail page to Hemi Earn

### DIFF
--- a/packages/hemi-earn-actions/src/constants.ts
+++ b/packages/hemi-earn-actions/src/constants.ts
@@ -3,7 +3,7 @@ import { type Address, zeroAddress } from 'viem'
 
 const EARN_VAULT_ADDRESSES: Record<number, Address[]> = {
   [hemi.id]: [
-    '0xC95873B97E28FFfC9230A335cE193D8D7f09e523', // TODO: replace with deployed hemiBTC vault address once provided, or via on-chain registry
+    zeroAddress, // TODO: replace with deployed hemiBTC vault address once provided, or via on-chain registry
     zeroAddress, // TODO: replace with deployed USDC vault address once provided, or via on-chain registry
   ],
   [hemiSepolia.id]: [

--- a/packages/hemi-earn-actions/src/constants.ts
+++ b/packages/hemi-earn-actions/src/constants.ts
@@ -3,7 +3,7 @@ import { type Address, zeroAddress } from 'viem'
 
 const EARN_VAULT_ADDRESSES: Record<number, Address[]> = {
   [hemi.id]: [
-    zeroAddress, // TODO: replace with deployed hemiBTC vault address once provided, or via on-chain registry
+    '0xC95873B97E28FFfC9230A335cE193D8D7f09e523', // TODO: replace with deployed hemiBTC vault address once provided, or via on-chain registry
     zeroAddress, // TODO: replace with deployed USDC vault address once provided, or via on-chain registry
   ],
   [hemiSepolia.id]: [

--- a/portal/app/[locale]/hemi-earn/_components/myPositionsTable/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/myPositionsTable/columns.tsx
@@ -3,6 +3,7 @@ import { Button } from 'components/button'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { RenderFiatBalance } from 'components/fiatBalance'
 import { Header } from 'components/table/_components/header'
+import { useRouter } from 'i18n/navigation'
 import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 import { formatFiatNumber } from 'utils/format'
@@ -15,6 +16,7 @@ import { PoolData } from '../poolData'
 const Fallback = () => <span className="text-sm text-neutral-950">-</span>
 
 export const useGetPositionsColumns = function () {
+  const router = useRouter()
   const t = useTranslations('hemi-earn')
 
   return useMemo(
@@ -84,10 +86,16 @@ export const useGetPositionsColumns = function () {
           meta: { width: '150px' },
         },
         {
-          cell: () => (
+          cell: ({ row }) => (
             <div className="flex w-full justify-start lg:justify-end">
-              {/* TODO: open manage drawer — to be implemented in a future PR */}
-              <Button size="xSmall" type="button" variant="secondary">
+              <Button
+                onClick={() =>
+                  router.push(`/hemi-earn/vault/${row.original.vaultAddress}`)
+                }
+                size="xSmall"
+                type="button"
+                variant="secondary"
+              >
                 {t('table.manage')}
               </Button>
             </div>
@@ -101,6 +109,6 @@ export const useGetPositionsColumns = function () {
           meta: { width: '100px' },
         },
       ] satisfies ColumnDef<EarnPosition>[],
-    [t],
+    [router, t],
   )
 }

--- a/portal/app/[locale]/hemi-earn/_components/myPositionsTable/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/myPositionsTable/columns.tsx
@@ -3,11 +3,13 @@ import { Button } from 'components/button'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { RenderFiatBalance } from 'components/fiatBalance'
 import { Header } from 'components/table/_components/header'
+import { useNetworkType } from 'hooks/useNetworkType'
 import { useRouter } from 'i18n/navigation'
 import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 import { formatFiatNumber } from 'utils/format'
-import { formatUnits } from 'viem'
+import { queryStringObjectToString } from 'utils/url'
+import { type Address, formatUnits } from 'viem'
 
 import { type EarnPosition } from '../../types'
 import { ApyWithTooltip } from '../apyWithTooltip'
@@ -15,8 +17,31 @@ import { PoolData } from '../poolData'
 
 const Fallback = () => <span className="text-sm text-neutral-950">-</span>
 
-export const useGetPositionsColumns = function () {
+const ManageAction = function ({ vaultAddress }: { vaultAddress: Address }) {
   const router = useRouter()
+  const t = useTranslations('hemi-earn')
+  const [networkType] = useNetworkType()
+  return (
+    <div className="flex w-full justify-start lg:justify-end">
+      <Button
+        onClick={() =>
+          router.push(
+            `/hemi-earn/vault/${vaultAddress}${queryStringObjectToString({
+              networkType,
+            })}`,
+          )
+        }
+        size="xSmall"
+        type="button"
+        variant="secondary"
+      >
+        {t('table.manage')}
+      </Button>
+    </div>
+  )
+}
+
+export const useGetPositionsColumns = function () {
   const t = useTranslations('hemi-earn')
 
   return useMemo(
@@ -87,18 +112,7 @@ export const useGetPositionsColumns = function () {
         },
         {
           cell: ({ row }) => (
-            <div className="flex w-full justify-start lg:justify-end">
-              <Button
-                onClick={() =>
-                  router.push(`/hemi-earn/vault/${row.original.vaultAddress}`)
-                }
-                size="xSmall"
-                type="button"
-                variant="secondary"
-              >
-                {t('table.manage')}
-              </Button>
-            </div>
+            <ManageAction vaultAddress={row.original.vaultAddress} />
           ),
           header: () => (
             <div className="w-full max-lg:pl-4 lg:pr-4 *:lg:text-right">
@@ -109,6 +123,6 @@ export const useGetPositionsColumns = function () {
           meta: { width: '100px' },
         },
       ] satisfies ColumnDef<EarnPosition>[],
-    [router, t],
+    [t],
   )
 }

--- a/portal/app/[locale]/hemi-earn/_components/poolsTable/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsTable/columns.tsx
@@ -3,6 +3,7 @@ import { Button } from 'components/button'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { RenderFiatBalance } from 'components/fiatBalance'
 import { Header } from 'components/table/_components/header'
+import { useRouter } from 'i18n/navigation'
 import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 import { formatFiatNumber } from 'utils/format'
@@ -16,6 +17,7 @@ import { PoolData } from '../poolData'
 const Fallback = () => <span className="text-sm text-neutral-950">-</span>
 
 export const useGetPoolsColumns = function () {
+  const router = useRouter()
   const t = useTranslations('hemi-earn')
 
   return useMemo(
@@ -83,10 +85,16 @@ export const useGetPoolsColumns = function () {
           meta: { width: '120px' },
         },
         {
-          cell: () => (
+          cell: ({ row }) => (
             <div className="flex w-full justify-start lg:justify-end">
-              {/* TODO: open deposit drawer — to be implemented in a future PR */}
-              <Button size="xSmall" type="button" variant="primary">
+              <Button
+                onClick={() =>
+                  router.push(`/hemi-earn/vault/${row.original.vaultAddress}`)
+                }
+                size="xSmall"
+                type="button"
+                variant="primary"
+              >
                 {t('table.deposit-and-earn-yield')}
               </Button>
             </div>
@@ -100,6 +108,6 @@ export const useGetPoolsColumns = function () {
           meta: { width: '260px' },
         },
       ] satisfies ColumnDef<EarnPool>[],
-    [t],
+    [router, t],
   )
 }

--- a/portal/app/[locale]/hemi-earn/_components/poolsTable/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsTable/columns.tsx
@@ -3,11 +3,13 @@ import { Button } from 'components/button'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { RenderFiatBalance } from 'components/fiatBalance'
 import { Header } from 'components/table/_components/header'
+import { useNetworkType } from 'hooks/useNetworkType'
 import { useRouter } from 'i18n/navigation'
 import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 import { formatFiatNumber } from 'utils/format'
-import { formatUnits } from 'viem'
+import { queryStringObjectToString } from 'utils/url'
+import { type Address, formatUnits } from 'viem'
 
 import { type EarnPool } from '../../types'
 import { ApyWithTooltip } from '../apyWithTooltip'
@@ -16,8 +18,31 @@ import { PoolData } from '../poolData'
 
 const Fallback = () => <span className="text-sm text-neutral-950">-</span>
 
-export const useGetPoolsColumns = function () {
+const DepositAction = function ({ vaultAddress }: { vaultAddress: Address }) {
   const router = useRouter()
+  const t = useTranslations('hemi-earn')
+  const [networkType] = useNetworkType()
+  return (
+    <div className="flex w-full justify-start lg:justify-end">
+      <Button
+        onClick={() =>
+          router.push(
+            `/hemi-earn/vault/${vaultAddress}${queryStringObjectToString({
+              networkType,
+            })}`,
+          )
+        }
+        size="xSmall"
+        type="button"
+        variant="primary"
+      >
+        {t('table.deposit-and-earn-yield')}
+      </Button>
+    </div>
+  )
+}
+
+export const useGetPoolsColumns = function () {
   const t = useTranslations('hemi-earn')
 
   return useMemo(
@@ -86,18 +111,7 @@ export const useGetPoolsColumns = function () {
         },
         {
           cell: ({ row }) => (
-            <div className="flex w-full justify-start lg:justify-end">
-              <Button
-                onClick={() =>
-                  router.push(`/hemi-earn/vault/${row.original.vaultAddress}`)
-                }
-                size="xSmall"
-                type="button"
-                variant="primary"
-              >
-                {t('table.deposit-and-earn-yield')}
-              </Button>
-            </div>
+            <DepositAction vaultAddress={row.original.vaultAddress} />
           ),
           header: () => (
             <div className="w-full max-lg:pl-4 lg:pr-4 *:lg:text-right">
@@ -108,6 +122,6 @@ export const useGetPoolsColumns = function () {
           meta: { width: '260px' },
         },
       ] satisfies ColumnDef<EarnPool>[],
-    [router, t],
+    [t],
   )
 }

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultCard.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultCard.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { Card } from 'components/card'
+import { type ReactNode } from 'react'
+import Skeleton from 'react-loading-skeleton'
+
+type Props = {
+  icon: ReactNode
+  isError: boolean
+  isLoading: boolean
+  label: string
+  value: ReactNode
+}
+
+export const VaultCard = ({
+  icon,
+  isError,
+  isLoading,
+  label,
+  value,
+}: Props) => (
+  <Card shadow="sm">
+    <div className="w-full p-4">
+      <div className="flex flex-col gap-y-2">
+        <div className="flex items-center justify-between">
+          <span className="body-text-medium text-neutral-500">{label}</span>
+          {icon}
+        </div>
+        <p className="text-2xl font-semibold text-neutral-950">
+          {!isLoading && !isError ? (
+            value
+          ) : isError ? (
+            '-'
+          ) : (
+            <Skeleton className="h-7 w-20" />
+          )}
+        </p>
+      </div>
+    </div>
+  </Card>
+)

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultInfoCards.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultInfoCards.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { RenderFiatBalance } from 'components/fiatBalance'
+import { useTranslations } from 'next-intl'
+import { formatFiatNumber } from 'utils/format'
+
+import { AvgApyIcon } from '../../../_icons/avgApyIcon'
+import { TotalDepositsIcon } from '../../../_icons/totalDepositsIcon'
+import { formatApyDisplay } from '../../../_utils'
+import { type EarnPool } from '../../../types'
+
+import { VaultCard } from './vaultCard'
+
+type Props = {
+  pool: EarnPool
+}
+
+export const VaultInfoCards = function ({ pool }: Props) {
+  const t = useTranslations('hemi-earn')
+
+  return (
+    <div className="xs:flex-row flex w-full flex-col items-stretch gap-4 md:gap-5">
+      <div className="flex-1">
+        <VaultCard
+          icon={<TotalDepositsIcon />}
+          isError={false}
+          isLoading={false}
+          label={t('vault.total-deposits')}
+          value={
+            <RenderFiatBalance
+              balance={pool.totalDeposits}
+              customFormatter={usd => `$${formatFiatNumber(usd)}`}
+              queryStatus="success"
+              token={pool.token}
+            />
+          }
+        />
+      </div>
+      <div className="flex-1">
+        <VaultCard
+          icon={<AvgApyIcon />}
+          isError={false}
+          isLoading={false}
+          label={t('vault.apy')}
+          value={<>{formatApyDisplay(pool.apy.total)}</>}
+        />
+      </div>
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultNavigation.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultNavigation.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { Button, ButtonIcon } from 'components/button'
+import { Chevron } from 'components/icons/chevron'
+import { Menu } from 'components/menu'
+import { useRouter } from 'i18n/navigation'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+
+import { useEarnPools } from '../../../_hooks/useEarnPools'
+import { type EarnPool } from '../../../types'
+
+type Props = {
+  pool: EarnPool
+}
+
+export const VaultNavigation = function ({ pool }: Props) {
+  const router = useRouter()
+  const t = useTranslations('hemi-earn')
+  const { data: pools = [] } = useEarnPools()
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+
+  return (
+    <div className="flex items-center gap-x-1">
+      <div className="group">
+        <ButtonIcon
+          aria-label={t('navigation.back')}
+          onClick={() => router.back()}
+          size="xSmall"
+          type="button"
+          variant="tertiary"
+        >
+          <Chevron.Left className="[&>path]:fill-neutral-500 [&>path]:transition-colors [&>path]:duration-300 group-hover:[&>path]:fill-neutral-950" />
+        </ButtonIcon>
+      </div>
+      <Button
+        onClick={() => router.push('/hemi-earn')}
+        size="xSmall"
+        type="button"
+        variant="tertiary"
+      >
+        {t('navigation.hemi-earn')}
+      </Button>
+      <span className="text-xs font-semibold text-neutral-950">/</span>
+      <div className="relative">
+        <Button
+          onClick={() => setIsDropdownOpen(prev => !prev)}
+          size="xSmall"
+          type="button"
+          variant="tertiary"
+        >
+          {t('navigation.vault-name', { tokenSymbol: pool.token.symbol })}
+          <Chevron.Bottom className="[&>path]:fill-neutral-950" />
+        </Button>
+        {isDropdownOpen && (
+          <>
+            <div
+              className="fixed inset-0 z-10"
+              onClick={() => setIsDropdownOpen(false)}
+            />
+            <div className="absolute left-0 top-full z-20 mt-1">
+              <Menu
+                items={pools.map(p => ({
+                  content: (
+                    <button
+                      className="w-full text-left text-sm"
+                      onClick={function () {
+                        setIsDropdownOpen(false)
+                        router.push(`/hemi-earn/vault/${p.vaultAddress}`)
+                      }}
+                      type="button"
+                    >
+                      {t('navigation.vault-name', {
+                        tokenSymbol: p.token.symbol,
+                      })}
+                    </button>
+                  ),
+                  id: p.vaultAddress,
+                }))}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultNavigation.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultNavigation.tsx
@@ -1,11 +1,14 @@
 'use client'
 
+import { useOnClickOutside } from '@hemilabs/react-hooks/useOnClickOutside'
 import { Button, ButtonIcon } from 'components/button'
 import { Chevron } from 'components/icons/chevron'
 import { Menu } from 'components/menu'
+import { useNetworkType } from 'hooks/useNetworkType'
 import { useRouter } from 'i18n/navigation'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
+import { queryStringObjectToString } from 'utils/url'
 
 import { useEarnPools } from '../../../_hooks/useEarnPools'
 import { type EarnPool } from '../../../types'
@@ -19,6 +22,10 @@ export const VaultNavigation = function ({ pool }: Props) {
   const t = useTranslations('hemi-earn')
   const { data: pools = [] } = useEarnPools()
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [networkType] = useNetworkType()
+  const dropdownRef = useOnClickOutside<HTMLDivElement>(() =>
+    setIsDropdownOpen(false),
+  )
 
   return (
     <div className="flex items-center gap-x-1">
@@ -34,7 +41,9 @@ export const VaultNavigation = function ({ pool }: Props) {
         </ButtonIcon>
       </div>
       <Button
-        onClick={() => router.push('/hemi-earn')}
+        onClick={() =>
+          router.push(`/hemi-earn${queryStringObjectToString({ networkType })}`)
+        }
         size="xSmall"
         type="button"
         variant="tertiary"
@@ -42,7 +51,7 @@ export const VaultNavigation = function ({ pool }: Props) {
         {t('navigation.hemi-earn')}
       </Button>
       <span className="text-xs font-semibold text-neutral-950">/</span>
-      <div className="relative">
+      <div className="relative" ref={dropdownRef}>
         <Button
           onClick={() => setIsDropdownOpen(prev => !prev)}
           size="xSmall"
@@ -53,33 +62,31 @@ export const VaultNavigation = function ({ pool }: Props) {
           <Chevron.Bottom className="[&>path]:fill-neutral-950" />
         </Button>
         {isDropdownOpen && (
-          <>
-            <div
-              className="fixed inset-0 z-10"
-              onClick={() => setIsDropdownOpen(false)}
+          <div className="absolute left-0 top-full z-20 mt-1">
+            <Menu
+              items={pools.map(p => ({
+                content: (
+                  <button
+                    className="-mx-2 -my-1 block px-2 py-1 text-left text-sm"
+                    onClick={function () {
+                      setIsDropdownOpen(false)
+                      router.push(
+                        `/hemi-earn/vault/${
+                          p.vaultAddress
+                        }${queryStringObjectToString({ networkType })}`,
+                      )
+                    }}
+                    type="button"
+                  >
+                    {t('navigation.vault-name', {
+                      tokenSymbol: p.token.symbol,
+                    })}
+                  </button>
+                ),
+                id: p.vaultAddress,
+              }))}
             />
-            <div className="absolute left-0 top-full z-20 mt-1">
-              <Menu
-                items={pools.map(p => ({
-                  content: (
-                    <button
-                      className="w-full text-left text-sm"
-                      onClick={function () {
-                        setIsDropdownOpen(false)
-                        router.push(`/hemi-earn/vault/${p.vaultAddress}`)
-                      }}
-                      type="button"
-                    >
-                      {t('navigation.vault-name', {
-                        tokenSymbol: p.token.symbol,
-                      })}
-                    </button>
-                  ),
-                  id: p.vaultAddress,
-                }))}
-              />
-            </div>
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
@@ -22,11 +22,7 @@ export const VaultPageContent = function ({ vaultAddress }: Props) {
   const router = useRouter()
   const locale = useLocale()
   const [networkType] = useNetworkType()
-  const { data: pools, fetchStatus, isPending } = useEarnPools()
-  // When `enabled: false` (no vaults on this chain), React Query keeps
-  // `isPending: true` forever. `fetchStatus === 'idle'` detects that case so
-  // we can still redirect instead of showing the skeleton indefinitely.
-  const isLoading = isPending && fetchStatus !== 'idle'
+  const { data: pools, isPending } = useEarnPools()
 
   const pool = pools?.find(
     p =>
@@ -51,14 +47,14 @@ export const VaultPageContent = function ({ vaultAddress }: Props) {
 
   useEffect(
     function redirectIfNotFound() {
-      if (!isLoading && !pool) {
+      if (!isPending && !pool) {
         router.push(`/hemi-earn${queryStringObjectToString({ networkType })}`)
       }
     },
-    [isLoading, networkType, pool, router],
+    [isPending, networkType, pool, router],
   )
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <PageLayout variant="wide">
         <Skeleton className="h-7 w-48 rounded-md" />

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { PageLayout } from 'components/pageLayout'
+import { useRouter } from 'i18n/navigation'
+import { useEffect } from 'react'
+import Skeleton from 'react-loading-skeleton'
+import { type Address } from 'viem'
+
+import { useEarnPools } from '../../../_hooks/useEarnPools'
+
+import { VaultInfoCards } from './vaultInfoCards'
+import { VaultNavigation } from './vaultNavigation'
+
+type Props = {
+  vaultAddress: string
+}
+
+export const VaultPageContent = function ({ vaultAddress }: Props) {
+  const router = useRouter()
+  const { data: pools, isPending } = useEarnPools()
+
+  const pool = pools?.find(
+    p =>
+      p.vaultAddress.toLowerCase() === (vaultAddress as Address).toLowerCase(),
+  )
+
+  useEffect(
+    function redirectIfNotFound() {
+      if (!isPending && !pool) {
+        router.push('/hemi-earn')
+      }
+    },
+    [isPending, pool, router],
+  )
+
+  if (isPending) {
+    return (
+      <PageLayout variant="wide">
+        <Skeleton className="h-7 w-48 rounded-md" />
+        <div className="mt-8 flex gap-4">
+          <Skeleton className="h-24 flex-1 rounded-xl" />
+          <Skeleton className="h-24 flex-1 rounded-xl" />
+        </div>
+      </PageLayout>
+    )
+  }
+
+  if (!pool) {
+    return null
+  }
+
+  return (
+    <PageLayout variant="wide">
+      <VaultNavigation pool={pool} />
+      <div className="mt-6">
+        <VaultInfoCards pool={pool} />
+      </div>
+    </PageLayout>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { PageLayout } from 'components/pageLayout'
+import { useNetworkType } from 'hooks/useNetworkType'
 import { useRouter } from 'i18n/navigation'
-import { useEffect } from 'react'
+import { useLocale } from 'next-intl'
+import { useEffect, useRef } from 'react'
 import Skeleton from 'react-loading-skeleton'
+import { queryStringObjectToString } from 'utils/url'
 import { type Address } from 'viem'
 
 import { useEarnPools } from '../../../_hooks/useEarnPools'
@@ -17,23 +20,45 @@ type Props = {
 
 export const VaultPageContent = function ({ vaultAddress }: Props) {
   const router = useRouter()
-  const { data: pools, isPending } = useEarnPools()
+  const locale = useLocale()
+  const [networkType] = useNetworkType()
+  const { data: pools, fetchStatus, isPending } = useEarnPools()
+  // When `enabled: false` (no vaults on this chain), React Query keeps
+  // `isPending: true` forever. `fetchStatus === 'idle'` detects that case so
+  // we can still redirect instead of showing the skeleton indefinitely.
+  const isLoading = isPending && fetchStatus !== 'idle'
 
   const pool = pools?.find(
     p =>
       p.vaultAddress.toLowerCase() === (vaultAddress as Address).toLowerCase(),
   )
 
+  const networkTypeRef = useRef(networkType)
   useEffect(
-    function redirectIfNotFound() {
-      if (!isPending && !pool) {
-        router.push('/hemi-earn')
-      }
+    function redirectOnNetworkChange() {
+      if (networkTypeRef.current === networkType) return
+      networkTypeRef.current = networkType
+      // nuqs defers its URL flush via setTimeout(~50ms). Calling router.push
+      // here fires immediately but nuqs's flush overwrites it 50ms later with
+      // the vault URL + ?networkType. Instead, we pre-set location.pathname to
+      // /hemi-earn via history.pushState *before* nuqs flushes. nuqs then reads
+      // the updated pathname and applies ?networkType to the earn page URL,
+      // and its own router.replace finishes the navigation — no hard reload needed.
+      history.pushState(null, '', `/${locale}/hemi-earn`)
     },
-    [isPending, pool, router],
+    [locale, networkType],
   )
 
-  if (isPending) {
+  useEffect(
+    function redirectIfNotFound() {
+      if (!isLoading && !pool) {
+        router.push(`/hemi-earn${queryStringObjectToString({ networkType })}`)
+      }
+    },
+    [isLoading, networkType, pool, router],
+  )
+
+  if (isLoading) {
     return (
       <PageLayout variant="wide">
         <Skeleton className="h-7 w-48 rounded-md" />

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/page.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/page.tsx
@@ -1,0 +1,21 @@
+import { getEarnVaultAddresses } from 'hemi-earn-actions'
+import { hemi, hemiSepolia } from 'hemi-viem'
+
+import { VaultPageContent } from './_components/vaultPageContent'
+
+type Props = {
+  params: Promise<{ vaultAddress: string }>
+}
+
+export const generateStaticParams = function () {
+  const addresses = [
+    ...getEarnVaultAddresses(hemi.id),
+    ...getEarnVaultAddresses(hemiSepolia.id),
+  ]
+  return [...new Set(addresses)].map(vaultAddress => ({ vaultAddress }))
+}
+
+export default async function Page({ params }: Props) {
+  const { vaultAddress } = await params
+  return <VaultPageContent vaultAddress={vaultAddress} />
+}

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/page.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/page.tsx
@@ -7,6 +7,11 @@ type Props = {
   params: Promise<{ vaultAddress: string }>
 }
 
+// We include addresses from both chains so the static export covers all
+// possible vault URLs regardless of which network the user has selected.
+// Chain enforcement happens at runtime: `useEarnPools` only returns pools for
+// the active chain, so navigating to a vault address that doesn't belong to
+// the current chain will find no matching pool and redirect back to /hemi-earn.
 export const generateStaticParams = function () {
   const addresses = [
     ...getEarnVaultAddresses(hemi.id),

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -12,7 +12,7 @@
     },
     "navigation": {
       "back": "Back",
-      "hemi-earn": "Hemi earn",
+      "hemi-earn": "Hemi Earn",
       "vault-name": "{tokenSymbol} vault"
     },
     "subheading": "One click earn for your assets",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -10,6 +10,11 @@
       "total-yield": "Total yield earned",
       "total-yield-tooltip": "Total yield you have earned across all vaults"
     },
+    "navigation": {
+      "back": "Back",
+      "hemi-earn": "Hemi earn",
+      "vault-name": "{tokenSymbol} vault"
+    },
     "subheading": "One click earn for your assets",
     "table": {
       "actions": "Actions",
@@ -27,6 +32,10 @@
       "total-deposits": "Total deposits",
       "yield-earned": "Yield earned",
       "your-deposit": "Your deposit"
+    },
+    "vault": {
+      "apy": "APY",
+      "total-deposits": "Vault total deposits"
     }
   },
   "bitcoin-yield": {

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -10,6 +10,11 @@
       "total-yield": "Rendimiento total ganado",
       "total-yield-tooltip": "Rendimiento total que ha ganado en todos los vaults"
     },
+    "navigation": {
+      "back": "Atrás",
+      "hemi-earn": "Hemi earn",
+      "vault-name": "vault {tokenSymbol}"
+    },
     "subheading": "Gane rendimiento con sus activos en un solo clic",
     "table": {
       "actions": "Acciones",
@@ -27,6 +32,10 @@
       "total-deposits": "Depósitos totales",
       "yield-earned": "Rendimiento ganado",
       "your-deposit": "Su depósito"
+    },
+    "vault": {
+      "apy": "TEA",
+      "total-deposits": "Depósitos totales del vault"
     }
   },
   "bitcoin-yield": {

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -12,7 +12,7 @@
     },
     "navigation": {
       "back": "Atrás",
-      "hemi-earn": "Hemi earn",
+      "hemi-earn": "Hemi Earn",
       "vault-name": "vault {tokenSymbol}"
     },
     "subheading": "Gane rendimiento con sus activos en un solo clic",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -12,7 +12,7 @@
     },
     "navigation": {
       "back": "Voltar",
-      "hemi-earn": "Hemi earn",
+      "hemi-earn": "Hemi Earn",
       "vault-name": "vault {tokenSymbol}"
     },
     "subheading": "Ganhe rendimento com seus ativos em um clique",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -10,6 +10,11 @@
       "total-yield": "Rendimento total ganho",
       "total-yield-tooltip": "Rendimento total que você ganhou em todos os vaults"
     },
+    "navigation": {
+      "back": "Voltar",
+      "hemi-earn": "Hemi earn",
+      "vault-name": "vault {tokenSymbol}"
+    },
     "subheading": "Ganhe rendimento com seus ativos em um clique",
     "table": {
       "actions": "Ações",
@@ -27,6 +32,10 @@
       "total-deposits": "Depósitos totais",
       "yield-earned": "Rendimento ganho",
       "your-deposit": "Seu depósito"
+    },
+    "vault": {
+      "apy": "TEA",
+      "total-deposits": "Depósitos totais do vault"
     }
   },
   "bitcoin-yield": {


### PR DESCRIPTION
### Description

This PR wires up the "Deposit and earn yield" and "Manage" buttons to navigate to /hemi-earn/vault/[vaultAddress]. The vault page shows a breadcrumb nav with a vault switcher dropdown and two info cards.. vault total deposits and APY, scoped to the selected vault. Vault page is a WIP though.

### Screenshots

https://github.com/user-attachments/assets/8c7fdc94-1d88-4c04-9f10-eb3b3bdd560f

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
