### PR TITLE
Fetch hemi-earn tokens from ERC4626 vaults

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/poolsTable/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsTable/index.tsx
@@ -9,6 +9,7 @@ import {
 import { Column } from 'components/table/_components/column'
 import { ColumnHeader } from 'components/table/_components/columnHeader'
 import { getNewColumnOrder } from 'components/table/_utils'
+import Skeleton from 'react-loading-skeleton'
 import { screenBreakpoints } from 'styles'
 
 import { useEarnPools } from '../../_hooks/useEarnPools'
@@ -17,7 +18,7 @@ import { useGetPoolsColumns } from './columns'
 
 export const PoolsTable = function () {
   const columns = useGetPoolsColumns()
-  const { data: pools = [] } = useEarnPools()
+  const { data: pools = [], isPending } = useEarnPools()
   const { width } = useWindowSize()
 
   const table = useReactTable({
@@ -33,6 +34,10 @@ export const PoolsTable = function () {
       }),
     },
   })
+
+  if (isPending) {
+    return <Skeleton className="h-17 w-full rounded-xl" />
+  }
 
   return (
     <div

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
@@ -1,9 +1,11 @@
 import { getEarnVaultAddresses } from 'hemi-earn-actions'
-import { getTokenByAddress, isEvmToken } from 'utils/token'
-import { type Chain, type PublicClient, zeroAddress } from 'viem'
+import { type Address, type Chain, type PublicClient, zeroAddress } from 'viem'
 import { asset } from 'viem-erc4626/actions'
 
-import { type VaultToken } from '../types'
+type VaultAsset = {
+  tokenAddress: Address
+  vaultAddress: Address
+}
 
 export const fetchHemiEarnTokens = async function ({
   chainId,
@@ -11,23 +13,15 @@ export const fetchHemiEarnTokens = async function ({
 }: {
   chainId: Chain['id']
   client: PublicClient
-}): Promise<VaultToken[]> {
-  const vaultAddresses = getEarnVaultAddresses(chainId)
-  const results = await Promise.all(
-    vaultAddresses.map(addr =>
-      addr === zeroAddress
-        ? Promise.resolve(null)
-        : asset(client, { address: addr }),
-    ),
+}): Promise<VaultAsset[]> {
+  const vaultAddresses = getEarnVaultAddresses(chainId).filter(
+    addr => addr !== zeroAddress,
   )
-  return results.reduce<VaultToken[]>(function (acc, tokenAddress, index) {
-    if (tokenAddress === null) {
-      return acc
-    }
-    const token = getTokenByAddress(tokenAddress, chainId)
-    if (token !== undefined && isEvmToken(token)) {
-      acc.push({ token, vaultAddress: vaultAddresses[index] })
-    }
-    return acc
-  }, [])
+  const tokenAddresses = await Promise.all(
+    vaultAddresses.map(addr => asset(client, { address: addr })),
+  )
+  return tokenAddresses.map((tokenAddress, index) => ({
+    tokenAddress,
+    vaultAddress: vaultAddresses[index],
+  }))
 }

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
@@ -21,11 +21,11 @@ export const fetchHemiEarnTokens = async function ({
     ),
   )
   return results.reduce<VaultToken[]>(function (acc, tokenAddress, index) {
-    if (tokenAddress == null) {
+    if (tokenAddress === null) {
       return acc
     }
     const token = getTokenByAddress(tokenAddress, chainId)
-    if (token != null && isEvmToken(token)) {
+    if (token !== undefined && isEvmToken(token)) {
       acc.push({ token, vaultAddress: vaultAddresses[index] })
     }
     return acc

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
@@ -1,8 +1,9 @@
 import { getEarnVaultAddresses } from 'hemi-earn-actions'
-import { type EvmToken } from 'types/token'
 import { getTokenByAddress, isEvmToken } from 'utils/token'
 import { type Chain, type PublicClient, zeroAddress } from 'viem'
 import { asset } from 'viem-erc4626/actions'
+
+import { type VaultToken } from '../types'
 
 export const fetchHemiEarnTokens = async function ({
   chainId,
@@ -10,14 +11,23 @@ export const fetchHemiEarnTokens = async function ({
 }: {
   chainId: Chain['id']
   client: PublicClient
-}): Promise<EvmToken[]> {
-  const vaultAddresses = getEarnVaultAddresses(chainId).filter(
-    addr => addr !== zeroAddress,
+}): Promise<VaultToken[]> {
+  const vaultAddresses = getEarnVaultAddresses(chainId)
+  const results = await Promise.all(
+    vaultAddresses.map(addr =>
+      addr === zeroAddress
+        ? Promise.resolve(null)
+        : asset(client, { address: addr }),
+    ),
   )
-  const addresses = await Promise.all(
-    vaultAddresses.map(addr => asset(client, { address: addr })),
-  )
-  return addresses
-    .map(addr => getTokenByAddress(addr, chainId))
-    .filter((t): t is EvmToken => t != null && isEvmToken(t))
+  return results.reduce<VaultToken[]>(function (acc, tokenAddress, index) {
+    if (tokenAddress == null) {
+      return acc
+    }
+    const token = getTokenByAddress(tokenAddress, chainId)
+    if (token != null && isEvmToken(token)) {
+      acc.push({ token, vaultAddress: vaultAddresses[index] })
+    }
+    return acc
+  }, [])
 }

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
@@ -1,0 +1,23 @@
+import { getEarnVaultAddresses } from 'hemi-earn-actions'
+import { type EvmToken } from 'types/token'
+import { getTokenByAddress, isEvmToken } from 'utils/token'
+import { type Chain, type PublicClient, zeroAddress } from 'viem'
+import { asset } from 'viem-erc4626/actions'
+
+export const fetchHemiEarnTokens = async function ({
+  chainId,
+  client,
+}: {
+  chainId: Chain['id']
+  client: PublicClient
+}): Promise<EvmToken[]> {
+  const vaultAddresses = getEarnVaultAddresses(chainId).filter(
+    addr => addr !== zeroAddress,
+  )
+  const addresses = await Promise.all(
+    vaultAddresses.map(addr => asset(client, { address: addr })),
+  )
+  return addresses
+    .map(addr => getTokenByAddress(addr, chainId))
+    .filter((t): t is EvmToken => t != null && isEvmToken(t))
+}

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits.ts
@@ -1,33 +1,26 @@
-import { getEarnVaultAddresses } from 'hemi-earn-actions'
-import { type EvmToken } from 'types/token'
-import { type Chain, type PublicClient, zeroAddress } from 'viem'
+import { type PublicClient } from 'viem'
 import { totalAssets } from 'viem-erc4626/actions'
 
-type VaultDeposit = {
+import { type VaultToken } from '../types'
+
+type VaultDeposit = VaultToken & {
   amount: bigint
-  token: EvmToken
 }
 
 export const fetchTotalDeposits = async function ({
-  chainId,
   client,
-  tokens,
+  vaultTokens,
 }: {
-  chainId: Chain['id']
   client: PublicClient
-  tokens: EvmToken[]
+  vaultTokens: VaultToken[]
 }): Promise<VaultDeposit[]> {
-  const vaultAddresses = getEarnVaultAddresses(chainId)
   const amounts = await Promise.all(
-    tokens.map(function (_, index) {
-      const vaultAddress = vaultAddresses[index]
-      return vaultAddress && vaultAddress !== zeroAddress
-        ? totalAssets(client, { address: vaultAddress })
-        : Promise.resolve(BigInt(0))
-    }),
+    vaultTokens.map(({ vaultAddress }) =>
+      totalAssets(client, { address: vaultAddress }),
+    ),
   )
-  return tokens.map((token, index) => ({
+  return vaultTokens.map((vt, index) => ({
+    ...vt,
     amount: amounts[index] ?? BigInt(0),
-    token,
   }))
 }

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits.ts
@@ -1,0 +1,33 @@
+import { getEarnVaultAddresses } from 'hemi-earn-actions'
+import { type EvmToken } from 'types/token'
+import { type Chain, type PublicClient, zeroAddress } from 'viem'
+import { totalAssets } from 'viem-erc4626/actions'
+
+type VaultDeposit = {
+  amount: bigint
+  token: EvmToken
+}
+
+export const fetchTotalDeposits = async function ({
+  chainId,
+  client,
+  tokens,
+}: {
+  chainId: Chain['id']
+  client: PublicClient
+  tokens: EvmToken[]
+}): Promise<VaultDeposit[]> {
+  const vaultAddresses = getEarnVaultAddresses(chainId)
+  const amounts = await Promise.all(
+    tokens.map(function (_, index) {
+      const vaultAddress = vaultAddresses[index]
+      return vaultAddress && vaultAddress !== zeroAddress
+        ? totalAssets(client, { address: vaultAddress })
+        : Promise.resolve(BigInt(0))
+    }),
+  )
+  return tokens.map((token, index) => ({
+    amount: amounts[index] ?? BigInt(0),
+    token,
+  }))
+}

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -16,7 +16,7 @@ import { useHemiEarnTokens } from './useHemiEarnTokens'
 export const useEarnPools = function () {
   const { id: chainId } = useHemi()
   const hemiClient = useHemiClient()
-  const tokens = useHemiEarnTokens()
+  const { data: tokens = [] } = useHemiEarnTokens()
 
   const vaultTokens = useMemo<{ token: EvmToken; vaultAddress: Address }[]>(
     function () {

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -1,12 +1,9 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { getEarnVaultAddresses } from 'hemi-earn-actions'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiClient } from 'hooks/useHemiClient'
-import { useMemo } from 'react'
-import { type EvmToken } from 'types/token'
-import { type Address, zeroAddress } from 'viem'
+import { type Address } from 'viem'
 import { totalAssets } from 'viem-erc4626/actions'
 
 import { type EarnPool } from '../types'
@@ -16,27 +13,14 @@ import { useHemiEarnTokens } from './useHemiEarnTokens'
 export const useEarnPools = function () {
   const { id: chainId } = useHemi()
   const hemiClient = useHemiClient()
-  const { data: tokens = [] } = useHemiEarnTokens()
-
-  const vaultTokens = useMemo<{ token: EvmToken; vaultAddress: Address }[]>(
-    function () {
-      const vaultAddresses = getEarnVaultAddresses(chainId)
-      return tokens.map((token, index) => ({
-        token,
-        vaultAddress: vaultAddresses[index] ?? zeroAddress,
-      }))
-    },
-    [tokens, chainId],
-  )
+  const { data: vaultTokens = [] } = useHemiEarnTokens()
 
   return useQuery<EarnPool[]>({
     enabled: vaultTokens.length > 0,
     async queryFn() {
       const deposits = await Promise.all(
         vaultTokens.map(({ vaultAddress }) =>
-          vaultAddress !== zeroAddress
-            ? totalAssets(hemiClient, { address: vaultAddress })
-            : Promise.resolve(BigInt(0)),
+          totalAssets(hemiClient, { address: vaultAddress }),
         ),
       )
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
@@ -11,7 +11,7 @@ import { useHemiEarnTokens } from './useHemiEarnTokens'
 
 export const useEarnPositions = function (): EarnPosition[] {
   const { id: chainId } = useHemi()
-  const tokens = useHemiEarnTokens()
+  const { data: tokens = [] } = useHemiEarnTokens()
 
   return useMemo(
     function () {

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
@@ -1,30 +1,24 @@
 'use client'
 
-import { getEarnVaultAddresses } from 'hemi-earn-actions'
-import { useHemi } from 'hooks/useHemi'
 import { useMemo } from 'react'
-import { zeroAddress } from 'viem'
 
 import { type EarnPosition } from '../types'
 
 import { useHemiEarnTokens } from './useHemiEarnTokens'
 
 export const useEarnPositions = function (): EarnPosition[] {
-  const { id: chainId } = useHemi()
-  const { data: tokens = [] } = useHemiEarnTokens()
+  const { data: vaultTokens = [] } = useHemiEarnTokens()
 
   return useMemo(
-    function () {
-      const vaultAddresses = getEarnVaultAddresses(chainId)
+    () =>
       // TODO: remove mock positions and fetch real user positions once vaults are deployed
-      return tokens.slice(0, 2).map((token, index) => ({
+      vaultTokens.slice(0, 2).map(({ token, vaultAddress }) => ({
         apy: { base: 1, incentivized: 3.32, total: 4.32 },
         token,
-        vaultAddress: vaultAddresses[index] ?? zeroAddress,
+        vaultAddress,
         yieldEarned: '$12.34',
         yourDeposit: BigInt(100000),
-      }))
-    },
-    [tokens, chainId],
+      })),
+    [vaultTokens],
   )
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
@@ -1,35 +1,19 @@
 'use client'
 
-import { hemi, hemiSepolia } from 'hemi-viem'
+import { useQuery } from '@tanstack/react-query'
 import { useHemi } from 'hooks/useHemi'
-import { useMemo } from 'react'
-import { tokenList } from 'tokenList'
+import { useHemiClient } from 'hooks/useHemiClient'
 import { type EvmToken } from 'types/token'
-import { toChecksumAddress } from 'utils/address'
-import { isEvmToken } from 'utils/token'
 
-// TODO: replace with vault.asset() calls when earn vaults are deployed
-const EARN_TOKEN_ADDRESSES: Partial<Record<number, string[]>> = {
-  [hemi.id]: [
-    toChecksumAddress('0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28'), // hemiBTC
-    toChecksumAddress('0xad11a8BEb98bbf61dbb1aa0F6d6F2ECD87b35afA'), // USDC.e
-  ],
-  [hemiSepolia.id]: [
-    toChecksumAddress('0xD47971C7F5B1067d25cd45d30b2c9eb60de96443'), // USDC.e
-  ],
-}
+import { fetchHemiEarnTokens } from '../_fetchers/fetchHemiEarnTokens'
 
 export const useHemiEarnTokens = function () {
-  const { id } = useHemi()
+  const { id: chainId } = useHemi()
+  const hemiClient = useHemiClient()
 
-  return useMemo(
-    () =>
-      tokenList.tokens.filter(
-        (t): t is EvmToken =>
-          isEvmToken(t) &&
-          t.chainId === id &&
-          (EARN_TOKEN_ADDRESSES[id] ?? []).includes(t.address),
-      ),
-    [id],
-  )
+  return useQuery<EvmToken[]>({
+    queryFn: () => fetchHemiEarnTokens({ chainId, client: hemiClient }),
+    queryKey: ['hemi-earn-tokens', chainId],
+    staleTime: Infinity,
+  })
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
@@ -3,15 +3,15 @@
 import { useQuery } from '@tanstack/react-query'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiClient } from 'hooks/useHemiClient'
-import { type EvmToken } from 'types/token'
 
 import { fetchHemiEarnTokens } from '../_fetchers/fetchHemiEarnTokens'
+import { type VaultToken } from '../types'
 
 export const useHemiEarnTokens = function () {
   const { id: chainId } = useHemi()
   const hemiClient = useHemiClient()
 
-  return useQuery<EvmToken[]>({
+  return useQuery<VaultToken[]>({
     queryFn: () => fetchHemiEarnTokens({ chainId, client: hemiClient }),
     queryKey: ['hemi-earn-tokens', chainId],
     staleTime: Infinity,

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
@@ -1,19 +1,45 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { useQueries, useQuery } from '@tanstack/react-query'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiClient } from 'hooks/useHemiClient'
+import { tokenQueryOptions } from 'hooks/useToken'
+import { isEvmToken } from 'utils/token'
+import { useConfig } from 'wagmi'
 
 import { fetchHemiEarnTokens } from '../_fetchers/fetchHemiEarnTokens'
 import { type VaultToken } from '../types'
 
 export const useHemiEarnTokens = function () {
   const { id: chainId } = useHemi()
+  const config = useConfig()
   const hemiClient = useHemiClient()
 
-  return useQuery<VaultToken[]>({
+  const { data: vaultAssets = [] } = useQuery({
     queryFn: () => fetchHemiEarnTokens({ chainId, client: hemiClient }),
     queryKey: ['hemi-earn-tokens', chainId],
     staleTime: Infinity,
   })
+
+  const tokenQueries = useQueries({
+    queries: vaultAssets.map(({ tokenAddress }) =>
+      tokenQueryOptions({ address: tokenAddress, chainId, config }),
+    ),
+  })
+
+  const isPending = tokenQueries.some(q => q.isPending)
+  const isError = tokenQueries.some(q => q.isError)
+
+  const data: VaultToken[] | undefined =
+    isPending || isError
+      ? undefined
+      : tokenQueries.reduce<VaultToken[]>(function (acc, query, index) {
+          const token = query.data
+          if (token !== undefined && isEvmToken(token)) {
+            acc.push({ token, vaultAddress: vaultAssets[index].vaultAddress })
+          }
+          return acc
+        }, [])
+
+  return { data, isError, isPending }
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalAvgApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalAvgApy.ts
@@ -12,7 +12,7 @@ type TotalAvgApyData = EarnCardData & { apy: number }
 
 export const useTotalAvgApy = function () {
   const { id } = useHemi()
-  const { data: tokens = [] } = useHemiEarnTokens()
+  const { data: vaultTokens = [] } = useHemiEarnTokens()
 
   const {
     data: queryData,
@@ -27,13 +27,13 @@ export const useTotalAvgApy = function () {
   const data: TotalAvgApyData | undefined = queryData
     ? {
         apy: queryData.apy,
-        vaultBreakdown: tokens.map(token => ({
+        vaultBreakdown: vaultTokens.map(({ token }) => ({
           name: token.symbol,
           tokenAddress: token.address,
           tokenChainId: id,
           value: formatApyDisplay(0),
         })),
-        vaultCount: tokens.length,
+        vaultCount: vaultTokens.length,
       }
     : undefined
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalAvgApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalAvgApy.ts
@@ -12,7 +12,7 @@ type TotalAvgApyData = EarnCardData & { apy: number }
 
 export const useTotalAvgApy = function () {
   const { id } = useHemi()
-  const tokens = useHemiEarnTokens()
+  const { data: tokens = [] } = useHemiEarnTokens()
 
   const {
     data: queryData,

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
@@ -14,12 +14,12 @@ import { type EarnCardData } from '../types'
 
 import { useHemiEarnTokens } from './useHemiEarnTokens'
 
-type TotalDepositsData = EarnCardData & { totalUsd: number }
+type TotalDepositsData = EarnCardData & { totalUsd: string }
 
 export const useTotalDeposits = function () {
   const { id: chainId } = useHemi()
   const hemiClient = useHemiClient()
-  const { data: tokens = [] } = useHemiEarnTokens()
+  const { data: vaultTokens = [] } = useHemiEarnTokens()
   const { data: prices } = useTokenPrices()
 
   const {
@@ -27,8 +27,8 @@ export const useTotalDeposits = function () {
     isError,
     isPending,
   } = useQuery({
-    enabled: tokens.length > 0,
-    queryFn: () => fetchTotalDeposits({ chainId, client: hemiClient, tokens }),
+    enabled: vaultTokens.length > 0,
+    queryFn: () => fetchTotalDeposits({ client: hemiClient, vaultTokens }),
     queryKey: ['hemi-earn', 'total-deposits', chainId],
   })
 
@@ -44,7 +44,7 @@ export const useTotalDeposits = function () {
               ),
             Big(0),
           )
-          .toNumber(),
+          .toFixed(),
         vaultBreakdown: deposits.map(({ amount, token }) => ({
           name: token.symbol,
           tokenAddress: token.address,

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
@@ -1,9 +1,15 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import Big from 'big.js'
 import { useHemi } from 'hooks/useHemi'
+import { useHemiClient } from 'hooks/useHemiClient'
+import { useTokenPrices } from 'hooks/useTokenPrices'
 import { formatFiatNumber } from 'utils/format'
+import { getTokenPrice } from 'utils/token'
+import { formatUnits } from 'viem'
 
+import { fetchTotalDeposits } from '../_fetchers/fetchTotalDeposits'
 import { type EarnCardData } from '../types'
 
 import { useHemiEarnTokens } from './useHemiEarnTokens'
@@ -11,29 +17,45 @@ import { useHemiEarnTokens } from './useHemiEarnTokens'
 type TotalDepositsData = EarnCardData & { totalUsd: number }
 
 export const useTotalDeposits = function () {
-  const { id } = useHemi()
-  const tokens = useHemiEarnTokens()
+  const { id: chainId } = useHemi()
+  const hemiClient = useHemiClient()
+  const { data: tokens = [] } = useHemiEarnTokens()
+  const { data: prices } = useTokenPrices()
 
   const {
-    data: queryData,
+    data: deposits,
     isError,
     isPending,
-  } = useQuery<{ totalUsd: number }>({
-    queryFn: () =>
-      new Promise(resolve => setTimeout(() => resolve({ totalUsd: 0 }), 2000)),
-    queryKey: ['hemi-earn', 'total-deposits', id],
+  } = useQuery({
+    enabled: tokens.length > 0,
+    queryFn: () => fetchTotalDeposits({ chainId, client: hemiClient, tokens }),
+    queryKey: ['hemi-earn', 'total-deposits', chainId],
   })
 
-  const data: TotalDepositsData | undefined = queryData
+  const data: TotalDepositsData | undefined = deposits
     ? {
-        totalUsd: queryData.totalUsd,
-        vaultBreakdown: tokens.map(token => ({
+        totalUsd: deposits
+          .reduce(
+            (acc, { amount, token }) =>
+              acc.plus(
+                Big(formatUnits(amount, token.decimals)).times(
+                  getTokenPrice(token, prices),
+                ),
+              ),
+            Big(0),
+          )
+          .toNumber(),
+        vaultBreakdown: deposits.map(({ amount, token }) => ({
           name: token.symbol,
           tokenAddress: token.address,
-          tokenChainId: id,
-          value: `$${formatFiatNumber(0)}`,
+          tokenChainId: chainId,
+          value: `$${formatFiatNumber(
+            Big(formatUnits(amount, token.decimals))
+              .times(getTokenPrice(token, prices))
+              .toFixed(),
+          )}`,
         })),
-        vaultCount: tokens.length,
+        vaultCount: deposits.length,
       }
     : undefined
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalYieldEarned.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalYieldEarned.ts
@@ -12,7 +12,7 @@ type TotalYieldEarnedData = EarnCardData & { totalUsd: number }
 
 export const useTotalYieldEarned = function () {
   const { id } = useHemi()
-  const { data: tokens = [] } = useHemiEarnTokens()
+  const { data: vaultTokens = [] } = useHemiEarnTokens()
 
   const {
     data: queryData,
@@ -27,13 +27,13 @@ export const useTotalYieldEarned = function () {
   const data: TotalYieldEarnedData | undefined = queryData
     ? {
         totalUsd: queryData.totalUsd,
-        vaultBreakdown: tokens.map(token => ({
+        vaultBreakdown: vaultTokens.map(({ token }) => ({
           name: token.symbol,
           tokenAddress: token.address,
           tokenChainId: id,
           value: `$${formatFiatNumber(0)}`,
         })),
-        vaultCount: tokens.length,
+        vaultCount: vaultTokens.length,
       }
     : undefined
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalYieldEarned.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalYieldEarned.ts
@@ -12,7 +12,7 @@ type TotalYieldEarnedData = EarnCardData & { totalUsd: number }
 
 export const useTotalYieldEarned = function () {
   const { id } = useHemi()
-  const tokens = useHemiEarnTokens()
+  const { data: tokens = [] } = useHemiEarnTokens()
 
   const {
     data: queryData,

--- a/portal/app/[locale]/hemi-earn/page.tsx
+++ b/portal/app/[locale]/hemi-earn/page.tsx
@@ -2,10 +2,12 @@
 
 import { PageLayout } from 'components/pageLayout'
 import dynamic from 'next/dynamic'
+import { type ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import { InfoCards } from './_components/infoCards'
 import { TopSection } from './_components/topSection'
+import { useHemiEarnTokens } from './_hooks/useHemiEarnTokens'
 
 const EarnTableSkeleton = () => (
   <div className="mt-10 w-full">
@@ -31,12 +33,22 @@ const EarnTable = dynamic(
   },
 )
 
+const TokensGate = function ({ children }: { children: ReactNode }) {
+  const { data } = useHemiEarnTokens()
+  if (data) {
+    return <>{children}</>
+  }
+  return <EarnTableSkeleton />
+}
+
 export default function Page() {
   return (
     <PageLayout variant="wide">
       <TopSection />
       <InfoCards />
-      <EarnTable />
+      <TokensGate>
+        <EarnTable />
+      </TokensGate>
     </PageLayout>
   )
 }

--- a/portal/app/[locale]/hemi-earn/page.tsx
+++ b/portal/app/[locale]/hemi-earn/page.tsx
@@ -34,10 +34,9 @@ const EarnTable = dynamic(
 )
 
 const TokensGate = function ({ children }: { children: ReactNode }) {
-  const { data } = useHemiEarnTokens()
-  if (data) {
-    return <>{children}</>
-  }
+  const { data, isError } = useHemiEarnTokens()
+  if (isError) return null
+  if (data) return <>{children}</>
   return <EarnTableSkeleton />
 }
 

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -1,6 +1,11 @@
 import { type EvmToken } from 'types/token'
 import { type Address } from 'viem'
 
+export type VaultToken = {
+  token: EvmToken
+  vaultAddress: Address
+}
+
 export type VaultBreakdown = {
   name: string
   tokenAddress: string

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.test.ts
@@ -1,7 +1,5 @@
 import { getEarnVaultAddresses } from 'hemi-earn-actions'
 import { hemi } from 'hemi-viem'
-import { type EvmToken } from 'types/token'
-import { getTokenByAddress } from 'utils/token'
 import { type Address, type PublicClient, zeroAddress } from 'viem'
 import { asset } from 'viem-erc4626/actions'
 import { describe, expect, it, vi } from 'vitest'
@@ -16,11 +14,6 @@ vi.mock('hemi-earn-actions', () => ({
   getEarnVaultAddresses: vi.fn(),
 }))
 
-vi.mock('utils/token', async () => ({
-  ...(await vi.importActual<typeof import('utils/token')>('utils/token')),
-  getTokenByAddress: vi.fn(),
-}))
-
 const chainId = hemi.id
 const client = {} as PublicClient
 
@@ -30,39 +23,18 @@ const vaultB = '0xaaaa000000000000000000000000000000000002' as Address
 const tokenAddressA = '0xbbbb000000000000000000000000000000000001' as Address
 const tokenAddressB = '0xbbbb000000000000000000000000000000000002' as Address
 
-const tokenA: EvmToken = {
-  address: tokenAddressA,
-  chainId,
-  decimals: 18,
-  logoURI: '',
-  name: 'Token A',
-  symbol: 'TKA',
-}
-
-const tokenB: EvmToken = {
-  address: tokenAddressB,
-  chainId,
-  decimals: 8,
-  logoURI: '',
-  name: 'Token B',
-  symbol: 'TKB',
-}
-
 describe('fetchHemiEarnTokens', function () {
-  it('returns vault-token pairs for each deployed vault', async function () {
+  it('returns vault-asset pairs for each deployed vault', async function () {
     vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, vaultB])
     vi.mocked(asset)
       .mockResolvedValueOnce(tokenAddressA)
       .mockResolvedValueOnce(tokenAddressB)
-    vi.mocked(getTokenByAddress)
-      .mockReturnValueOnce(tokenA)
-      .mockReturnValueOnce(tokenB)
 
     const result = await fetchHemiEarnTokens({ chainId, client })
 
     expect(result).toEqual([
-      { token: tokenA, vaultAddress: vaultA },
-      { token: tokenB, vaultAddress: vaultB },
+      { tokenAddress: tokenAddressA, vaultAddress: vaultA },
+      { tokenAddress: tokenAddressB, vaultAddress: vaultB },
     ])
     expect(asset).toHaveBeenCalledTimes(2)
     expect(asset).toHaveBeenCalledWith(client, { address: vaultA })
@@ -72,16 +44,17 @@ describe('fetchHemiEarnTokens', function () {
   it('skips zero-address vaults', async function () {
     vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, zeroAddress])
     vi.mocked(asset).mockResolvedValueOnce(tokenAddressA)
-    vi.mocked(getTokenByAddress).mockReturnValueOnce(tokenA)
 
     const result = await fetchHemiEarnTokens({ chainId, client })
 
-    expect(result).toEqual([{ token: tokenA, vaultAddress: vaultA }])
+    expect(result).toEqual([
+      { tokenAddress: tokenAddressA, vaultAddress: vaultA },
+    ])
     expect(asset).toHaveBeenCalledTimes(1)
     expect(asset).toHaveBeenCalledWith(client, { address: vaultA })
   })
 
-  it('preserves correct vault-token pairing with interleaved zero addresses', async function () {
+  it('preserves correct vault-asset pairing with interleaved zero addresses', async function () {
     vi.mocked(getEarnVaultAddresses).mockReturnValue([
       zeroAddress,
       vaultA,
@@ -91,33 +64,16 @@ describe('fetchHemiEarnTokens', function () {
     vi.mocked(asset)
       .mockResolvedValueOnce(tokenAddressA)
       .mockResolvedValueOnce(tokenAddressB)
-    vi.mocked(getTokenByAddress)
-      .mockReturnValueOnce(tokenA)
-      .mockReturnValueOnce(tokenB)
 
     const result = await fetchHemiEarnTokens({ chainId, client })
 
     expect(result).toEqual([
-      { token: tokenA, vaultAddress: vaultA },
-      { token: tokenB, vaultAddress: vaultB },
+      { tokenAddress: tokenAddressA, vaultAddress: vaultA },
+      { tokenAddress: tokenAddressB, vaultAddress: vaultB },
     ])
     expect(asset).toHaveBeenCalledTimes(2)
     expect(asset).toHaveBeenNthCalledWith(1, client, { address: vaultA })
     expect(asset).toHaveBeenNthCalledWith(2, client, { address: vaultB })
-  })
-
-  it('filters out addresses not found in the token list', async function () {
-    vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, vaultB])
-    vi.mocked(asset)
-      .mockResolvedValueOnce(tokenAddressA)
-      .mockResolvedValueOnce(tokenAddressB)
-    vi.mocked(getTokenByAddress)
-      .mockReturnValueOnce(tokenA)
-      .mockReturnValueOnce(undefined)
-
-    const result = await fetchHemiEarnTokens({ chainId, client })
-
-    expect(result).toEqual([{ token: tokenA, vaultAddress: vaultA }])
   })
 
   it('returns an empty array when all vaults are zero addresses', async function () {

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.test.ts
@@ -49,7 +49,7 @@ const tokenB: EvmToken = {
 }
 
 describe('fetchHemiEarnTokens', function () {
-  it('returns resolved EVM tokens for each non-zero vault', async function () {
+  it('returns vault-token pairs for each deployed vault', async function () {
     vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, vaultB])
     vi.mocked(asset)
       .mockResolvedValueOnce(tokenAddressA)
@@ -60,7 +60,10 @@ describe('fetchHemiEarnTokens', function () {
 
     const result = await fetchHemiEarnTokens({ chainId, client })
 
-    expect(result).toEqual([tokenA, tokenB])
+    expect(result).toEqual([
+      { token: tokenA, vaultAddress: vaultA },
+      { token: tokenB, vaultAddress: vaultB },
+    ])
     expect(asset).toHaveBeenCalledTimes(2)
     expect(asset).toHaveBeenCalledWith(client, { address: vaultA })
     expect(asset).toHaveBeenCalledWith(client, { address: vaultB })
@@ -73,9 +76,34 @@ describe('fetchHemiEarnTokens', function () {
 
     const result = await fetchHemiEarnTokens({ chainId, client })
 
-    expect(result).toEqual([tokenA])
+    expect(result).toEqual([{ token: tokenA, vaultAddress: vaultA }])
     expect(asset).toHaveBeenCalledTimes(1)
     expect(asset).toHaveBeenCalledWith(client, { address: vaultA })
+  })
+
+  it('preserves correct vault-token pairing with interleaved zero addresses', async function () {
+    vi.mocked(getEarnVaultAddresses).mockReturnValue([
+      zeroAddress,
+      vaultA,
+      zeroAddress,
+      vaultB,
+    ])
+    vi.mocked(asset)
+      .mockResolvedValueOnce(tokenAddressA)
+      .mockResolvedValueOnce(tokenAddressB)
+    vi.mocked(getTokenByAddress)
+      .mockReturnValueOnce(tokenA)
+      .mockReturnValueOnce(tokenB)
+
+    const result = await fetchHemiEarnTokens({ chainId, client })
+
+    expect(result).toEqual([
+      { token: tokenA, vaultAddress: vaultA },
+      { token: tokenB, vaultAddress: vaultB },
+    ])
+    expect(asset).toHaveBeenCalledTimes(2)
+    expect(asset).toHaveBeenNthCalledWith(1, client, { address: vaultA })
+    expect(asset).toHaveBeenNthCalledWith(2, client, { address: vaultB })
   })
 
   it('filters out addresses not found in the token list', async function () {
@@ -89,7 +117,7 @@ describe('fetchHemiEarnTokens', function () {
 
     const result = await fetchHemiEarnTokens({ chainId, client })
 
-    expect(result).toEqual([tokenA])
+    expect(result).toEqual([{ token: tokenA, vaultAddress: vaultA }])
   })
 
   it('returns an empty array when all vaults are zero addresses', async function () {

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.test.ts
@@ -1,0 +1,103 @@
+import { getEarnVaultAddresses } from 'hemi-earn-actions'
+import { hemi } from 'hemi-viem'
+import { type EvmToken } from 'types/token'
+import { getTokenByAddress } from 'utils/token'
+import { type Address, type PublicClient, zeroAddress } from 'viem'
+import { asset } from 'viem-erc4626/actions'
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchHemiEarnTokens } from '../../../../../app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens'
+
+vi.mock('viem-erc4626/actions', () => ({
+  asset: vi.fn(),
+}))
+
+vi.mock('hemi-earn-actions', () => ({
+  getEarnVaultAddresses: vi.fn(),
+}))
+
+vi.mock('utils/token', async () => ({
+  ...(await vi.importActual<typeof import('utils/token')>('utils/token')),
+  getTokenByAddress: vi.fn(),
+}))
+
+const chainId = hemi.id
+const client = {} as PublicClient
+
+const vaultA = '0xaaaa000000000000000000000000000000000001' as Address
+const vaultB = '0xaaaa000000000000000000000000000000000002' as Address
+
+const tokenAddressA = '0xbbbb000000000000000000000000000000000001' as Address
+const tokenAddressB = '0xbbbb000000000000000000000000000000000002' as Address
+
+const tokenA: EvmToken = {
+  address: tokenAddressA,
+  chainId,
+  decimals: 18,
+  logoURI: '',
+  name: 'Token A',
+  symbol: 'TKA',
+}
+
+const tokenB: EvmToken = {
+  address: tokenAddressB,
+  chainId,
+  decimals: 8,
+  logoURI: '',
+  name: 'Token B',
+  symbol: 'TKB',
+}
+
+describe('fetchHemiEarnTokens', function () {
+  it('returns resolved EVM tokens for each non-zero vault', async function () {
+    vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, vaultB])
+    vi.mocked(asset)
+      .mockResolvedValueOnce(tokenAddressA)
+      .mockResolvedValueOnce(tokenAddressB)
+    vi.mocked(getTokenByAddress)
+      .mockReturnValueOnce(tokenA)
+      .mockReturnValueOnce(tokenB)
+
+    const result = await fetchHemiEarnTokens({ chainId, client })
+
+    expect(result).toEqual([tokenA, tokenB])
+    expect(asset).toHaveBeenCalledTimes(2)
+    expect(asset).toHaveBeenCalledWith(client, { address: vaultA })
+    expect(asset).toHaveBeenCalledWith(client, { address: vaultB })
+  })
+
+  it('skips zero-address vaults', async function () {
+    vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, zeroAddress])
+    vi.mocked(asset).mockResolvedValueOnce(tokenAddressA)
+    vi.mocked(getTokenByAddress).mockReturnValueOnce(tokenA)
+
+    const result = await fetchHemiEarnTokens({ chainId, client })
+
+    expect(result).toEqual([tokenA])
+    expect(asset).toHaveBeenCalledTimes(1)
+    expect(asset).toHaveBeenCalledWith(client, { address: vaultA })
+  })
+
+  it('filters out addresses not found in the token list', async function () {
+    vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, vaultB])
+    vi.mocked(asset)
+      .mockResolvedValueOnce(tokenAddressA)
+      .mockResolvedValueOnce(tokenAddressB)
+    vi.mocked(getTokenByAddress)
+      .mockReturnValueOnce(tokenA)
+      .mockReturnValueOnce(undefined)
+
+    const result = await fetchHemiEarnTokens({ chainId, client })
+
+    expect(result).toEqual([tokenA])
+  })
+
+  it('returns an empty array when all vaults are zero addresses', async function () {
+    vi.mocked(getEarnVaultAddresses).mockReturnValue([zeroAddress, zeroAddress])
+
+    const result = await fetchHemiEarnTokens({ chainId, client })
+
+    expect(result).toEqual([])
+    expect(asset).not.toHaveBeenCalled()
+  })
+})

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits.test.ts
@@ -1,7 +1,6 @@
-import { getEarnVaultAddresses } from 'hemi-earn-actions'
 import { hemi } from 'hemi-viem'
 import { type EvmToken } from 'types/token'
-import { type Address, type PublicClient, zeroAddress } from 'viem'
+import { type Address, type PublicClient } from 'viem'
 import { totalAssets } from 'viem-erc4626/actions'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -9,10 +8,6 @@ import { fetchTotalDeposits } from '../../../../../app/[locale]/hemi-earn/_fetch
 
 vi.mock('viem-erc4626/actions', () => ({
   totalAssets: vi.fn(),
-}))
-
-vi.mock('hemi-earn-actions', () => ({
-  getEarnVaultAddresses: vi.fn(),
 }))
 
 const chainId = hemi.id
@@ -41,50 +36,31 @@ const tokenB: EvmToken = {
 
 describe('fetchTotalDeposits', function () {
   it('returns deposit amounts per vault', async function () {
-    vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, vaultB])
     vi.mocked(totalAssets)
       .mockResolvedValueOnce(BigInt(1000))
       .mockResolvedValueOnce(BigInt(2000))
 
     const result = await fetchTotalDeposits({
-      chainId,
       client,
-      tokens: [tokenA, tokenB],
+      vaultTokens: [
+        { token: tokenA, vaultAddress: vaultA },
+        { token: tokenB, vaultAddress: vaultB },
+      ],
     })
 
     expect(result).toEqual([
-      { amount: BigInt(1000), token: tokenA },
-      { amount: BigInt(2000), token: tokenB },
+      { amount: BigInt(1000), token: tokenA, vaultAddress: vaultA },
+      { amount: BigInt(2000), token: tokenB, vaultAddress: vaultB },
     ])
     expect(totalAssets).toHaveBeenCalledTimes(2)
     expect(totalAssets).toHaveBeenCalledWith(client, { address: vaultA })
     expect(totalAssets).toHaveBeenCalledWith(client, { address: vaultB })
   })
 
-  it('returns zero for zero-address vaults', async function () {
-    vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, zeroAddress])
-    vi.mocked(totalAssets).mockResolvedValueOnce(BigInt(500))
-
+  it('returns empty array for empty vault tokens', async function () {
     const result = await fetchTotalDeposits({
-      chainId,
       client,
-      tokens: [tokenA, tokenB],
-    })
-
-    expect(result).toEqual([
-      { amount: BigInt(500), token: tokenA },
-      { amount: BigInt(0), token: tokenB },
-    ])
-    expect(totalAssets).toHaveBeenCalledTimes(1)
-  })
-
-  it('returns empty array for empty tokens', async function () {
-    vi.mocked(getEarnVaultAddresses).mockReturnValue([])
-
-    const result = await fetchTotalDeposits({
-      chainId,
-      client,
-      tokens: [],
+      vaultTokens: [],
     })
 
     expect(result).toEqual([])

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits.test.ts
@@ -1,0 +1,93 @@
+import { getEarnVaultAddresses } from 'hemi-earn-actions'
+import { hemi } from 'hemi-viem'
+import { type EvmToken } from 'types/token'
+import { type Address, type PublicClient, zeroAddress } from 'viem'
+import { totalAssets } from 'viem-erc4626/actions'
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchTotalDeposits } from '../../../../../app/[locale]/hemi-earn/_fetchers/fetchTotalDeposits'
+
+vi.mock('viem-erc4626/actions', () => ({
+  totalAssets: vi.fn(),
+}))
+
+vi.mock('hemi-earn-actions', () => ({
+  getEarnVaultAddresses: vi.fn(),
+}))
+
+const chainId = hemi.id
+const client = {} as PublicClient
+
+const vaultA = '0xaaaa000000000000000000000000000000000001' as Address
+const vaultB = '0xaaaa000000000000000000000000000000000002' as Address
+
+const tokenA: EvmToken = {
+  address: '0xbbbb000000000000000000000000000000000001',
+  chainId,
+  decimals: 18,
+  logoURI: '',
+  name: 'Token A',
+  symbol: 'TKA',
+}
+
+const tokenB: EvmToken = {
+  address: '0xbbbb000000000000000000000000000000000002',
+  chainId,
+  decimals: 8,
+  logoURI: '',
+  name: 'Token B',
+  symbol: 'TKB',
+}
+
+describe('fetchTotalDeposits', function () {
+  it('returns deposit amounts per vault', async function () {
+    vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, vaultB])
+    vi.mocked(totalAssets)
+      .mockResolvedValueOnce(BigInt(1000))
+      .mockResolvedValueOnce(BigInt(2000))
+
+    const result = await fetchTotalDeposits({
+      chainId,
+      client,
+      tokens: [tokenA, tokenB],
+    })
+
+    expect(result).toEqual([
+      { amount: BigInt(1000), token: tokenA },
+      { amount: BigInt(2000), token: tokenB },
+    ])
+    expect(totalAssets).toHaveBeenCalledTimes(2)
+    expect(totalAssets).toHaveBeenCalledWith(client, { address: vaultA })
+    expect(totalAssets).toHaveBeenCalledWith(client, { address: vaultB })
+  })
+
+  it('returns zero for zero-address vaults', async function () {
+    vi.mocked(getEarnVaultAddresses).mockReturnValue([vaultA, zeroAddress])
+    vi.mocked(totalAssets).mockResolvedValueOnce(BigInt(500))
+
+    const result = await fetchTotalDeposits({
+      chainId,
+      client,
+      tokens: [tokenA, tokenB],
+    })
+
+    expect(result).toEqual([
+      { amount: BigInt(500), token: tokenA },
+      { amount: BigInt(0), token: tokenB },
+    ])
+    expect(totalAssets).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns empty array for empty tokens', async function () {
+    vi.mocked(getEarnVaultAddresses).mockReturnValue([])
+
+    const result = await fetchTotalDeposits({
+      chainId,
+      client,
+      tokens: [],
+    })
+
+    expect(result).toEqual([])
+    expect(totalAssets).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### Description

This PR replaces the hardcoded token addresses with dynamic vault asset() calls using the fetcher/hook pattern. It also adds a TokensGate on the page to prevent re-render cascades when tokens load, while keeping the title, subtitle and info cards visible immediately.

Implement real total deposits calculation using totalAssets and token prices instead of mocked setTimeout data.

Add unit tests for fetchHemiEarnTokens and fetchTotalDeposits.

### Screenshots

No UI changes.

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
