### PR TITLE
Patch vulnerabilities in Alpine 3.23

### DIFF
--- a/portal-backend/api/Dockerfile
+++ b/portal-backend/api/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:24.14.0-alpine3.23
 
-ENV NODE_ENV=production
-
+# Patch vulnerabilities
+RUN apk update
+RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23 
+RUN apk add --upgrade openssl=3.5.6-r0
 RUN npm install --global npm@11.12.0
 
 WORKDIR /app
+
+ENV NODE_ENV=production
 
 COPY package*.json .
 RUN npm install --omit=dev

--- a/portal-backend/cron/hemi-supply/Dockerfile
+++ b/portal-backend/cron/hemi-supply/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:24.14.0-alpine3.23
 
-ENV NODE_ENV=production
-
+# Patch vulnerabilities
+RUN apk update
+RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23 
+RUN apk add --upgrade openssl=3.5.6-r0
 RUN npm install --global npm@11.12.0
 
 WORKDIR /app
+
+ENV NODE_ENV=production
 
 COPY package*.json .
 RUN npm install --omit=dev

--- a/portal-backend/cron/token-prices/Dockerfile
+++ b/portal-backend/cron/token-prices/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:24.14.0-alpine3.23
 
-ENV NODE_ENV=production
-
+# Patch vulnerabilities
+RUN apk update
+RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23 
+RUN apk add --upgrade openssl=3.5.6-r0
 RUN npm install --global npm@11.12.0
 
 WORKDIR /app
+
+ENV NODE_ENV=production
 
 COPY package*.json .
 RUN npm install --omit=dev

--- a/portal-backend/cron/vaults-monitor/Dockerfile
+++ b/portal-backend/cron/vaults-monitor/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:24.14.0-alpine3.23
 
-ENV NODE_ENV=production
-
+# Patch vulnerabilities
+RUN apk update
+RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23 
+RUN apk add --upgrade openssl=3.5.6-r0
 RUN npm install --global npm@11.12.0
 
 WORKDIR /app
+
+ENV NODE_ENV=production
 
 COPY package*.json .
 RUN npm install --omit=dev

--- a/subgraph-api/Dockerfile
+++ b/subgraph-api/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:24.14.0-alpine3.23
 
-ENV NODE_ENV=production
-
+# Patch vulnerabilities
+RUN apk update
+RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23 
+RUN apk add --upgrade openssl=3.5.6-r0
 RUN npm install --global npm@11.12.0
 
 WORKDIR /app
+
+ENV NODE_ENV=production
 
 COPY package*.json .
 RUN npm install --omit=dev


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Vulnerabilities found in `openssl` and `musl` had to be patched in the image build script as there are no new base Node images that include those.

#### Packages and Vulnerabilities

- pkg:apk/alpine/openssl@3.5.5-r0
  - CVE-2026-31790
  - CVE-2026-28390
  - CVE-2026-28389
  - CVE-2026-28388
  - CVE-2026-2673
- pkg:apk/alpine/musl@1.2.5-r21
  - CVE-2026-40200

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
