### PR TITLE
Add multi-chain support to Hemi Earn

### DIFF
--- a/packages/hemi-earn-actions/index.ts
+++ b/packages/hemi-earn-actions/index.ts
@@ -1,3 +1,3 @@
-export { getEarnVaultAddresses } from './src/constants'
+export { getEarnChainIds, getEarnVaultAddresses } from './src/constants'
 
 export type { DepositEvents, WithdrawEvents } from './src/types'

--- a/packages/hemi-earn-actions/src/constants.ts
+++ b/packages/hemi-earn-actions/src/constants.ts
@@ -19,3 +19,6 @@ export const getEarnVaultAddresses = function (chainId: number): Address[] {
   }
   return [...addresses]
 }
+
+export const getEarnChainIds = () =>
+  Object.keys(EARN_VAULT_ADDRESSES).map(Number)

--- a/portal/app/[locale]/hemi-earn/_components/poolData.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolData.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink } from 'components/externalLink'
 import { TokenLogo } from 'components/tokenLogo'
-import { useHemi } from 'hooks/useHemi'
+import { useChain } from 'hooks/useChain'
 import { type Token } from 'types/token'
 import { formatEvmAddress } from 'utils/format'
 import { type Address } from 'viem'
@@ -11,7 +11,7 @@ type Props = {
 }
 
 export const PoolData = function ({ token, vaultAddress }: Props) {
-  const hemi = useHemi()
+  const chain = useChain(token.chainId)
 
   return (
     <div className="flex items-center gap-x-3">
@@ -24,7 +24,7 @@ export const PoolData = function ({ token, vaultAddress }: Props) {
         </span>
         <span className="body-text-normal text-neutral-500 hover:text-neutral-950">
           <ExternalLink
-            href={`${hemi.blockExplorers!.default.url}/address/${vaultAddress}`}
+            href={`${chain?.blockExplorers?.default.url}/address/${vaultAddress}`}
           >
             {formatEvmAddress(vaultAddress)}
           </ExternalLink>

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.ts
@@ -3,6 +3,7 @@ import { type Address, type Chain, type PublicClient, zeroAddress } from 'viem'
 import { asset } from 'viem-erc4626/actions'
 
 type VaultAsset = {
+  chainId: Chain['id']
   tokenAddress: Address
   vaultAddress: Address
 }
@@ -21,6 +22,7 @@ export const fetchHemiEarnTokens = async function ({
     vaultAddresses.map(addr => asset(client, { address: addr })),
   )
   return tokenAddresses.map((tokenAddress, index) => ({
+    chainId,
     tokenAddress,
     vaultAddress: vaultAddresses[index],
   }))

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -61,22 +61,8 @@ export const earnPoolsQueryOptions = ({
     queryKey: getEarnPoolsQueryKey(chainId),
   })
 
-export const groupByChain = function (vaultTokens: VaultToken[]) {
-  const grouped = new Map<Chain['id'], VaultToken[]>()
-
-  for (const vaultToken of vaultTokens) {
-    const chainId = vaultToken.token.chainId
-    const existing = grouped.get(chainId)
-
-    if (existing) {
-      existing.push(vaultToken)
-    } else {
-      grouped.set(chainId, [vaultToken])
-    }
-  }
-
-  return grouped
-}
+export const groupByChain = (vaultTokens: VaultToken[]) =>
+  Map.groupBy(vaultTokens, vt => vt.token.chainId)
 
 export const useEarnPools = function () {
   const [networkType] = useNetworkType()

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { queryOptions, useQuery } from '@tanstack/react-query'
+import { queryOptions, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { type Address, type Chain, type PublicClient } from 'viem'
 import { totalAssets } from 'viem-erc4626/actions'
@@ -61,12 +61,27 @@ export const earnPoolsQueryOptions = ({
     queryKey: getEarnPoolsQueryKey(chainId),
   })
 
-const groupByChain = (vaultTokens: VaultToken[]) =>
-  Map.groupBy(vaultTokens, vt => vt.token.chainId)
+export const groupByChain = function (vaultTokens: VaultToken[]) {
+  const grouped = new Map<Chain['id'], VaultToken[]>()
+
+  for (const vaultToken of vaultTokens) {
+    const chainId = vaultToken.token.chainId
+    const existing = grouped.get(chainId)
+
+    if (existing) {
+      existing.push(vaultToken)
+    } else {
+      grouped.set(chainId, [vaultToken])
+    }
+  }
+
+  return grouped
+}
 
 export const useEarnPools = function () {
   const [networkType] = useNetworkType()
   const config = useConfig()
+  const queryClient = useQueryClient()
   const { data: vaultTokens = [] } = useHemiEarnTokens()
 
   return useQuery<EarnPool[]>({
@@ -75,11 +90,13 @@ export const useEarnPools = function () {
       const perChainPools = await Promise.all(
         Array.from(groupByChain(vaultTokens).entries()).map(
           ([chainId, tokens]) =>
-            earnPoolsQueryOptions({
-              chainId,
-              client: getPublicClient(config, { chainId })!,
-              vaultTokens: tokens,
-            }).queryFn!({} as never),
+            queryClient.ensureQueryData(
+              earnPoolsQueryOptions({
+                chainId,
+                client: getPublicClient(config, { chainId })!,
+                vaultTokens: tokens,
+              }),
+            ),
         ),
       )
       return perChainPools.flat()

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -1,35 +1,37 @@
 'use client'
 
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
-import { useHemiClient } from 'hooks/useHemiClient'
+import { useNetworkType } from 'hooks/useNetworkType'
 import { type Address, type Chain, type PublicClient } from 'viem'
 import { totalAssets } from 'viem-erc4626/actions'
+import { useConfig } from 'wagmi'
+import { getPublicClient } from 'wagmi/actions'
 
 import { type EarnPool, type VaultToken } from '../types'
 
 import { useHemiEarnTokens } from './useHemiEarnTokens'
 
-export const getEarnPoolsQueryKey = (chainId: Chain['id']) => [
-  'hemi-earn',
-  'pools',
+export const earnPoolsKeyPrefix = ['hemi-earn', 'pools']
+
+const getEarnPoolsQueryKey = (chainId: Chain['id']) => [
+  ...earnPoolsKeyPrefix,
   chainId,
 ]
 
 export const earnPoolsQueryOptions = ({
   chainId,
-  hemiClient,
+  client,
   vaultTokens,
 }: {
   chainId: Chain['id']
-  hemiClient: PublicClient
+  client: PublicClient
   vaultTokens: VaultToken[]
 }) =>
   queryOptions<EarnPool[]>({
     async queryFn() {
       const deposits = await Promise.all(
         vaultTokens.map(({ vaultAddress }) =>
-          totalAssets(hemiClient, { address: vaultAddress }),
+          totalAssets(client, { address: vaultAddress }),
         ),
       )
 
@@ -59,13 +61,33 @@ export const earnPoolsQueryOptions = ({
     queryKey: getEarnPoolsQueryKey(chainId),
   })
 
+const groupByChain = (vaultTokens: VaultToken[]) =>
+  Map.groupBy(vaultTokens, vt => vt.token.chainId)
+
 export const useEarnPools = function () {
-  const { id: chainId } = useHemi()
-  const hemiClient = useHemiClient()
+  const [networkType] = useNetworkType()
+  const config = useConfig()
   const { data: vaultTokens = [] } = useHemiEarnTokens()
 
-  return useQuery({
-    ...earnPoolsQueryOptions({ chainId, hemiClient: hemiClient!, vaultTokens }),
+  return useQuery<EarnPool[]>({
     enabled: vaultTokens.length > 0,
+    async queryFn() {
+      const perChainPools = await Promise.all(
+        Array.from(groupByChain(vaultTokens).entries()).map(
+          ([chainId, tokens]) =>
+            earnPoolsQueryOptions({
+              chainId,
+              client: getPublicClient(config, { chainId })!,
+              vaultTokens: tokens,
+            }).queryFn!({} as never),
+        ),
+      )
+      return perChainPools.flat()
+    },
+    queryKey: [
+      ...earnPoolsKeyPrefix,
+      networkType,
+      vaultTokens.map(vt => vt.vaultAddress),
+    ],
   })
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -104,7 +104,7 @@ export const useEarnPools = function () {
     queryKey: [
       ...earnPoolsKeyPrefix,
       networkType,
-      vaultTokens.map(vt => vt.vaultAddress),
+      ...vaultTokens.map(vt => vt.vaultAddress),
     ],
   })
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
@@ -70,7 +70,7 @@ export const useEarnPositions = function () {
       ...earnPositionsKeyPrefix,
       networkType,
       address,
-      vaultTokens.map(vt => vt.vaultAddress),
+      ...vaultTokens.map(vt => vt.vaultAddress),
     ],
   })
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
@@ -8,7 +8,7 @@ import { getPublicClient } from 'wagmi/actions'
 import { type EarnPosition } from '../types'
 import { userVaultBalanceQueryOptions } from '../vault/[vaultAddress]/_hooks/useUserVaultBalance'
 
-import { earnPoolsQueryOptions } from './useEarnPools'
+import { earnPoolsQueryOptions, groupByChain } from './useEarnPools'
 import { useHemiEarnTokens } from './useHemiEarnTokens'
 
 export const earnPositionsKeyPrefix = ['hemi-earn', 'positions']
@@ -24,9 +24,10 @@ export const useEarnPositions = function () {
     enabled: !!address && vaultTokens.length > 0,
     async queryFn() {
       const allPositions = await Promise.all(
-        Array.from(
-          Map.groupBy(vaultTokens, vt => vt.token.chainId).entries(),
-        ).map(async function ([chainId, tokens]) {
+        Array.from(groupByChain(vaultTokens).entries()).map(async function ([
+          chainId,
+          tokens,
+        ]) {
           const client = getPublicClient(config, { chainId })!
 
           const pools = await queryClient.ensureQueryData(

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
@@ -1,10 +1,9 @@
 'use client'
 
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
-import { useHemiClient } from 'hooks/useHemiClient'
-import { type Address, type Chain } from 'viem'
-import { useAccount } from 'wagmi'
+import { useNetworkType } from 'hooks/useNetworkType'
+import { useAccount, useConfig } from 'wagmi'
+import { getPublicClient } from 'wagmi/actions'
 
 import { type EarnPosition } from '../types'
 import { userVaultBalanceQueryOptions } from '../vault/[vaultAddress]/_hooks/useUserVaultBalance'
@@ -12,53 +11,65 @@ import { userVaultBalanceQueryOptions } from '../vault/[vaultAddress]/_hooks/use
 import { earnPoolsQueryOptions } from './useEarnPools'
 import { useHemiEarnTokens } from './useHemiEarnTokens'
 
-export const getEarnPositionsQueryKey = (
-  chainId: Chain['id'],
-  address: Address | undefined,
-) => ['hemi-earn', 'positions', chainId, address]
+export const earnPositionsKeyPrefix = ['hemi-earn', 'positions']
 
 export const useEarnPositions = function () {
-  const { id: chainId } = useHemi()
-  const hemiClient = useHemiClient()
+  const [networkType] = useNetworkType()
   const { address } = useAccount()
+  const config = useConfig()
   const queryClient = useQueryClient()
   const { data: vaultTokens = [] } = useHemiEarnTokens()
 
   return useQuery<EarnPosition[]>({
-    enabled: !!address && !!hemiClient && vaultTokens.length > 0,
+    enabled: !!address && vaultTokens.length > 0,
     async queryFn() {
-      const pools = await queryClient.ensureQueryData(
-        earnPoolsQueryOptions({
-          chainId,
-          hemiClient: hemiClient!,
-          vaultTokens,
+      const allPositions = await Promise.all(
+        Array.from(
+          Map.groupBy(vaultTokens, vt => vt.token.chainId).entries(),
+        ).map(async function ([chainId, tokens]) {
+          const client = getPublicClient(config, { chainId })!
+
+          const pools = await queryClient.ensureQueryData(
+            earnPoolsQueryOptions({
+              chainId,
+              client,
+              vaultTokens: tokens,
+            }),
+          )
+
+          const balances = await Promise.all(
+            pools.map(pool =>
+              queryClient.ensureQueryData(
+                userVaultBalanceQueryOptions({
+                  address: address!,
+                  chainId,
+                  client,
+                  vaultAddress: pool.vaultAddress,
+                }),
+              ),
+            ),
+          )
+
+          return pools
+            .map((pool, index) => ({
+              apy: pool.apy,
+              token: pool.token,
+              vaultAddress: pool.vaultAddress,
+              // TODO: yield earned requires off-chain data once available
+              yieldEarned: '-',
+              yourDeposit: balances[index] ?? BigInt(0),
+            }))
+            .filter(position => position.yourDeposit > BigInt(0))
         }),
       )
 
-      const balances = await Promise.all(
-        pools.map(pool =>
-          queryClient.ensureQueryData(
-            userVaultBalanceQueryOptions({
-              address: address!,
-              chainId,
-              hemiClient: hemiClient!,
-              vaultAddress: pool.vaultAddress,
-            }),
-          ),
-        ),
-      )
-
-      return pools
-        .map((pool, index) => ({
-          apy: pool.apy,
-          token: pool.token,
-          vaultAddress: pool.vaultAddress,
-          // TODO: yield earned requires off-chain data once available
-          yieldEarned: '-',
-          yourDeposit: balances[index] ?? BigInt(0),
-        }))
-        .filter(position => position.yourDeposit > BigInt(0))
+      return allPositions.flat()
     },
-    queryKey: getEarnPositionsQueryKey(chainId, address),
+    queryKey: [
+      ...earnPositionsKeyPrefix,
+      networkType,
+      address,
+      vaultTokens.map(vt => vt.vaultAddress),
+    ],
   })
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
@@ -1,34 +1,58 @@
 'use client'
 
-import { useQueries, useQuery } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
-import { useHemiClient } from 'hooks/useHemiClient'
+import { useQueries } from '@tanstack/react-query'
+import { getEarnChainIds } from 'hemi-earn-actions'
+import { type NetworkType, useNetworkType } from 'hooks/useNetworkType'
 import { tokenQueryOptions } from 'hooks/useToken'
+import { useMemo } from 'react'
+import { findChainById } from 'utils/chain'
 import { isEvmToken } from 'utils/token'
 import { useConfig } from 'wagmi'
+import { getPublicClient } from 'wagmi/actions'
 
 import { fetchHemiEarnTokens } from '../_fetchers/fetchHemiEarnTokens'
 import { type VaultToken } from '../types'
 
-export const useHemiEarnTokens = function () {
-  const { id: chainId } = useHemi()
-  const config = useConfig()
-  const hemiClient = useHemiClient()
-
-  const { data: vaultAssets = [] } = useQuery({
-    queryFn: () => fetchHemiEarnTokens({ chainId, client: hemiClient }),
-    queryKey: ['hemi-earn-tokens', chainId],
-    staleTime: Infinity,
+const getEarnChainIdsByNetworkType = (networkType: NetworkType) =>
+  getEarnChainIds().filter(function (chainId) {
+    const chain = findChainById(chainId)
+    return networkType === 'testnet' ? chain?.testnet : !chain?.testnet
   })
 
+export const useHemiEarnTokens = function () {
+  const [networkType] = useNetworkType()
+  const config = useConfig()
+  const earnChainIds = getEarnChainIdsByNetworkType(networkType)
+
+  const vaultAssetQueries = useQueries({
+    queries: earnChainIds.map(chainId => ({
+      queryFn: () =>
+        fetchHemiEarnTokens({
+          chainId,
+          client: getPublicClient(config, { chainId })!,
+        }),
+      queryKey: ['hemi-earn-tokens', chainId],
+      staleTime: Infinity,
+    })),
+  })
+
+  const vaultAssets = useMemo(
+    () => vaultAssetQueries.flatMap(q => (q.isSuccess ? q.data : [])),
+    [vaultAssetQueries],
+  )
+
   const tokenQueries = useQueries({
-    queries: vaultAssets.map(({ tokenAddress }) =>
+    queries: vaultAssets.map(({ chainId, tokenAddress }) =>
       tokenQueryOptions({ address: tokenAddress, chainId, config }),
     ),
   })
 
-  const isPending = tokenQueries.some(q => q.isPending)
-  const isError = tokenQueries.some(q => q.isError)
+  const isPending =
+    vaultAssetQueries.every(q => q.isPending) ||
+    (vaultAssets.length > 0 && tokenQueries.some(q => q.isPending))
+  const isError =
+    vaultAssetQueries.every(q => q.isError) ||
+    (vaultAssets.length > 0 && tokenQueries.every(q => q.isError))
 
   const data: VaultToken[] | undefined =
     isPending || isError

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnTokens.ts
@@ -16,7 +16,10 @@ import { type VaultToken } from '../types'
 const getEarnChainIdsByNetworkType = (networkType: NetworkType) =>
   getEarnChainIds().filter(function (chainId) {
     const chain = findChainById(chainId)
-    return networkType === 'testnet' ? chain?.testnet : !chain?.testnet
+    if (!chain) {
+      return false
+    }
+    return networkType === 'testnet' ? chain.testnet : !chain.testnet
   })
 
 export const useHemiEarnTokens = function () {
@@ -48,11 +51,12 @@ export const useHemiEarnTokens = function () {
   })
 
   const isPending =
-    vaultAssetQueries.every(q => q.isPending) ||
+    vaultAssetQueries.some(q => q.isPending) ||
     (vaultAssets.length > 0 && tokenQueries.some(q => q.isPending))
   const isError =
-    vaultAssetQueries.every(q => q.isError) ||
-    (vaultAssets.length > 0 && tokenQueries.every(q => q.isError))
+    !isPending &&
+    (vaultAssetQueries.every(q => q.isError) ||
+      (vaultAssets.length > 0 && tokenQueries.every(q => q.isError)))
 
   const data: VaultToken[] | undefined =
     isPending || isError

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalAvgApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalAvgApy.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
+import { useNetworkType } from 'hooks/useNetworkType'
 
 import { formatApyDisplay } from '../_utils'
 import { type EarnCardData } from '../types'
@@ -10,8 +10,9 @@ import { useHemiEarnTokens } from './useHemiEarnTokens'
 
 type TotalAvgApyData = EarnCardData & { apy: number }
 
+// TODO: this is a placeholder until we have the actual APY data available.
 export const useTotalAvgApy = function () {
-  const { id } = useHemi()
+  const [networkType] = useNetworkType()
   const { data: vaultTokens = [] } = useHemiEarnTokens()
 
   const {
@@ -21,7 +22,7 @@ export const useTotalAvgApy = function () {
   } = useQuery<{ apy: number }>({
     queryFn: () =>
       new Promise(resolve => setTimeout(() => resolve({ apy: 0 }), 2000)),
-    queryKey: ['hemi-earn', 'total-avg-apy', id],
+    queryKey: ['hemi-earn', 'total-avg-apy', networkType],
   })
 
   const data: TotalAvgApyData | undefined = queryData
@@ -30,7 +31,7 @@ export const useTotalAvgApy = function () {
         vaultBreakdown: vaultTokens.map(({ token }) => ({
           name: token.symbol,
           tokenAddress: token.address,
-          tokenChainId: id,
+          tokenChainId: token.chainId,
           value: formatApyDisplay(0),
         })),
         vaultCount: vaultTokens.length,

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
@@ -1,24 +1,29 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import Big from 'big.js'
-import { useHemi } from 'hooks/useHemi'
-import { useHemiClient } from 'hooks/useHemiClient'
+import { useNetworkType } from 'hooks/useNetworkType'
 import { useTokenPrices } from 'hooks/useTokenPrices'
 import { formatFiatNumber } from 'utils/format'
 import { getTokenPrice } from 'utils/token'
 import { formatUnits } from 'viem'
+import { useAccount, useConfig } from 'wagmi'
+import { getPublicClient } from 'wagmi/actions'
 
-import { fetchTotalDeposits } from '../_fetchers/fetchTotalDeposits'
 import { type EarnCardData } from '../types'
+import { userVaultBalanceQueryOptions } from '../vault/[vaultAddress]/_hooks/useUserVaultBalance'
 
 import { useHemiEarnTokens } from './useHemiEarnTokens'
+
+export const totalDepositsKeyPrefix = ['hemi-earn', 'total-deposits']
 
 type TotalDepositsData = EarnCardData & { totalUsd: string }
 
 export const useTotalDeposits = function () {
-  const { id: chainId } = useHemi()
-  const hemiClient = useHemiClient()
+  const [networkType] = useNetworkType()
+  const { address } = useAccount()
+  const config = useConfig()
+  const queryClient = useQueryClient()
   const { data: vaultTokens = [] } = useHemiEarnTokens()
   const { data: prices } = useTokenPrices()
 
@@ -27,9 +32,32 @@ export const useTotalDeposits = function () {
     isError,
     isPending,
   } = useQuery({
-    enabled: vaultTokens.length > 0,
-    queryFn: () => fetchTotalDeposits({ client: hemiClient, vaultTokens }),
-    queryKey: ['hemi-earn', 'total-deposits', chainId],
+    enabled: !!address && vaultTokens.length > 0,
+    async queryFn() {
+      const balances = await Promise.all(
+        vaultTokens.map(({ token, vaultAddress }) =>
+          queryClient.ensureQueryData(
+            userVaultBalanceQueryOptions({
+              address: address!,
+              chainId: token.chainId,
+              client: getPublicClient(config, { chainId: token.chainId })!,
+              vaultAddress,
+            }),
+          ),
+        ),
+      )
+      return vaultTokens.map(({ token, vaultAddress }, index) => ({
+        amount: balances[index] ?? BigInt(0),
+        token,
+        vaultAddress,
+      }))
+    },
+    queryKey: [
+      ...totalDepositsKeyPrefix,
+      networkType,
+      address,
+      vaultTokens.map(vt => vt.vaultAddress),
+    ],
   })
 
   const data: TotalDepositsData | undefined = deposits
@@ -48,7 +76,7 @@ export const useTotalDeposits = function () {
         vaultBreakdown: deposits.map(({ amount, token }) => ({
           name: token.symbol,
           tokenAddress: token.address,
-          tokenChainId: chainId,
+          tokenChainId: token.chainId,
           value: `$${formatFiatNumber(
             Big(formatUnits(amount, token.decimals))
               .times(getTokenPrice(token, prices))

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalYieldEarned.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalYieldEarned.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
+import { useNetworkType } from 'hooks/useNetworkType'
 import { formatFiatNumber } from 'utils/format'
 
 import { type EarnCardData } from '../types'
@@ -10,8 +10,9 @@ import { useHemiEarnTokens } from './useHemiEarnTokens'
 
 type TotalYieldEarnedData = EarnCardData & { totalUsd: number }
 
+// TODO: this is a placeholder until we have the actual APY data available.
 export const useTotalYieldEarned = function () {
-  const { id } = useHemi()
+  const [networkType] = useNetworkType()
   const { data: vaultTokens = [] } = useHemiEarnTokens()
 
   const {
@@ -21,7 +22,7 @@ export const useTotalYieldEarned = function () {
   } = useQuery<{ totalUsd: number }>({
     queryFn: () =>
       new Promise(resolve => setTimeout(() => resolve({ totalUsd: 0 }), 2000)),
-    queryKey: ['hemi-earn', 'total-yield-earned', id],
+    queryKey: ['hemi-earn', 'total-yield-earned', networkType],
   })
 
   const data: TotalYieldEarnedData | undefined = queryData
@@ -30,7 +31,7 @@ export const useTotalYieldEarned = function () {
         vaultBreakdown: vaultTokens.map(({ token }) => ({
           name: token.symbol,
           tokenAddress: token.address,
-          tokenChainId: id,
+          tokenChainId: token.chainId,
           value: `$${formatFiatNumber(0)}`,
         })),
         vaultCount: vaultTokens.length,

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/index.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/index.tsx
@@ -4,7 +4,7 @@ import { Card } from 'components/card'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
-import { type Address } from 'viem'
+import { type Address, type Chain } from 'viem'
 
 import { CompositionIcon } from '../../../../_icons/compositionIcon'
 import {
@@ -33,10 +33,11 @@ const compositionColors = [
 ]
 
 type Props = {
+  chainId: Chain['id']
   vaultAddress: Address
 }
 
-export const Composition = function ({ vaultAddress }: Props) {
+export const Composition = function ({ chainId, vaultAddress }: Props) {
   const t = useTranslations('hemi-earn.vault.composition')
   const [viewMode, setViewMode] = useState<CompositionViewMode>('token')
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
@@ -46,6 +47,7 @@ export const Composition = function ({ vaultAddress }: Props) {
     isError,
     isPending,
   } = useComposition({
+    chainId,
     vaultAddress,
     viewMode,
   })

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/deposit.tsx
@@ -1,19 +1,20 @@
 'use client'
 
-import { HemiFees } from 'components/hemiFees'
+import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { encodeDepositToken } from 'hemi-earn-actions/actions'
 import { useTokenBalance } from 'hooks/useBalance'
+import { useChain } from 'hooks/useChain'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useEstimateFees } from 'hooks/useEstimateFees'
-import { useHemi } from 'hooks/useHemi'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
+import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
 import { validateSubmit } from 'utils/validateSubmit'
 import { walletIsConnected } from 'utils/wallet'
-import { type Address } from 'viem'
+import { type Address, formatUnits } from 'viem'
 import { useAccount as useEvmAccount, useEstimateGas } from 'wagmi'
 
 import { useVaultForm } from '../_context/vaultFormContext'
@@ -47,7 +48,6 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
   } = useVaultForm()
 
   const { address, status } = useEvmAccount()
-  const hemi = useHemi()
 
   const amount = parseTokenUnits(input, pool.token)
 
@@ -95,7 +95,7 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
 
   const { fees: depositGasFees, isError: isDepositGasFeesError } =
     useEstimateFees({
-      chainId: hemi.id,
+      chainId: pool.token.chainId,
       gasUnits: depositGasUnits,
       isGasUnitsError: isDepositGasUnitsError,
     })
@@ -130,11 +130,29 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
     setOperationRunning(needsApproval ? 'approving' : 'depositing')
   }
 
+  const chain = useChain(pool.token.chainId)
+  const nativeToken = getNativeToken(pool.token.chainId)
+
   function RenderBelowForm() {
     if (!canDeposit) {
       return null
     }
-    return <HemiFees fees={totalFees} isError={isFeesError} />
+    return (
+      <div className="px-4">
+        <EvmFeesSummary
+          gas={{
+            amount: formatUnits(
+              totalFees,
+              chain?.nativeCurrency.decimals ?? 18,
+            ),
+            isError: isFeesError,
+            label: t('common.network-gas-fee', { network: chain?.name ?? '' }),
+            token: nativeToken,
+          }}
+          operationToken={nativeToken}
+        />
+      </div>
+    )
   }
 
   return (

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/index.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/index.tsx
@@ -4,7 +4,7 @@ import { Card } from 'components/card'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
-import { type Address } from 'viem'
+import { type Address, type Chain } from 'viem'
 
 import { HistoricalMetricsIcon } from '../../../../_icons/historicalMetricsIcon'
 import {
@@ -18,15 +18,17 @@ import { HeadlineValue } from './headlineValue'
 import { HistoricalMetricsChart } from './historicalMetricsChart'
 
 type Props = {
+  chainId: Chain['id']
   vaultAddress: Address
 }
 
-export const HistoricalMetrics = function ({ vaultAddress }: Props) {
+export const HistoricalMetrics = function ({ chainId, vaultAddress }: Props) {
   const t = useTranslations('hemi-earn.vault.historical-metrics')
   const [period, setPeriod] = useState<MetricPeriod>('1w')
   const [metricType, setMetricType] = useState<MetricType>('deposits')
 
   const { data, isError, isPending } = useHistoricalMetrics({
+    chainId,
     metricType,
     period,
     vaultAddress,

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/userVaultBalance.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/userVaultBalance.tsx
@@ -10,7 +10,10 @@ type Props = {
 
 export const UserVaultBalance = function ({ token }: Props) {
   const { pool } = useVaultForm()
-  const { data: balance, status } = useUserVaultBalance(pool.vaultAddress)
+  const { data: balance, status } = useUserVaultBalance(
+    pool.vaultAddress,
+    pool.token.chainId,
+  )
 
   return <RenderCryptoBalance balance={balance} status={status} token={token} />
 }

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultForm.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultForm.tsx
@@ -81,12 +81,14 @@ export const VaultForm = function () {
     <>
       {showDepositToast && (
         <VaultToast
+          chainId={pool.token.chainId}
           title={t('deposit-successful')}
           transactionHash={depositOperation.transactionHash!}
         />
       )}
       {showWithdrawToast && (
         <VaultToast
+          chainId={pool.token.chainId}
           title={t('withdraw-successful')}
           transactionHash={withdrawOperation.transactionHash!}
         />

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultNavigation.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultNavigation.tsx
@@ -67,7 +67,7 @@ export const VaultNavigation = function ({ pool }: Props) {
               items={pools.map(p => ({
                 content: (
                   <button
-                    className="-mx-2 -my-1 block px-2 py-1 text-left text-sm"
+                    className="-mx-2 -my-1 block whitespace-nowrap px-2 py-1 text-left text-sm"
                     onClick={function () {
                       setIsDropdownOpen(false)
                       router.push(

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
@@ -81,8 +81,14 @@ export const VaultPageContent = function ({ vaultAddress }: Props) {
         <div className="mt-6 flex flex-col gap-3 md:gap-5 lg:flex-row">
           <div className="order-2 flex flex-col gap-4 md:gap-5 lg:order-1 lg:basis-2/3">
             <VaultInfoCards pool={pool} />
-            <HistoricalMetrics vaultAddress={pool.vaultAddress} />
-            <Composition vaultAddress={pool.vaultAddress} />
+            <HistoricalMetrics
+              chainId={pool.token.chainId}
+              vaultAddress={pool.vaultAddress}
+            />
+            <Composition
+              chainId={pool.token.chainId}
+              vaultAddress={pool.vaultAddress}
+            />
           </div>
           <div className="order-1 lg:order-2 lg:basis-1/3">
             <VaultForm />

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultReview/reviewDeposit.tsx
@@ -9,9 +9,9 @@ import {
 } from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { encodeDepositToken } from 'hemi-earn-actions/actions'
+import { useChain } from 'hooks/useChain'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useEstimateFees } from 'hooks/useEstimateFees'
-import { useHemi } from 'hooks/useHemi'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import { useToken } from 'hooks/useToken'
 import { useTranslations } from 'next-intl'
@@ -36,7 +36,8 @@ export const ReviewDeposit = function ({ onClose }: Props) {
   const { depositOperation, input, pool } = useVaultForm()
   const t = useTranslations('hemi-earn.vault.drawer')
   const tCommon = useTranslations('common')
-  const hemi = useHemi()
+  const chainId = pool.token.chainId
+  const chain = useChain(chainId)
   const { address } = useAccount()
 
   const depositStatus =
@@ -47,7 +48,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
   const { needsApproval } = useNeedsApproval({
     address: pool.token.address,
     amount,
-    chainId: pool.token.chainId,
+    chainId,
     spender: pool.vaultAddress,
   })
 
@@ -73,10 +74,12 @@ export const ReviewDeposit = function ({ onClose }: Props) {
 
   const { fees: depositGasFees, isError: isDepositGasFeesError } =
     useEstimateFees({
-      chainId: hemi.id,
+      chainId,
       gasUnits: depositGasUnits,
       isGasUnitsError: isDepositGasUnitsError,
     })
+
+  const nativeDecimals = chain?.nativeCurrency.decimals ?? 18
 
   const getStepFees = ({
     fee,
@@ -89,9 +92,9 @@ export const ReviewDeposit = function ({ onClose }: Props) {
   }): StepPropsWithoutPosition['fees'] =>
     show
       ? {
-          amount: formatUnits(fee, hemi.nativeCurrency.decimals),
+          amount: formatUnits(fee, nativeDecimals),
           isError,
-          token: getNativeToken(hemi.id),
+          token: getNativeToken(chainId),
         }
       : undefined
 
@@ -119,11 +122,11 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       description: (
         <ChainLabel
           active={depositStatus === VaultDepositStatus.APPROVAL_TX_PENDING}
-          chainId={hemi.id}
+          chainId={chainId}
           label={t('approving', { symbol: pool.token.symbol })}
         />
       ),
-      explorerChainId: pool.token.chainId,
+      explorerChainId: chainId,
       fees: getStepFees({
         fee: approvalGasFees,
         isError: isApprovalGasFeesError,
@@ -154,11 +157,11 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       description: (
         <ChainLabel
           active={depositStatus === VaultDepositStatus.DEPOSIT_TX_PENDING}
-          chainId={hemi.id}
+          chainId={chainId}
           label={t('deposit-token', { symbol: pool.token.symbol })}
         />
       ),
-      explorerChainId: pool.token.chainId,
+      explorerChainId: chainId,
       fees: getStepFees({
         fee: depositGasFees,
         isError: isDepositGasFeesError,
@@ -180,7 +183,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
 
   const { data: vaultShareToken } = useToken({
     address: pool.vaultAddress,
-    chainId: hemi.id,
+    chainId,
   })
 
   const getCallToAction = function (status: VaultDepositStatusType) {

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultReview/reviewWithdraw.tsx
@@ -8,8 +8,8 @@ import {
 } from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { encodeWithdraw } from 'hemi-earn-actions/actions'
+import { useChain } from 'hooks/useChain'
 import { useEstimateFees } from 'hooks/useEstimateFees'
-import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
 import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
@@ -32,7 +32,8 @@ type Props = {
 export const ReviewWithdraw = function ({ onClose }: Props) {
   const { input, pool, withdrawOperation } = useVaultForm()
   const t = useTranslations('hemi-earn.vault.drawer')
-  const hemi = useHemi()
+  const chainId = pool.token.chainId
+  const chain = useChain(chainId)
   const { address } = useAccount()
 
   const withdrawStatus =
@@ -42,6 +43,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
 
   const { data: shares } = useConvertToShares({
     assets: amount,
+    chainId,
     vaultAddress: pool.vaultAddress,
   })
 
@@ -61,10 +63,12 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
 
   const { fees: withdrawGasFees, isError: isWithdrawGasFeesError } =
     useEstimateFees({
-      chainId: hemi.id,
+      chainId,
       gasUnits: withdrawGasUnits,
       isGasUnitsError: isWithdrawGasUnitsError,
     })
+
+  const nativeDecimals = chain?.nativeCurrency.decimals ?? 18
 
   const showFees = [
     VaultWithdrawStatus.WITHDRAW_TX_PENDING,
@@ -82,16 +86,16 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
       description: (
         <ChainLabel
           active={withdrawStatus === VaultWithdrawStatus.WITHDRAW_TX_PENDING}
-          chainId={hemi.id}
+          chainId={chainId}
           label={t('withdraw-token', { symbol: pool.token.symbol })}
         />
       ),
-      explorerChainId: pool.token.chainId,
+      explorerChainId: chainId,
       fees: showFees
         ? {
-            amount: formatUnits(withdrawGasFees, hemi.nativeCurrency.decimals),
+            amount: formatUnits(withdrawGasFees, nativeDecimals),
             isError: isWithdrawGasFeesError,
-            token: getNativeToken(hemi.id),
+            token: getNativeToken(chainId),
           }
         : undefined,
       status: statusMap[withdrawStatus] ?? ProgressStatus.PROGRESS,

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultToast.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultToast.tsx
@@ -1,23 +1,28 @@
 import { Toast } from 'components/toast'
-import { useHemi } from 'hooks/useHemi'
+import { useChain } from 'hooks/useChain'
 import { useTranslations } from 'next-intl'
 import { formatEvmHash } from 'utils/format'
-import { type Hash } from 'viem'
+import { type Chain, type Hash } from 'viem'
 
 type Props = {
+  chainId: Chain['id']
   title: string
   transactionHash: Hash
 }
 
-export const VaultToast = function ({ title, transactionHash }: Props) {
-  const hemi = useHemi()
+export const VaultToast = function ({
+  chainId,
+  title,
+  transactionHash,
+}: Props) {
+  const chain = useChain(chainId)
   const t = useTranslations('hemi-earn.vault')
   return (
     <Toast
       description={t('here-is-your-tx')}
       title={title}
       tx={{
-        href: `${hemi.blockExplorers?.default.url}/tx/${transactionHash}`,
+        href: `${chain?.blockExplorers?.default.url}/tx/${transactionHash}`,
         label: formatEvmHash(transactionHash),
       }}
     />

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/withdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/withdraw.tsx
@@ -1,15 +1,16 @@
 'use client'
 
-import { HemiFees } from 'components/hemiFees'
+import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { encodeWithdraw } from 'hemi-earn-actions/actions'
+import { useChain } from 'hooks/useChain'
 import { useEstimateFees } from 'hooks/useEstimateFees'
-import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
+import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
 import { validateSubmit } from 'utils/validateSubmit'
 import { walletIsConnected } from 'utils/wallet'
-import { type Address } from 'viem'
+import { type Address, formatUnits } from 'viem'
 import { useAccount as useEvmAccount, useEstimateGas } from 'wagmi'
 
 import { useVaultForm } from '../_context/vaultFormContext'
@@ -42,12 +43,11 @@ export const Withdraw = function ({ onSwitchToDeposit }: Props) {
   } = useVaultForm()
 
   const { address, status } = useEvmAccount()
-  const hemi = useHemi()
 
   const amount = parseTokenUnits(input, pool.token)
 
   const { data: vaultBalance, isSuccess: vaultBalanceLoaded } =
-    useUserVaultBalance(pool.vaultAddress)
+    useUserVaultBalance(pool.vaultAddress, pool.token.chainId)
 
   const {
     canSubmit: validInput,
@@ -65,6 +65,7 @@ export const Withdraw = function ({ onSwitchToDeposit }: Props) {
 
   const { data: shares } = useConvertToShares({
     assets: amount,
+    chainId: pool.token.chainId,
     enabled: canWithdraw,
     vaultAddress: pool.vaultAddress,
   })
@@ -85,7 +86,7 @@ export const Withdraw = function ({ onSwitchToDeposit }: Props) {
 
   const { fees: withdrawGasFees, isError: isWithdrawGasFeesError } =
     useEstimateFees({
-      chainId: hemi.id,
+      chainId: pool.token.chainId,
       gasUnits: withdrawGasUnits,
       isGasUnitsError: isWithdrawGasUnitsError,
     })
@@ -112,11 +113,29 @@ export const Withdraw = function ({ onSwitchToDeposit }: Props) {
     setOperationRunning('withdrawing')
   }
 
+  const chain = useChain(pool.token.chainId)
+  const nativeToken = getNativeToken(pool.token.chainId)
+
   function RenderBelowForm() {
     if (!canWithdraw) {
       return null
     }
-    return <HemiFees fees={withdrawGasFees} isError={isWithdrawGasFeesError} />
+    return (
+      <div className="px-4">
+        <EvmFeesSummary
+          gas={{
+            amount: formatUnits(
+              withdrawGasFees,
+              chain?.nativeCurrency.decimals ?? 18,
+            ),
+            isError: isWithdrawGasFeesError,
+            label: t('common.network-gas-fee', { network: chain?.name ?? '' }),
+            token: nativeToken,
+          }}
+          operationToken={nativeToken}
+        />
+      </div>
+    )
   }
 
   return (

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/withdrawMaxBalance.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/withdrawMaxBalance.tsx
@@ -17,7 +17,10 @@ export const WithdrawMaxBalance = function ({
   token,
 }: Props) {
   const { pool } = useVaultForm()
-  const { data: balance, isPending } = useUserVaultBalance(pool.vaultAddress)
+  const { data: balance, isPending } = useUserVaultBalance(
+    pool.vaultAddress,
+    pool.token.chainId,
+  )
 
   return (
     <MaxButton

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useComposition.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useComposition.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
-import { type Address } from 'viem'
+import { type Address, type Chain } from 'viem'
 
 export type CompositionViewMode = 'token' | 'protocol'
 
@@ -53,21 +52,21 @@ const generateMockData = function (viewMode: CompositionViewMode) {
 const mockDelay = 2000
 
 type UseComposition = {
+  chainId: Chain['id']
   vaultAddress: Address
   viewMode: CompositionViewMode
 }
 
 // TODO: replace mocked data with real API call once the backend endpoint is available.
-export const useComposition = function ({
+export const useComposition = ({
+  chainId,
   vaultAddress,
   viewMode,
-}: UseComposition) {
-  const { id: chainId } = useHemi()
-  return useQuery({
+}: UseComposition) =>
+  useQuery({
     queryFn: () =>
       new Promise<CompositionItem[]>(resolve =>
         setTimeout(() => resolve(generateMockData(viewMode)), mockDelay),
       ),
     queryKey: ['composition', chainId, vaultAddress, viewMode],
   })
-}

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useConvertToShares.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useConvertToShares.ts
@@ -1,29 +1,28 @@
 import { useQuery } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
-import { useHemiClient } from 'hooks/useHemiClient'
-import { type Address } from 'viem'
+import { type Address, type Chain } from 'viem'
 import { convertToShares } from 'viem-erc4626/actions'
-import { useAccount } from 'wagmi'
+import { useAccount, usePublicClient } from 'wagmi'
 
 export const useConvertToShares = function ({
   assets,
+  chainId,
   enabled = true,
   vaultAddress,
 }: {
   assets: bigint
+  chainId: Chain['id']
   enabled?: boolean
   vaultAddress: Address
 }) {
-  const { id: chainId } = useHemi()
-  const hemiClient = useHemiClient()
+  const client = usePublicClient({ chainId })
   const { address } = useAccount()
 
   const isEnabled = enabled && !!address && assets > BigInt(0)
 
   return useQuery({
-    enabled: isEnabled && !!hemiClient,
+    enabled: isEnabled && !!client,
     queryFn: () =>
-      convertToShares(hemiClient, {
+      convertToShares(client!, {
         address: vaultAddress,
         assets,
       }),

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useDeposit.ts
@@ -6,15 +6,15 @@ import { EventEmitter } from 'events'
 import { type DepositEvents } from 'hemi-earn-actions'
 import { depositToken } from 'hemi-earn-actions/actions'
 import { useTokenBalance } from 'hooks/useBalance'
-import { useHemi } from 'hooks/useHemi'
-import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { buildAllowanceQueryKey } from 'utils/allowanceQueryKey'
 import { parseTokenUnits } from 'utils/token'
 import { erc4626Abi, parseEventLogs } from 'viem'
-import { useAccount } from 'wagmi'
+import { useAccount, useConfig } from 'wagmi'
+import { getWalletClient } from 'wagmi/actions'
 
-import { getEarnPoolsQueryKey } from '../../../_hooks/useEarnPools'
-import { getEarnPositionsQueryKey } from '../../../_hooks/useEarnPositions'
+import { earnPoolsKeyPrefix } from '../../../_hooks/useEarnPools'
+import { earnPositionsKeyPrefix } from '../../../_hooks/useEarnPositions'
+import { totalDepositsKeyPrefix } from '../../../_hooks/useTotalDeposits'
 import { type EarnPool } from '../../../types'
 import {
   type VaultDepositOperation,
@@ -38,30 +38,26 @@ export const useDeposit = function ({
   updateDepositOperation,
 }: UseDeposit) {
   const amount = parseTokenUnits(input, pool.token)
+  const chainId = pool.token.chainId
 
   const { setDrawerQueryString } = useDrawerVaultQueryString()
   const { address } = useAccount()
-  const hemi = useHemi()
+  const config = useConfig()
   const ensureConnectedTo = useEnsureConnectedTo()
   const queryClient = useQueryClient()
 
   const { queryKey: tokenBalanceQueryKey } = useTokenBalance(
-    pool.token.chainId,
+    chainId,
     pool.token.address,
   )
 
-  const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
-    pool.token.chainId,
-  )
+  const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(chainId)
 
-  const updateNativeBalanceAfterFees = useUpdateNativeBalanceAfterReceipt(
-    pool.token.chainId,
-  )
-
-  const { hemiWalletClient } = useHemiWalletClient()
+  const updateNativeBalanceAfterFees =
+    useUpdateNativeBalanceAfterReceipt(chainId)
 
   const allowanceQueryKey = buildAllowanceQueryKey({
-    chainId: pool.token.chainId,
+    chainId,
     owner: address,
     spender: pool.vaultAddress,
     tokenAddress: pool.token.address,
@@ -73,13 +69,15 @@ export const useDeposit = function ({
         throw new Error('No account connected')
       }
 
-      await ensureConnectedTo(hemi.id)
+      await ensureConnectedTo(chainId)
+
+      const walletClient = await getWalletClient(config, { chainId })
 
       const { emitter, promise } = depositToken({
         account: address,
         amount,
         vaultAddress: pool.vaultAddress,
-        walletClient: hemiWalletClient!,
+        walletClient,
       })
 
       emitter.on('user-signed-approval', function (approvalTxHash) {
@@ -146,7 +144,7 @@ export const useDeposit = function ({
           // Update vault balance
           queryClient.setQueryData(
             getUserVaultBalanceQueryKey({
-              chainId: hemi.id,
+              chainId,
               vaultAddress: pool.vaultAddress,
             }),
             (old: bigint | undefined) =>
@@ -183,16 +181,19 @@ export const useDeposit = function ({
       queryClient.invalidateQueries({ queryKey: allowanceQueryKey })
       queryClient.invalidateQueries({ queryKey: nativeTokenBalanceQueryKey })
       queryClient.invalidateQueries({
-        queryKey: getEarnPoolsQueryKey(hemi.id),
+        queryKey: earnPoolsKeyPrefix,
       })
       queryClient.invalidateQueries({
         queryKey: getUserVaultBalanceQueryKey({
-          chainId: hemi.id,
+          chainId,
           vaultAddress: pool.vaultAddress,
         }),
       })
       queryClient.invalidateQueries({
-        queryKey: getEarnPositionsQueryKey(hemi.id, address),
+        queryKey: earnPositionsKeyPrefix,
+      })
+      queryClient.invalidateQueries({
+        queryKey: totalDepositsKeyPrefix,
       })
     },
   })

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useHistoricalMetrics.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useHistoricalMetrics.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
-import { type Address } from 'viem'
+import { type Address, type Chain } from 'viem'
 
 export type MetricPeriod = '1w' | '1m' | '3m' | '1y'
 export type MetricType = 'deposits' | 'apy'
@@ -47,19 +46,20 @@ const generateMockData = function (
 const mockDelay = 2000
 
 type UseHistoricalMetrics = {
+  chainId: Chain['id']
   metricType: MetricType
   period: MetricPeriod
   vaultAddress: Address
 }
 
 // TODO: replace mocked data with real API call once the backend endpoint is available.
-export const useHistoricalMetrics = function ({
+export const useHistoricalMetrics = ({
+  chainId,
   metricType,
   period,
   vaultAddress,
-}: UseHistoricalMetrics) {
-  const { id: chainId } = useHemi()
-  return useQuery({
+}: UseHistoricalMetrics) =>
+  useQuery({
     queryFn: () =>
       new Promise<MetricDataPoint[]>(resolve =>
         setTimeout(
@@ -69,4 +69,3 @@ export const useHistoricalMetrics = function ({
       ),
     queryKey: ['historical-metrics', chainId, vaultAddress, period, metricType],
   })
-}

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useUserVaultBalance.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useUserVaultBalance.ts
@@ -1,9 +1,7 @@
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { useHemi } from 'hooks/useHemi'
-import { useHemiClient } from 'hooks/useHemiClient'
 import { type Address, type Chain, type PublicClient } from 'viem'
 import { balanceOf, convertToAssets } from 'viem-erc4626/actions'
-import { useAccount } from 'wagmi'
+import { useAccount, usePublicClient } from 'wagmi'
 
 export const getUserVaultBalanceQueryKey = ({
   chainId,
@@ -16,17 +14,17 @@ export const getUserVaultBalanceQueryKey = ({
 export const userVaultBalanceQueryOptions = ({
   address,
   chainId,
-  hemiClient,
+  client,
   vaultAddress,
 }: {
   address: Address
   chainId: Chain['id']
-  hemiClient: PublicClient
+  client: PublicClient
   vaultAddress: Address
 }) =>
   queryOptions({
     async queryFn() {
-      const shares = await balanceOf(hemiClient, {
+      const shares = await balanceOf(client, {
         account: address,
         address: vaultAddress,
       })
@@ -35,7 +33,7 @@ export const userVaultBalanceQueryOptions = ({
         return BigInt(0)
       }
 
-      return convertToAssets(hemiClient, {
+      return convertToAssets(client, {
         address: vaultAddress,
         shares,
       })
@@ -43,18 +41,20 @@ export const userVaultBalanceQueryOptions = ({
     queryKey: getUserVaultBalanceQueryKey({ chainId, vaultAddress }),
   })
 
-export const useUserVaultBalance = function (vaultAddress: Address) {
-  const { id: chainId } = useHemi()
-  const hemiClient = useHemiClient()
+export const useUserVaultBalance = function (
+  vaultAddress: Address,
+  chainId: Chain['id'],
+) {
+  const client = usePublicClient({ chainId })
   const { address } = useAccount()
 
   return useQuery({
     ...userVaultBalanceQueryOptions({
       address: address!,
       chainId,
-      hemiClient: hemiClient!,
+      client: client!,
       vaultAddress,
     }),
-    enabled: !!address && !!hemiClient,
+    enabled: !!address && !!client,
   })
 }

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useWithdraw.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useWithdraw.ts
@@ -6,15 +6,15 @@ import { EventEmitter } from 'events'
 import { type WithdrawEvents } from 'hemi-earn-actions'
 import { withdraw } from 'hemi-earn-actions/actions'
 import { useTokenBalance } from 'hooks/useBalance'
-import { useHemi } from 'hooks/useHemi'
-import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { parseTokenUnits } from 'utils/token'
 import { erc4626Abi, parseEventLogs } from 'viem'
 import { convertToShares } from 'viem-erc4626/actions'
-import { useAccount } from 'wagmi'
+import { useAccount, useConfig } from 'wagmi'
+import { getWalletClient } from 'wagmi/actions'
 
-import { getEarnPoolsQueryKey } from '../../../_hooks/useEarnPools'
-import { getEarnPositionsQueryKey } from '../../../_hooks/useEarnPositions'
+import { earnPoolsKeyPrefix } from '../../../_hooks/useEarnPools'
+import { earnPositionsKeyPrefix } from '../../../_hooks/useEarnPositions'
+import { totalDepositsKeyPrefix } from '../../../_hooks/useTotalDeposits'
 import { type EarnPool } from '../../../types'
 import {
   type VaultWithdrawOperation,
@@ -39,24 +39,20 @@ export const useWithdraw = function ({
 }: UseWithdraw) {
   const { setDrawerQueryString } = useDrawerVaultQueryString()
   const { address } = useAccount()
-  const hemi = useHemi()
+  const chainId = pool.token.chainId
+  const config = useConfig()
   const ensureConnectedTo = useEnsureConnectedTo()
   const queryClient = useQueryClient()
 
   const { queryKey: tokenBalanceQueryKey } = useTokenBalance(
-    pool.token.chainId,
+    chainId,
     pool.token.address,
   )
 
-  const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
-    pool.token.chainId,
-  )
+  const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(chainId)
 
-  const updateNativeBalanceAfterFees = useUpdateNativeBalanceAfterReceipt(
-    pool.token.chainId,
-  )
-
-  const { hemiWalletClient } = useHemiWalletClient()
+  const updateNativeBalanceAfterFees =
+    useUpdateNativeBalanceAfterReceipt(chainId)
 
   return useMutation({
     async mutationFn() {
@@ -64,13 +60,15 @@ export const useWithdraw = function ({
         throw new Error('No account connected')
       }
 
-      await ensureConnectedTo(hemi.id)
+      await ensureConnectedTo(chainId)
+
+      const walletClient = await getWalletClient(config, { chainId })
 
       const amount = parseTokenUnits(input, pool.token)
 
       // Convert assets to shares for withdrawal.
       // Read from the contract directly (not from a cached hook) to get a fresh value.
-      const shares = await convertToShares(hemiWalletClient!, {
+      const shares = await convertToShares(walletClient, {
         address: pool.vaultAddress,
         assets: amount,
       })
@@ -80,7 +78,7 @@ export const useWithdraw = function ({
         receiver: address,
         shares,
         vaultAddress: pool.vaultAddress,
-        walletClient: hemiWalletClient!,
+        walletClient,
       })
 
       emitter.on('user-signed-withdraw', function (transactionHash) {
@@ -123,7 +121,7 @@ export const useWithdraw = function ({
           // Update vault balance
           queryClient.setQueryData(
             getUserVaultBalanceQueryKey({
-              chainId: hemi.id,
+              chainId,
               vaultAddress: pool.vaultAddress,
             }),
             (old: bigint | undefined) =>
@@ -153,16 +151,19 @@ export const useWithdraw = function ({
       queryClient.invalidateQueries({ queryKey: tokenBalanceQueryKey })
       queryClient.invalidateQueries({ queryKey: nativeTokenBalanceQueryKey })
       queryClient.invalidateQueries({
-        queryKey: getEarnPoolsQueryKey(hemi.id),
+        queryKey: earnPoolsKeyPrefix,
       })
       queryClient.invalidateQueries({
         queryKey: getUserVaultBalanceQueryKey({
-          chainId: hemi.id,
+          chainId,
           vaultAddress: pool.vaultAddress,
         }),
       })
       queryClient.invalidateQueries({
-        queryKey: getEarnPositionsQueryKey(hemi.id, address),
+        queryKey: earnPositionsKeyPrefix,
+      })
+      queryClient.invalidateQueries({
+        queryKey: totalDepositsKeyPrefix,
       })
     },
   })

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/page.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/page.tsx
@@ -1,5 +1,4 @@
-import { getEarnVaultAddresses } from 'hemi-earn-actions'
-import { hemi, hemiSepolia } from 'hemi-viem'
+import { getEarnChainIds, getEarnVaultAddresses } from 'hemi-earn-actions'
 
 import { VaultPageContent } from './_components/vaultPageContent'
 
@@ -7,16 +6,13 @@ type Props = {
   params: Promise<{ vaultAddress: string }>
 }
 
-// We include addresses from both chains so the static export covers all
+// We include addresses from all chains so the static export covers all
 // possible vault URLs regardless of which network the user has selected.
 // Chain enforcement happens at runtime: `useEarnPools` only returns pools for
 // the active chain, so navigating to a vault address that doesn't belong to
 // the current chain will find no matching pool and redirect back to /hemi-earn.
 export const generateStaticParams = function () {
-  const addresses = [
-    ...getEarnVaultAddresses(hemi.id),
-    ...getEarnVaultAddresses(hemiSepolia.id),
-  ]
+  const addresses = getEarnChainIds().flatMap(getEarnVaultAddresses)
   return [...new Set(addresses)].map(vaultAddress => ({ vaultAddress }))
 }
 

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnTokens.test.ts
@@ -33,8 +33,8 @@ describe('fetchHemiEarnTokens', function () {
     const result = await fetchHemiEarnTokens({ chainId, client })
 
     expect(result).toEqual([
-      { tokenAddress: tokenAddressA, vaultAddress: vaultA },
-      { tokenAddress: tokenAddressB, vaultAddress: vaultB },
+      { chainId, tokenAddress: tokenAddressA, vaultAddress: vaultA },
+      { chainId, tokenAddress: tokenAddressB, vaultAddress: vaultB },
     ])
     expect(asset).toHaveBeenCalledTimes(2)
     expect(asset).toHaveBeenCalledWith(client, { address: vaultA })
@@ -48,7 +48,7 @@ describe('fetchHemiEarnTokens', function () {
     const result = await fetchHemiEarnTokens({ chainId, client })
 
     expect(result).toEqual([
-      { tokenAddress: tokenAddressA, vaultAddress: vaultA },
+      { chainId, tokenAddress: tokenAddressA, vaultAddress: vaultA },
     ])
     expect(asset).toHaveBeenCalledTimes(1)
     expect(asset).toHaveBeenCalledWith(client, { address: vaultA })
@@ -68,8 +68,8 @@ describe('fetchHemiEarnTokens', function () {
     const result = await fetchHemiEarnTokens({ chainId, client })
 
     expect(result).toEqual([
-      { tokenAddress: tokenAddressA, vaultAddress: vaultA },
-      { tokenAddress: tokenAddressB, vaultAddress: vaultB },
+      { chainId, tokenAddress: tokenAddressA, vaultAddress: vaultA },
+      { chainId, tokenAddress: tokenAddressB, vaultAddress: vaultB },
     ])
     expect(asset).toHaveBeenCalledTimes(2)
     expect(asset).toHaveBeenNthCalledWith(1, client, { address: vaultA })


### PR DESCRIPTION
### Description

This PR decouples earn hooks from useHemi/useHemiClient so vaults on Ethereum mainnet and Sepolia can be listed alongside Hemi ones. Chain is now derived from pool.token.chainId throughout, matching the pattern used in the tunnel feature.

- Expose getEarnChainIds from hemi-earn-actions to avoid duplicating chain lists in the portal
- Use useQueries in useHemiEarnTokens so a failing chain does not block the others
- Share queryOptions between aggregators via ensureQueryData and invalidate by prefix in deposit/withdraw mutations
- Fix "Your total deposits" card to read user balances instead of vault TVL, and invalidate its cache on mutations
- Use EvmFeesSummary directly in deposit/withdraw so gas labels show the correct chain, keeping HemiFees scoped to Hemi
- Make explorer URLs in poolData and vaultToast chain-aware

### Screenshots

https://github.com/user-attachments/assets/1fee7632-128c-427d-88fd-013429514124

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
