### PR TITLE
Add vault history endpoint to subgraph-api

### DIFF
--- a/subgraph-api/README.md
+++ b/subgraph-api/README.md
@@ -23,6 +23,7 @@ These environment variables control how the API works:
 - `GET /:chainId/staked`
 - `GET /:chainId/claim/:address/:claimGroup`
 - `GET /:chainId/earn/vaults/:address/history`
+  - Optional query param: `since=<unix-seconds>` to return history entries from that timestamp onward.
 
 ## Local development and testing
 

--- a/subgraph-api/README.md
+++ b/subgraph-api/README.md
@@ -22,8 +22,7 @@ These environment variables control how the API works:
 - `GET /:chainId/withdrawals/:address/(btc|evm)`
 - `GET /:chainId/staked`
 - `GET /:chainId/claim/:address/:claimGroup`
-- `GET /:chainId/earn/vaults/:address/history`
-  - Optional query param: `since=<unix-seconds>` to return history entries from that timestamp onward.
+- `GET /:chainId/earn/vaults/:address/history?period=<1w|1m|3m|1y>`
 
 ## Local development and testing
 

--- a/subgraph-api/README.md
+++ b/subgraph-api/README.md
@@ -22,6 +22,7 @@ These environment variables control how the API works:
 - `GET /:chainId/withdrawals/:address/(btc|evm)`
 - `GET /:chainId/staked`
 - `GET /:chainId/claim/:address/:claimGroup`
+- `GET /:chainId/earn/vaults/:address/history`
 
 ## Local development and testing
 

--- a/subgraph-api/config/custom-environment-variables.json
+++ b/subgraph-api/config/custom-environment-variables.json
@@ -19,6 +19,10 @@
     "apiKey": "SUBGRAPH_API_KEY",
     "apiUrl": "SUBGRAPH_API_URL",
     "origin": "SUBGRAPH_ORIGIN",
+    "earn": {
+      "mainnet": "SUBGRAPH_EARN_MAINNET",
+      "testnet": "SUBGRAPH_EARN_TESTNET"
+    },
     "veHemi": {
       "testnet": "SUBGRAPH_VE_HEMI_TESTNET"
     }

--- a/subgraph-api/config/default.json
+++ b/subgraph-api/config/default.json
@@ -35,6 +35,10 @@
         "testnet": "6aTMqKg6Et48FzbAL9uYu8GZGoCMwYE9qWWTXpXmwgDR"
       }
     },
+    "earn": {
+      "mainnet": "",
+      "testnet": ""
+    },
     "veHemi": {
       "mainnet": "56TUB5qxv2zED5z1vhbCwgj9z2jXbYYwVAo2wmKznruZ",
       "testnet": "HFj92373tN3eEdEtYqsWmVftpwhshRGzfwgzg9eG3W7S"

--- a/subgraph-api/src/api-server.ts
+++ b/subgraph-api/src/api-server.ts
@@ -13,6 +13,7 @@ import type { ChainIdPathParams, ReqData } from '../types/server.ts'
 import { getBtcDepositOnHemi } from './route-handlers/get-btc-deposit-on-hemi.ts'
 import { getClaimTransactionHandler } from './route-handlers/get-claim-transaction-hash.ts'
 import { getLockedPositionsHandler } from './route-handlers/get-locked-positions.ts'
+import { getVaultHistoryHandler } from './route-handlers/get-vault-history.ts'
 import { getWithdrawalProofAndClaimHandler } from './route-handlers/get-withdrawal-proof-and-claim.ts'
 import {
   getBtcWithdrawals,
@@ -214,6 +215,13 @@ export function createApiServer() {
     parseChainId,
     validateChainIsHemi,
     asyncHandler(getLockedPositionsHandler),
+  )
+
+  app.get(
+    '/:chainIdStr(\\d+)/earn/vaults/:address(0x[0-9a-fA-F]{40})/history',
+    parseChainId,
+    validateChainIsHemi,
+    asyncHandler(getVaultHistoryHandler),
   )
 
   app.use(function (req: Request, res: Response) {

--- a/subgraph-api/src/route-handlers/get-vault-history.ts
+++ b/subgraph-api/src/route-handlers/get-vault-history.ts
@@ -34,13 +34,11 @@ export async function getVaultHistoryHandler(
 ) {
   const { chainId } = req.data
   const { address } = req.params
-  const { period } = req.query
+  const { period = '1w' } = req.query
 
-  if (!period || !validPeriods.includes(period as Period)) {
+  if (!validPeriods.includes(period as Period)) {
     sendJsonResponse(res, 400, {
-      error: `period is required and must be one of: ${validPeriods.join(
-        ', ',
-      )}`,
+      error: `period must be one of: ${validPeriods.join(', ')}`,
     })
     return
   }

--- a/subgraph-api/src/route-handlers/get-vault-history.ts
+++ b/subgraph-api/src/route-handlers/get-vault-history.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { type Address } from 'viem'
 
 import { getVaultHistory } from '../subgraph.ts'
-import { isInteger, sendJsonResponse } from '../utils.ts'
+import { sendJsonResponse } from '../utils.ts'
 
 type PathParameters = {
   address: Address
@@ -12,8 +12,20 @@ type Data = {
   chainId: number
 }
 
+const validPeriods = ['1w', '1m', '3m', '1y'] as const
+type Period = (typeof validPeriods)[number]
+
+/* eslint-disable sort-keys */
+const periodSeconds: Record<Period, number> = {
+  '1w': 7 * 86400,
+  '1m': 30 * 86400,
+  '3m': 90 * 86400,
+  '1y': 365 * 86400,
+}
+/* eslint-enable sort-keys */
+
 type QueryParams = {
-  since?: string
+  period?: string
 }
 
 export async function getVaultHistoryHandler(
@@ -22,19 +34,24 @@ export async function getVaultHistoryHandler(
 ) {
   const { chainId } = req.data
   const { address } = req.params
-  const { since } = req.query
+  const { period } = req.query
 
-  if (since !== undefined && !isInteger(since)) {
-    sendJsonResponse(res, 400, { error: 'since must be a number' })
+  if (!period || !validPeriods.includes(period as Period)) {
+    sendJsonResponse(res, 400, {
+      error: `period is required and must be one of: ${validPeriods.join(
+        ', ',
+      )}`,
+    })
     return
   }
 
-  const sinceTimestamp = since ? Number.parseInt(since) : 0
+  const now = Math.floor(Date.now() / 1000)
+  const since = now - periodSeconds[period as Period]
 
   const history = await getVaultHistory({
     address,
     chainId,
-    since: sinceTimestamp,
+    since,
   })
 
   sendJsonResponse(res, 200, { history })

--- a/subgraph-api/src/route-handlers/get-vault-history.ts
+++ b/subgraph-api/src/route-handlers/get-vault-history.ts
@@ -1,0 +1,41 @@
+import type { Request, Response } from 'express'
+import { type Address } from 'viem'
+
+import { getVaultHistory } from '../subgraph.ts'
+import { isInteger, sendJsonResponse } from '../utils.ts'
+
+type PathParameters = {
+  address: Address
+}
+
+type Data = {
+  chainId: number
+}
+
+type QueryParams = {
+  since?: string
+}
+
+export async function getVaultHistoryHandler(
+  req: Request<PathParameters, object, object, QueryParams> & { data: Data },
+  res: Response,
+) {
+  const { chainId } = req.data
+  const { address } = req.params
+  const { since } = req.query
+
+  if (since !== undefined && !isInteger(since)) {
+    sendJsonResponse(res, 400, { error: 'since must be a number' })
+    return
+  }
+
+  const sinceTimestamp = since ? Number.parseInt(since) : 0
+
+  const history = await getVaultHistory({
+    address,
+    chainId,
+    since: sinceTimestamp,
+  })
+
+  sendJsonResponse(res, 200, { history })
+}

--- a/subgraph-api/src/subgraph.ts
+++ b/subgraph-api/src/subgraph.ts
@@ -632,7 +632,7 @@ type GetVaultHistoryQueryResponse = GraphResponse<{
   vaultHistories: VaultHistoryEntry[]
 }>
 
-export const getVaultHistory = function ({
+export const getVaultHistory = async function ({
   address,
   chainId,
   since,
@@ -647,35 +647,54 @@ export const getVaultHistory = function ({
   }
 
   const subgraphUrl = getSubgraphUrl({ chainId, subgraphIds })
+  const vault = address.toLowerCase()
+  const limit = 100
+  const allHistories: VaultHistoryEntry[] = []
+  let sinceTimestamp = since.toString()
 
-  const schema = {
-    query: `query GetVaultHistory($vault: Bytes!, $since: BigInt!) {
-      vaultHistories(
-        where: { vault: $vault, timestamp_gte: $since }
-        orderBy: timestamp
-        orderDirection: asc
-        first: 1000
-      ) {
-        id
-        shareValue
-        timestamp
-        totalAssets
-        vault
-      }
-    }`,
-    variables: { since: since.toString(), vault: address.toLowerCase() },
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const schema = {
+      query: `query GetVaultHistory($vault: Bytes!, $since: BigInt!, $limit: Int!) {
+        vaultHistories(
+          where: { vault: $vault, timestamp_gte: $since }
+          orderBy: timestamp
+          orderDirection: asc
+          first: $limit
+        ) {
+          id
+          shareValue
+          timestamp
+          totalAssets
+          vault
+        }
+      }`,
+      variables: { limit, since: sinceTimestamp, vault },
+    }
+
+    const response = await request<GetVaultHistoryQueryResponse>(
+      subgraphUrl,
+      schema,
+    )
+    checkGraphQLErrors(response)
+    const { vaultHistories } = response.data
+
+    allHistories.push(...vaultHistories)
+
+    if (vaultHistories.length < limit) {
+      break
+    }
+
+    // Advance past the last timestamp to avoid duplicates
+    const lastTimestamp = vaultHistories[vaultHistories.length - 1].timestamp
+    sinceTimestamp = (Number(lastTimestamp) + 1).toString()
   }
 
-  return request<GetVaultHistoryQueryResponse>(subgraphUrl, schema).then(
-    function (response) {
-      checkGraphQLErrors(response)
-      return response.data.vaultHistories.map(history => ({
-        ...history,
-        // @ts-expect-error vault is address lowercased
-        vault: toChecksum(history.vault),
-      }))
-    },
-  )
+  return allHistories.map(history => ({
+    ...history,
+    // @ts-expect-error vault is address lowercased
+    vault: toChecksum(history.vault),
+  }))
 }
 
 type GetLockedPositionsQueryResponse = GraphResponse<{

--- a/subgraph-api/src/subgraph.ts
+++ b/subgraph-api/src/subgraph.ts
@@ -620,6 +620,60 @@ export const getMerkleClaim = function ({
   )
 }
 
+type VaultHistoryEntry = {
+  id: string
+  shareValue: string
+  timestamp: string
+  totalAssets: string
+  vault: string
+}
+
+type GetVaultHistoryQueryResponse = GraphResponse<{
+  vaultHistories: VaultHistoryEntry[]
+}>
+
+export const getVaultHistory = function ({
+  address,
+  chainId,
+  since,
+}: {
+  address: Address
+  chainId: Chain['id']
+  since: number
+}) {
+  const subgraphIds = {
+    [hemi.id]: subgraphConfig.earn.mainnet,
+    [hemiSepolia.id]: subgraphConfig.earn.testnet,
+  }
+
+  const subgraphUrl = getSubgraphUrl({ chainId, subgraphIds })
+
+  const schema = {
+    query: `query GetVaultHistory($vault: Bytes!, $since: BigInt!) {
+      vaultHistories(
+        where: { vault: $vault, timestamp_gte: $since }
+        orderBy: timestamp
+        orderDirection: asc
+        first: 1000
+      ) {
+        id
+        shareValue
+        timestamp
+        totalAssets
+        vault
+      }
+    }`,
+    variables: { since: since.toString(), vault: address.toLowerCase() },
+  }
+
+  return request<GetVaultHistoryQueryResponse>(subgraphUrl, schema).then(
+    function (response) {
+      checkGraphQLErrors(response)
+      return response.data.vaultHistories
+    },
+  )
+}
+
 type GetLockedPositionsQueryResponse = GraphResponse<{
   lockedPositions: {
     amount: string

--- a/subgraph-api/src/subgraph.ts
+++ b/subgraph-api/src/subgraph.ts
@@ -669,7 +669,11 @@ export const getVaultHistory = function ({
   return request<GetVaultHistoryQueryResponse>(subgraphUrl, schema).then(
     function (response) {
       checkGraphQLErrors(response)
-      return response.data.vaultHistories
+      return response.data.vaultHistories.map(history => ({
+        ...history,
+        // @ts-expect-error vault is address lowercased
+        vault: toChecksum(history.vault),
+      }))
     },
   )
 }


### PR DESCRIPTION
### Description

Expose VaultHistory data from the hemi-earn-vaults-subgraph via a new REST route: 
GET /:chainId/earn/vaults/:address/history. Supports an optional "since" query param (unix timestamp) for filtering by time period.

### Screenshots

https://github.com/user-attachments/assets/f1ec3826-681f-4c38-a907-aff1c041b49c

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
