### PR TITLE
Integrate vault history API for deposits chart

### DIFF
--- a/portal/app/[locale]/hemi-earn/_utils/vaultHistory.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/vaultHistory.ts
@@ -4,6 +4,7 @@ import { formatUnits } from 'viem'
 import { type MetricDataPoint } from '../types'
 
 export type VaultHistoryPoint = {
+  shareValue: string
   timestamp: string
   totalAssets: string
 }

--- a/portal/app/[locale]/hemi-earn/_utils/vaultHistory.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/vaultHistory.ts
@@ -1,0 +1,23 @@
+import Big from 'big.js'
+import { formatUnits } from 'viem'
+
+import { type MetricDataPoint } from '../types'
+
+export type VaultHistoryPoint = {
+  timestamp: string
+  totalAssets: string
+}
+
+export const calculateTvlHistory = (
+  history: VaultHistoryPoint[],
+  tokenDecimals: number,
+  tokenPrice: string,
+): MetricDataPoint[] =>
+  history.map(function ({ timestamp, totalAssets }) {
+    const assets = formatUnits(BigInt(totalAssets), tokenDecimals)
+    const tvl = Big(assets).times(tokenPrice).toNumber()
+    return {
+      x: Number(timestamp) * 1000, // To milliseconds
+      y: tvl,
+    }
+  })

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -1,6 +1,10 @@
 import { type EvmToken } from 'types/token'
 import { type Address } from 'viem'
 
+export type MetricDataPoint = { x: number; y: number }
+export type MetricPeriod = '1w' | '1m' | '3m' | '1y'
+export type MetricType = 'deposits' | 'apy'
+
 export type VaultToken = {
   token: EvmToken
   vaultAddress: Address

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/headlineValue.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/headlineValue.tsx
@@ -1,7 +1,7 @@
 import { useLocale } from 'next-intl'
 import { formatCompactFiatParts, formatPercentage } from 'utils/format'
 
-import { type MetricType } from '../../_hooks/useHistoricalMetrics'
+import { type MetricType } from '../../../../types'
 
 type Props = {
   metricType: MetricType

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
@@ -23,7 +23,7 @@ import {
   type MetricDataPoint,
   type MetricPeriod,
   type MetricType,
-} from '../../_hooks/useHistoricalMetrics'
+} from '../../../../types'
 
 const getChartPadding = (metricType: MetricType) => ({
   bottom: 24,

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/index.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/index.tsx
@@ -4,14 +4,12 @@ import { Card } from 'components/card'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
+import { type EvmToken } from 'types/token'
 import { type Address, type Chain } from 'viem'
 
 import { HistoricalMetricsIcon } from '../../../../_icons/historicalMetricsIcon'
-import {
-  type MetricPeriod,
-  type MetricType,
-  useHistoricalMetrics,
-} from '../../_hooks/useHistoricalMetrics'
+import { type MetricPeriod, type MetricType } from '../../../../types'
+import { useHistoricalMetrics } from '../../_hooks/useHistoricalMetrics'
 import { SegmentedControlItem } from '../segmentedControlItem'
 
 import { HeadlineValue } from './headlineValue'
@@ -19,10 +17,15 @@ import { HistoricalMetricsChart } from './historicalMetricsChart'
 
 type Props = {
   chainId: Chain['id']
+  token: EvmToken
   vaultAddress: Address
 }
 
-export const HistoricalMetrics = function ({ chainId, vaultAddress }: Props) {
+export const HistoricalMetrics = function ({
+  chainId,
+  token,
+  vaultAddress,
+}: Props) {
   const t = useTranslations('hemi-earn.vault.historical-metrics')
   const [period, setPeriod] = useState<MetricPeriod>('1w')
   const [metricType, setMetricType] = useState<MetricType>('deposits')
@@ -31,6 +34,7 @@ export const HistoricalMetrics = function ({ chainId, vaultAddress }: Props) {
     chainId,
     metricType,
     period,
+    token,
     vaultAddress,
   })
 

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/index.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/historicalMetrics/index.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { type EvmToken } from 'types/token'
-import { type Address, type Chain } from 'viem'
+import { type Address } from 'viem'
 
 import { HistoricalMetricsIcon } from '../../../../_icons/historicalMetricsIcon'
 import { type MetricPeriod, type MetricType } from '../../../../types'
@@ -16,22 +16,16 @@ import { HeadlineValue } from './headlineValue'
 import { HistoricalMetricsChart } from './historicalMetricsChart'
 
 type Props = {
-  chainId: Chain['id']
   token: EvmToken
   vaultAddress: Address
 }
 
-export const HistoricalMetrics = function ({
-  chainId,
-  token,
-  vaultAddress,
-}: Props) {
+export const HistoricalMetrics = function ({ token, vaultAddress }: Props) {
   const t = useTranslations('hemi-earn.vault.historical-metrics')
   const [period, setPeriod] = useState<MetricPeriod>('1w')
   const [metricType, setMetricType] = useState<MetricType>('deposits')
 
   const { data, isError, isPending } = useHistoricalMetrics({
-    chainId,
     metricType,
     period,
     token,

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
@@ -82,7 +82,6 @@ export const VaultPageContent = function ({ vaultAddress }: Props) {
           <div className="order-2 flex flex-col gap-4 md:gap-5 lg:order-1 lg:basis-2/3">
             <VaultInfoCards pool={pool} />
             <HistoricalMetrics
-              chainId={pool.token.chainId}
               token={pool.token}
               vaultAddress={pool.vaultAddress}
             />

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/vaultPageContent.tsx
@@ -83,6 +83,7 @@ export const VaultPageContent = function ({ vaultAddress }: Props) {
             <VaultInfoCards pool={pool} />
             <HistoricalMetrics
               chainId={pool.token.chainId}
+              token={pool.token}
               vaultAddress={pool.vaultAddress}
             />
             <Composition

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useHistoricalMetrics.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useHistoricalMetrics.ts
@@ -1,10 +1,24 @@
 import { useQuery } from '@tanstack/react-query'
+import fetch from 'fetch-plus-plus'
+import { useTokenPrices } from 'hooks/useTokenPrices'
+import { type EvmToken } from 'types/token'
+import { getTokenPrice } from 'utils/token'
+import { isValidUrl } from 'utils/url'
 import { type Address, type Chain } from 'viem'
 
-export type MetricPeriod = '1w' | '1m' | '3m' | '1y'
-export type MetricType = 'deposits' | 'apy'
-export type MetricDataPoint = { x: number; y: number }
+import {
+  calculateTvlHistory,
+  type VaultHistoryPoint,
+} from '../../../_utils/vaultHistory'
+import { type MetricPeriod, type MetricType } from '../../../types'
 
+const subgraphApiUrl = process.env.NEXT_PUBLIC_SUBGRAPHS_API_URL
+
+type VaultHistoryResponse = {
+  history: VaultHistoryPoint[]
+}
+
+// TODO: replace mock APY data with real calculation from shareValue once approach is defined
 const periodDurations: Record<MetricPeriod, number> = {
   '1m': 30 * 24 * 60 * 60 * 1000,
   '1w': 7 * 24 * 60 * 60 * 1000,
@@ -12,60 +26,70 @@ const periodDurations: Record<MetricPeriod, number> = {
   '3m': 90 * 24 * 60 * 60 * 1000,
 }
 
-// Simple seeded pseudo-random for deterministic mock data
 const seededRandom = function (seed: number) {
   const x = Math.sin(seed) * 10000
   return x - Math.floor(x)
 }
 
-const generateMockData = function (
-  period: MetricPeriod,
-  metricType: MetricType,
-) {
+const generateMockApyData = function (period: MetricPeriod) {
   const now = Date.now()
   const duration = periodDurations[period]
   const points = 20
   const step = duration / (points - 1)
 
   return Array.from({ length: points }, function (_, i) {
-    const seed = i + (metricType === 'apy' ? 100 : 200)
-    const random = seededRandom(seed)
-
-    const y =
-      metricType === 'apy'
-        ? 2 + random * 3 // APY between 2% and 5%
-        : 380_000_000 + random * 50_000_000 // Deposits between $380M and $430M
-
+    const random = seededRandom(i + 100)
     return {
       x: now - duration + i * step,
-      y,
+      y: 2 + random * 3,
     }
   })
 }
 
-const mockDelay = 2000
+const fetchVaultHistory = (
+  chainId: Chain['id'],
+  vaultAddress: Address,
+  period: MetricPeriod,
+) =>
+  fetch(`${subgraphApiUrl}/${chainId}/earn/vaults/${vaultAddress}/history`, {
+    method: 'GET',
+    queryString: { period },
+  }).then((data: VaultHistoryResponse) => data.history) as Promise<
+    VaultHistoryPoint[]
+  >
 
 type UseHistoricalMetrics = {
   chainId: Chain['id']
   metricType: MetricType
   period: MetricPeriod
+  token: EvmToken
   vaultAddress: Address
 }
 
-// TODO: replace mocked data with real API call once the backend endpoint is available.
-export const useHistoricalMetrics = ({
+export const useHistoricalMetrics = function ({
   chainId,
   metricType,
   period,
+  token,
   vaultAddress,
-}: UseHistoricalMetrics) =>
-  useQuery({
-    queryFn: () =>
-      new Promise<MetricDataPoint[]>(resolve =>
-        setTimeout(
-          () => resolve(generateMockData(period, metricType)),
-          mockDelay,
-        ),
-      ),
+}: UseHistoricalMetrics) {
+  const { data: prices } = useTokenPrices()
+
+  return useQuery({
+    enabled:
+      subgraphApiUrl !== undefined &&
+      isValidUrl(subgraphApiUrl) &&
+      prices !== undefined,
+    async queryFn() {
+      if (metricType === 'apy') {
+        // TODO: replace mock APY data with real calculation from shareValue once approach is defined
+        return generateMockApyData(period)
+      }
+
+      const history = await fetchVaultHistory(chainId, vaultAddress, period)
+      const tokenPrice = getTokenPrice(token, prices)
+      return calculateTvlHistory(history, token.decimals, tokenPrice)
+    },
     queryKey: ['historical-metrics', chainId, vaultAddress, period, metricType],
   })
+}

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useHistoricalMetrics.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useHistoricalMetrics.ts
@@ -4,7 +4,7 @@ import { useTokenPrices } from 'hooks/useTokenPrices'
 import { type EvmToken } from 'types/token'
 import { getTokenPrice } from 'utils/token'
 import { isValidUrl } from 'utils/url'
-import { type Address, type Chain } from 'viem'
+import { type Address } from 'viem'
 
 import {
   calculateTvlHistory,
@@ -19,16 +19,14 @@ type VaultHistoryResponse = {
 }
 
 const fetchVaultHistory = (
-  chainId: Chain['id'],
+  chainId: EvmToken['chainId'],
   vaultAddress: Address,
   period: MetricPeriod,
 ) =>
   fetch(`${subgraphApiUrl}/${chainId}/earn/vaults/${vaultAddress}/history`, {
     method: 'GET',
     queryString: { period },
-  }).then((data: VaultHistoryResponse) => data.history) as Promise<
-    VaultHistoryPoint[]
-  >
+  }).then((data: VaultHistoryResponse) => data.history)
 
 // TODO: replace mock APY with real calculation from shareValue once approach is defined
 const generateMockApyData = (history: VaultHistoryPoint[]) =>
@@ -42,7 +40,6 @@ const generateMockApyData = (history: VaultHistoryPoint[]) =>
   })
 
 type UseHistoricalMetrics = {
-  chainId: Chain['id']
   metricType: MetricType
   period: MetricPeriod
   token: EvmToken
@@ -50,7 +47,6 @@ type UseHistoricalMetrics = {
 }
 
 export const useHistoricalMetrics = function ({
-  chainId,
   metricType,
   period,
   token,
@@ -61,8 +57,8 @@ export const useHistoricalMetrics = function ({
 
   return useQuery({
     enabled: subgraphApiUrl !== undefined && isValidUrl(subgraphApiUrl),
-    queryFn: () => fetchVaultHistory(chainId, vaultAddress, period),
-    queryKey: ['historical-metrics', chainId, metricType, period, vaultAddress],
+    queryFn: () => fetchVaultHistory(token.chainId, vaultAddress, period),
+    queryKey: ['historical-metrics', period, token.chainId, vaultAddress],
     select(history) {
       if (metricType === 'deposits') {
         return calculateTvlHistory(history, token.decimals, tokenPrice)

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useHistoricalMetrics.ts
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_hooks/useHistoricalMetrics.ts
@@ -18,34 +18,6 @@ type VaultHistoryResponse = {
   history: VaultHistoryPoint[]
 }
 
-// TODO: replace mock APY data with real calculation from shareValue once approach is defined
-const periodDurations: Record<MetricPeriod, number> = {
-  '1m': 30 * 24 * 60 * 60 * 1000,
-  '1w': 7 * 24 * 60 * 60 * 1000,
-  '1y': 365 * 24 * 60 * 60 * 1000,
-  '3m': 90 * 24 * 60 * 60 * 1000,
-}
-
-const seededRandom = function (seed: number) {
-  const x = Math.sin(seed) * 10000
-  return x - Math.floor(x)
-}
-
-const generateMockApyData = function (period: MetricPeriod) {
-  const now = Date.now()
-  const duration = periodDurations[period]
-  const points = 20
-  const step = duration / (points - 1)
-
-  return Array.from({ length: points }, function (_, i) {
-    const random = seededRandom(i + 100)
-    return {
-      x: now - duration + i * step,
-      y: 2 + random * 3,
-    }
-  })
-}
-
 const fetchVaultHistory = (
   chainId: Chain['id'],
   vaultAddress: Address,
@@ -57,6 +29,17 @@ const fetchVaultHistory = (
   }).then((data: VaultHistoryResponse) => data.history) as Promise<
     VaultHistoryPoint[]
   >
+
+// TODO: replace mock APY with real calculation from shareValue once approach is defined
+const generateMockApyData = (history: VaultHistoryPoint[]) =>
+  history.map(function ({ timestamp }, i) {
+    const x = Math.sin(i + 100) * 10000
+    const random = x - Math.floor(x)
+    return {
+      x: Number(timestamp) * 1000,
+      y: 2 + random * 3,
+    }
+  })
 
 type UseHistoricalMetrics = {
   chainId: Chain['id']
@@ -74,22 +57,18 @@ export const useHistoricalMetrics = function ({
   vaultAddress,
 }: UseHistoricalMetrics) {
   const { data: prices } = useTokenPrices()
+  const tokenPrice = getTokenPrice(token, prices)
 
   return useQuery({
-    enabled:
-      subgraphApiUrl !== undefined &&
-      isValidUrl(subgraphApiUrl) &&
-      prices !== undefined,
-    async queryFn() {
-      if (metricType === 'apy') {
-        // TODO: replace mock APY data with real calculation from shareValue once approach is defined
-        return generateMockApyData(period)
+    enabled: subgraphApiUrl !== undefined && isValidUrl(subgraphApiUrl),
+    queryFn: () => fetchVaultHistory(chainId, vaultAddress, period),
+    queryKey: ['historical-metrics', chainId, metricType, period, vaultAddress],
+    select(history) {
+      if (metricType === 'deposits') {
+        return calculateTvlHistory(history, token.decimals, tokenPrice)
       }
-
-      const history = await fetchVaultHistory(chainId, vaultAddress, period)
-      const tokenPrice = getTokenPrice(token, prices)
-      return calculateTvlHistory(history, token.decimals, tokenPrice)
+      // TODO: replace mock APY with real calculation from shareValue once approach is defined
+      return generateMockApyData(history)
     },
-    queryKey: ['historical-metrics', chainId, vaultAddress, period, metricType],
   })
 }

--- a/portal/test/app/[locale]/hemi-earn/_utils/vaultHistory.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/vaultHistory.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  calculateTvlHistory,
+  type VaultHistoryPoint,
+} from '../../../../../app/[locale]/hemi-earn/_utils/vaultHistory'
+
+describe('vaultHistory', function () {
+  describe('calculateTvlHistory', function () {
+    it('should return empty array for empty history', function () {
+      expect(calculateTvlHistory([], 18, '2000')).toEqual([])
+    })
+
+    it('should convert totalAssets to dollar value with 18 decimals', function () {
+      const history: VaultHistoryPoint[] = [
+        {
+          shareValue: '1000000000000000000',
+          timestamp: '1700000000',
+          totalAssets: '1000000000000000000',
+        },
+      ]
+      const result = calculateTvlHistory(history, 18, '2000')
+      expect(result).toEqual([{ x: 1700000000000, y: 2000 }])
+    })
+
+    it('should convert totalAssets to dollar value with 8 decimals', function () {
+      const history: VaultHistoryPoint[] = [
+        {
+          shareValue: '100000000',
+          timestamp: '1700000000',
+          totalAssets: '100000000',
+        },
+      ]
+      const result = calculateTvlHistory(history, 8, '60000')
+      expect(result).toEqual([{ x: 1700000000000, y: 60000 }])
+    })
+
+    it('should handle multiple points', function () {
+      const history: VaultHistoryPoint[] = [
+        {
+          shareValue: '1000000000000000000',
+          timestamp: '1700000000',
+          totalAssets: '500000000000000000000',
+        },
+        {
+          shareValue: '1000000000000000000',
+          timestamp: '1700086400',
+          totalAssets: '600000000000000000000',
+        },
+      ]
+      const result = calculateTvlHistory(history, 18, '2000')
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({ x: 1700000000000, y: 1000000 })
+      expect(result[1]).toEqual({ x: 1700086400000, y: 1200000 })
+    })
+
+    it('should return zero TVL when price is zero', function () {
+      const history: VaultHistoryPoint[] = [
+        {
+          shareValue: '1000000000000000000',
+          timestamp: '1700000000',
+          totalAssets: '1000000000000000000',
+        },
+      ]
+      const result = calculateTvlHistory(history, 18, '0')
+      expect(result).toEqual([{ x: 1700000000000, y: 0 }])
+    })
+
+    it('should convert timestamps from seconds to milliseconds', function () {
+      const history: VaultHistoryPoint[] = [
+        {
+          shareValue: '1000000000000000000',
+          timestamp: '1700000000',
+          totalAssets: '1000000000000000000',
+        },
+      ]
+      const result = calculateTvlHistory(history, 18, '1')
+      expect(result[0].x).toBe(1700000000000)
+    })
+  })
+})


### PR DESCRIPTION
### Description

This PR replaces the mock data in `useHistoricalMetrics` with real API calls to the subgraph-api vault history endpoint for the deposits (TVL) metric. 

Note: APY is not included in this change and will be addressed in a future iteration.

It also adds a unit tests for TVL calculation.

### Screenshots

https://github.com/user-attachments/assets/b5ecc0c1-5776-4b85-9cf5-13886a4d253e

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
