### PR TITLE
Add static mode to Table component

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/myPositionsTable/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/myPositionsTable/index.tsx
@@ -1,22 +1,13 @@
 'use client'
 
-import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
-import {
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table'
 import { Button } from 'components/button'
 import { WalletIcon } from 'components/icons/walletIcon'
-import { Column } from 'components/table/_components/column'
-import { ColumnHeader } from 'components/table/_components/columnHeader'
-import { getNewColumnOrder } from 'components/table/_utils'
+import { Table } from 'components/table'
 import { TableEmptyState } from 'components/tableEmptyState'
 import { useDrawerContext } from 'hooks/useDrawerContext'
 import { useUmami } from 'hooks/useUmami'
 import { useTranslations } from 'next-intl'
 import Skeleton from 'react-loading-skeleton'
-import { screenBreakpoints } from 'styles'
 import { walletIsConnected } from 'utils/wallet'
 import { useAccount } from 'wagmi'
 
@@ -73,98 +64,28 @@ export const MyPositionsTable = function () {
   const columns = useGetPositionsColumns()
   const { data: positions = [], isPending } = useEarnPositions()
   const { status } = useAccount()
-  const { width } = useWindowSize()
 
-  const table = useReactTable({
-    columns,
-    data: positions,
-    getCoreRowModel: getCoreRowModel(),
-    state: {
-      columnOrder: getNewColumnOrder({
-        breakpoint: screenBreakpoints.lg,
-        columns,
-        priorityColumnIds: ['actions'],
-        width,
-      }),
-    },
-  })
+  const isConnected = walletIsConnected(status)
 
-  const tableHead = (
-    <thead className="sticky top-0 z-10">
-      {table.getHeaderGroups().map(headerGroup => (
-        <tr className="flex w-full items-center" key={headerGroup.id}>
-          {headerGroup.headers.map(header => (
-            <ColumnHeader
-              key={header.id}
-              style={{
-                width: header.column.columnDef.meta?.width,
-              }}
-            >
-              {flexRender(header.column.columnDef.header, header.getContext())}
-            </ColumnHeader>
-          ))}
-        </tr>
-      ))}
-    </thead>
-  )
-
-  if (!walletIsConnected(status)) {
-    return (
-      <div className="w-full overflow-hidden rounded-xl bg-neutral-100 text-sm font-medium">
-        <table className="w-full border-separate border-spacing-0 px-1">
-          {tableHead}
-        </table>
-        <div className="mx-1 -mt-1.5 mb-1 rounded-xl bg-white shadow-md">
-          <ConnectWalletEmptyState />
-        </div>
-      </div>
-    )
-  }
-
-  if (isPending) {
+  if (isConnected && isPending) {
     return <Skeleton className="h-17 w-full rounded-xl" />
   }
 
-  if (positions.length === 0) {
-    return (
-      <div className="w-full overflow-hidden rounded-xl bg-neutral-100 text-sm font-medium">
-        <table className="w-full border-separate border-spacing-0 px-1">
-          {tableHead}
-        </table>
-        <div className="mx-1 -mt-1.5 mb-1 rounded-xl bg-white shadow-md">
-          <NoPositionsEmptyState />
-        </div>
-      </div>
-    )
-  }
+  const placeholder = !isConnected ? (
+    <ConnectWalletEmptyState />
+  ) : positions.length === 0 ? (
+    <NoPositionsEmptyState />
+  ) : undefined
 
   return (
-    <div
-      className="w-full overflow-x-auto rounded-xl bg-neutral-100 text-sm font-medium"
-      style={{
-        scrollbarColor: '#d4d4d4 transparent',
-        scrollbarWidth: 'thin',
-      }}
-    >
-      <table className="w-full border-separate border-spacing-0 whitespace-nowrap px-1">
-        {tableHead}
-        <tbody className="-mt-1.5 mb-1 flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden rounded-xl bg-white shadow-md">
-          {table.getRowModel().rows.map(row => (
-            <tr className="group/row flex w-full items-center" key={row.id}>
-              {row.getVisibleCells().map(cell => (
-                <Column
-                  key={cell.id}
-                  style={{
-                    width: cell.column.columnDef.meta?.width,
-                  }}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </Column>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="w-full rounded-xl bg-neutral-100 text-sm font-medium">
+      <Table
+        columns={columns}
+        data={positions}
+        mode="static"
+        placeholder={placeholder}
+        priorityColumnIdsOnSmall={['actions']}
+      />
     </div>
   )
 }

--- a/portal/app/[locale]/hemi-earn/_components/poolsTable/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsTable/index.tsx
@@ -1,16 +1,7 @@
 'use client'
 
-import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
-import {
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table'
-import { Column } from 'components/table/_components/column'
-import { ColumnHeader } from 'components/table/_components/columnHeader'
-import { getNewColumnOrder } from 'components/table/_utils'
+import { Table } from 'components/table'
 import Skeleton from 'react-loading-skeleton'
-import { screenBreakpoints } from 'styles'
 
 import { useEarnPools } from '../../_hooks/useEarnPools'
 
@@ -19,71 +10,19 @@ import { useGetPoolsColumns } from './columns'
 export const PoolsTable = function () {
   const columns = useGetPoolsColumns()
   const { data: pools = [], isPending } = useEarnPools()
-  const { width } = useWindowSize()
-
-  const table = useReactTable({
-    columns,
-    data: pools,
-    getCoreRowModel: getCoreRowModel(),
-    state: {
-      columnOrder: getNewColumnOrder({
-        breakpoint: screenBreakpoints.lg,
-        columns,
-        priorityColumnIds: ['actions'],
-        width,
-      }),
-    },
-  })
 
   if (isPending) {
     return <Skeleton className="h-17 w-full rounded-xl" />
   }
 
   return (
-    <div
-      className="w-full overflow-x-auto rounded-xl bg-neutral-100 text-sm font-medium"
-      style={{
-        scrollbarColor: '#d4d4d4 transparent',
-        scrollbarWidth: 'thin',
-      }}
-    >
-      <table className="w-full border-separate border-spacing-0 whitespace-nowrap px-1">
-        <thead className="sticky top-0 z-10">
-          {table.getHeaderGroups().map(headerGroup => (
-            <tr className="flex w-full items-center" key={headerGroup.id}>
-              {headerGroup.headers.map(header => (
-                <ColumnHeader
-                  key={header.id}
-                  style={{
-                    width: header.column.columnDef.meta?.width,
-                  }}
-                >
-                  {flexRender(
-                    header.column.columnDef.header,
-                    header.getContext(),
-                  )}
-                </ColumnHeader>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody className="-mt-1.5 mb-1 flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden rounded-xl bg-white shadow-md">
-          {table.getRowModel().rows.map(row => (
-            <tr className="group/row flex w-full items-center" key={row.id}>
-              {row.getVisibleCells().map(cell => (
-                <Column
-                  key={cell.id}
-                  style={{
-                    width: cell.column.columnDef.meta?.width,
-                  }}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </Column>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="w-full rounded-xl bg-neutral-100 text-sm font-medium">
+      <Table
+        columns={columns}
+        data={pools}
+        mode="static"
+        priorityColumnIdsOnSmall={['actions']}
+      />
     </div>
   )
 }

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/compositionTable.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/compositionTable.tsx
@@ -11,7 +11,9 @@ import {
 
 const CompositionCell = ({ className, ...props }: ComponentProps<'td'>) => (
   <td
-    className={`flex size-full flex-grow cursor-pointer items-center border-b border-solid border-neutral-100 py-3 group-hover/row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pr-4 ${className}`}
+    className={`flex size-full flex-grow cursor-pointer items-center border-b border-solid border-neutral-100 py-3 group-hover/row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pr-4 ${
+      className ?? ''
+    }`}
     {...props}
   />
 )

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/compositionTable.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/compositionTable.tsx
@@ -1,17 +1,20 @@
 'use client'
 
-import {
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table'
-import { ColumnHeader } from 'components/table/_components/columnHeader'
+import { Table } from 'components/table'
+import { ComponentProps } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import {
   type CompositionItemWithColor,
   useGetCompositionColumns,
 } from './compositionColumns'
+
+const CompositionCell = ({ className, ...props }: ComponentProps<'td'>) => (
+  <td
+    className={`flex size-full flex-grow cursor-pointer items-center border-b border-solid border-neutral-100 py-3 group-hover/row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pr-4 ${className}`}
+    {...props}
+  />
+)
 
 type Props = {
   data: CompositionItemWithColor[]
@@ -25,12 +28,6 @@ export const CompositionTable = function ({
   onHoveredIndexChange,
 }: Props) {
   const columns = useGetCompositionColumns()
-
-  const table = useReactTable({
-    columns,
-    data,
-    getCoreRowModel: getCoreRowModel(),
-  })
 
   if (isPending) {
     return (
@@ -57,59 +54,14 @@ export const CompositionTable = function ({
   }
 
   return (
-    <div
-      className="w-full overflow-x-auto rounded-xl bg-neutral-100 text-sm font-medium"
-      style={{
-        scrollbarColor: '#d4d4d4 transparent',
-        scrollbarWidth: 'thin',
-      }}
-    >
-      <table className="w-full border-separate border-spacing-0 whitespace-nowrap px-1">
-        <thead className="sticky top-0 z-10">
-          {table.getHeaderGroups().map(headerGroup => (
-            <tr className="flex w-full items-center" key={headerGroup.id}>
-              {headerGroup.headers.map(header => (
-                <ColumnHeader
-                  className={header.column.columnDef.meta?.className}
-                  key={header.id}
-                  style={{
-                    width: header.column.columnDef.meta?.width,
-                  }}
-                >
-                  {flexRender(
-                    header.column.columnDef.header,
-                    header.getContext(),
-                  )}
-                </ColumnHeader>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody className="-mt-1.5 mb-1 flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden rounded-xl bg-white shadow-md">
-          {table.getRowModel().rows.map(row => (
-            <tr
-              className="group/row flex w-full items-center"
-              key={row.id}
-              onMouseEnter={() => onHoveredIndexChange(row.index)}
-              onMouseLeave={() => onHoveredIndexChange(null)}
-            >
-              {row.getVisibleCells().map(cell => (
-                <td
-                  className={`flex size-full flex-grow cursor-pointer items-center border-b border-solid border-neutral-100 py-3 group-hover/row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pr-4 ${
-                    cell.column.columnDef.meta?.className ?? ''
-                  }`}
-                  key={cell.id}
-                  style={{
-                    width: cell.column.columnDef.meta?.width,
-                  }}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="w-full rounded-xl bg-neutral-100 text-sm font-medium">
+      <Table
+        cellComponent={CompositionCell}
+        columns={columns}
+        data={data}
+        mode="static"
+        onRowHover={onHoveredIndexChange}
+      />
     </div>
   )
 }

--- a/portal/components/table/_components/column.tsx
+++ b/portal/components/table/_components/column.tsx
@@ -3,7 +3,9 @@ import { ComponentProps } from 'react'
 export const Column = ({ className, ...props }: ComponentProps<'td'>) => (
   <td
     className={`flex h-full min-h-16 w-full flex-grow cursor-pointer items-center border-b border-solid 
-      border-neutral-300/55 py-2.5 group-hover/row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pr-4 ${className}`}
+      border-neutral-300/55 py-2.5 group-hover/row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pr-4 ${
+        className ?? ''
+      }`}
     {...props}
   />
 )

--- a/portal/components/table/_components/staticRows.tsx
+++ b/portal/components/table/_components/staticRows.tsx
@@ -1,0 +1,52 @@
+import { flexRender, Row } from '@tanstack/react-table'
+import { ComponentProps, ComponentType } from 'react'
+
+import { Column } from './column'
+
+type Props<TData> = {
+  CellComponent?: ComponentType<ComponentProps<'td'>>
+  loading: boolean
+  onRowClick?: (row: TData) => void
+  onRowHover?: (index: number | null) => void
+  rows: Row<TData>[]
+}
+
+export function StaticRows<TData>({
+  CellComponent = Column,
+  loading,
+  onRowClick,
+  onRowHover,
+  rows,
+}: Props<TData>) {
+  if (loading && rows.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      {rows.map(row => (
+        <tr
+          className="group/row flex w-full items-center"
+          key={row.id}
+          onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+          onMouseEnter={onRowHover ? () => onRowHover(row.index) : undefined}
+          onMouseLeave={onRowHover ? () => onRowHover(null) : undefined}
+        >
+          {row.getVisibleCells().map(cell => (
+            <CellComponent
+              className={
+                cell.column.columnDef.meta?.className ?? 'justify-start'
+              }
+              key={cell.id}
+              style={{
+                width: cell.column.columnDef.meta?.width,
+              }}
+            >
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </CellComponent>
+          ))}
+        </tr>
+      ))}
+    </>
+  )
+}

--- a/portal/components/table/_components/virtualRows.tsx
+++ b/portal/components/table/_components/virtualRows.tsx
@@ -1,18 +1,23 @@
 import { flexRender, Row } from '@tanstack/react-table'
 import type { VirtualItem } from '@tanstack/react-virtual'
+import { ComponentProps, ComponentType } from 'react'
 
 import { Column } from './column'
 
 type Props<TData> = {
+  CellComponent?: ComponentType<ComponentProps<'td'>>
   loading: boolean
   onRowClick?: (row: TData) => void
+  onRowHover?: (index: number | null) => void
   rows: Row<TData>[]
   virtualItems: VirtualItem[]
 }
 
 export function VirtualRows<TData>({
+  CellComponent = Column,
   loading,
   onRowClick,
+  onRowHover,
   rows,
   virtualItems,
 }: Props<TData>) {
@@ -29,14 +34,16 @@ export function VirtualRows<TData>({
             className="group/row absolute flex w-full items-center"
             data-index={virtualRow.index}
             key={row.id}
-            onClick={() => onRowClick?.(row.original)}
+            onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+            onMouseEnter={onRowHover ? () => onRowHover(row.index) : undefined}
+            onMouseLeave={onRowHover ? () => onRowHover(null) : undefined}
             style={{
               height: `${virtualRow.size}px`,
               transform: `translateY(${virtualRow.start}px)`,
             }}
           >
             {row.getVisibleCells().map(cell => (
-              <Column
+              <CellComponent
                 className={
                   cell.column.columnDef.meta?.className ?? 'justify-start'
                 }
@@ -46,7 +53,7 @@ export function VirtualRows<TData>({
                 }}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </Column>
+              </CellComponent>
             ))}
           </tr>
         )

--- a/portal/components/table/_hooks/useTableData.tsx
+++ b/portal/components/table/_hooks/useTableData.tsx
@@ -45,7 +45,8 @@ export function useTableData<TData>({
     () => new Array(skeletonRows).fill(null),
     [skeletonRows],
   )
-  const safeData = data && data.length > 0 ? data : skeletonArray
+  const safeData =
+    data && data.length > 0 ? data : showSkeleton ? skeletonArray : []
 
   const columnOrder = getNewColumnOrder({
     breakpoint: smallBreakpoint,

--- a/portal/components/table/index.tsx
+++ b/portal/components/table/index.tsx
@@ -7,12 +7,20 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { ReactNode, RefObject, useRef } from 'react'
+import {
+  ComponentProps,
+  ComponentType,
+  ReactNode,
+  RefObject,
+  useRef,
+} from 'react'
 import { screenBreakpoints } from 'styles'
 
+import { Column } from './_components/column'
 import { ColumnHeader } from './_components/columnHeader'
 import { LoadingMoreIndicator } from './_components/loadingMoreIndicator'
 import { LoadingSkeletonRows } from './_components/loadingSkeletonRows'
+import { StaticRows } from './_components/staticRows'
 import { TableBodyContainer } from './_components/tableBodyContainer'
 import { VirtualRows } from './_components/virtualRows'
 import { useInfiniteScroll } from './_hooks/useInfiniteScroll'
@@ -66,10 +74,12 @@ const TableHeader = <TData,>({
 )
 
 type TableBodyProps<TData> = {
+  CellComponent: ComponentType<ComponentProps<'td'>>
   fetchMoreOnBottomReached: (el?: HTMLDivElement | null) => void
   isFetching: boolean
   loading: boolean
   onRowClick?: (row: TData) => void
+  onRowHover?: (index: number | null) => void
   placeholder?: ReactNode
   rowSize: number
   rowVirtualizer: ReturnType<typeof useTableVirtualizer<TData>>
@@ -79,10 +89,12 @@ type TableBodyProps<TData> = {
 }
 
 function TableBody<TData>({
+  CellComponent,
   fetchMoreOnBottomReached,
   isFetching,
   loading,
   onRowClick,
+  onRowHover,
   placeholder,
   rowSize,
   rowVirtualizer,
@@ -122,8 +134,10 @@ function TableBody<TData>({
               table={table}
             />
             <VirtualRows
+              CellComponent={CellComponent}
               loading={loading}
               onRowClick={onRowClick}
+              onRowHover={onRowHover}
               rows={rows}
               virtualItems={virtualItems}
             />
@@ -143,14 +157,65 @@ function TableBody<TData>({
   )
 }
 
+type StaticTableBodyProps<TData> = {
+  CellComponent: ComponentType<ComponentProps<'td'>>
+  loading: boolean
+  onRowClick?: (row: TData) => void
+  onRowHover?: (index: number | null) => void
+  placeholder?: ReactNode
+  skeletonRows: number
+  table: ReturnType<typeof useReactTable<TData>>
+}
+
+function StaticTableBody<TData>({
+  CellComponent,
+  loading,
+  onRowClick,
+  onRowHover,
+  placeholder,
+  skeletonRows,
+  table,
+}: StaticTableBodyProps<TData>) {
+  const { rows } = table.getRowModel()
+
+  return (
+    <div className="-mt-1.5 mb-1 overflow-hidden rounded-xl bg-white shadow-md">
+      {!placeholder ? (
+        <table className="w-full border-separate border-spacing-0 whitespace-nowrap">
+          <tbody>
+            <LoadingSkeletonRows
+              loading={loading}
+              rows={rows}
+              skeletonRows={skeletonRows}
+              table={table}
+            />
+            <StaticRows
+              CellComponent={CellComponent}
+              loading={loading}
+              onRowClick={onRowClick}
+              onRowHover={onRowHover}
+              rows={rows}
+            />
+          </tbody>
+        </table>
+      ) : (
+        placeholder
+      )}
+    </div>
+  )
+}
+
 export type TableProps<TData> = {
+  cellComponent?: ComponentType<ComponentProps<'td'>>
   columns: ColumnDef<TData>[]
   data: TData[] | undefined
   fetchNextPage?: VoidFunction
   hasNextPage?: boolean
   isFetching?: boolean
   loading?: boolean
+  mode?: 'static' | 'virtual'
   onRowClick?: (row: TData) => void
+  onRowHover?: (index: number | null) => void
   placeholder?: ReactNode
   priorityColumnIdsOnSmall?: string[]
   rowSize?: number
@@ -159,13 +224,16 @@ export type TableProps<TData> = {
 }
 
 export function Table<TData>({
+  cellComponent: CellComponent = Column,
   columns,
   data = [],
   fetchNextPage,
   hasNextPage = false,
   isFetching = false,
   loading = false,
+  mode = 'virtual',
   onRowClick,
+  onRowHover,
   placeholder,
   priorityColumnIdsOnSmall,
   rowSize = 64,
@@ -215,35 +283,52 @@ export function Table<TData>({
 
   const virtualItems = rowVirtualizer.getVirtualItems()
 
+  const isVirtual = mode === 'virtual'
+  const heightClass = isVirtual ? ' h-full' : ''
+
   return (
-    <div className="flex h-full flex-col">
+    <div className={`flex flex-col${heightClass}`}>
       <div
-        className="flex h-full flex-col overflow-x-auto"
+        className={`flex flex-col overflow-x-auto${heightClass}`}
         style={{
           scrollbarColor: '#d4d4d4 transparent',
           scrollbarWidth: 'thin',
         }}
       >
-        <div className="flex h-full min-w-max flex-col px-1">
+        <div className={`flex min-w-max flex-col px-1${heightClass}`}>
           <TableHeader
             hasVerticalBodyScrollbar={hasVerticalBodyScrollbar}
             smallBreakpoint={smallBreakpoint}
             table={table}
             width={width}
           />
-          <TableBody
-            fetchMoreOnBottomReached={fetchMoreOnBottomReached}
-            isFetching={isFetching}
-            loading={loading}
-            onRowClick={onRowClick}
-            placeholder={placeholder}
-            rowSize={rowSize}
-            rowVirtualizer={rowVirtualizer}
-            scrollContainerRef={scrollContainerRef}
-            skeletonRows={skeletonRows}
-            table={table}
-            virtualItems={virtualItems}
-          />
+          {isVirtual ? (
+            <TableBody
+              CellComponent={CellComponent}
+              fetchMoreOnBottomReached={fetchMoreOnBottomReached}
+              isFetching={isFetching}
+              loading={loading}
+              onRowClick={onRowClick}
+              onRowHover={onRowHover}
+              placeholder={placeholder}
+              rowSize={rowSize}
+              rowVirtualizer={rowVirtualizer}
+              scrollContainerRef={scrollContainerRef}
+              skeletonRows={skeletonRows}
+              table={table}
+              virtualItems={virtualItems}
+            />
+          ) : (
+            <StaticTableBody
+              CellComponent={CellComponent}
+              loading={loading}
+              onRowClick={onRowClick}
+              onRowHover={onRowHover}
+              placeholder={placeholder}
+              skeletonRows={skeletonRows}
+              table={table}
+            />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Description

This PR allows the standard Table component to render without virtual scroll by passing mode="static". This enables tables with few rows to grow dynamically with content instead of requiring a fixed-height container.

Migrate PoolsTable, MyPositionsTable and CompositionTable in hemi-earn to use the standard Table, removing ~200 lines of duplicated table logic.

### Screenshots

https://github.com/user-attachments/assets/0c6f659c-749c-4437-946f-8333b82bd8f4

### Related issue(s)

Closes #1856 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
