### PR TITLE
Improve Table layout on mobile viewports

### DIFF
--- a/portal/app/[locale]/btc-yield/_components/poolTable/columns.tsx
+++ b/portal/app/[locale]/btc-yield/_components/poolTable/columns.tsx
@@ -26,7 +26,7 @@ export const useGetColumns = function () {
           ),
           header: () => <Header text={t('bitcoin-yield.table.pool')} />,
           id: 'pool',
-          meta: { width: '200px' },
+          meta: { width: 200 },
         },
         {
           cell: () => (
@@ -38,7 +38,7 @@ export const useGetColumns = function () {
             <Header text={t('bitcoin-yield.table.staked-balance')} />
           ),
           id: 'balance',
-          meta: { width: '200px' },
+          meta: { width: 200 },
         },
         {
           cell: () => (
@@ -48,7 +48,7 @@ export const useGetColumns = function () {
           ),
           header: () => <Header text={t('bitcoin-yield.table.rewards')} />,
           id: 'rewards',
-          meta: { width: '200px' },
+          meta: { width: 200 },
         },
         {
           cell: ({ row }) => <Actions row={row} />,
@@ -58,7 +58,7 @@ export const useGetColumns = function () {
             </div>
           ),
           id: 'actions',
-          meta: { width: '350px' },
+          meta: { width: 350 },
         },
       ] satisfies ColumnDef<Vault>[],
     [t],

--- a/portal/app/[locale]/hemi-earn/_components/myPositionsTable/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/myPositionsTable/columns.tsx
@@ -58,7 +58,7 @@ export const useGetPositionsColumns = function () {
           ),
           header: () => <Header text={t('table.pool')} />,
           id: 'pool',
-          meta: { width: '200px' },
+          meta: { width: 200 },
         },
         {
           cell: ({ row }) => (
@@ -86,7 +86,7 @@ export const useGetPositionsColumns = function () {
           ),
           header: () => <Header text={t('table.your-deposit')} />,
           id: 'your-deposit',
-          meta: { width: '200px' },
+          meta: { width: 200 },
         },
         {
           cell: ({ row }) => (
@@ -96,7 +96,7 @@ export const useGetPositionsColumns = function () {
           ),
           header: () => <Header text={t('table.apy')} />,
           id: 'apy',
-          meta: { width: '120px' },
+          meta: { width: 120 },
         },
         {
           cell: ({ row }) => (
@@ -108,7 +108,7 @@ export const useGetPositionsColumns = function () {
           ),
           header: () => <Header text={t('table.yield-earned')} />,
           id: 'yield-earned',
-          meta: { width: '150px' },
+          meta: { width: 150 },
         },
         {
           cell: ({ row }) => (
@@ -120,7 +120,7 @@ export const useGetPositionsColumns = function () {
             </div>
           ),
           id: 'actions',
-          meta: { width: '100px' },
+          meta: { width: 100 },
         },
       ] satisfies ColumnDef<EarnPosition>[],
     [t],

--- a/portal/app/[locale]/hemi-earn/_components/poolsTable/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsTable/columns.tsx
@@ -59,7 +59,7 @@ export const useGetPoolsColumns = function () {
           ),
           header: () => <Header text={t('table.pool')} />,
           id: 'pool',
-          meta: { width: '200px' },
+          meta: { width: 200 },
         },
         {
           cell: ({ row }) => (
@@ -87,7 +87,7 @@ export const useGetPoolsColumns = function () {
           ),
           header: () => <Header text={t('table.total-deposits')} />,
           id: 'total-deposits',
-          meta: { width: '200px' },
+          meta: { width: 200 },
         },
         {
           cell: ({ row }) => (
@@ -97,7 +97,7 @@ export const useGetPoolsColumns = function () {
           ),
           header: () => <Header text={t('table.apy')} />,
           id: 'apy',
-          meta: { width: '120px' },
+          meta: { width: 120 },
         },
         {
           cell: ({ row }) => (
@@ -107,7 +107,7 @@ export const useGetPoolsColumns = function () {
           ),
           header: () => <Header text={t('table.exposure')} />,
           id: 'exposure',
-          meta: { width: '120px' },
+          meta: { width: 120 },
         },
         {
           cell: ({ row }) => (
@@ -119,7 +119,7 @@ export const useGetPoolsColumns = function () {
             </div>
           ),
           id: 'actions',
-          meta: { width: '260px' },
+          meta: { width: 260 },
         },
       ] satisfies ColumnDef<EarnPool>[],
     [t],

--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/compositionColumns.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/compositionColumns.tsx
@@ -28,7 +28,7 @@ export const useGetCompositionColumns = function () {
           ),
           header: () => <Header text={t('position')} />,
           id: 'position',
-          meta: { width: '200px' },
+          meta: { width: 200 },
         },
         {
           cell: ({ row }) => (
@@ -38,7 +38,7 @@ export const useGetCompositionColumns = function () {
           ),
           header: () => <Header text={t('amount')} />,
           id: 'amount',
-          meta: { className: 'justify-end', width: '120px' },
+          meta: { className: 'justify-end', width: 120 },
         },
         {
           cell: ({ row }) => (
@@ -48,7 +48,7 @@ export const useGetCompositionColumns = function () {
           ),
           header: () => <Header text={t('apy')} />,
           id: 'apy',
-          meta: { className: 'justify-end', width: '80px' },
+          meta: { className: 'justify-end', width: 80 },
         },
         {
           cell: ({ row }) => (
@@ -58,7 +58,7 @@ export const useGetCompositionColumns = function () {
           ),
           header: () => <Header text={t('share')} />,
           id: 'share',
-          meta: { className: 'justify-end', width: '80px' },
+          meta: { className: 'justify-end', width: 80 },
         },
       ] satisfies ColumnDef<CompositionItemWithColor>[],
     [t],

--- a/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -28,7 +28,7 @@ const stakeColumns = ({ t }: StakeColumnsProps): ColumnDef<StakeToken>[] => [
     ),
     header: () => <Header text={t('protocol')} />,
     id: 'protocol',
-    meta: { width: '150px' },
+    meta: { width: 150 },
   },
   {
     cell: ({ row }) => (
@@ -39,7 +39,7 @@ const stakeColumns = ({ t }: StakeColumnsProps): ColumnDef<StakeToken>[] => [
     ),
     header: () => <Header text={t('asset')} />,
     id: 'asset',
-    meta: { width: '120px' },
+    meta: { width: 120 },
   },
   {
     cell: ({ row }) => (
@@ -50,7 +50,7 @@ const stakeColumns = ({ t }: StakeColumnsProps): ColumnDef<StakeToken>[] => [
     ),
     header: () => <Header text={t('wallet-balance')} />,
     id: 'wallet-balance',
-    meta: { width: '100px' },
+    meta: { width: 100 },
   },
   {
     cell: function CallToAction({ row }) {
@@ -80,7 +80,7 @@ const stakeColumns = ({ t }: StakeColumnsProps): ColumnDef<StakeToken>[] => [
     },
     header: () => <Header text={t('stake.action')} />,
     id: 'action',
-    meta: { width: '80px' },
+    meta: { width: 80 },
   },
 ]
 

--- a/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -68,7 +68,7 @@ const stakeColumns = ({ t }: StakeColumnsProps): ColumnDef<StakeToken>[] => [
     ),
     header: () => <Header text={t('protocol')} />,
     id: 'protocol',
-    meta: { width: '150px' },
+    meta: { width: 150 },
   },
   {
     cell: ({ row }) => (
@@ -79,7 +79,7 @@ const stakeColumns = ({ t }: StakeColumnsProps): ColumnDef<StakeToken>[] => [
     ),
     header: () => <Header text={t('asset')} />,
     id: 'asset',
-    meta: { width: '120px' },
+    meta: { width: 120 },
   },
   {
     cell: ({ row }) => (
@@ -90,7 +90,7 @@ const stakeColumns = ({ t }: StakeColumnsProps): ColumnDef<StakeToken>[] => [
     ),
     header: () => <Header text={t('dashboard.staked')} />,
     id: 'staked',
-    meta: { width: '100px' },
+    meta: { width: 100 },
   },
   {
     cell: ({ row }) => (
@@ -100,7 +100,7 @@ const stakeColumns = ({ t }: StakeColumnsProps): ColumnDef<StakeToken>[] => [
     ),
     header: () => <Header text={t('action')} />,
     id: 'action',
-    meta: { className: 'justify-end', width: '75px' },
+    meta: { className: 'justify-end', width: 75 },
   },
 ]
 

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
@@ -49,7 +49,7 @@ const stakingColumns = ({
     ),
     header: () => <Header text={t('table.locked-amount')} />,
     id: 'locked-amount',
-    meta: { width: '170px' },
+    meta: { width: 170 },
   },
   {
     cell({ row }) {
@@ -64,7 +64,7 @@ const stakingColumns = ({
     },
     header: () => <Header text={t('table.lockup')} />,
     id: 'lockup',
-    meta: { width: '120px' },
+    meta: { width: 120 },
   },
   {
     cell({ row }) {
@@ -77,7 +77,7 @@ const stakingColumns = ({
     },
     header: () => <Header text={t('voting-power')} />,
     id: 'voting-power',
-    meta: { width: '150px' },
+    meta: { width: 150 },
   },
   {
     cell({ row }) {
@@ -90,20 +90,20 @@ const stakingColumns = ({
     },
     header: () => <Header text={t('table.claimable-rewards')} />,
     id: 'rewards',
-    meta: { width: '170px' },
+    meta: { width: 170 },
   },
   {
     cell: ({ row }) => <TimeRemaining operation={row.original} />,
     header: () => <Header text={t('table.time-remaining')} />,
     id: 'time-remaining',
-    meta: { className: 'justify-end', width: '140px' },
+    meta: { className: 'justify-end', width: 140 },
   },
   {
     cell: ({ row }) => (
       <ActionCell openRowId={openRowId} row={row} setOpenRowId={setOpenRowId} />
     ),
     id: 'action',
-    meta: { width: '60px' },
+    meta: { width: 60 },
   },
 ]
 

--- a/portal/components/table/_components/column.tsx
+++ b/portal/components/table/_components/column.tsx
@@ -2,7 +2,7 @@ import { ComponentProps } from 'react'
 
 export const Column = ({ className, ...props }: ComponentProps<'td'>) => (
   <td
-    className={`flex h-full min-h-16 w-full flex-grow cursor-pointer items-center border-b border-solid 
+    className={`flex h-full min-h-16 w-full min-w-0 flex-grow cursor-pointer items-center border-b border-solid
       border-neutral-300/55 py-2.5 group-hover/row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pr-4 ${
         className ?? ''
       }`}

--- a/portal/components/table/_components/columnHeader.tsx
+++ b/portal/components/table/_components/columnHeader.tsx
@@ -6,7 +6,7 @@ export const ColumnHeader = ({
   style,
 }: ComponentProps<'th'>) => (
   <th
-    className={`flex w-full flex-grow items-center ${className} whitespace-nowrap font-medium first:[&>span]:pl-4 last:[&>span]:pr-4`}
+    className={`flex w-full min-w-0 flex-grow items-center ${className} whitespace-nowrap font-medium first:[&>span]:pl-4 last:[&>span]:pr-4`}
     style={style}
   >
     {children}

--- a/portal/components/table/_components/tableBodyContainer.tsx
+++ b/portal/components/table/_components/tableBodyContainer.tsx
@@ -1,10 +1,17 @@
-import { ComponentProps } from 'react'
+import { ComponentProps, RefObject } from 'react'
 
-export const TableBodyContainer = (
-  props: Omit<ComponentProps<'div'>, 'className'>,
-) => (
-  <div
-    className="-mt-1.5 mb-1 min-h-0 flex-1 overflow-y-auto overflow-x-hidden rounded-xl bg-white shadow-md"
-    {...props}
-  />
+type Props = Omit<ComponentProps<'div'>, 'className' | 'ref'> & {
+  scrollRef?: RefObject<HTMLDivElement | null>
+}
+
+export const TableBodyContainer = ({
+  children,
+  scrollRef,
+  ...props
+}: Props) => (
+  <div className="-mt-1.5 mb-1 min-h-0 flex-1 overflow-hidden rounded-xl bg-white shadow-md">
+    <div className="size-full overflow-auto" ref={scrollRef} {...props}>
+      {children}
+    </div>
+  </div>
 )

--- a/portal/components/table/index.tsx
+++ b/portal/components/table/index.tsx
@@ -12,6 +12,7 @@ import {
   ComponentType,
   ReactNode,
   RefObject,
+  UIEventHandler,
   useRef,
 } from 'react'
 import { screenBreakpoints } from 'styles'
@@ -30,15 +31,19 @@ import { useTableVirtualizer } from './_hooks/useTableVirtualizer'
 
 type TableHeaderProps<TData> = {
   hasVerticalBodyScrollbar: boolean
+  headerScrollRef: RefObject<HTMLDivElement | null>
   smallBreakpoint: number
   table: ReturnType<typeof useReactTable<TData>>
+  tableMinWidth: number
   width: number
 }
 
 const TableHeader = <TData,>({
   hasVerticalBodyScrollbar,
+  headerScrollRef,
   smallBreakpoint,
   table,
+  tableMinWidth,
   width,
 }: TableHeaderProps<TData>) => (
   <div
@@ -46,36 +51,42 @@ const TableHeader = <TData,>({
       hasVerticalBodyScrollbar && width >= smallBreakpoint ? 'pr-2.5' : ''
     }`}
   >
-    <table className="w-full border-separate border-spacing-0 whitespace-nowrap">
-      <thead>
-        {table.getHeaderGroups().map(headerGroup => (
-          <tr className="flex w-full items-center" key={headerGroup.id}>
-            {headerGroup.headers.map(header => (
-              <ColumnHeader
-                className={
-                  header.column.columnDef.meta?.className ?? 'justify-start'
-                }
-                key={header.id}
-                style={{
-                  width: header.column.columnDef.meta?.width,
-                }}
-              >
-                {flexRender(
-                  header.column.columnDef.header,
-                  header.getContext(),
-                )}
-              </ColumnHeader>
-            ))}
-          </tr>
-        ))}
-      </thead>
-    </table>
+    <div className="overflow-x-hidden" ref={headerScrollRef}>
+      <table
+        className="w-full border-separate border-spacing-0 whitespace-nowrap"
+        style={{ minWidth: `${tableMinWidth}px` }}
+      >
+        <thead>
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr className="flex w-full items-center" key={headerGroup.id}>
+              {headerGroup.headers.map(header => (
+                <ColumnHeader
+                  className={
+                    header.column.columnDef.meta?.className ?? 'justify-start'
+                  }
+                  key={header.id}
+                  style={{
+                    width: header.column.columnDef.meta?.width,
+                  }}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+                </ColumnHeader>
+              ))}
+            </tr>
+          ))}
+        </thead>
+      </table>
+    </div>
   </div>
 )
 
 type TableBodyProps<TData> = {
   CellComponent: ComponentType<ComponentProps<'td'>>
   fetchMoreOnBottomReached: (el?: HTMLDivElement | null) => void
+  headerScrollRef: RefObject<HTMLDivElement | null>
   isFetching: boolean
   loading: boolean
   onRowClick?: (row: TData) => void
@@ -86,11 +97,13 @@ type TableBodyProps<TData> = {
   scrollContainerRef: RefObject<HTMLDivElement | null>
   skeletonRows: number
   table: ReturnType<typeof useReactTable<TData>>
+  tableMinWidth: number
 }
 
 function TableBody<TData>({
   CellComponent,
   fetchMoreOnBottomReached,
+  headerScrollRef,
   isFetching,
   loading,
   onRowClick,
@@ -101,23 +114,34 @@ function TableBody<TData>({
   scrollContainerRef,
   skeletonRows,
   table,
+  tableMinWidth,
   virtualItems,
 }: TableBodyProps<TData> & {
   virtualItems: ReturnType<typeof rowVirtualizer.getVirtualItems>
 }) {
   const { rows } = table.getRowModel()
 
+  const handleScroll: UIEventHandler<HTMLDivElement> = function (e) {
+    fetchMoreOnBottomReached(e.currentTarget)
+    if (headerScrollRef.current) {
+      headerScrollRef.current.scrollLeft = e.currentTarget.scrollLeft
+    }
+  }
+
   return (
     <TableBodyContainer
-      onScroll={e => fetchMoreOnBottomReached(e.currentTarget)}
-      ref={scrollContainerRef}
+      onScroll={handleScroll}
+      scrollRef={scrollContainerRef}
       style={{
         scrollbarColor: '#d4d4d4 transparent',
         scrollbarWidth: 'thin',
       }}
     >
       {!placeholder ? (
-        <table className="w-full border-separate border-spacing-0 whitespace-nowrap">
+        <table
+          className="w-full border-separate border-spacing-0 whitespace-nowrap"
+          style={{ minWidth: `${tableMinWidth}px` }}
+        >
           <tbody
             className="relative"
             style={{
@@ -159,48 +183,70 @@ function TableBody<TData>({
 
 type StaticTableBodyProps<TData> = {
   CellComponent: ComponentType<ComponentProps<'td'>>
+  headerScrollRef: RefObject<HTMLDivElement | null>
   loading: boolean
   onRowClick?: (row: TData) => void
   onRowHover?: (index: number | null) => void
   placeholder?: ReactNode
   skeletonRows: number
   table: ReturnType<typeof useReactTable<TData>>
+  tableMinWidth: number
 }
 
 function StaticTableBody<TData>({
   CellComponent,
+  headerScrollRef,
   loading,
   onRowClick,
   onRowHover,
   placeholder,
   skeletonRows,
   table,
+  tableMinWidth,
 }: StaticTableBodyProps<TData>) {
   const { rows } = table.getRowModel()
 
+  const handleScroll: UIEventHandler<HTMLDivElement> = function (e) {
+    if (headerScrollRef.current) {
+      headerScrollRef.current.scrollLeft = e.currentTarget.scrollLeft
+    }
+  }
+
   return (
     <div className="-mt-1.5 mb-1 overflow-hidden rounded-xl bg-white shadow-md">
-      {!placeholder ? (
-        <table className="w-full border-separate border-spacing-0 whitespace-nowrap">
-          <tbody>
-            <LoadingSkeletonRows
-              loading={loading}
-              rows={rows}
-              skeletonRows={skeletonRows}
-              table={table}
-            />
-            <StaticRows
-              CellComponent={CellComponent}
-              loading={loading}
-              onRowClick={onRowClick}
-              onRowHover={onRowHover}
-              rows={rows}
-            />
-          </tbody>
-        </table>
-      ) : (
-        placeholder
-      )}
+      <div
+        className="overflow-x-auto"
+        onScroll={handleScroll}
+        style={{
+          scrollbarColor: '#d4d4d4 transparent',
+          scrollbarWidth: 'thin',
+        }}
+      >
+        {!placeholder ? (
+          <table
+            className="w-full border-separate border-spacing-0 whitespace-nowrap"
+            style={{ minWidth: `${tableMinWidth}px` }}
+          >
+            <tbody>
+              <LoadingSkeletonRows
+                loading={loading}
+                rows={rows}
+                skeletonRows={skeletonRows}
+                table={table}
+              />
+              <StaticRows
+                CellComponent={CellComponent}
+                loading={loading}
+                onRowClick={onRowClick}
+                onRowHover={onRowHover}
+                rows={rows}
+              />
+            </tbody>
+          </table>
+        ) : (
+          placeholder
+        )}
+      </div>
     </div>
   )
 }
@@ -241,6 +287,7 @@ export function Table<TData>({
   smallBreakpoint = screenBreakpoints.lg,
 }: TableProps<TData>) {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const headerScrollRef = useRef<HTMLDivElement>(null)
   const { height, width } = useWindowSize()
 
   const hasVerticalBodyScrollbar = useScrollbarDetection({
@@ -266,6 +313,11 @@ export function Table<TData>({
     state: { columnOrder },
   })
 
+  const tableMinWidth = columns.reduce(
+    (sum, col) => sum + (col.meta?.width ?? 0),
+    0,
+  )
+
   const { rows } = table.getRowModel()
 
   const { fetchMoreOnBottomReached } = useInfiniteScroll({
@@ -287,50 +339,46 @@ export function Table<TData>({
   const heightClass = isVirtual ? ' h-full' : ''
 
   return (
-    <div className={`flex flex-col${heightClass}`}>
-      <div
-        className={`flex flex-col overflow-x-auto${heightClass}`}
-        style={{
-          scrollbarColor: '#d4d4d4 transparent',
-          scrollbarWidth: 'thin',
-        }}
-      >
-        <div className={`flex min-w-max flex-col px-1${heightClass}`}>
-          <TableHeader
-            hasVerticalBodyScrollbar={hasVerticalBodyScrollbar}
-            smallBreakpoint={smallBreakpoint}
-            table={table}
-            width={width}
-          />
-          {isVirtual ? (
-            <TableBody
-              CellComponent={CellComponent}
-              fetchMoreOnBottomReached={fetchMoreOnBottomReached}
-              isFetching={isFetching}
-              loading={loading}
-              onRowClick={onRowClick}
-              onRowHover={onRowHover}
-              placeholder={placeholder}
-              rowSize={rowSize}
-              rowVirtualizer={rowVirtualizer}
-              scrollContainerRef={scrollContainerRef}
-              skeletonRows={skeletonRows}
-              table={table}
-              virtualItems={virtualItems}
-            />
-          ) : (
-            <StaticTableBody
-              CellComponent={CellComponent}
-              loading={loading}
-              onRowClick={onRowClick}
-              onRowHover={onRowHover}
-              placeholder={placeholder}
-              skeletonRows={skeletonRows}
-              table={table}
-            />
-          )}
-        </div>
-      </div>
+    <div className={`flex flex-col px-1${heightClass}`}>
+      <TableHeader
+        hasVerticalBodyScrollbar={hasVerticalBodyScrollbar}
+        headerScrollRef={headerScrollRef}
+        smallBreakpoint={smallBreakpoint}
+        table={table}
+        tableMinWidth={tableMinWidth}
+        width={width}
+      />
+      {isVirtual ? (
+        <TableBody
+          CellComponent={CellComponent}
+          fetchMoreOnBottomReached={fetchMoreOnBottomReached}
+          headerScrollRef={headerScrollRef}
+          isFetching={isFetching}
+          loading={loading}
+          onRowClick={onRowClick}
+          onRowHover={onRowHover}
+          placeholder={placeholder}
+          rowSize={rowSize}
+          rowVirtualizer={rowVirtualizer}
+          scrollContainerRef={scrollContainerRef}
+          skeletonRows={skeletonRows}
+          table={table}
+          tableMinWidth={tableMinWidth}
+          virtualItems={virtualItems}
+        />
+      ) : (
+        <StaticTableBody
+          CellComponent={CellComponent}
+          headerScrollRef={headerScrollRef}
+          loading={loading}
+          onRowClick={onRowClick}
+          onRowHover={onRowHover}
+          placeholder={placeholder}
+          skeletonRows={skeletonRows}
+          table={table}
+          tableMinWidth={tableMinWidth}
+        />
+      )}
     </div>
   )
 }

--- a/portal/components/table/index.tsx
+++ b/portal/components/table/index.tsx
@@ -313,10 +313,9 @@ export function Table<TData>({
     state: { columnOrder },
   })
 
-  const tableMinWidth = columns.reduce(
-    (sum, col) => sum + (col.meta?.width ?? 0),
-    0,
-  )
+  const tableMinWidth = table
+    .getVisibleLeafColumns()
+    .reduce((sum, column) => sum + (column.columnDef.meta?.width ?? 0), 0)
 
   const { rows } = table.getRowModel()
 

--- a/portal/react-table.d.ts
+++ b/portal/react-table.d.ts
@@ -4,6 +4,6 @@ declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData, TValue> {
     className?: string
-    width?: string
+    width: number
   }
 }


### PR DESCRIPTION
### Description

This PR Improves mobile table layout to keep card in viewport. Previously the rounded card chrome of the Table component grew with content on small viewports, bleeding past the viewport edge and clipping rounded corners and trailing columns.

Restructure the chrome so the gray header and white body cards stay viewport-width while horizontal scroll happens inside each card. The header is scroll-synced with the body so columns stay aligned.

To prevent body cells expanding past their declared widths (which caused header/body misalignment in virtual mode tables), add min-w-0 to cells and pin both tables to an explicit min-width derived from the sum of column widths.

Tighten ColumnMeta.width to a required number (px) so unit ambiguity is gone at the type level and missing widths fail at compile time. Update all 32 callers from 'XXpx' strings to numbers.

### Screenshots

https://github.com/user-attachments/assets/2d7f8386-8e68-44f5-9004-98db0c285daa

### Related issue(s)

Closes #1594 
Fixes #1594 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
