### PR TITLE
Align mobile Get Started button with secondary-xl

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/getStarted/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/getStarted/index.tsx
@@ -1,4 +1,4 @@
-import { ButtonLink } from 'components/button'
+import { ButtonLink, type ButtonSize } from 'components/button'
 import { Chevron } from 'components/icons/chevron'
 import { Link } from 'components/link'
 import { useUmami } from 'hooks/useUmami'
@@ -6,11 +6,12 @@ import { useTranslations } from 'next-intl'
 import React, { ComponentProps, Suspense } from 'react'
 
 type Props = Pick<ComponentProps<typeof Link>, 'href' | 'onClick'> & {
+  size?: ButtonSize
   t: ReturnType<typeof useTranslations<'navbar'>>
 }
 
-const UI = ({ href, onClick, t }: Props) => (
-  <ButtonLink href={href} onClick={onClick} size="small" variant="secondary">
+const UI = ({ href, onClick, size = 'small', t }: Props) => (
+  <ButtonLink href={href} onClick={onClick} size={size} variant="secondary">
     <span>{t('get-started')}</span>
     <Chevron.Right className="[&>path]:fill-neutral-500" />
   </ButtonLink>
@@ -24,9 +25,10 @@ const GetStartedImpl = function (props: Omit<Props, 'onClick'>) {
   return <UI {...props} onClick={onClick} />
 }
 
-export const GetStarted = function () {
+export const GetStarted = function ({ size }: { size?: ButtonSize } = {}) {
   const props = {
     href: '/get-started',
+    size,
     t: useTranslations('navbar'),
   }
 

--- a/portal/app/[locale]/_components/navbar/navbarMobile.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarMobile.tsx
@@ -147,9 +147,9 @@ export const NavbarMobile = function () {
           </FullItem>
         </ul>
       </div>
-      <div className="flex w-full shrink-0 items-center gap-x-3 bg-white p-5 [&_a]:size-full [&_button]:size-11">
+      <div className="flex w-full shrink-0 items-center gap-x-3 bg-white p-5 [&_a]:w-full [&_button]:size-11">
         <Help />
-        <GetStarted />
+        <GetStarted size="xLarge" />
       </div>
     </div>
   )


### PR DESCRIPTION
### Description

This PR fixes the mobile navbar's Get Started CTA, which was using `size="small"` stretched to 44px via `[&_a]:size-full` and didn't match the design system's `secondary-xl` token.

### Screenshots

Before:
<img width="447" height="118" alt="Captura de Tela 2026-04-30 às 10 16 02" src="https://github.com/user-attachments/assets/b7a23df8-8960-4c60-a76f-54a24afba325" />


After:
<img width="436" height="132" alt="Captura de Tela 2026-04-30 às 10 15 53" src="https://github.com/user-attachments/assets/3f79e3e4-05c8-4a08-ac89-f30435ec3e47" />

### Related issue(s)

Closes #1748
Fixes #1748 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
