### PR TITLE
Refactor Spinner color prop to variant

### DIFF
--- a/portal/app/[locale]/btc-yield/_components/actions.tsx
+++ b/portal/app/[locale]/btc-yield/_components/actions.tsx
@@ -77,7 +77,7 @@ export const Actions = function ({ row }: Props) {
           variant="secondary"
         >
           {loadingStrategies ? (
-            <Spinner size="xSmall" variant="orange-600" />
+            <Spinner size="xSmall" variant="orange" />
           ) : row.getIsExpanded() ? (
             <Chevron.Up className={cssHoverChevron} />
           ) : (

--- a/portal/app/[locale]/btc-yield/_components/actions.tsx
+++ b/portal/app/[locale]/btc-yield/_components/actions.tsx
@@ -5,7 +5,6 @@ import { Chevron } from 'components/icons/chevron'
 import { Spinner } from 'components/spinner'
 import { useTokenBalance } from 'hooks/useBalance'
 import { useTranslations } from 'next-intl'
-import { orange600 } from 'styles'
 
 import { useOperationDrawer } from '../_hooks/useOperationDrawer'
 import { usePoolAsset } from '../_hooks/usePoolAsset'
@@ -78,7 +77,7 @@ export const Actions = function ({ row }: Props) {
           variant="secondary"
         >
           {loadingStrategies ? (
-            <Spinner color={orange600} size="xSmall" />
+            <Spinner size="xSmall" variant="orange-600" />
           ) : row.getIsExpanded() ? (
             <Chevron.Up className={cssHoverChevron} />
           ) : (

--- a/portal/app/[locale]/btc-yield/_components/claim.tsx
+++ b/portal/app/[locale]/btc-yield/_components/claim.tsx
@@ -40,7 +40,7 @@ export const Claim = function () {
       !address ? (
         t('bitcoin-yield.table.claim-rewards')
       ) : (
-        <Spinner size="xSmall" variant="orange-600" />
+        <Spinner size="xSmall" variant="orange" />
       )}
     </Button>
   )

--- a/portal/app/[locale]/btc-yield/_components/claim.tsx
+++ b/portal/app/[locale]/btc-yield/_components/claim.tsx
@@ -2,7 +2,6 @@ import { Button } from 'components/button'
 import { Spinner } from 'components/spinner'
 import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
-import { orange600 } from 'styles'
 import { useAccount } from 'wagmi'
 
 import { useHasClaimableRewards } from '../_hooks/useHasClaimableRewards'
@@ -41,7 +40,7 @@ export const Claim = function () {
       !address ? (
         t('bitcoin-yield.table.claim-rewards')
       ) : (
-        <Spinner color={orange600} size="xSmall" />
+        <Spinner size="xSmall" variant="orange-600" />
       )}
     </Button>
   )

--- a/portal/app/[locale]/btc-yield/_components/withdraw.tsx
+++ b/portal/app/[locale]/btc-yield/_components/withdraw.tsx
@@ -30,7 +30,7 @@ export const Withdraw = function () {
       variant="secondary"
     >
       {poolBalanceLoading && !!address ? (
-        <Spinner size="xSmall" variant="orange-600" />
+        <Spinner size="xSmall" variant="orange" />
       ) : (
         t('common.withdraw')
       )}

--- a/portal/app/[locale]/btc-yield/_components/withdraw.tsx
+++ b/portal/app/[locale]/btc-yield/_components/withdraw.tsx
@@ -1,7 +1,6 @@
 import { Button } from 'components/button'
 import { Spinner } from 'components/spinner'
 import { useTranslations } from 'next-intl'
-import { orange600 } from 'styles'
 import { useAccount } from 'wagmi'
 
 import { useOperationDrawer } from '../_hooks/useOperationDrawer'
@@ -31,7 +30,7 @@ export const Withdraw = function () {
       variant="secondary"
     >
       {poolBalanceLoading && !!address ? (
-        <Spinner color={orange600} size="xSmall" />
+        <Spinner size="xSmall" variant="orange-600" />
       ) : (
         t('common.withdraw')
       )}

--- a/portal/app/[locale]/genesis-drop/_components/eligible.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/eligible.tsx
@@ -63,7 +63,7 @@ export const Eligible = function ({ eligibility }: Props) {
   if (isClaimable === undefined) {
     return (
       <div className="mt-5">
-        <Spinner size="small" variant="orange-bright" />
+        <Spinner size="small" variant="orange" />
       </div>
     )
   }

--- a/portal/app/[locale]/genesis-drop/_components/eligible.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/eligible.tsx
@@ -63,7 +63,7 @@ export const Eligible = function ({ eligibility }: Props) {
   if (isClaimable === undefined) {
     return (
       <div className="mt-5">
-        <Spinner color="#FF6A00" size="small" />
+        <Spinner size="small" variant="orange-bright" />
       </div>
     )
   }

--- a/portal/app/[locale]/genesis-drop/page.tsx
+++ b/portal/app/[locale]/genesis-drop/page.tsx
@@ -67,7 +67,7 @@ export default function Page() {
 
     const spinner = (
       <div className="mt-5">
-        <Spinner size="small" variant="orange-bright" />
+        <Spinner size="small" variant="orange" />
       </div>
     )
 

--- a/portal/app/[locale]/genesis-drop/page.tsx
+++ b/portal/app/[locale]/genesis-drop/page.tsx
@@ -67,7 +67,7 @@ export default function Page() {
 
     const spinner = (
       <div className="mt-5">
-        <Spinner color="#FF6A00" size="small" />
+        <Spinner size="small" variant="orange-bright" />
       </div>
     )
 

--- a/portal/app/[locale]/tunnel/transaction-history/_components/tunnelHistorySyncStatus.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/tunnelHistorySyncStatus.tsx
@@ -14,7 +14,7 @@ export const TunnelHistorySyncStatus = function () {
     <div
       className={`flex items-center gap-x-1 ${hide ? 'invisible' : 'block'}`}
     >
-      <Spinner size={15} variant="orange-warm" />
+      <Spinner size={15} variant="orange" />
       <span className="text-neutral-600">{t('loading-transactions')}</span>
     </div>
   )

--- a/portal/app/[locale]/tunnel/transaction-history/_components/tunnelHistorySyncStatus.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/tunnelHistorySyncStatus.tsx
@@ -14,7 +14,7 @@ export const TunnelHistorySyncStatus = function () {
     <div
       className={`flex items-center gap-x-1 ${hide ? 'invisible' : 'block'}`}
     >
-      <Spinner color="#FF6C15" size={15} />
+      <Spinner size={15} variant="orange-warm" />
       <span className="text-neutral-600">{t('loading-transactions')}</span>
     </div>
   )

--- a/portal/components/spinner.tsx
+++ b/portal/components/spinner.tsx
@@ -1,15 +1,24 @@
 import React, { useId } from 'react'
 
+const variantColors = {
+  'light': '#FFF7F0',
+  'orange-600': '#FF4600',
+  'orange-bright': '#FF6A00',
+  'orange-warm': '#FF6C15',
+} as const
+
+type SpinnerVariant = keyof typeof variantColors
+
 type SpinnerProps = {
-  size?: 'xSmall' | 'small' | 'medium' | 'large' | number
-  color?: string
   className?: string
+  size?: 'xSmall' | 'small' | 'medium' | 'large' | number
+  variant?: SpinnerVariant
 }
 
 export const Spinner = function ({
   className = '',
-  color = '#FFF7F0',
   size = 'medium',
+  variant = 'light',
 }: SpinnerProps) {
   // IMPORTANT: We generate a unique ID for each spinner instance using React's useId() hook.
   // This ensures that when multiple spinners are used on the same page, each has its own
@@ -18,6 +27,8 @@ export const Spinner = function ({
   // have different colors. The unique ID prevents these conflicts by giving each spinner
   // its own isolated gradient definitions in the SVG.
   const uniqueId = useId()
+
+  const color = variantColors[variant]
 
   const getDimensions = function () {
     if (typeof size === 'number') {

--- a/portal/components/spinner.tsx
+++ b/portal/components/spinner.tsx
@@ -1,10 +1,9 @@
 import React, { useId } from 'react'
+import { orange600 } from 'styles'
 
 const variantColors = {
-  'light': '#FFF7F0',
-  'orange-600': '#FF4600',
-  'orange-bright': '#FF6A00',
-  'orange-warm': '#FF6C15',
+  light: '#FFF7F0',
+  orange: orange600,
 } as const
 
 type SpinnerVariant = keyof typeof variantColors


### PR DESCRIPTION
### Description

This PR refactors the Spinner component to expose a typed `variant` prop instead of a free-form `color` string. The component now owns the small set of valid colors (`light`, `orange-600`, `orange-bright`, `orange-warm`) and call sites pick one by name, which keeps loading states visually consistent across the portal and avoids arbitrary hex values scattered around the codebase.

### Screenshots

No UI changes.

### Related issue(s)

Closes #1651 
Fixes #1651 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
