### PR TITLE
Bump @tanstack/react-table to 8.21.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10343,12 +10343,12 @@
       }
     },
     "node_modules/@tanstack/react-table": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.2.tgz",
-      "integrity": "sha512-11tNlEDTdIhMJba2RBH+ecJ9l1zgS2kjmexDPAraulc8jeNA4xocSNeyzextT0XJyASil4XsCYlJmf5jEWAtYg==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/table-core": "8.21.2"
+        "@tanstack/table-core": "8.21.3"
       },
       "engines": {
         "node": ">=12"
@@ -10380,9 +10380,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.2.tgz",
-      "integrity": "sha512-uvXk/U4cBiFMxt+p9/G7yUWI/UbHYbyghLCjlpWZ3mLeIZiUBSKcUnw9UnKkdRz7Z/N4UBuFLWQdJCjUe7HjvA==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -29345,7 +29345,7 @@
         "@rainbow-me/rainbowkit": "2.2.8",
         "@sentry/nextjs": "9.9.0",
         "@tanstack/react-query": "5.69.0",
-        "@tanstack/react-table": "8.21.2",
+        "@tanstack/react-table": "8.21.3",
         "@tanstack/react-virtual": "3.13.4",
         "big.js": "7.0.1",
         "btc-wallet": "1.0.0",

--- a/portal/package.json
+++ b/portal/package.json
@@ -22,7 +22,7 @@
     "@rainbow-me/rainbowkit": "2.2.8",
     "@sentry/nextjs": "9.9.0",
     "@tanstack/react-query": "5.69.0",
-    "@tanstack/react-table": "8.21.2",
+    "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.4",
     "big.js": "7.0.1",
     "btc-wallet": "1.0.0",


### PR DESCRIPTION
### Description

This PR bumps `@tanstack/react-table` from 8.21.2 to 8.21.3 in the portal workspace. It's a single-patch release with one bug fix: `getResizeHandler` now uses the correct `Document` instance for the column-sizing feature. No API changes, no deprecations, no follow-up work needed in our code.

### Screenshots

No UI changes.

### Related issue(s)

Related to #1886 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
