### PR TITLE
Bump @tanstack/react-virtual to 3.13.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -924,7 +924,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -942,7 +941,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -960,7 +958,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -978,7 +975,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -996,7 +992,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1014,7 +1009,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1032,7 +1026,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1050,7 +1043,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1068,7 +1060,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1086,7 +1077,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1104,7 +1094,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1122,7 +1111,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1140,7 +1128,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1158,7 +1145,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1176,7 +1162,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1194,7 +1179,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1212,7 +1196,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1230,7 +1213,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1248,7 +1230,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1266,7 +1247,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1284,7 +1264,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1302,7 +1281,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1320,7 +1298,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1338,7 +1315,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1356,7 +1332,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1374,7 +1349,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9188,8 +9162,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
       "version": "4.35.0",
@@ -9229,8 +9202,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.35.0",
@@ -9257,8 +9229,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.35.0",
@@ -9311,8 +9282,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.35.0",
@@ -9352,8 +9322,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.35.0",
@@ -10890,12 +10859,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.4.tgz",
-      "integrity": "sha512-jPWC3BXvVLHsMX67NEHpJaZ+/FySoNxFfBEiF4GBc1+/nVwdRm+UcSCYnKP3pXQr0eEsDpXi/PQZhNfJNopH0g==",
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.4"
+        "@tanstack/virtual-core": "3.14.0"
       },
       "funding": {
         "type": "github",
@@ -10920,9 +10889,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.4.tgz",
-      "integrity": "sha512-fNGO9fjjSLns87tlcto106enQQLycCKR4DPNpgq3djP5IdcPFdPAmaKjsgzIeRhH7hWrELgW12hYnRthS5kLUw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -28456,8 +28425,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-android-arm64": {
       "version": "4.53.2",
@@ -28471,8 +28439,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.53.2",
@@ -28486,8 +28453,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.53.2",
@@ -28501,8 +28467,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.53.2",
@@ -28516,8 +28481,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.53.2",
@@ -28531,8 +28495,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.53.2",
@@ -28546,8 +28509,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.53.2",
@@ -28561,8 +28523,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.53.2",
@@ -28576,8 +28537,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.53.2",
@@ -28591,8 +28551,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.53.2",
@@ -28606,8 +28565,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.53.2",
@@ -28621,8 +28579,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.53.2",
@@ -28636,8 +28593,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.53.2",
@@ -28651,8 +28607,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.53.2",
@@ -28666,8 +28621,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.53.2",
@@ -28681,8 +28635,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.53.2",
@@ -28696,8 +28649,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/vite/node_modules/postcss": {
       "version": "8.5.6",
@@ -29962,7 +29914,7 @@
         "@sentry/nextjs": "9.9.0",
         "@tanstack/react-query": "5.69.0",
         "@tanstack/react-table": "8.21.3",
-        "@tanstack/react-virtual": "3.13.4",
+        "@tanstack/react-virtual": "3.13.24",
         "big.js": "7.0.1",
         "btc-wallet": "1.0.0",
         "camelcase-keys": "10.0.0",

--- a/portal/package.json
+++ b/portal/package.json
@@ -23,7 +23,7 @@
     "@sentry/nextjs": "9.9.0",
     "@tanstack/react-query": "5.69.0",
     "@tanstack/react-table": "8.21.3",
-    "@tanstack/react-virtual": "3.13.4",
+    "@tanstack/react-virtual": "3.13.24",
     "big.js": "7.0.1",
     "btc-wallet": "1.0.0",
     "camelcase-keys": "10.0.0",


### PR DESCRIPTION
### Description

This PR bumps `@tanstack/react-virtual` from 3.13.4 to 3.13.24 in the portal workspace. The only substantive addition is the new `useFlushSync` option introduced in 3.13.15, which defaults to `true` and therefore preserves the current behavior. No deprecations, no renames, no API surface changes.

Reference: https://github.com/TanStack/virtual/blob/main/packages/react-virtual/CHANGELOG.md

### Screenshots

No UI changes.

### Related issue(s)

Related to #1886 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
