### PR TITLE
Bump @tanstack/react-query to 5.100.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10813,9 +10813,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.69.0.tgz",
-      "integrity": "sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ==",
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -10823,12 +10823,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.69.0.tgz",
-      "integrity": "sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==",
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.69.0"
+        "@tanstack/query-core": "5.100.9"
       },
       "funding": {
         "type": "github",
@@ -29590,7 +29590,7 @@
         "esplora-client": "1.2.0"
       },
       "devDependencies": {
-        "@tanstack/react-query": "5.69.0",
+        "@tanstack/react-query": "5.100.9",
         "@types/react": "19.1.13",
         "react": "19.1.1",
         "typescript": "5.8.3",
@@ -29912,7 +29912,7 @@
         "@hemilabs/wallet-watch-asset": "1.0.2",
         "@rainbow-me/rainbowkit": "2.2.8",
         "@sentry/nextjs": "9.9.0",
-        "@tanstack/react-query": "5.69.0",
+        "@tanstack/react-query": "5.100.9",
         "@tanstack/react-table": "8.21.3",
         "@tanstack/react-virtual": "3.13.24",
         "big.js": "7.0.1",

--- a/packages/btc-wallet/package.json
+++ b/packages/btc-wallet/package.json
@@ -11,7 +11,7 @@
     "esplora-client": "1.2.0"
   },
   "devDependencies": {
-    "@tanstack/react-query": "5.69.0",
+    "@tanstack/react-query": "5.100.9",
     "@types/react": "19.1.13",
     "react": "19.1.1",
     "typescript": "5.8.3",

--- a/portal/package.json
+++ b/portal/package.json
@@ -21,7 +21,7 @@
     "@hemilabs/wallet-watch-asset": "1.0.2",
     "@rainbow-me/rainbowkit": "2.2.8",
     "@sentry/nextjs": "9.9.0",
-    "@tanstack/react-query": "5.69.0",
+    "@tanstack/react-query": "5.100.9",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.24",
     "big.js": "7.0.1",


### PR DESCRIPTION
### Description

This PR bumps `@tanstack/react-query` from 5.69.0 to 5.100.9 across the workspaces that pin it (`portal` as a runtime dep, `packages/btc-wallet` as a devDep). Both had to move together.

Range covers 31 minor releases but the changelog is mostly "Updated dependencies" rolls of `@tanstack/query-core`. The only documented additive features are `environmentManager` (5.91) and a callback form for `retryOnMount` (5.99). No breaking changes, no deprecations, none of the imported APIs across the 90 portal callsites were touched.

 Reference: https://github.com/TanStack/query/blob/main/packages/react-query/CHANGELOG.md

### Screenshots

No UI changes.

### Related issue(s)

Related to #1886 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
