### PR TITLE
Fix manual BTC deposit button size

### DIFF
--- a/portal/app/[locale]/tunnel/_components/confirmBtcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/confirmBtcDeposit.tsx
@@ -113,7 +113,7 @@ export const ConfirmBtcDeposit = function ({ deposit }: Props) {
       submitButton={
         <Button
           disabled={!isReadyToConfirm || isConfirming}
-          size="xLarge"
+          size="small"
           type="submit"
         >
           {t(`tunnel-page.submit-button.${getText()}`)}


### PR DESCRIPTION
### Description

This tiny PR fixes the size of the "Confirm deposit manually" button shown in the BTC deposit drawer when a deposit can't be processed automatically and the user has to confirm it by hand.

### Screenshots

Before
<img width="568" height="407" alt="Captura de Tela 2026-05-07 às 16 30 27" src="https://github.com/user-attachments/assets/d52ce248-3c31-4699-a239-4e2cc8eac578" />


After
<img width="604" height="455" alt="Captura de Tela 2026-05-07 às 16 30 38" src="https://github.com/user-attachments/assets/138a34ee-f293-4387-9db5-01745f989db1" />


### Related issue(s)


Closes #1890 
Fixes #1890 

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
