### PR TITLE
Fix Table infinite render loop on empty data

### DIFF
--- a/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/index.tsx
+++ b/portal/app/[locale]/hemi-earn/vault/[vaultAddress]/_components/composition/index.tsx
@@ -2,7 +2,7 @@
 
 import { Card } from 'components/card'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { type Address, type Chain } from 'viem'
 
@@ -52,10 +52,14 @@ export const Composition = function ({ chainId, vaultAddress }: Props) {
     viewMode,
   })
 
-  const dataWithColors = data.map((item, index) => ({
-    ...item,
-    color: compositionColors[index % compositionColors.length],
-  }))
+  const dataWithColors = useMemo(
+    () =>
+      data.map((item, index) => ({
+        ...item,
+        color: compositionColors[index % compositionColors.length],
+      })),
+    [data],
+  )
 
   const renderHeadline = function () {
     if (dataWithColors.length > 0) {

--- a/portal/components/table/_hooks/useTableData.tsx
+++ b/portal/components/table/_hooks/useTableData.tsx
@@ -17,6 +17,9 @@ type Props<TData> = Omit<
     width: number
   }
 
+// using a stable reference
+const emptyArray: unknown[] = []
+
 export function useTableData<TData>({
   columns,
   data,
@@ -46,7 +49,7 @@ export function useTableData<TData>({
     [skeletonRows],
   )
   const safeData =
-    data && data.length > 0 ? data : showSkeleton ? skeletonArray : []
+    data && data.length > 0 ? data : showSkeleton ? skeletonArray : emptyArray
 
   const columnOrder = getNewColumnOrder({
     breakpoint: smallBreakpoint,

--- a/portal/components/table/index.tsx
+++ b/portal/components/table/index.tsx
@@ -272,7 +272,7 @@ export type TableProps<TData> = {
 export function Table<TData>({
   cellComponent: CellComponent = Column,
   columns,
-  data = [],
+  data,
   fetchNextPage,
   hasNextPage = false,
   isFetching = false,


### PR DESCRIPTION
### Description

The portal was freezing on `/stake/dashboard` when the wallet was disconnected — the entire app got stuck in a render loop. Root cause: an unstable `data` reference being fed into `useReactTable` from the shared `Table` component.

In `useTableData`, the `safeData` fallback returned a fresh `[]` literal every render in the "empty and not loading" branch. With `data` changing reference each render, react-table's internal `getCoreRowModel` memo invalidated continuously, which fires `_autoResetPageIndex`, which queues a `setPagination` state update, which triggers another render — indefinitely.

This is the exact case called out in the TanStack Table FAQ: [How do I stop infinite rendering loops?](https://tanstack.com/table/latest/docs/faq#how-do-i-stop-infinite-rendering-loops) — `data` and `columns` must be referentially stable.

**Changes:**

- Hoist a module-level `emptyArray` in `useTableData` so the empty branch returns a stable reference.
- Remove the `data = []` default from the `Table` component — `useTableData` now handles empty/undefined consistently.
- Memoize `dataWithColors` in the vault `Composition` view; it was the only remaining caller passing an unstable array (inline `.map`) into `Table`.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.