### PR TITLE
Test Table safeData reference stability

### DIFF
--- a/portal/components/table/_hooks/useTableData.tsx
+++ b/portal/components/table/_hooks/useTableData.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
-import { getNewColumnOrder } from '../_utils'
+import { getNewColumnOrder, getSafeData } from '../_utils'
 import { TableProps } from '../index'
 
 type Props<TData> = Omit<
@@ -16,9 +16,6 @@ type Props<TData> = Omit<
   > & {
     width: number
   }
-
-// using a stable reference
-const emptyArray: unknown[] = []
 
 export function useTableData<TData>({
   columns,
@@ -48,8 +45,7 @@ export function useTableData<TData>({
     () => new Array(skeletonRows).fill(null),
     [skeletonRows],
   )
-  const safeData =
-    data && data.length > 0 ? data : showSkeleton ? skeletonArray : emptyArray
+  const safeData = getSafeData(data, showSkeleton, skeletonArray)
 
   const columnOrder = getNewColumnOrder({
     breakpoint: smallBreakpoint,

--- a/portal/components/table/_utils/index.ts
+++ b/portal/components/table/_utils/index.ts
@@ -1,5 +1,29 @@
 import { type ColumnDef } from '@tanstack/react-table'
 
+// Stable reference for the empty-data branch of getSafeData. Passing a fresh
+// `[]` literal to useReactTable invalidates getCoreRowModel's memo every render
+// and triggers an infinite render loop via _autoResetPageIndex → setPagination.
+const emptyArray: unknown[] = []
+
+/**
+ * Selects the array passed to useReactTable. Preserves referential stability:
+ * the empty branch always returns the same module-level reference so consumers
+ * don't trip useReactTable's getCoreRowModel memo invalidation.
+ */
+export function getSafeData<TData>(
+  data: TData[] | undefined,
+  showSkeleton: boolean,
+  skeletonArray: TData[],
+): TData[] {
+  if (data && data.length > 0) {
+    return data
+  }
+  if (showSkeleton) {
+    return skeletonArray
+  }
+  return emptyArray as TData[]
+}
+
 /**
  * Determines the column order for a table based on screen width and priority columns.
  * Returns the new column order only when the width exceeds the breakpoint and priority columns are provided.

--- a/portal/test/components/table/_utils/index.test.ts
+++ b/portal/test/components/table/_utils/index.test.ts
@@ -1,5 +1,5 @@
 import { type ColumnDef } from '@tanstack/react-table'
-import { getNewColumnOrder } from 'components/table/_utils'
+import { getNewColumnOrder, getSafeData } from 'components/table/_utils'
 import { describe, expect, it } from 'vitest'
 
 type TestData = {
@@ -106,5 +106,44 @@ describe('getNewColumnOrder', function () {
     })
 
     expect(result).toEqual(['updated', 'name', 'status', 'amount', 'created'])
+  })
+})
+
+describe('getSafeData', function () {
+  // Regression guard for PR #1898: returning a fresh `[]` literal in the
+  // empty branch breaks referential stability for useReactTable, which
+  // invalidates the getCoreRowModel memo every render and triggers an
+  // infinite render loop via _autoResetPageIndex → setPagination.
+  it('returns the same empty-array reference across calls when data is empty and not loading', function () {
+    const a = getSafeData<TestData>(undefined, false, [])
+    const b = getSafeData<TestData>([], false, [])
+    const c = getSafeData<TestData>(undefined, false, [])
+
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+  })
+
+  it('returns the caller-provided data reference when non-empty', function () {
+    const data: TestData[] = [
+      { amount: 1, id: 'a', name: 'Alice', status: 'ok' },
+    ]
+
+    expect(getSafeData(data, false, [])).toBe(data)
+  })
+
+  it('returns the skeleton array when data is empty and showSkeleton is true', function () {
+    const skeleton: TestData[] = [null, null] as unknown as TestData[]
+
+    expect(getSafeData<TestData>(undefined, true, skeleton)).toBe(skeleton)
+    expect(getSafeData<TestData>([], true, skeleton)).toBe(skeleton)
+  })
+
+  it('prefers real data over the skeleton when both are available', function () {
+    const data: TestData[] = [
+      { amount: 1, id: 'a', name: 'Alice', status: 'ok' },
+    ]
+    const skeleton: TestData[] = [null] as unknown as TestData[]
+
+    expect(getSafeData(data, true, skeleton)).toBe(data)
   })
 })


### PR DESCRIPTION
### Description

This PR adds a regression guard for the Table infinite render loop. The bug itself is already gone, but the failure mode is silent — type-check, lint, build and the existing test suite all pass when the empty-data branch in `useTableData` returns a fresh `[]` literal, even though useReactTable's `getCoreRowModel` memo invalidates every render and locks up the app via `_autoResetPageIndex` to `setPagination`.

To make it testable without dragging `@testing-library/react` + `jsdom` into the portal (the current convention is pure-function tests only), I extracted the array-selection logic out of `useTableData` into a new `getSafeData` helper in `components/table/_utils`. The hook now just calls `getSafeData(data, showSkeleton, skeletonArray)`. Behaviour is unchanged.

### Screenshots

https://github.com/user-attachments/assets/51e7503b-cfdb-4315-92ef-b9fe40f4d1d4

### Related issue(s)

Related to #1898 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
