### PR TITLE
Filter-out extraneous releases

### DIFF
--- a/portal/instrumentation-client.ts
+++ b/portal/instrumentation-client.ts
@@ -61,7 +61,29 @@ function enableSentry() {
     ...walletConnectErrors,
   ]
 
+  // Matches the format "portal@yyyymmdd_sequence". The project name is
+  // hardcoded as we are not going to change it anytime soon. Reading it from an
+  // environment variable would be possible but it would add unnecessary
+  // complexity IMO.
+  const releaseNameRegex = /^portal@\d{8}_\d+$/
+
   Sentry.init({
+    // This is a workaround to filter out errors that are not actionable and
+    // that we know are coming from browser extensions or unsupported wallets.
+    // We want to keep the noise down in Sentry to be able to focus on real
+    // issues.
+    beforeSend(event) {
+      if (event.release && !releaseNameRegex.test(event.release)) {
+        return null // Drops the error event
+      }
+      return event
+    },
+    beforeSendTransaction(event) {
+      if (event.release && !releaseNameRegex.test(event.release)) {
+        return null // Drops the transaction event
+      }
+      return event
+    },
     denyUrls: [
       // Filter all Wallet Connect related urls
       /(https|wss):\/\/.*\.walletconnect\.(com|org)/,

--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -41,16 +41,6 @@ const nextConfig: NextConfig = {
   },
 }
 
-const release =
-  process.env.SENTRY_ENVIRONMENT && process.env.SENTRY_RELEASE
-    ? {
-        deploy: {
-          env: process.env.SENTRY_ENVIRONMENT,
-        },
-        name: process.env.SENTRY_RELEASE,
-      }
-    : { create: false, finalize: false }
-
 const sentryOptions: SentryBuildOptions = {
   authToken: process.env.SENTRY_AUTH_TOKEN,
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#widen-the-upload-scope
@@ -59,7 +49,15 @@ const sentryOptions: SentryBuildOptions = {
   reactComponentAnnotation: {
     enabled: true,
   },
-  release,
+  release:
+    process.env.SENTRY_ENVIRONMENT && process.env.SENTRY_RELEASE
+      ? {
+          deploy: {
+            env: process.env.SENTRY_ENVIRONMENT,
+          },
+          name: process.env.SENTRY_RELEASE,
+        }
+      : undefined,
   // eslint-disable-next-line camelcase
   unstable_sentryWebpackPluginOptions: {
     applicationKey: process.env.NEXT_PUBLIC_SENTRY_FILTER_KEY_ID,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request introduces improvements to Sentry error and transaction filtering in the client instrumentation, and refactors how the Sentry release configuration is handled in the Next.js configuration. The main goal is to reduce noise in Sentry by filtering out irrelevant events and to simplify the release configuration logic.

**Sentry event filtering enhancements:**

* Added `beforeSend` and `beforeSendTransaction` hooks in `enableSentry` to filter out Sentry events whose `release` field does not match the expected format (`portal@yyyymmdd_sequence`). This helps reduce noise from errors originating from browser extensions or unsupported wallets.

**Sentry release configuration refactor:**

* Refactored the Sentry release configuration in `next.config.ts` to directly assign the `release` property in the `sentryOptions` object, making the logic more concise and removing the unnecessary intermediate `release` variable. [[1]](diffhunk://#diff-ceae93e68ff61f389a5d2e2b1c8114c5d856c7d42bb167e00d81efb8f576b33fL44-L53) [[2]](diffhunk://#diff-ceae93e68ff61f389a5d2e2b1c8114c5d856c7d42bb167e00d81efb8f576b33fL62-R60)

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1891 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
