### PR TITLE
Sort pnpm-workspace.yaml keys alphabetically

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,19 +1,14 @@
-packages:
-  - 'packages/*'
-  - 'portal'
-  - 'portal-backend/api'
-  - 'portal-backend/cron/*'
-  - 'subgraph-api'
-  - 'subgraphs/*'
+blockExoticSubdeps: true
+
+ignoredBuiltDependencies:
+  - 'bufferutil' # optional native ws speedup; ws falls back to pure JS
+  - 'core-js' # only a sponsor-banner postinstall, no functional payload
+  - 'keccak' # has a pure-JS fallback; the native addon is never loaded in the browser bundle
+  - 'utf-8-validate' # optional native ws speedup; ws falls back to pure JS
 
 minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - '@hemilabs/*'
-
-blockExoticSubdeps: true
-
-publicHoistPattern:
-  - '*eslint*'
 
 onlyBuiltDependencies:
   - '@parcel/watcher' # native file watcher used by next-intl in dev mode
@@ -23,14 +18,19 @@ onlyBuiltDependencies:
   - 'sharp' # libvips bindings required by Next.js production image optimization
   - 'unrs-resolver' # Rust resolver required by eslint-import-resolver-typescript during lint
 
-ignoredBuiltDependencies:
-  - 'bufferutil' # optional native ws speedup; ws falls back to pure JS
-  - 'core-js' # only a sponsor-banner postinstall, no functional payload
-  - 'keccak' # has a pure-JS fallback; the native addon is never loaded in the browser bundle
-  - 'utf-8-validate' # optional native ws speedup; ws falls back to pure JS
+packages:
+  - 'packages/*'
+  - 'portal'
+  - 'portal-backend/api'
+  - 'portal-backend/cron/*'
+  - 'subgraph-api'
+  - 'subgraphs/*'
 
 patchedDependencies:
   '@hemilabs/token-list@2.6.1': 'patches/@hemilabs__token-list@2.6.1.patch'
   '@hemilabs/wallet-watch-asset@1.0.2': 'patches/@hemilabs__wallet-watch-asset@1.0.2.patch'
   'coinselect@3.1.13': 'patches/coinselect@3.1.13.patch'
   'viem@*': 'patches/viem.patch'
+
+publicHoistPattern:
+  - '*eslint*'


### PR DESCRIPTION
### Description

Reorder the top-level keys in `pnpm-workspace.yaml` alphabetically (`blockExoticSubdeps`, `ignoredBuiltDependencies`, `minimumReleaseAge`, `minimumReleaseAgeExclude`, `onlyBuiltDependencies`, `packages`, `patchedDependencies`, `publicHoistPattern`) to make the file easier to scan and reduce churn when adding new keys. No behavior change — pnpm doesn't care about key order.

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.