### PR TITLE
Prevent extensions to hijack Sentry release name

### DIFF
--- a/.github/actions/deploy-portal/action.yml
+++ b/.github/actions/deploy-portal/action.yml
@@ -84,6 +84,9 @@ inputs:
   NEXT_PUBLIC_SENTRY_DSN:
     required: false
     description: Sentry DSN URL
+  NEXT_PUBLIC_SENTRY_RELEASE:
+    required: false
+    description: Sentry release name
   NEXT_PUBLIC_SUBGRAPHS_API_URL:
     required: false
     description: Subgraphs API URL
@@ -105,9 +108,6 @@ inputs:
   SENTRY_PROJECT:
     required: false
     description: Sentry project
-  SENTRY_RELEASE:
-    required: false
-    description: Sentry Release version
 
 runs:
   using: composite
@@ -138,6 +138,7 @@ runs:
         NEXT_PUBLIC_ENABLE_STAKE_TESTNET: ${{ inputs.NEXT_PUBLIC_ENABLE_STAKE_TESTNET }}
         NEXT_PUBLIC_PORTAL_API_URL: ${{ inputs.NEXT_PUBLIC_PORTAL_API_URL }}
         NEXT_PUBLIC_SENTRY_DSN: ${{ inputs.NEXT_PUBLIC_SENTRY_DSN }}
+        NEXT_PUBLIC_SENTRY_RELEASE: ${{ inputs.NEXT_PUBLIC_SENTRY_RELEASE }}
         NEXT_PUBLIC_SUBGRAPHS_API_URL: ${{ inputs.NEXT_PUBLIC_SUBGRAPHS_API_URL }}
         NEXT_PUBLIC_TRACES_SAMPLE_RATE: ${{ inputs.NEXT_PUBLIC_TRACES_SAMPLE_RATE }}
         NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ inputs.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID }}
@@ -145,7 +146,6 @@ runs:
         SENTRY_ENVIRONMENT: ${{ inputs.SENTRY_ENVIRONMENT }}
         SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
-        SENTRY_RELEASE: ${{ inputs.SENTRY_RELEASE }}
     - name: Check portal build
       id: portal_build
       uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0

--- a/.github/workflows/hostinger-deployment.yml
+++ b/.github/workflows/hostinger-deployment.yml
@@ -63,6 +63,7 @@ jobs:
           NEXT_PUBLIC_ENABLE_STAKE_TESTNET: ${{ vars.NEXT_PUBLIC_ENABLE_STAKE_TESTNET }}
           NEXT_PUBLIC_PORTAL_API_URL: ${{ vars.NEXT_PUBLIC_PORTAL_API_URL }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_SENTRY_RELEASE: ${{ format('{0}@{1}', vars.SENTRY_PROJECT, github.event.release.name) }}
           NEXT_PUBLIC_SUBGRAPHS_API_URL: ${{ vars.NEXT_PUBLIC_SUBGRAPHS_API_URL }}
           NEXT_PUBLIC_TRACES_SAMPLE_RATE: ${{ vars.NEXT_PUBLIC_TRACES_SAMPLE_RATE }}
           NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID }}
@@ -70,7 +71,6 @@ jobs:
           SENTRY_ENVIRONMENT: ${{ vars.ENVIRONMENT_NAME }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-          SENTRY_RELEASE: ${{ format('{0}@{1}', vars.SENTRY_PROJECT, github.event.release.name) }}
       - if: ${{ !cancelled() }}
         uses: bloq/actions/notify-deploy-to-slack@ffeb51ecfe42bb78533630b64c1082b09ef3bd2f # v1.6.1
         with:

--- a/portal/instrumentation-client.ts
+++ b/portal/instrumentation-client.ts
@@ -1,7 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
 
-const enabled = !!process.env.NEXT_PUBLIC_SENTRY_DSN
-
 const unsupportedWalletErrors = [
   '@polkadot/keyring requires direct dependencies',
   "Backpack couldn't override `window.ethereum`.",
@@ -67,23 +65,12 @@ function enableSentry() {
   // complexity IMO.
   const releaseNameRegex = /^portal@\d{8}_\d+$/
 
+  // Inlined at build time via NEXT_PUBLIC_ prefix, so it cannot be tampered
+  // with by browser extensions overwriting globalThis.SENTRY_RELEASE.
+  // See https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/791
+  const release = process.env.NEXT_PUBLIC_SENTRY_RELEASE
+
   Sentry.init({
-    // This is a workaround to filter out errors that are not actionable and
-    // that we know are coming from browser extensions or unsupported wallets.
-    // We want to keep the noise down in Sentry to be able to focus on real
-    // issues.
-    beforeSend(event) {
-      if (event.release && !releaseNameRegex.test(event.release)) {
-        return null // Drops the error event
-      }
-      return event
-    },
-    beforeSendTransaction(event) {
-      if (event.release && !releaseNameRegex.test(event.release)) {
-        return null // Drops the transaction event
-      }
-      return event
-    },
     denyUrls: [
       // Filter all Wallet Connect related urls
       /(https|wss):\/\/.*\.walletconnect\.(com|org)/,
@@ -91,8 +78,8 @@ function enableSentry() {
       // filter in case any of the env variables are undefined, although in prod all should be defined.
     ].filter(Boolean) as (string | RegExp)[],
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    enabled,
     ignoreErrors,
+    // Integrations listed here are added alongside the default ones.
     integrations: [
       // See https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/integrations/captureconsole/
       Sentry.captureConsoleIntegration({
@@ -122,14 +109,36 @@ function enableSentry() {
       }),
     ],
     normalizeDepth: 6,
+    release,
     tracesSampleRate:
       process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE &&
       !Number.isNaN(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)
         ? Number(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)
         : undefined,
+    // Custom transport wrapper to prevent phantom releases created by browser
+    // extensions that pollute globalThis.SENTRY_RELEASE. Rewrites any foreign
+    // release in the envelope header to our own release. This covers sessions,
+    // client reports and other envelope types.
+    // See https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/791
+    transport(options: Parameters<typeof Sentry.makeFetchTransport>[0]) {
+      const inner = Sentry.makeFetchTransport(options)
+      return {
+        ...inner,
+        send(envelope: Parameters<typeof inner.send>[0]) {
+          const [header] = envelope
+          if (
+            header.release &&
+            !releaseNameRegex.test(header.release as string)
+          ) {
+            header.release = release
+          }
+          return inner.send(envelope)
+        },
+      }
+    },
   })
 }
 
-if (enabled) {
+if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   enableSentry()
 }

--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -50,12 +50,12 @@ const sentryOptions: SentryBuildOptions = {
     enabled: true,
   },
   release:
-    process.env.SENTRY_ENVIRONMENT && process.env.SENTRY_RELEASE
+    process.env.SENTRY_ENVIRONMENT && process.env.NEXT_PUBLIC_SENTRY_RELEASE
       ? {
           deploy: {
             env: process.env.SENTRY_ENVIRONMENT,
           },
-          name: process.env.SENTRY_RELEASE,
+          name: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
         }
       : undefined,
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
This is a follow-up of #1904 as the filters introduced in that PR were not enough. Some extensions call `Sentry.init()` with their own release name and that ends up affecting the events sent by our code. See https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/791/ for more information.

### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request refactors how Sentry release information is handled and passed through the deployment pipeline and client code. The main goal is to ensure that the Sentry release name is always set using the `NEXT_PUBLIC_SENTRY_RELEASE` environment variable, which is inlined at build time and cannot be tampered with by browser extensions. This change addresses issues with phantom releases caused by browser extension interference and improves the reliability of Sentry error reporting.

**Sentry Release Handling Improvements:**

* Replaced all usage of the `SENTRY_RELEASE` environment variable with `NEXT_PUBLIC_SENTRY_RELEASE` across the deployment workflow, GitHub Action configuration, and client code, ensuring the release name is injected at build time and is immutable at runtime. [[1]](diffhunk://#diff-f6cd7085682f607476ac26c2c0b86bccc5f0ca94fcf95a9bc73dbd3370fb09b9R87-R89) [[2]](diffhunk://#diff-f6cd7085682f607476ac26c2c0b86bccc5f0ca94fcf95a9bc73dbd3370fb09b9L108-L110) [[3]](diffhunk://#diff-f6cd7085682f607476ac26c2c0b86bccc5f0ca94fcf95a9bc73dbd3370fb09b9R141-L148) [[4]](diffhunk://#diff-2d37e5e53e96091c0dfe5572f7a388d715735a8505959b9b867e7d4f80e4eff5R66-L73) [[5]](diffhunk://#diff-ceae93e68ff61f389a5d2e2b1c8114c5d856c7d42bb167e00d81efb8f576b33fL53-R58)
* Updated the Hostinger deployment workflow to set `NEXT_PUBLIC_SENTRY_RELEASE` using a combination of the Sentry project and the GitHub release name, and removed the now-unused `SENTRY_RELEASE` variable.

**Client-Side Sentry Initialization Hardening:**

* Refactored `portal/instrumentation-client.ts` to use `NEXT_PUBLIC_SENTRY_RELEASE` for the release name, and removed custom `beforeSend` and `beforeSendTransaction` filters in favor of a custom Sentry transport. This transport overwrites any release value not matching the expected pattern, preventing browser extensions from injecting invalid release names. [[1]](diffhunk://#diff-d58290dfaf4901ff97e2047ca36e1ab3f2a212f3f67b5e3121219e3e1c0c98c8L3-L4) [[2]](diffhunk://#diff-d58290dfaf4901ff97e2047ca36e1ab3f2a212f3f67b5e3121219e3e1c0c98c8R68-R82) [[3]](diffhunk://#diff-d58290dfaf4901ff97e2047ca36e1ab3f2a212f3f67b5e3121219e3e1c0c98c8R112-R142)
* Ensured Sentry is only enabled if `NEXT_PUBLIC_SENTRY_DSN` is present, simplifying the enablement logic. [[1]](diffhunk://#diff-d58290dfaf4901ff97e2047ca36e1ab3f2a212f3f67b5e3121219e3e1c0c98c8L3-L4) [[2]](diffhunk://#diff-d58290dfaf4901ff97e2047ca36e1ab3f2a212f3f67b5e3121219e3e1c0c98c8R112-R142)

**Build Configuration Consistency:**

* Updated the Sentry build options in `portal/next.config.ts` to use `NEXT_PUBLIC_SENTRY_RELEASE` instead of `SENTRY_RELEASE` for both the release name and deployment environment, maintaining consistency across all environments.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
