### PR TITLE
Fix veHemi logo valid tooltip

### DIFF
--- a/portal/components/displayAmount.tsx
+++ b/portal/components/displayAmount.tsx
@@ -45,7 +45,7 @@ export const DisplayAmount = function ({
       id={`amount-tooltip-${token.symbol}`}
       text={
         notZero ? (
-          <span className="flex items-center gap-x-1">
+          <div className="flex items-center gap-x-1">
             {showTokenLogo && (
               <TokenLogo size="small" token={token} version={logoVersion} />
             )}
@@ -56,7 +56,7 @@ export const DisplayAmount = function ({
               // @ts-expect-error NumberFormat.format accept strings, typings are wrong. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#parameters
               amount,
             )} ${token.symbol}`}</span>
-          </span>
+          </div>
         ) : null
       }
       variant="simple"

--- a/portal/components/tooltip/base.tsx
+++ b/portal/components/tooltip/base.tsx
@@ -33,7 +33,7 @@ function getOverlay(props: BaseTooltipProps) {
   if (variant === 'simple') {
     return (
       <div className={`${commonCss} rounded-md px-1.5 py-1`}>
-        <p className="font-medium text-white">{text}</p>
+        <div className="font-medium text-white">{text}</div>
       </div>
     )
   }
@@ -41,7 +41,7 @@ function getOverlay(props: BaseTooltipProps) {
   if (variant === 'info') {
     return (
       <div className={`${commonCss} rounded-xl p-3`}>
-        <p className="font-medium text-white">{text}</p>
+        <div className="font-medium text-white">{text}</div>
       </div>
     )
   }
@@ -51,7 +51,7 @@ function getOverlay(props: BaseTooltipProps) {
       {props.title && (
         <p className="text-smd font-semibold text-white">{props.title}</p>
       )}
-      <p className="text-sm font-medium text-neutral-400">{text}</p>
+      <div className="text-sm font-medium text-neutral-400">{text}</div>
     </div>
   )
 }

--- a/portal/hooks/useVeHemiToken.ts
+++ b/portal/hooks/useVeHemiToken.ts
@@ -1,4 +1,7 @@
+import { useHemiToken } from 'hooks/useHemiToken'
 import { useToken } from 'hooks/useToken'
+import { useMemo } from 'react'
+import { type Token } from 'types/token'
 import { getVeHemiContractAddress } from 've-hemi-actions'
 
 import { useHemi } from './useHemi'
@@ -6,9 +9,28 @@ import { useHemi } from './useHemi'
 export const useVeHemiToken = function () {
   const chainId = useHemi().id
   const veHemiAddress = getVeHemiContractAddress(chainId)
-
-  return useToken({
+  const hemiToken = useHemiToken()
+  const query = useToken({
     address: veHemiAddress,
     chainId,
   })
+
+  const data = useMemo(
+    (): Token | undefined =>
+      query.data
+        ? {
+            ...query.data,
+            extensions: {
+              ...query.data.extensions,
+              l1LogoURI:
+                query.data.extensions?.l1LogoURI ??
+                hemiToken.extensions?.l1LogoURI,
+            },
+            logoURI: query.data.logoURI ?? hemiToken.logoURI,
+          }
+        : undefined,
+    [hemiToken.extensions?.l1LogoURI, hemiToken.logoURI, query.data],
+  )
+
+  return { ...query, data }
 }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Fix the Governance Staking tooltip for **veHEMI** voting power amounts shown via `DisplayAmount`.

## Changes

1. **`portal/hooks/useVeHemiToken.ts`**  
   The veHEMI contract token from `useToken` often has no `logoURI` (and no `l1LogoURI`), so `TokenLogo` fell back to the generic badge and looked wrong next to the full-precision amount. We merge in HEMI’s `logoURI` and `l1LogoURI` when the ve token is missing them, since veHEMI is a vote-escrowed HEMI and should present the same visual identity.

2. **` portal/components/displayAmount.tsx`** (tooltip content)  
   Replaced the flex wrapper from `<span>` to `<div>` because `TokenLogo` renders block-level nodes (`<div>`). A `<span>` must only contain phrasing content; nesting a `<div>` inside it is invalid HTML and relies on browser error recovery.

3. **` portal/components/tooltip/base.tsx`** (overlay)  
   Replaced the wrappers around dynamic `{text}` from `<p>` to `<div>` for the `simple`, `info`, and rich body cases. A `<p>` cannot legally contain `<div>` (e.g., from `TokenLogo`), which again produced invalid markup and unpredictable DOM repair.


### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img alt="Captura de pantalla 2026-05-14 a la(s) 4 25 51 p  m" src="https://github.com/user-attachments/assets/75267da6-6696-431b-860a-03976bd9894f" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1874 
Fixes #1874 
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
