### PR TITLE
Bump js-checks-pnpm workflow to v1.2.0

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   js-checks:
-    uses: hemilabs/.github/.github/workflows/js-checks-pnpm.yml@e9f85a5eb81dda87d4c046eda82e45822bc1ee32
+    uses: hemilabs/.github/.github/workflows/js-checks-pnpm.yml@c0d930f1959633dd7dc1203d95ec6634dbaf9a34 #v1.2.0


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

There's a warning when running the `js-checks` workflow in this repo

<img width="1531" height="156" alt="image" src="https://github.com/user-attachments/assets/dbf30939-f0bf-4af6-9b94-c7d1763dc4b0" />

>  Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020, pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This has been fixed in upstream, so this PR just bumps the hash of the  `js-checks.yml` workflow

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

N/A

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
