### PR TITLE
Pin graph-cli in deploy-subgraph action

### DIFF
--- a/.github/actions/deploy-subgraph/action.yml
+++ b/.github/actions/deploy-subgraph/action.yml
@@ -33,7 +33,7 @@ runs:
     - uses: hemilabs/actions/setup-node-env@8f87619b7f0122c39e14a32514ab3e4e0d4c3966 # v2.3.0
       with:
         package-manager: pnpm
-    - run: pnpm exec graph auth "$GRAPH_API_KEY"
+    - run: pnpm run graph:auth "$GRAPH_API_KEY"
       shell: bash
       working-directory: subgraphs/${{ inputs.subgraph }}
       env:

--- a/.github/actions/deploy-subgraph/action.yml
+++ b/.github/actions/deploy-subgraph/action.yml
@@ -33,8 +33,9 @@ runs:
     - uses: hemilabs/actions/setup-node-env@8f87619b7f0122c39e14a32514ab3e4e0d4c3966 # v2.3.0
       with:
         package-manager: pnpm
-    - run: pnpm dlx @graphprotocol/graph-cli auth "$GRAPH_API_KEY"
+    - run: pnpm exec graph auth "$GRAPH_API_KEY"
       shell: bash
+      working-directory: subgraphs/${{ inputs.subgraph }}
       env:
         GRAPH_API_KEY: ${{ inputs.graph-api-key }}
     - run: pnpm run deploy


### PR DESCRIPTION
### Description

The `deploy-subgraph` composite action authenticated with The Graph via `pnpm dlx @graphprotocol/graph-cli auth`, which re-fetched the CLI from the public registry on every deploy run. That made the deploy non-deterministic and exposed `$GRAPH_API_KEY` to whatever the latest `graph-cli` release happened to contain — a supply-chain gap the `pnpm-workspace.yaml` hardening from #1906 didn't cover, since `dlx` bypasses workspace installs.

Switch to `pnpm run graph:auth`, executed from the targeted subgraph workspace (`subgraphs/<inputs.subgraph>`). Each subgraph already defines `"graph:auth": "graph auth"` in its `package.json` and declares `@graphprotocol/graph-cli@0.97.1` as a dependency (locked in `pnpm-lock.yaml`). The auth step now uses the same locally-installed, pinned binary the subsequent `pnpm run deploy` step does — no network fetch, no version drift between deploys, and future bumps go through the same `minimumReleaseAge` review as everything else in the workspace. Going through the package.json script (rather than `pnpm exec graph`) also keeps `knip` happy, since it can statically attribute the `graph` invocation to the subgraph workspace that declares the dep.

### Screenshots

N/A — CI-only change.

### Related issue(s)

Closes #1908

### Checklist

- [x] Manual testing passed. (Locally verified `pnpm run graph:auth --help` from a subgraph workspace resolves to the pinned 0.97.1; `pnpm run deps:check` passes. Full proof requires a staging deploy.)
- [ ] Automated tests added, or N/A. — N/A (no test harness covers composite actions)
- [ ] Documentation updated, or N/A. — N/A
- [ ] Environment variables set in CI, or N/A. — N/A (no new vars)