### PR TITLE
Update lodash to 4.18.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,8 +394,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/hemi-viem-stake-actions
       lodash:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
       merkl-claim-rewards:
         specifier: workspace:*
         version: link:../packages/merkl-claim-rewards
@@ -10530,12 +10530,6 @@ packages:
     resolution:
       {
         integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==,
-      }
-
-  lodash@4.17.21:
-    resolution:
-      {
-        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
       }
 
   lodash@4.18.1:
@@ -22336,8 +22330,6 @@ snapshots:
 
   lodash.upperfirst@4.3.1: {}
 
-  lodash@4.17.21: {}
-
   lodash@4.18.1: {}
 
   log-symbols@3.0.0:
@@ -24439,61 +24431,61 @@ snapshots:
 
   victory-area@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
       victory-vendor: 37.3.6
 
   victory-axis@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-bar@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
       victory-vendor: 37.3.6
 
   victory-box-plot@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
       victory-vendor: 37.3.6
 
   victory-brush-container@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-core: 37.3.6(react@19.1.1)
 
   victory-brush-line@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-core: 37.3.6(react@19.1.1)
 
   victory-candlestick@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-canvas@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-bar: 37.3.6(react@19.1.1)
       victory-core: 37.3.6(react@19.1.1)
 
   victory-chart@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-axis: 37.3.6(react@19.1.1)
@@ -24503,14 +24495,14 @@ snapshots:
 
   victory-core@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-vendor: 37.3.6
 
   victory-create-container@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-brush-container: 37.3.6(react@19.1.1)
       victory-core: 37.3.6(react@19.1.1)
@@ -24521,19 +24513,19 @@ snapshots:
 
   victory-cursor-container@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-errorbar@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-group@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-core: 37.3.6(react@19.1.1)
@@ -24541,7 +24533,7 @@ snapshots:
 
   victory-histogram@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-bar: 37.3.6(react@19.1.1)
@@ -24550,53 +24542,53 @@ snapshots:
 
   victory-legend@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-line@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
       victory-vendor: 37.3.6
 
   victory-pie@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
       victory-vendor: 37.3.6
 
   victory-polar-axis@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-scatter@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-selection-container@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-shared-events@37.3.6(react@19.1.1):
     dependencies:
       json-stringify-safe: 5.0.1
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-core: 37.3.6(react@19.1.1)
 
   victory-stack@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-core: 37.3.6(react@19.1.1)
@@ -24604,7 +24596,7 @@ snapshots:
 
   victory-tooltip@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
@@ -24628,7 +24620,7 @@ snapshots:
   victory-voronoi-container@37.3.6(react@19.1.1):
     dependencies:
       delaunay-find: 0.0.6
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       react-fast-compare: 3.2.2
       victory-core: 37.3.6(react@19.1.1)
@@ -24637,13 +24629,13 @@ snapshots:
   victory-voronoi@37.3.6(react@19.1.1):
     dependencies:
       d3-voronoi: 1.1.4
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 
   victory-zoom-container@37.3.6(react@19.1.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       react: 19.1.1
       victory-core: 37.3.6(react@19.1.1)
 

--- a/portal/package.json
+++ b/portal/package.json
@@ -41,7 +41,7 @@
     "hemi-tunnel-actions": "workspace:*",
     "hemi-viem": "2.7.0",
     "hemi-viem-stake-actions": "workspace:*",
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
     "merkl-claim-rewards": "workspace:*",
     "next": "15.5.3",
     "next-intl": "4.11.0",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request upgrades the `lodash` dependency from version 4.17.21 to 4.18.1 throughout the project. This change affects both direct dependencies and all packages that transitively rely on `lodash`, ensuring consistency and the latest bug fixes or security patches.

**Dependency upgrade:**

* Updated the `lodash` version from 4.17.21 to 4.18.1 in `portal/package.json` and across all relevant entries in `pnpm-lock.yaml`, including direct dependencies and all `victory-*` packages. [[1]](diffhunk://#diff-2343f692507d91623314be8e93faf7ed31d48b68c984fed78c615958afb0d410L44-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL397-R398) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24442-R24488) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24506-R24505) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24524-R24536) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24553-R24599) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24631-R24623) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24640-R24638)

**Lockfile maintenance:**

* Removed all references to the old `lodash@4.17.21` version and replaced them with `lodash@4.18.1` to ensure all dependencies use the updated version. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10535-L10540) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL22339-L22340)

### Details

Two security fixes between 4.17.21 and 4.18.1, both in **v4.18.0** (March 31, 2026):

**1. `_.unset` / `_.omit` — Prototype Pollution** ([GHSA-f23m-r3pf-42rh](https://github.com/lodash/lodash/security/advisories/GHSA-f23m-r3pf-42rh))

Array-wrapped path segments and primitive roots could bypass existing guards, allowing deletion of properties from built-in prototypes via `constructor`/`prototype` path traversal. Now `constructor` and `prototype` are unconditionally blocked as non-terminal path keys — calls that previously deleted the property now return `false` and leave the target untouched.

Note: a partial fix existed in **v4.17.23** (January 21, 2026) as [CVE-2025-13465](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg), but v4.18.0 contains the complete fix.

**2. `_.template` — Code Injection via `imports` keys** ([GHSA-r5fr-rjxr-66jc](https://github.com/lodash/lodash/security/advisories/GHSA-r5fr-rjxr-66jc), **CVE-2026-4800**)

Incomplete patch for CVE-2021-23337. The `variable` option was validated but `importsKeys` was left unguarded, allowing code injection via the `Function()` constructor. `imports` keys with forbidden identifier characters now throw `"Invalid imports option passed into _.template"`.

In addition, upgrade from `4.17.21` to `4.18.1`. The v4.18.1 patch itself only fixes a `ReferenceError` bug in `template`/`fromPairs` from modular builds (not security-related).

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1886 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
