### PR TITLE
Update postcss to 8.5.14

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: 8.5.14
+
 patchedDependencies:
   '@hemilabs/token-list@2.6.1':
     hash: 44296f3915d68c777468256a8b6e514b9aaf70d347654dac093ba95b410a7e92
@@ -6480,7 +6483,7 @@ packages:
     engines: { node: ^10 || ^12 || >=14 }
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.14
 
   available-typed-arrays@1.0.7:
     resolution:
@@ -11802,7 +11805,7 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: 8.5.14
 
   postcss-import@16.1.0:
     resolution:
@@ -11811,7 +11814,7 @@ packages:
       }
     engines: { node: '>=18.0.0' }
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: 8.5.14
 
   postcss-js@4.1.0:
     resolution:
@@ -11820,7 +11823,7 @@ packages:
       }
     engines: { node: ^12 || ^14 || >= 16 }
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: 8.5.14
 
   postcss-load-config@4.0.2:
     resolution:
@@ -11829,7 +11832,7 @@ packages:
       }
     engines: { node: '>= 14' }
     peerDependencies:
-      postcss: '>=8.0.9'
+      postcss: 8.5.14
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -11844,7 +11847,7 @@ packages:
       }
     engines: { node: '>=12.0' }
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: 8.5.14
 
   postcss-selector-parser@6.1.2:
     resolution:
@@ -11858,13 +11861,6 @@ packages:
       {
         integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
       }
-
-  postcss@8.4.31:
-    resolution:
-      {
-        integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
 
   postcss@8.5.14:
     resolution:
@@ -22570,7 +22566,7 @@ snapshots:
       '@next/env': 15.5.3
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001791
-      postcss: 8.4.31
+      postcss: 8.5.14
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.1.1)
@@ -23055,12 +23051,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.14:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,13 +507,13 @@ importers:
         version: 19.1.9(@types/react@19.1.13)
       autoprefixer:
         specifier: 10.4.16
-        version: 10.4.16(postcss@8.4.32)
+        version: 10.4.16(postcss@8.5.14)
       postcss:
-        specifier: 8.4.32
-        version: 8.4.32
+        specifier: 8.5.14
+        version: 8.5.14
       postcss-import:
         specifier: 16.1.0
-        version: 16.1.0(postcss@8.4.32)
+        version: 16.1.0(postcss@8.5.14)
       qrcode-terminal:
         specifier: 0.12.0
         version: 0.12.0
@@ -11866,13 +11866,6 @@ packages:
       }
     engines: { node: ^10 || ^12 || >=14 }
 
-  postcss@8.4.32:
-    resolution:
-      {
-        integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
-
   postcss@8.5.14:
     resolution:
       {
@@ -19691,14 +19684,14 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.4.16(postcss@8.4.32):
+  autoprefixer@10.4.16(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001791
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.4.32
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -23025,35 +23018,35 @@ snapshots:
 
   post-message-to-slack@1.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.4.32):
+  postcss-import@15.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.4.32
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-import@16.1.0(postcss@8.4.32):
+  postcss-import@16.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.4.32
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.4.32):
+  postcss-js@4.1.0(postcss@8.5.14):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.32
+      postcss: 8.5.14
 
-  postcss-load-config@4.0.2(postcss@8.4.32):
+  postcss-load-config@4.0.2(postcss@8.5.14):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.4
     optionalDependencies:
-      postcss: 8.4.32
+      postcss: 8.5.14
 
-  postcss-nested@6.2.0(postcss@8.4.32):
+  postcss-nested@6.2.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.4.32
+      postcss: 8.5.14
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -23064,12 +23057,6 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.4.32:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -24079,11 +24066,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.4.32
-      postcss-import: 15.1.0(postcss@8.4.32)
-      postcss-js: 4.1.0(postcss@8.4.32)
-      postcss-load-config: 4.0.2(postcss@8.4.32)
-      postcss-nested: 6.2.0(postcss@8.4.32)
+      postcss: 8.5.14
+      postcss-import: 15.1.0(postcss@8.5.14)
+      postcss-js: 4.1.0(postcss@8.5.14)
+      postcss-load-config: 4.0.2(postcss@8.5.14)
+      postcss-nested: 6.2.0(postcss@8.5.14)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,9 @@ onlyBuiltDependencies:
   - 'sharp' # libvips bindings required by Next.js production image optimization
   - 'unrs-resolver' # Rust resolver required by eslint-import-resolver-typescript during lint
 
+overrides:
+  postcss: '8.5.14' # Needed as Next pins 8.4.31 exactly
+
 packages:
   - 'packages/*'
   - 'portal'

--- a/portal/package.json
+++ b/portal/package.json
@@ -81,7 +81,7 @@
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",
     "autoprefixer": "10.4.16",
-    "postcss": "8.4.32",
+    "postcss": "8.5.14",
     "postcss-import": "16.1.0",
     "qrcode-terminal": "0.12.0",
     "serve": "14.2.4",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request updates the `postcss` dependency and related packages to version 8.5.14 throughout the project. This ensures that all plugins and tools relying on `postcss` are now using the latest compatible version, which can bring in bug fixes, security updates, and improved compatibility.

**Dependency upgrades:**

* Updated `postcss` from version 8.4.32 to 8.5.14 in `portal/package.json` and throughout `pnpm-lock.yaml`, ensuring all references and dependent packages use the new version. [[1]](diffhunk://#diff-2343f692507d91623314be8e93faf7ed31d48b68c984fed78c615958afb0d410L84-R84) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL510-R516) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11869-L11875) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL23072-L23077)

* Updated related `postcss` plugins and dependencies to versions compatible with `postcss@8.5.14` in `pnpm-lock.yaml`, including `autoprefixer`, `postcss-import`, `postcss-js`, `postcss-load-config`, and `postcss-nested`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL510-R516) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL19694-R19694) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL23028-R23049) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24082-R24073)

These changes help keep our build tooling up to date and reduce the risk of issues from outdated dependencies.

### Details

Analysis of changes from `8.4.32` → `8.5.14`:

**Security fixes (most important):**
- **8.5.10**: XSS via unescaped `</style>` in non-bundler cases
- **8.5.12**: Arbitrary file reading via user-generated CSS (also adds `opts.unsafeMap` opt-out)

**New feature (8.5):**
- `Input#document` for CSS-in-JS / HTML multi-document sources

**Performance:**
- 8.5.7: Faster source map annotation cleaning
- 8.5.11: Faster nested brackets parsing

**Notable regressions introduced and then fixed in 8.5.x:**
- 8.5.1–8.5.4: Parser backwards compat issues (end positions, Parcel, package exports)
- 8.5.13–8.5.14: `postcss-scss` comment regression and custom syntax regression — both fixed by 8.5.14

**Impact on this project:**
- `postcss` is a `devDependency` used only at build time with controlled CSS (Tailwind). Neither security issue (XSS or file reading) applies to the build pipeline.
- The 8.5.x minor bump is otherwise backwards-compatible.

**Note:**
8.5.15 is 10 hours old. The only thing 8.5.14 misses is **8.5.15's declaration parsing performance fix** — a build-time perf improvement, not a correctness or security issue.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1886

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
