### PR TITLE
Fix icon DEXs and Drawer navbarMobile

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
@@ -1,4 +1,5 @@
 import { useOnClickOutside } from '@hemilabs/react-hooks/useOnClickOutside'
+import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
 import { AnalyticsEvent } from 'app/analyticsEvents'
 import { ExternalLink as AnchorTag } from 'components/externalLink'
 import { ArrowDownLeftIcon } from 'components/icons/arrowDownLeftIcon'
@@ -17,7 +18,8 @@ import {
   useState,
 } from 'react'
 import ReactDOM from 'react-dom'
-import { getPortalContainer } from 'utils/document'
+import { screenBreakpoints } from 'styles'
+import { getDrawerPortalContainer, getPortalContainer } from 'utils/document'
 
 import { IconContainer } from '../iconContainer'
 import { ItemContainer, ItemText, Row } from '../navItem'
@@ -129,7 +131,14 @@ const DexImpl = function () {
   const [networkType] = useNetworkType()
   const isTestnet = networkType === 'testnet'
 
-  const dropdownPortalContainer = getPortalContainer()
+  const { width } = useWindowSize()
+  // Below `xl`, the navbar is rendered inside a Drawer portaled to body, so
+  // portal the dropdown to body too — otherwise it lands in #app-layout-container
+  // which sits behind the Drawer and the content stays hidden.
+  const isInlineNavbar = width != null && width >= screenBreakpoints.xl
+  const dropdownPortalContainer = isInlineNavbar
+    ? getPortalContainer()
+    : getDrawerPortalContainer()
 
   return isTestnet ? (
     <HemiSwapLink event="nav - dex" text={t('title')} />
@@ -167,7 +176,7 @@ const DexImpl = function () {
             className="md:translate-y-30 absolute bottom-0 left-0 top-24
               z-30 flex w-full flex-col items-start overflow-y-auto rounded-t-2xl
               bg-white p-4 shadow-lg md:top-0 md:h-fit md:w-64 md:translate-x-56
-              md:rounded-lg md:p-1 lg:translate-x-2"
+              md:rounded-lg md:p-1 xl:translate-x-2"
             onMouseDown={e => e.stopPropagation()}
             onTouchStart={e => e.stopPropagation()}
             ref={ref}

--- a/portal/app/[locale]/_components/navbar/_components/navItem.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/navItem.tsx
@@ -31,7 +31,7 @@ export const ItemContainer = ({
   }) => (
   <div
     {...props}
-    className={`group/item group/nav flex ${justifyItems} h-auto cursor-pointer items-center rounded-lg ${padding} transition-colors duration-300 md:rounded-md ${
+    className={`group/item group/nav flex ${justifyItems} h-full cursor-pointer items-center rounded-lg md:h-auto ${padding} transition-colors duration-300 md:rounded-md ${
       selected ? selectedClassName : hoverClassName
     }`}
   >

--- a/portal/app/[locale]/_components/navbar/_components/navItem.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/navItem.tsx
@@ -31,7 +31,7 @@ export const ItemContainer = ({
   }) => (
   <div
     {...props}
-    className={`group/item group/nav flex ${justifyItems} h-full cursor-pointer items-center rounded-lg ${padding} transition-colors duration-300 md:rounded-md ${
+    className={`group/item group/nav flex ${justifyItems} h-auto cursor-pointer items-center rounded-lg ${padding} transition-colors duration-300 md:rounded-md ${
       selected ? selectedClassName : hoverClassName
     }`}
   >


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Fix broken icon rendering in Safari and resolve another issue affecting the drawer on mobile.
The issue occurred when clicking DEX items: the drawer opened behind the navbar, causing only the overlay and part of the submenu to be visible across browsers, and on mobile devices only the overlay was visible.


### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->


**Issue**
<img  alt="Captura de pantalla 2026-05-20 a la(s) 10 46 14 a  m" src="https://github.com/user-attachments/assets/ddaf607f-584a-462b-87da-29c32d5f6a78" />

**Fix**

<img  alt="Captura de pantalla 2026-05-20 a la(s) 12 02 18 p  m" src="https://github.com/user-attachments/assets/2e0db770-bfbb-403a-91a9-ae5a603ec490" />

**issue**

<img  alt="Captura de pantalla 2026-05-20 a la(s) 11 37 53 a  m" src="https://github.com/user-attachments/assets/c345f971-ff89-467f-9209-1f75e259bdf0" />

**Fix**


<img alt="Captura de pantalla 2026-05-20 a la(s) 11 42 17 a  m" src="https://github.com/user-attachments/assets/ec0c1d99-cb04-402e-9988-0dc298eb3b1e" />





### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1896 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
