### PR TITLE
Index redeems in hemi-earn-router subgraph

### DIFF
--- a/subgraphs/hemi-earn-router-subgraph/abis/Router.json
+++ b/subgraphs/hemi-earn-router-subgraph/abis/Router.json
@@ -46,6 +46,43 @@
         "type": "uint256"
       },
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "automatic",
+        "type": "bool"
+      }
+    ],
+    "name": "RedeemRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "requestId",
+        "type": "uint256"
+      },
+      {
         "indexed": false,
         "internalType": "uint256",
         "name": "amountIn",

--- a/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
+++ b/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
@@ -1,5 +1,6 @@
 import {
   DepositRequested as DepositRequestedEvent,
+  RedeemRequested as RedeemRequestedEvent,
   RequestClaimed as RequestClaimedEvent,
   RequestFulfilled as RequestFulfilledEvent,
   RequestRecovered as RequestRecoveredEvent,
@@ -22,13 +23,28 @@ export function handleDepositRequested(event: DepositRequestedEvent): void {
   request.save()
 }
 
+export function handleRedeemRequested(event: RedeemRequestedEvent): void {
+  const id = event.params.requestId.toString()
+  const request = new Request(id)
+  request.requestId = event.params.requestId
+  request.kind = 'REDEEM'
+  request.asset = event.params.asset
+  request.amountIn = event.params.shares
+  request.receiver = event.params.receiver
+  request.automatic = event.params.automatic
+  request.initiatedAt = event.block.timestamp
+  request.status = 'PENDING'
+  request.initiateTxHash = event.transaction.hash
+  request.save()
+}
+
 export function handleRequestFulfilled(event: RequestFulfilledEvent): void {
   const request = Request.load(event.params.requestId.toString())
   if (request == null) {
     return
   }
   request.status = 'FULFILLED'
-  // These are the actual shares the user received
+  // Actual amount the user received (shares for deposits, assets for redeems)
   request.amountOut = event.params.amountIn
   request.save()
 }

--- a/subgraphs/hemi-earn-router-subgraph/subgraph.yaml
+++ b/subgraphs/hemi-earn-router-subgraph/subgraph.yaml
@@ -25,6 +25,9 @@ dataSources:
             DepositRequested(indexed uint256,indexed address,uint256,indexed
             address,bool)
           handler: handleDepositRequested
+        - event: RedeemRequested(indexed uint256,indexed address,uint256,indexed
+            address,bool)
+          handler: handleRedeemRequested
         - event: RequestFulfilled(indexed uint256,uint256)
           handler: handleRequestFulfilled
         - event: RequestClaimed(indexed uint256,indexed address)

--- a/subgraphs/hemi-earn-router-subgraph/tests/router-utils.ts
+++ b/subgraphs/hemi-earn-router-subgraph/tests/router-utils.ts
@@ -3,6 +3,7 @@ import { newMockEvent } from 'matchstick-as'
 
 import {
   DepositRequested,
+  RedeemRequested,
   RequestClaimed,
   RequestFulfilled,
   RequestRecovered,
@@ -41,6 +42,43 @@ export function createDepositRequestedEvent(
     new ethereum.EventParam(
       'assets',
       ethereum.Value.fromUnsignedBigInt(assets),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam('receiver', ethereum.Value.fromAddress(receiver)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam('automatic', ethereum.Value.fromBoolean(automatic)),
+  )
+  setTxHash(event, txHash)
+  setBlockTimestamp(event, timestamp)
+  return event
+}
+
+export function createRedeemRequestedEvent(
+  requestId: BigInt,
+  asset: Address,
+  shares: BigInt,
+  receiver: Address,
+  automatic: boolean,
+  txHash: Bytes,
+  timestamp: BigInt,
+): RedeemRequested {
+  const event = changetype<RedeemRequested>(newMockEvent())
+  event.parameters = new Array<ethereum.EventParam>()
+  event.parameters.push(
+    new ethereum.EventParam(
+      'requestId',
+      ethereum.Value.fromUnsignedBigInt(requestId),
+    ),
+  )
+  event.parameters.push(
+    new ethereum.EventParam('asset', ethereum.Value.fromAddress(asset)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      'shares',
+      ethereum.Value.fromUnsignedBigInt(shares),
     ),
   )
   event.parameters.push(

--- a/subgraphs/hemi-earn-router-subgraph/tests/router.test.ts
+++ b/subgraphs/hemi-earn-router-subgraph/tests/router.test.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   handleDepositRequested,
+  handleRedeemRequested,
   handleRequestClaimed,
   handleRequestFulfilled,
   handleRequestRecovered,
@@ -17,6 +18,7 @@ import {
 
 import {
   createDepositRequestedEvent,
+  createRedeemRequestedEvent,
   createRequestClaimedEvent,
   createRequestFulfilledEvent,
   createRequestRecoveredEvent,
@@ -35,6 +37,9 @@ const receiver = Address.fromString(
 const assets = BigInt.fromString('1000000000000000000') // 1e18
 const sharesOut = BigInt.fromString('950000000000000000') // 0.95e18
 const assetsReturned = BigInt.fromString('990000000000000000') // 0.99e18 (Agent kept a fee)
+const shares = BigInt.fromString('800000000000000000') // 0.8e18
+const assetsOut = BigInt.fromString('790000000000000000') // 0.79e18 (Agent kept a fee)
+const sharesReturned = BigInt.fromString('800000000000000000') // 0.8e18
 const initiatedAt = BigInt.fromI32(1769731200) // 2026-01-30 00:00:00 UTC
 
 const depositTxHash = Bytes.fromHexString(
@@ -52,6 +57,9 @@ const undoTxHash = Bytes.fromHexString(
 const recoverTxHash = Bytes.fromHexString(
   '0xaa00000000000000000000000000000000000000000000000000000000000005',
 ) as Bytes
+const redeemTxHash = Bytes.fromHexString(
+  '0xaa00000000000000000000000000000000000000000000000000000000000006',
+) as Bytes
 
 function emitDeposit(automatic: boolean): void {
   handleDepositRequested(
@@ -62,6 +70,20 @@ function emitDeposit(automatic: boolean): void {
       receiver,
       automatic,
       depositTxHash,
+      initiatedAt,
+    ),
+  )
+}
+
+function emitRedeem(automatic: boolean): void {
+  handleRedeemRequested(
+    createRedeemRequestedEvent(
+      requestId,
+      asset,
+      shares,
+      receiver,
+      automatic,
+      redeemTxHash,
       initiatedAt,
     ),
   )
@@ -176,7 +198,7 @@ describe('Router subgraph', function () {
     )
   })
 
-  test('Shared events for an unknown requestId (simulating redeem) are no-ops', function () {
+  test('Shared events for an unknown requestId are no-ops', function () {
     const unknownId = BigInt.fromI32(9999)
 
     handleRequestFulfilled(
@@ -193,6 +215,103 @@ describe('Router subgraph', function () {
     )
 
     assert.entityCount(ENTITY, 0)
+  })
+
+  test('RedeemRequested creates a Request with kind=REDEEM and status=PENDING', function () {
+    emitRedeem(false)
+
+    assert.entityCount(ENTITY, 1)
+    assert.fieldEquals(ENTITY, requestIdString, 'kind', 'REDEEM')
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'requestId',
+      requestId.toString(),
+    )
+    assert.fieldEquals(ENTITY, requestIdString, 'asset', asset.toHexString())
+    assert.fieldEquals(ENTITY, requestIdString, 'amountIn', shares.toString())
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'receiver',
+      receiver.toHexString(),
+    )
+    assert.fieldEquals(ENTITY, requestIdString, 'automatic', 'false')
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'initiatedAt',
+      initiatedAt.toString(),
+    )
+    assert.fieldEquals(ENTITY, requestIdString, 'status', 'PENDING')
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'initiateTxHash',
+      redeemTxHash.toHexString(),
+    )
+  })
+
+  test('Redeem happy path: fulfilled records asset amountOut and claimed transitions to CLAIMED', function () {
+    emitRedeem(false)
+
+    handleRequestFulfilled(
+      createRequestFulfilledEvent(requestId, assetsOut, fulfillTxHash),
+    )
+    assert.entityCount(ENTITY, 1)
+    assert.fieldEquals(ENTITY, requestIdString, 'status', 'FULFILLED')
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'amountOut',
+      assetsOut.toString(),
+    )
+
+    handleRequestClaimed(
+      createRequestClaimedEvent(requestId, receiver, claimTxHash),
+    )
+    assert.entityCount(ENTITY, 1)
+    assert.fieldEquals(ENTITY, requestIdString, 'status', 'CLAIMED')
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'claimTxHash',
+      claimTxHash.toHexString(),
+    )
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'initiateTxHash',
+      redeemTxHash.toHexString(),
+    )
+  })
+
+  test('Redeem undo path: undone records returned shares and recovered transitions to RECOVERED', function () {
+    emitRedeem(false)
+
+    handleRequestUndone(
+      createRequestUndoneEvent(requestId, sharesReturned, undoTxHash),
+    )
+    assert.entityCount(ENTITY, 1)
+    assert.fieldEquals(ENTITY, requestIdString, 'status', 'UNDONE')
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'amountOut',
+      sharesReturned.toString(),
+    )
+
+    handleRequestRecovered(
+      createRequestRecoveredEvent(requestId, receiver, recoverTxHash),
+    )
+    assert.entityCount(ENTITY, 1)
+    assert.fieldEquals(ENTITY, requestIdString, 'status', 'RECOVERED')
+    assert.fieldEquals(
+      ENTITY,
+      requestIdString,
+      'recoverTxHash',
+      recoverTxHash.toHexString(),
+    )
   })
 
   test('automatic = true follows the same state machine', function () {


### PR DESCRIPTION
### Description

The Router contract emits `RedeemRequested` alongside `DepositRequested`, both feeding the same `RequestFulfilled` / `RequestUndone` / `RequestClaimed` / `RequestRecovered` lifecycle. Until now the subgraph only indexed deposits, so redeem requests never appeared as `Request` entities and the schema's `RequestKind.REDEEM` value was unreachable.

This PR adds the `RedeemRequested` event to the Router ABI, registers a `handleRedeemRequested` mapping (`kind = REDEEM`, `amountIn = shares`), and extends the matchstick tests with the redeem `PENDING → FULFILLED → CLAIMED` and `PENDING → UNDONE → RECOVERED` paths. The shared lifecycle handlers already load entities by `requestId` kind-agnostically, so they need no changes. No schema changes were required.

### Screenshots

N/A — subgraph indexing change with no UI surface.

### Related issue(s)

Closes #1937

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.