### PR TITLE
Update nuqs to 2.8.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,8 +418,8 @@ importers:
         specifier: 4.11.0
         version: 4.11.0(next@15.5.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(typescript@5.8.3)
       nuqs:
-        specifier: 2.4.3
-        version: 2.4.3(next@15.5.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        specifier: 2.8.9
+        version: 2.8.9(next@15.5.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       p-all:
         specifier: 5.0.0
         version: 5.0.0
@@ -4669,6 +4669,12 @@ packages:
     resolution:
       {
         integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==,
+      }
+
+  '@standard-schema/spec@1.0.0':
+    resolution:
+      {
+        integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==,
       }
 
   '@standard-schema/spec@1.1.0':
@@ -10794,12 +10800,6 @@ packages:
       typescript:
         optional: true
 
-  mitt@3.0.1:
-    resolution:
-      {
-        integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==,
-      }
-
   modern-ahocorasick@1.1.0:
     resolution:
       {
@@ -11054,19 +11054,22 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
-  nuqs@2.4.3:
+  nuqs@2.8.9:
     resolution:
       {
-        integrity: sha512-BgtlYpvRwLYiJuWzxt34q2bXu/AIS66sLU1QePIMr2LWkb+XH0vKXdbLSgn9t6p7QKzwI7f38rX3Wl9llTXQ8Q==,
+        integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==,
       }
     peerDependencies:
       '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
       next: '>=14.2.0'
       react: '>=18.2.0 || ^19.0.0-0'
-      react-router: ^6 || ^7
-      react-router-dom: ^6 || ^7
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
     peerDependenciesMeta:
       '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
         optional: true
       next:
         optional: true
@@ -17815,6 +17818,8 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/core-darwin-arm64@1.15.33':
@@ -22131,8 +22136,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  mitt@3.0.1: {}
-
   modern-ahocorasick@1.1.0: {}
 
   module-details-from-path@1.0.4: {}
@@ -22257,9 +22260,9 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
-  nuqs@2.4.3(next@15.5.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
+  nuqs@2.8.9(next@15.5.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
-      mitt: 3.0.1
+      '@standard-schema/spec': 1.0.0
       react: 19.1.1
     optionalDependencies:
       next: 15.5.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)

--- a/portal/package.json
+++ b/portal/package.json
@@ -46,7 +46,7 @@
     "merkl-claim-rewards": "workspace:*",
     "next": "15.5.3",
     "next-intl": "4.11.0",
-    "nuqs": "2.4.3",
+    "nuqs": "2.8.9",
     "p-all": "5.0.0",
     "p-do-whilst": "2.1.0",
     "p-queue": "9.2.0",


### PR DESCRIPTION
### Description

Bumps `nuqs` from 2.4.3 to 2.8.9 in `portal`. The upgrade spans 4 minor versions; the bulk of upstream changes is internal refactor (move from `tsup` to `tsdown`, queue management split into `lib/queues/`), plus new opt-in features (TanStack Router adapter, debouncing/throttling, Standard Schema validators for `parseAsJson`, key isolation). One runtime dep was dropped (`mitt` — inlined) and one added (`@standard-schema/spec@1.0.0`, pinned exact, zero-deps).

Compare: https://github.com/47ng/nuqs/compare/v2.4.3...v2.8.9.

### Related issue(s)

Related to #1886

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.