### PR TITLE
Add getTotalVeHemiSupplyAt to ve-hemi-actions

### DIFF
--- a/packages/ve-hemi-actions/abi.ts
+++ b/packages/ve-hemi-actions/abi.ts
@@ -207,4 +207,11 @@ export const veHemiAbi = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [{ internalType: 'uint256', name: 'timestamp_', type: 'uint256' }],
+    name: 'totalVeHemiSupplyAt',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
 ] as const

--- a/packages/ve-hemi-actions/actions/index.ts
+++ b/packages/ve-hemi-actions/actions/index.ts
@@ -12,3 +12,4 @@ export {
   getPositionsVotingPowerSum,
   getTotalVotingPower,
 } from './public/veHemi'
+export { getTotalVeHemiSupplyAt } from './public/getTotalVeHemiSupplyAt'

--- a/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
+++ b/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
@@ -11,7 +11,7 @@ export const getTotalVeHemiSupplyAt = async function (
   if (!client.chain) {
     throw new Error('Client chain is not defined')
   }
-  if (!Number.isFinite(timestamp)) {
+  if (!Number.isSafeInteger(timestamp)) {
     throw new Error('Invalid timestamp')
   }
 

--- a/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
+++ b/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
@@ -11,7 +11,7 @@ export const getTotalVeHemiSupplyAt = async function (
   if (!client.chain) {
     throw new Error('Client chain is not defined')
   }
-  if (!Number.isSafeInteger(timestamp)) {
+  if (!Number.isSafeInteger(timestamp) || timestamp < 0) {
     throw new Error('Invalid timestamp')
   }
 

--- a/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
+++ b/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
@@ -1,0 +1,26 @@
+import type { Client } from 'viem'
+import { readContract } from 'viem/actions'
+
+import { veHemiAbi } from '../../abi'
+import { getVeHemiContractAddress } from '../../constants'
+
+export const getTotalVeHemiSupplyAt = async function (
+  client: Client,
+  timestamp: number,
+) {
+  if (!client.chain) {
+    throw new Error('Client chain is not defined')
+  }
+  if (!Number.isFinite(timestamp)) {
+    throw new Error('Invalid timestamp')
+  }
+
+  const veHemiAddress = getVeHemiContractAddress(client.chain.id)
+
+  return readContract(client, {
+    abi: veHemiAbi,
+    address: veHemiAddress,
+    args: [BigInt(timestamp)],
+    functionName: 'totalVeHemiSupplyAt',
+  })
+}

--- a/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
+++ b/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
@@ -6,8 +6,10 @@ import { getVeHemiContractAddress } from '../../constants'
 
 export const getTotalVeHemiSupplyAt = async function (
   client: Client,
-  timestamp: number,
+  options: { timestamp: number },
 ) {
+  const { timestamp } = options ?? {}
+
   if (!client.chain) {
     throw new Error('Client chain is not defined')
   }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

`totalVeHemiSupplyAt`  is consumed from `portal-backend`, but it wasn't in the `ve-hemi-actions` package. In order to update the `portal-backend` to use it, we first must add it!

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1425

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
