### PR TITLE
Add rewardPeriods to ve-hemi-rewards

### DIFF
--- a/packages/ve-hemi-rewards/actions/index.ts
+++ b/packages/ve-hemi-rewards/actions/index.ts
@@ -1,3 +1,4 @@
+export { getRewardPeriod } from './public/getRewardPeriod'
 export { calculateRewards, getRewardTokens } from './public/veHemiRewards'
 export {
   collectAllRewards,

--- a/packages/ve-hemi-rewards/actions/public/getRewardPeriod.ts
+++ b/packages/ve-hemi-rewards/actions/public/getRewardPeriod.ts
@@ -1,0 +1,37 @@
+import {
+  getAddress as toChecksumAddress,
+  isAddress,
+  type Address,
+  type Client,
+} from 'viem'
+import { readContract } from 'viem/actions'
+
+import { veHemiRewardsAbi } from '../../abi'
+import { getVeHemiRewardsContractAddress } from '../../constants'
+
+export const getRewardPeriod = async function (
+  client: Client,
+  { timestamp, tokenAddress }: { tokenAddress: Address; timestamp: number },
+) {
+  if (!client) {
+    throw new Error('Client is not defined')
+  }
+  if (!client.chain) {
+    throw new Error('Client chain is not defined')
+  }
+  if (!isAddress(tokenAddress)) {
+    throw new Error('Invalid token address')
+  }
+  if (!Number.isSafeInteger(timestamp)) {
+    throw new Error('Invalid timestamp')
+  }
+
+  const veHemiRewardsAddress = getVeHemiRewardsContractAddress(client.chain.id)
+
+  return readContract(client, {
+    abi: veHemiRewardsAbi,
+    address: veHemiRewardsAddress,
+    args: [toChecksumAddress(tokenAddress), BigInt(timestamp)],
+    functionName: 'rewardPeriods',
+  })
+}

--- a/packages/ve-hemi-rewards/actions/public/getRewardPeriod.ts
+++ b/packages/ve-hemi-rewards/actions/public/getRewardPeriod.ts
@@ -22,7 +22,7 @@ export const getRewardPeriod = async function (
   if (!isAddress(tokenAddress)) {
     throw new Error('Invalid token address')
   }
-  if (!Number.isSafeInteger(timestamp)) {
+  if (!Number.isSafeInteger(timestamp) || timestamp < 0) {
     throw new Error('Invalid timestamp')
   }
 

--- a/packages/ve-hemi-rewards/test/public/getRewardPeriod.test.ts
+++ b/packages/ve-hemi-rewards/test/public/getRewardPeriod.test.ts
@@ -1,0 +1,77 @@
+import { hemi } from 'hemi-viem'
+import type { Address, PublicClient } from 'viem'
+import { readContract } from 'viem/actions'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getRewardPeriod } from '../../actions/public/getRewardPeriod'
+
+vi.mock('viem/actions', () => ({
+  readContract: vi.fn(),
+}))
+
+describe('getRewardPeriod', function () {
+  const mockClient = {
+    chain: { id: hemi.id },
+  } as PublicClient
+
+  const tokenAddress: Address = '0x1234567890123456789012345678901234567890'
+  const timestamp = 1_700_000_000
+
+  it('returns the reward period read from the contract', async function () {
+    vi.mocked(readContract).mockResolvedValueOnce(BigInt(42))
+
+    const result = await getRewardPeriod(mockClient, {
+      timestamp,
+      tokenAddress,
+    })
+
+    expect(result).toBe(BigInt(42))
+    expect(readContract).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when client is not defined', async function () {
+    await expect(
+      // @ts-expect-error testing invalid input
+      getRewardPeriod(undefined, { timestamp, tokenAddress }),
+    ).rejects.toThrow('Client is not defined')
+  })
+
+  it('throws when client chain is not defined', async function () {
+    const invalidClient = {}
+
+    await expect(
+      // @ts-expect-error testing invalid input
+      getRewardPeriod(invalidClient, { timestamp, tokenAddress }),
+    ).rejects.toThrow('Client chain is not defined')
+  })
+
+  it('throws on non-integer timestamp', async function () {
+    await expect(
+      getRewardPeriod(mockClient, { timestamp: 1.5, tokenAddress }),
+    ).rejects.toThrow('Invalid timestamp')
+  })
+
+  it('throws on NaN timestamp', async function () {
+    await expect(
+      getRewardPeriod(mockClient, { timestamp: Number.NaN, tokenAddress }),
+    ).rejects.toThrow('Invalid timestamp')
+  })
+
+  it('throws on Infinity timestamp', async function () {
+    await expect(
+      getRewardPeriod(mockClient, {
+        timestamp: Number.POSITIVE_INFINITY,
+        tokenAddress,
+      }),
+    ).rejects.toThrow('Invalid timestamp')
+  })
+
+  it('throws on malformed token address', async function () {
+    await expect(
+      getRewardPeriod(mockClient, {
+        timestamp,
+        tokenAddress: '0xnot-an-address',
+      }),
+    ).rejects.toThrow('Invalid token address')
+  })
+})

--- a/packages/ve-hemi-rewards/test/public/getRewardPeriod.test.ts
+++ b/packages/ve-hemi-rewards/test/public/getRewardPeriod.test.ts
@@ -66,6 +66,12 @@ describe('getRewardPeriod', function () {
     ).rejects.toThrow('Invalid timestamp')
   })
 
+  it('throws on negative timestamp', async function () {
+    await expect(
+      getRewardPeriod(mockClient, { timestamp: -1, tokenAddress }),
+    ).rejects.toThrow('Invalid timestamp')
+  })
+
   it('throws on malformed token address', async function () {
     await expect(
       getRewardPeriod(mockClient, {

--- a/packages/ve-hemi-rewards/test/public/getRewardPeriod.test.ts
+++ b/packages/ve-hemi-rewards/test/public/getRewardPeriod.test.ts
@@ -1,6 +1,6 @@
-import { hemi } from 'hemi-viem'
 import type { Address, PublicClient } from 'viem'
 import { readContract } from 'viem/actions'
+import { hemi } from 'viem/chains'
 import { describe, expect, it, vi } from 'vitest'
 
 import { getRewardPeriod } from '../../actions/public/getRewardPeriod'
@@ -9,9 +9,13 @@ vi.mock('viem/actions', () => ({
   readContract: vi.fn(),
 }))
 
+vi.mock('../../constants', () => ({
+  getVeHemiRewardsContractAddress: vi.fn(() => '0x123'),
+}))
+
 describe('getRewardPeriod', function () {
   const mockClient = {
-    chain: { id: hemi.id },
+    chain: hemi,
   } as PublicClient
 
   const tokenAddress: Address = '0x1234567890123456789012345678901234567890'


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Similar to #1940 , this PR adds `rewardPeriods` to `ve-hemi-rewards` in order to be able to consume it from the `portal-backend`.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1425

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
