### PR TITLE
Rename UNDONE to CANCELLED in earn subgraph

### DIFF
--- a/subgraphs/hemi-earn-router-subgraph/abis/Router.json
+++ b/subgraphs/hemi-earn-router-subgraph/abis/Router.json
@@ -127,7 +127,7 @@
         "type": "uint256"
       }
     ],
-    "name": "RequestUndone",
+    "name": "RequestCancelled",
     "type": "event"
   },
   {

--- a/subgraphs/hemi-earn-router-subgraph/schema.graphql
+++ b/subgraphs/hemi-earn-router-subgraph/schema.graphql
@@ -7,7 +7,7 @@ enum RequestStatus {
   PENDING
   FULFILLED
   CLAIMED
-  UNDONE
+  CANCELLED
   RECOVERED
 }
 

--- a/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
+++ b/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
@@ -1,10 +1,10 @@
 import {
   DepositRequested as DepositRequestedEvent,
   RedeemRequested as RedeemRequestedEvent,
+  RequestCancelled as RequestCancelledEvent,
   RequestClaimed as RequestClaimedEvent,
   RequestFulfilled as RequestFulfilledEvent,
   RequestRecovered as RequestRecoveredEvent,
-  RequestUndone as RequestUndoneEvent,
 } from '../../generated/Router/Router'
 import { Request } from '../../generated/schema'
 
@@ -59,12 +59,12 @@ export function handleRequestClaimed(event: RequestClaimedEvent): void {
   request.save()
 }
 
-export function handleRequestUndone(event: RequestUndoneEvent): void {
+export function handleRequestCancelled(event: RequestCancelledEvent): void {
   const request = Request.load(event.params.requestId.toString())
   if (request == null) {
     return
   }
-  request.status = 'UNDONE'
+  request.status = 'CANCELLED'
   // Amount of assets the user will receive back. This should match the
   // request's amountIn, but the contract overwrites this field, so we
   // capture whatever value actually returns.

--- a/subgraphs/hemi-earn-router-subgraph/subgraph.yaml
+++ b/subgraphs/hemi-earn-router-subgraph/subgraph.yaml
@@ -32,8 +32,8 @@ dataSources:
           handler: handleRequestFulfilled
         - event: RequestClaimed(indexed uint256,indexed address)
           handler: handleRequestClaimed
-        - event: RequestUndone(indexed uint256,uint256)
-          handler: handleRequestUndone
+        - event: RequestCancelled(indexed uint256,uint256)
+          handler: handleRequestCancelled
         - event: RequestRecovered(indexed uint256,indexed address)
           handler: handleRequestRecovered
       file: ./src/mappings/router.ts

--- a/subgraphs/hemi-earn-router-subgraph/tests/router-utils.ts
+++ b/subgraphs/hemi-earn-router-subgraph/tests/router-utils.ts
@@ -4,10 +4,10 @@ import { newMockEvent } from 'matchstick-as'
 import {
   DepositRequested,
   RedeemRequested,
+  RequestCancelled,
   RequestClaimed,
   RequestFulfilled,
   RequestRecovered,
-  RequestUndone,
 } from '../generated/Router/Router'
 
 function setTxHash(event: ethereum.Event, txHash: Bytes): void {
@@ -135,12 +135,12 @@ export function createRequestClaimedEvent(
   return event
 }
 
-export function createRequestUndoneEvent(
+export function createRequestCancelledEvent(
   requestId: BigInt,
   amountIn: BigInt,
   txHash: Bytes,
-): RequestUndone {
-  const event = changetype<RequestUndone>(newMockEvent())
+): RequestCancelled {
+  const event = changetype<RequestCancelled>(newMockEvent())
   event.parameters = new Array<ethereum.EventParam>()
   event.parameters.push(
     new ethereum.EventParam(

--- a/subgraphs/hemi-earn-router-subgraph/tests/router.test.ts
+++ b/subgraphs/hemi-earn-router-subgraph/tests/router.test.ts
@@ -10,19 +10,19 @@ import {
 import {
   handleDepositRequested,
   handleRedeemRequested,
+  handleRequestCancelled,
   handleRequestClaimed,
   handleRequestFulfilled,
   handleRequestRecovered,
-  handleRequestUndone,
 } from '../src/mappings/router'
 
 import {
   createDepositRequestedEvent,
   createRedeemRequestedEvent,
+  createRequestCancelledEvent,
   createRequestClaimedEvent,
   createRequestFulfilledEvent,
   createRequestRecoveredEvent,
-  createRequestUndoneEvent,
 } from './router-utils'
 
 const ENTITY = 'Request'
@@ -51,7 +51,7 @@ const fulfillTxHash = Bytes.fromHexString(
 const claimTxHash = Bytes.fromHexString(
   '0xaa00000000000000000000000000000000000000000000000000000000000003',
 ) as Bytes
-const undoTxHash = Bytes.fromHexString(
+const cancelTxHash = Bytes.fromHexString(
   '0xaa00000000000000000000000000000000000000000000000000000000000004',
 ) as Bytes
 const recoverTxHash = Bytes.fromHexString(
@@ -170,14 +170,14 @@ describe('Router subgraph', function () {
     )
   })
 
-  test('Undo path: undone records returned amountOut and recovered transitions to RECOVERED with recoverTxHash', function () {
+  test('Cancel path: cancelled records returned amountOut and recovered transitions to RECOVERED with recoverTxHash', function () {
     emitDeposit(false)
 
-    handleRequestUndone(
-      createRequestUndoneEvent(requestId, assetsReturned, undoTxHash),
+    handleRequestCancelled(
+      createRequestCancelledEvent(requestId, assetsReturned, cancelTxHash),
     )
     assert.entityCount(ENTITY, 1)
-    assert.fieldEquals(ENTITY, requestIdString, 'status', 'UNDONE')
+    assert.fieldEquals(ENTITY, requestIdString, 'status', 'CANCELLED')
     assert.fieldEquals(
       ENTITY,
       requestIdString,
@@ -207,8 +207,8 @@ describe('Router subgraph', function () {
     handleRequestClaimed(
       createRequestClaimedEvent(unknownId, receiver, claimTxHash),
     )
-    handleRequestUndone(
-      createRequestUndoneEvent(unknownId, assetsReturned, undoTxHash),
+    handleRequestCancelled(
+      createRequestCancelledEvent(unknownId, assetsReturned, cancelTxHash),
     )
     handleRequestRecovered(
       createRequestRecoveredEvent(unknownId, receiver, recoverTxHash),
@@ -286,14 +286,14 @@ describe('Router subgraph', function () {
     )
   })
 
-  test('Redeem undo path: undone records returned shares and recovered transitions to RECOVERED', function () {
+  test('Redeem cancel path: cancelled records returned shares and recovered transitions to RECOVERED', function () {
     emitRedeem(false)
 
-    handleRequestUndone(
-      createRequestUndoneEvent(requestId, sharesReturned, undoTxHash),
+    handleRequestCancelled(
+      createRequestCancelledEvent(requestId, sharesReturned, cancelTxHash),
     )
     assert.entityCount(ENTITY, 1)
-    assert.fieldEquals(ENTITY, requestIdString, 'status', 'UNDONE')
+    assert.fieldEquals(ENTITY, requestIdString, 'status', 'CANCELLED')
     assert.fieldEquals(
       ENTITY,
       requestIdString,


### PR DESCRIPTION
### Description

This PR renames `UNDONE` → `CANCELLED` across the hemi-earn-router-subgraph to match the Router contract rename. The companion changes for the `hemi-earn-actions` package and the portal already
  landed (or are landing) in their own PR — this one was deliberately split out so the subgraph could move on its own cadence.

  Everything is mechanical: the event entry in `abis/Router.json`, the `RequestStatus` enum in `schema.graphql`, the manifest event binding and handler name, the mapping function
  `handleRequestCancelled` with `request.status = 'CANCELLED'`, and the test factory/assertions in `router-utils.ts` and `router.test.ts`. The `undoTxHash` local in tests was also renamed to
  `cancelTxHash` for consistency.

  The subgraph still uses the zero address as its `source.address` (not deployed in production), so this is a free breaking change to the enum — no historical data to worry about.

### Screenshots

N/A. No UI changes.

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
