### PR TITLE
Add earn-requests endpoint to Subgraphs endpoint in Portal Backend

### DIFF
--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -163,6 +163,15 @@ $ curl http://localhost:3006/subgraphs/43111/locks/0x000000000000000000000000000
 {"positions":[]}
 ```
 
+##### `GET /subgraphs/:chain-id/earn-requests/:address`
+
+Returns the Hemi Earn Router requests (deposits and redeems) for the given address. Runs on Hemi mainnet only.
+
+```console
+$ curl http://localhost:3006/subgraphs/43111/earn-requests/0x0000000000000000000000000000000000000001
+{"requests":[{"id":"0x...","requestId":"1","kind":"DEPOSIT","asset":"0x0000...","amountIn":"1000000000000000000","amountOut":"998000000000000000","receiver":"0x1234...","automatic":false,"initiatedAt":"1759162804","status":"FULFILLED","initiateTxHash":"0xabc...","claimTxHash":"0xdef...","recoverTxHash":null}]}
+```
+
 ### Configuration
 
 These environment variables control how the cache works:

--- a/portal-backend/api/config/default.json
+++ b/portal-backend/api/config/default.json
@@ -16,6 +16,9 @@
   "subgraph": {
     "apiKey": "",
     "apiUrl": "https://gateway.thegraph.com/api",
+    "hemiEarnRouter": {
+      "mainnet": ""
+    },
     "origin": "https://app.hemi.xyz",
     "stake": {
       "mainnet": "7qiewFZ7UyDpj3gyNaCDUk55NqHLdbjWQLduS5dcYfQ4",

--- a/portal-backend/api/src/subgraphs/route-handlers/get-earn-requests.ts
+++ b/portal-backend/api/src/subgraphs/route-handlers/get-earn-requests.ts
@@ -1,0 +1,21 @@
+import type { Request, Response } from 'express'
+import { type Address } from 'viem'
+
+import type { ChainIdPathParams } from '../../types.ts'
+import { getEarnRequests } from '../subgraph.ts'
+
+export async function getEarnRequestsHandler(
+  req: Request<ChainIdPathParams & { address: Address }>,
+  res: Response,
+) {
+  const { chainId } = req.data
+  const { address } = req.params
+
+  const requests = await getEarnRequests({
+    address,
+    // @ts-expect-error: chainId is validated at this point by validateChainIsHemiMainnet
+    chainId,
+  })
+
+  res.status(200).json({ requests })
+}

--- a/portal-backend/api/src/subgraphs/router.ts
+++ b/portal-backend/api/src/subgraphs/router.ts
@@ -8,6 +8,7 @@ import type { ChainIdPathParams, ReqData } from '../types.ts'
 
 import { getBtcDepositOnHemi } from './route-handlers/get-btc-deposit-on-hemi.ts'
 import { getClaimTransactionHandler } from './route-handlers/get-claim-transaction-hash.ts'
+import { getEarnRequestsHandler } from './route-handlers/get-earn-requests.ts'
 import { getLockedPositionsHandler } from './route-handlers/get-locked-positions.ts'
 import { getWithdrawalProofAndClaimHandler } from './route-handlers/get-withdrawal-proof-and-claim.ts'
 import {
@@ -55,6 +56,18 @@ function validateChainIsHemi(
     req.data.chainId &&
     [hemi.id, hemiSepolia.id].includes(req.data.chainId)
   ) {
+    next()
+  } else {
+    next('route')
+  }
+}
+
+function validateChainIsHemiMainnet(
+  req: Request & ReqData,
+  res: Response,
+  next: NextFunction,
+) {
+  if (req.data.chainId === hemi.id) {
     next()
   } else {
     next('route')
@@ -251,6 +264,14 @@ export function createSubgraphsRouter() {
     validateAddress,
     validateChainIsHemi,
     getLockedPositionsHandler,
+  )
+
+  router.get(
+    '/:chainIdStr/earn-requests/:address',
+    parseChainId,
+    validateAddress,
+    validateChainIsHemiMainnet,
+    getEarnRequestsHandler,
   )
 
   return router

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -763,10 +763,10 @@ type EarnRequestRow = {
   id: string
   requestId: string
   kind: 'DEPOSIT' | 'REDEEM'
-  asset: string
+  asset: Address
   amountIn: string
   amountOut: string | null
-  receiver: string
+  receiver: Address
   automatic: boolean
   initiatedAt: string
   status: 'PENDING' | 'FULFILLED' | 'CLAIMED' | 'CANCELLED' | 'RECOVERED'
@@ -845,11 +845,9 @@ export const getEarnRequests = async function ({
     ...r,
     // The Subgraph lowercases all Bytes when saving; convert address-shaped
     // fields back to checksum to avoid mismatches in the consumer.
-    // @ts-expect-error subgraph stores addresses as lowercased Bytes
     asset: toChecksum(r.asset),
     claimTxHash: r.claimTxHash ? toChecksum(r.claimTxHash) : null,
     initiateTxHash: toChecksum(r.initiateTxHash),
-    // @ts-expect-error subgraph stores addresses as lowercased Bytes
     receiver: toChecksum(r.receiver),
     recoverTxHash: r.recoverTxHash ? toChecksum(r.recoverTxHash) : null,
   }))

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -770,9 +770,9 @@ type EarnRequestRow = {
   automatic: boolean
   initiatedAt: string
   status: 'PENDING' | 'FULFILLED' | 'CLAIMED' | 'CANCELLED' | 'RECOVERED'
-  initiateTxHash: Address
-  claimTxHash: Address | null
-  recoverTxHash: Address | null
+  initiateTxHash: Hash
+  claimTxHash: Hash | null
+  recoverTxHash: Hash | null
 }
 
 type GetEarnRequestsQueryResponse = GraphResponse<{
@@ -846,9 +846,6 @@ export const getEarnRequests = async function ({
     // The Subgraph lowercases all Bytes when saving; convert address-shaped
     // fields back to checksum to avoid mismatches in the consumer.
     asset: toChecksum(r.asset),
-    claimTxHash: r.claimTxHash ? toChecksum(r.claimTxHash) : null,
-    initiateTxHash: toChecksum(r.initiateTxHash),
     receiver: toChecksum(r.receiver),
-    recoverTxHash: r.recoverTxHash ? toChecksum(r.recoverTxHash) : null,
   }))
 }

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -21,7 +21,10 @@ import type {
 
 type Schema = {
   query: string
-  variables?: Record<string, string | number>
+  // undefined is allowed so optional cursor variables (e.g. an inclusive
+  // pagination bound that is absent on the first page) can be passed through;
+  // graph-node treats an absent/null variable as "ignore that filter".
+  variables?: Record<string, string | number | undefined>
 }
 
 type SuccessResponse<T> = { data: T }
@@ -87,6 +90,66 @@ function checkGraphQLErrors<T>(
     const errorMessages = response.errors.map(e => e.message).join(', ')
     throw new Error(`GraphQL Error: ${errorMessages}`)
   }
+}
+
+// graph-node doesn't support cursor pagination and rejects a $skip greater than
+// 5000. See https://github.com/graphprotocol/graph-node/issues/613
+const maxSkip = 5000
+
+/**
+ * Fetches every row of a paginated subgraph collection.
+ *
+ * graph-node only offers limit/skip pagination and caps $skip at 5000, so this
+ * pages with skip until the next page would cross that cap, then resets skip to
+ * 0 and advances a cursor (the order-by field value of the last row seen) so
+ * the next window continues where the previous one ended. Because the cursor
+ * filter is inclusive, rows are deduped by their id.
+ *
+ * The caller owns the query, including the order field, the direction and the
+ * inclusive cursor filter matching that direction (e.g. `field_lte` for `desc`,
+ * `field_gte` for `asc`); this helper only drives skip, the cursor and dedup.
+ *
+ * @param fetchPage Runs one request given the page window and the current
+ * cursor (undefined on the first window), returning that page's rows.
+ * @param getCursor Reads the cursor value (the order-by field) from a row.
+ * @param pageSize Rows to request per page. Defaults to 100.
+ */
+const paginateSubgraph = async function <TRow extends { id: string }>({
+  fetchPage,
+  getCursor,
+  pageSize = 100,
+}: {
+  fetchPage: (window: {
+    cursor: string | undefined
+    first: number
+    skip: number
+  }) => Promise<TRow[]>
+  getCursor: (row: TRow) => string
+  pageSize?: number
+}) {
+  const byId = new Map<string, TRow>()
+  let cursor: string | undefined
+  let skip = 0
+  let page: TRow[]
+
+  do {
+    page = await fetchPage({ cursor, first: pageSize, skip })
+    for (const row of page) {
+      byId.set(row.id, row)
+    }
+
+    if (skip + pageSize > maxSkip) {
+      skip = 0
+      const last = page.at(-1)
+      if (last) {
+        cursor = getCursor(last)
+      }
+    } else {
+      skip += pageSize
+    }
+  } while (page.length === pageSize)
+
+  return [...byId.values()]
 }
 
 /**
@@ -694,4 +757,100 @@ export const getLockedPositions = function ({
       }))
     },
   )
+}
+
+type EarnRequestRow = {
+  id: string
+  requestId: string
+  kind: 'DEPOSIT' | 'REDEEM'
+  asset: string
+  amountIn: string
+  amountOut: string | null
+  receiver: string
+  automatic: boolean
+  initiatedAt: string
+  status: 'PENDING' | 'FULFILLED' | 'CLAIMED' | 'CANCELLED' | 'RECOVERED'
+  initiateTxHash: Address
+  claimTxHash: Address | null
+  recoverTxHash: Address | null
+}
+
+type GetEarnRequestsQueryResponse = GraphResponse<{
+  requests: EarnRequestRow[]
+}>
+
+/**
+ * Retrieves the full list of Hemi Earn Router requests (deposits and redeems)
+ * for a given user, paginating internally against the subgraph until exhausted.
+ */
+export const getEarnRequests = async function ({
+  address,
+  chainId,
+}: {
+  address: Address
+  chainId: Chain['id']
+}) {
+  const subgraphIds = {
+    [hemi.id]: subgraphConfig.hemiEarnRouter.mainnet,
+  }
+
+  const url = getSubgraphUrl({ chainId, subgraphIds })
+  const lowercasedAddress = address.toLowerCase()
+
+  const rows = await paginateSubgraph<EarnRequestRow>({
+    async fetchPage({ cursor, first, skip }) {
+      const schema = {
+        // Ordered by initiatedAt desc, so the cursor walks downward with an
+        // inclusive initiatedAt_lte. graph-node ignores the filter when the
+        // value is null (the first window).
+        query: `query GetEarnRequests($address: Bytes!, $first: Int!, $initiatedAtMax: BigInt, $skip: Int!) {
+          requests(
+            first: $first,
+            skip: $skip,
+            orderBy: initiatedAt,
+            orderDirection: desc,
+            where: { receiver: $address, initiatedAt_lte: $initiatedAtMax }
+          ) {
+            amountIn
+            amountOut
+            asset
+            automatic
+            claimTxHash
+            id
+            initiatedAt
+            initiateTxHash
+            kind
+            receiver
+            recoverTxHash
+            requestId
+            status
+          }
+        }`,
+        variables: {
+          address: lowercasedAddress,
+          first,
+          initiatedAtMax: cursor,
+          skip,
+        },
+      }
+
+      const response = await request<GetEarnRequestsQueryResponse>(url, schema)
+      checkGraphQLErrors(response)
+      return response.data.requests
+    },
+    getCursor: row => row.initiatedAt,
+  })
+
+  return rows.map(r => ({
+    ...r,
+    // The Subgraph lowercases all Bytes when saving; convert address-shaped
+    // fields back to checksum to avoid mismatches in the consumer.
+    // @ts-expect-error subgraph stores addresses as lowercased Bytes
+    asset: toChecksum(r.asset),
+    claimTxHash: r.claimTxHash ? toChecksum(r.claimTxHash) : null,
+    initiateTxHash: toChecksum(r.initiateTxHash),
+    // @ts-expect-error subgraph stores addresses as lowercased Bytes
+    receiver: toChecksum(r.receiver),
+    recoverTxHash: r.recoverTxHash ? toChecksum(r.recoverTxHash) : null,
+  }))
 }


### PR DESCRIPTION
### Description

Adds a new `GET /:chainId/earn-requests/:address` endpoint to the portal-baclend API that returns a user's Hemi Earn Router requests (deposits and redeems), gated to Hemi mainnet.

Pagination is extracted into a reusable `paginateSubgraph` helper: it pages with `skip` until the next page would cross graph-node's hard 5000 `skip` cap, then resets `skip` and advances an `initiatedAt` cursor, deduping rows by `id`. This is intended to be reused by future paginated subgraph queries.

> [!WARNING]
> **This cannot be merged yet.** The Hemi Earn Router subgraph this endpoint queries has not been published, so `hemiEarnRouter.mainnet` in `config/default.json` is intentionally left empty. Until the subgraph is published and its ID is available, the endpoint will throw on every call (`Unsupported subgraph...` → 500). Opening as a draft and holding until then.

### Screenshots

N/A — backend only.

### Related issue(s)

Related to #1848

### Checklist

- [ ] Manual testing passed. <!-- blocked: subgraph not yet published -->
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A. <!-- `hemiEarnRouter.mainnet` subgraph ID must be set once the subgraph is published -->
