### PR TITLE
Add .ts extensions to ve-hemi packages for Node ESM

### DIFF
--- a/packages/ve-hemi-actions/actions/index.ts
+++ b/packages/ve-hemi-actions/actions/index.ts
@@ -1,15 +1,18 @@
-export { createLock, encodeCreateLock } from './wallet/createLock'
-export { encodeIncreaseAmount, increaseAmount } from './wallet/increaseAmount'
+export { createLock, encodeCreateLock } from './wallet/createLock.ts'
+export {
+  encodeIncreaseAmount,
+  increaseAmount,
+} from './wallet/increaseAmount.ts'
 export {
   encodeIncreaseUnlockTime,
   increaseUnlockTime,
-} from './wallet/increaseUnlockTime'
-export { encodeWithdraw, withdraw } from './wallet/withdraw'
+} from './wallet/increaseUnlockTime.ts'
+export { encodeWithdraw, withdraw } from './wallet/withdraw.ts'
 export {
   getBalanceOfNFTAt,
   getLockedBalance,
   getPositionVotingPowerDetails,
   getPositionsVotingPowerSum,
   getTotalVotingPower,
-} from './public/veHemi'
-export { getTotalVeHemiSupplyAt } from './public/getTotalVeHemiSupplyAt'
+} from './public/veHemi.ts'
+export { getTotalVeHemiSupplyAt } from './public/getTotalVeHemiSupplyAt.ts'

--- a/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
+++ b/packages/ve-hemi-actions/actions/public/getTotalVeHemiSupplyAt.ts
@@ -1,8 +1,8 @@
 import type { Client } from 'viem'
 import { readContract } from 'viem/actions'
 
-import { veHemiAbi } from '../../abi'
-import { getVeHemiContractAddress } from '../../constants'
+import { veHemiAbi } from '../../abi.ts'
+import { getVeHemiContractAddress } from '../../constants.ts'
 
 export const getTotalVeHemiSupplyAt = async function (
   client: Client,

--- a/packages/ve-hemi-actions/actions/public/veHemi.ts
+++ b/packages/ve-hemi-actions/actions/public/veHemi.ts
@@ -2,10 +2,10 @@ import pMemoize from 'promise-mem'
 import { isAddress, isAddressEqual, type Address, type Client } from 'viem'
 import { multicall, readContract } from 'viem/actions'
 
-import { veHemiAbi } from '../../abi'
-import { veHemiVoteDelegationAbi } from '../../voteDelegationAbi'
+import { veHemiAbi } from '../../abi.ts'
+import { veHemiVoteDelegationAbi } from '../../voteDelegationAbi.ts'
 
-import { getVeHemiContractAddress } from './../../constants'
+import { getVeHemiContractAddress } from './../../constants.ts'
 
 export const getHemiTokenAddress = async function (client: Client) {
   if (!client.chain) {

--- a/packages/ve-hemi-actions/actions/wallet/approval.ts
+++ b/packages/ve-hemi-actions/actions/wallet/approval.ts
@@ -3,7 +3,7 @@ import type { Address, TransactionReceipt, WalletClient } from 'viem'
 import { waitForTransactionReceipt } from 'viem/actions'
 import { approve, allowance } from 'viem-erc20/actions'
 
-import type { ApprovalEvents } from '../../types'
+import type { ApprovalEvents } from '../../types.ts'
 
 type DefaultEventMap = [never]
 type EventMap<T> = Record<keyof T, unknown[]> | DefaultEventMap

--- a/packages/ve-hemi-actions/actions/wallet/createLock.ts
+++ b/packages/ve-hemi-actions/actions/wallet/createLock.ts
@@ -5,13 +5,13 @@ import { encodeFunctionData } from 'viem'
 import { waitForTransactionReceipt, writeContract } from 'viem/actions'
 import { balanceOf } from 'viem-erc20/actions'
 
-import { veHemiAbi } from '../../abi'
-import { getVeHemiContractAddress } from '../../constants'
-import type { CreateLockEvents } from '../../types'
-import { validateCreateLockInputs } from '../../utils'
-import { memoizedGetHemiTokenAddress } from '../public/veHemi'
+import { veHemiAbi } from '../../abi.ts'
+import { getVeHemiContractAddress } from '../../constants.ts'
+import type { CreateLockEvents } from '../../types.ts'
+import { validateCreateLockInputs } from '../../utils.ts'
+import { memoizedGetHemiTokenAddress } from '../public/veHemi.ts'
 
-import { handleApproval } from './approval'
+import { handleApproval } from './approval.ts'
 
 const canCreateLock = async function ({
   account,

--- a/packages/ve-hemi-actions/actions/wallet/increaseAmount.ts
+++ b/packages/ve-hemi-actions/actions/wallet/increaseAmount.ts
@@ -5,13 +5,16 @@ import { encodeFunctionData } from 'viem'
 import { waitForTransactionReceipt, writeContract } from 'viem/actions'
 import { balanceOf } from 'viem-erc20/actions'
 
-import { veHemiAbi } from '../../abi'
-import { getVeHemiContractAddress } from '../../constants'
-import type { IncreaseAmountEvents } from '../../types'
-import { validateIncreaseAmountInputs } from '../../utils'
-import { getLockedBalance, memoizedGetHemiTokenAddress } from '../public/veHemi'
+import { veHemiAbi } from '../../abi.ts'
+import { getVeHemiContractAddress } from '../../constants.ts'
+import type { IncreaseAmountEvents } from '../../types.ts'
+import { validateIncreaseAmountInputs } from '../../utils.ts'
+import {
+  getLockedBalance,
+  memoizedGetHemiTokenAddress,
+} from '../public/veHemi.ts'
 
-import { handleApproval } from './approval'
+import { handleApproval } from './approval.ts'
 
 const canIncreaseAmount = async function ({
   account,

--- a/packages/ve-hemi-actions/actions/wallet/increaseUnlockTime.ts
+++ b/packages/ve-hemi-actions/actions/wallet/increaseUnlockTime.ts
@@ -4,11 +4,11 @@ import type { Address, TransactionReceipt, WalletClient } from 'viem'
 import { encodeFunctionData } from 'viem'
 import { waitForTransactionReceipt, writeContract } from 'viem/actions'
 
-import { veHemiAbi } from '../../abi'
-import { getVeHemiContractAddress } from '../../constants'
-import type { IncreaseUnlockTimeEvents } from '../../types'
-import { validateIncreaseUnlockTimeInputs } from '../../utils'
-import { getLockedBalance } from '../public/veHemi'
+import { veHemiAbi } from '../../abi.ts'
+import { getVeHemiContractAddress } from '../../constants.ts'
+import type { IncreaseUnlockTimeEvents } from '../../types.ts'
+import { validateIncreaseUnlockTimeInputs } from '../../utils.ts'
+import { getLockedBalance } from '../public/veHemi.ts'
 
 const canIncreaseUnlockTime = async function ({
   account,

--- a/packages/ve-hemi-actions/actions/wallet/withdraw.ts
+++ b/packages/ve-hemi-actions/actions/wallet/withdraw.ts
@@ -4,11 +4,11 @@ import type { Address, TransactionReceipt, WalletClient } from 'viem'
 import { encodeFunctionData } from 'viem'
 import { waitForTransactionReceipt, writeContract } from 'viem/actions'
 
-import { veHemiAbi } from '../../abi'
-import { getVeHemiContractAddress } from '../../constants'
-import type { WithdrawEvents } from '../../types'
-import { validateWithdrawInputs } from '../../utils'
-import { getLockedBalance, getOwnerOf } from '../public/veHemi'
+import { veHemiAbi } from '../../abi.ts'
+import { getVeHemiContractAddress } from '../../constants.ts'
+import type { WithdrawEvents } from '../../types.ts'
+import { validateWithdrawInputs } from '../../utils.ts'
+import { getLockedBalance, getOwnerOf } from '../public/veHemi.ts'
 
 const canRunWithdraw = async function ({
   account,

--- a/packages/ve-hemi-actions/index.ts
+++ b/packages/ve-hemi-actions/index.ts
@@ -3,13 +3,13 @@ export type {
   IncreaseAmountEvents,
   IncreaseUnlockTimeEvents,
   WithdrawEvents,
-} from './types'
+} from './types.ts'
 
 export {
   getVeHemiContractAddress,
   MaxLockDurationSeconds,
   MinLockDurationSeconds,
   SixDaysSeconds,
-} from './constants'
+} from './constants.ts'
 
-export { getLockEvent, validateCreateLockInputs } from './utils'
+export { getLockEvent, validateCreateLockInputs } from './utils.ts'

--- a/packages/ve-hemi-actions/package.json
+++ b/packages/ve-hemi-actions/package.json
@@ -35,6 +35,7 @@
   "peerDependencies": {
     "viem": "^2.x"
   },
+  "type": "module",
   "exports": {
     ".": "./index.ts",
     "./actions": "./actions/index.ts"

--- a/packages/ve-hemi-actions/tsconfig.json
+++ b/packages/ve-hemi-actions/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "baseUrl": "./",
     "erasableSyntaxOnly": true,
     "noEmit": true

--- a/packages/ve-hemi-actions/utils.ts
+++ b/packages/ve-hemi-actions/utils.ts
@@ -1,12 +1,12 @@
 import type { Address, TransactionReceipt } from 'viem'
 import { isAddress, parseEventLogs, zeroAddress } from 'viem'
 
-import { veHemiAbi } from './abi'
+import { veHemiAbi } from './abi.ts'
 import {
   MaxLockDurationSeconds,
   MinLockDurationSeconds,
   SupportedChains,
-} from './constants'
+} from './constants.ts'
 
 const validateAccount = function (account: Address) {
   if (!isAddress(account)) {

--- a/packages/ve-hemi-rewards/actions/index.ts
+++ b/packages/ve-hemi-rewards/actions/index.ts
@@ -1,6 +1,6 @@
-export { getRewardPeriod } from './public/getRewardPeriod'
-export { calculateRewards, getRewardTokens } from './public/veHemiRewards'
+export { getRewardPeriod } from './public/getRewardPeriod.ts'
+export { calculateRewards, getRewardTokens } from './public/veHemiRewards.ts'
 export {
   collectAllRewards,
   encodeCollectAllRewards,
-} from './wallet/collectRewards'
+} from './wallet/collectRewards.ts'

--- a/packages/ve-hemi-rewards/actions/public/getRewardPeriod.ts
+++ b/packages/ve-hemi-rewards/actions/public/getRewardPeriod.ts
@@ -6,8 +6,8 @@ import {
 } from 'viem'
 import { readContract } from 'viem/actions'
 
-import { veHemiRewardsAbi } from '../../abi'
-import { getVeHemiRewardsContractAddress } from '../../constants'
+import { veHemiRewardsAbi } from '../../abi.ts'
+import { getVeHemiRewardsContractAddress } from '../../constants.ts'
 
 export const getRewardPeriod = async function (
   client: Client,

--- a/packages/ve-hemi-rewards/actions/public/veHemiRewards.ts
+++ b/packages/ve-hemi-rewards/actions/public/veHemiRewards.ts
@@ -1,8 +1,8 @@
 import { getAddress, type Address, type Client } from 'viem'
 import { readContract } from 'viem/actions'
 
-import { veHemiRewardsAbi } from '../../abi'
-import { getVeHemiRewardsContractAddress } from '../../constants'
+import { veHemiRewardsAbi } from '../../abi.ts'
+import { getVeHemiRewardsContractAddress } from '../../constants.ts'
 
 export const calculateRewards = async function (
   client: Client,

--- a/packages/ve-hemi-rewards/actions/wallet/collectRewards.ts
+++ b/packages/ve-hemi-rewards/actions/wallet/collectRewards.ts
@@ -4,9 +4,9 @@ import type { Address, TransactionReceipt, WalletClient } from 'viem'
 import { encodeFunctionData } from 'viem'
 import { waitForTransactionReceipt, writeContract } from 'viem/actions'
 
-import { veHemiRewardsAbi } from '../../abi'
-import { getVeHemiRewardsContractAddress } from '../../constants'
-import type { CollectAllRewardsEvents } from '../../types'
+import { veHemiRewardsAbi } from '../../abi.ts'
+import { getVeHemiRewardsContractAddress } from '../../constants.ts'
+import type { CollectAllRewardsEvents } from '../../types.ts'
 
 const canCollectAllRewards = async function ({
   tokenId,

--- a/packages/ve-hemi-rewards/index.ts
+++ b/packages/ve-hemi-rewards/index.ts
@@ -1,3 +1,3 @@
-export { getVeHemiRewardsContractAddress } from './constants'
+export { getVeHemiRewardsContractAddress } from './constants.ts'
 
-export type { CollectAllRewardsEvents } from './types'
+export type { CollectAllRewardsEvents } from './types.ts'

--- a/packages/ve-hemi-rewards/package.json
+++ b/packages/ve-hemi-rewards/package.json
@@ -34,6 +34,7 @@
   "peerDependencies": {
     "viem": "^2.x"
   },
+  "type": "module",
   "exports": {
     ".": "./index.ts",
     "./actions": "./actions/index.ts"

--- a/packages/ve-hemi-rewards/tsconfig.json
+++ b/packages/ve-hemi-rewards/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "baseUrl": "./",
     "erasableSyntaxOnly": true,
     "noEmit": true

--- a/portal/tsconfig.json
+++ b/portal/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "baseUrl": "./",
     "erasableSyntaxOnly": true,
     "lib": ["dom", "dom.iterable", "esnext", "WebWorker"],


### PR DESCRIPTION
### Description

As preparation for unifying `portal-api` and `subgraph-api` (#1425), `portal-backend/api` is being migrated to ESM TypeScript run **directly by Node** via native type-stripping (no bundler, no `tsx`). That api imports the `ve-hemi-actions` and `ve-hemi-rewards` workspace packages.

Node's native ESM loader performs **no** extension resolution — relative imports must carry explicit extensions — so these packages' extensionless imports (`from './abi'`, `from './wallet/createLock'`, …) throw `ERR_MODULE_NOT_FOUND` the moment Node runs them. They worked until now only because their sole consumer was the `portal` Next.js app, whose bundler tolerates extensionless imports.

This PR makes both packages resolve under **both** the portal's bundler and raw Node, with no behavior change:

- Add explicit `.ts` to every relative import in both packages' **source** files (barrels included). Test files are left as-is — vitest/esbuild resolve them regardless.
- Add `allowImportingTsExtensions: true` to both package `tsconfig.json` (required for `tsc` to accept `.ts` import specifiers) and to `portal/tsconfig.json` (so `next build`'s typecheck of the transpiled packages doesn't fail with `TS5097`). Safe because every consumer runs `noEmit`.
- Add `"type": "module"` to both packages so Node stops emitting `MODULE_TYPELESS_PACKAGE_JSON` warnings and the reparse overhead.

No Docker/runtime changes here — the api migration and its image build land separately.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #1425

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.