### PR TITLE
Make Router subgraph mapping idempotent

### DIFF
--- a/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
+++ b/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
@@ -1,3 +1,5 @@
+import { BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
+
 import {
   DepositRequested as DepositRequestedEvent,
   RedeemRequested as RedeemRequestedEvent,
@@ -8,9 +10,56 @@ import {
 } from '../../generated/Router/Router'
 import { Request } from '../../generated/schema'
 
+// Loads the Request entity, or creates one with sentinel field values when a
+// lifecycle event (Fulfilled / Claimed / Cancelled / Recovered) arrives
+// BEFORE the originating DepositRequested / RedeemRequested. This happens:
+//   1. When graph-node processes events in an order where the lifecycle event
+//      precedes the request-creation event in the same tx (e.g. the local
+//      anvil mock that collapses the cross-chain hop into one transaction
+//      emits RequestFulfilled inside the requestDeposit call, ahead of the
+//      final `emit DepositRequested(...)`); production cross-chain timing
+//      naturally separates these into different blocks.
+//   2. When the subgraph is (re)indexed with `startBlock` past a request's
+//      creation block, so DepositRequested was never observed locally.
+// Sentinels are placeholders for the required (non-null) fields. When (and
+// if) the corresponding DepositRequested / RedeemRequested arrives later, it
+// overwrites them with the real values — but does NOT touch `status`, which
+// is owned by the lifecycle handlers.
+function loadOrInitRequest(
+  id: string,
+  requestId: BigInt,
+  event: ethereum.Event,
+): Request {
+  let request = Request.load(id)
+  if (request == null) {
+    request = new Request(id)
+    request.requestId = requestId
+    // Sentinels for required fields — overwritten by Deposit/Redeem when the
+    // request-creation event arrives (later in same tx, or never if missed).
+    request.kind = 'DEPOSIT'
+    request.asset = Bytes.empty()
+    request.amountIn = BigInt.zero()
+    request.receiver = Bytes.empty()
+    request.automatic = false
+    request.initiatedAt = event.block.timestamp
+    request.initiateTxHash = event.transaction.hash
+    request.status = 'PENDING'
+  }
+  return request
+}
+
 export function handleDepositRequested(event: DepositRequestedEvent): void {
   const id = event.params.requestId.toString()
-  const request = new Request(id)
+  let request = Request.load(id)
+  if (request == null) {
+    request = new Request(id)
+    request.status = 'PENDING'
+  }
+  // Populate request-time fields. `status` is intentionally NOT reassigned
+  // when the entity pre-exists — a lifecycle handler (Fulfilled / Claimed /
+  // Cancelled / Recovered) already wrote the current status and resetting to
+  // PENDING here would clobber it. The `new Request(...)` branch above seeds
+  // PENDING for the fresh-entity case.
   request.requestId = event.params.requestId
   request.kind = 'DEPOSIT'
   request.asset = event.params.asset
@@ -18,14 +67,17 @@ export function handleDepositRequested(event: DepositRequestedEvent): void {
   request.receiver = event.params.receiver
   request.automatic = event.params.automatic
   request.initiatedAt = event.block.timestamp
-  request.status = 'PENDING'
   request.initiateTxHash = event.transaction.hash
   request.save()
 }
 
 export function handleRedeemRequested(event: RedeemRequestedEvent): void {
   const id = event.params.requestId.toString()
-  const request = new Request(id)
+  let request = Request.load(id)
+  if (request == null) {
+    request = new Request(id)
+    request.status = 'PENDING'
+  }
   request.requestId = event.params.requestId
   request.kind = 'REDEEM'
   request.asset = event.params.asset
@@ -33,16 +85,16 @@ export function handleRedeemRequested(event: RedeemRequestedEvent): void {
   request.receiver = event.params.receiver
   request.automatic = event.params.automatic
   request.initiatedAt = event.block.timestamp
-  request.status = 'PENDING'
   request.initiateTxHash = event.transaction.hash
   request.save()
 }
 
 export function handleRequestFulfilled(event: RequestFulfilledEvent): void {
-  const request = Request.load(event.params.requestId.toString())
-  if (request == null) {
-    return
-  }
+  const request = loadOrInitRequest(
+    event.params.requestId.toString(),
+    event.params.requestId,
+    event,
+  )
   request.status = 'FULFILLED'
   // Actual amount the user received (shares for deposits, assets for redeems)
   request.amountOut = event.params.amountIn
@@ -50,20 +102,22 @@ export function handleRequestFulfilled(event: RequestFulfilledEvent): void {
 }
 
 export function handleRequestClaimed(event: RequestClaimedEvent): void {
-  const request = Request.load(event.params.requestId.toString())
-  if (request == null) {
-    return
-  }
+  const request = loadOrInitRequest(
+    event.params.requestId.toString(),
+    event.params.requestId,
+    event,
+  )
   request.status = 'CLAIMED'
   request.claimTxHash = event.transaction.hash
   request.save()
 }
 
 export function handleRequestCancelled(event: RequestCancelledEvent): void {
-  const request = Request.load(event.params.requestId.toString())
-  if (request == null) {
-    return
-  }
+  const request = loadOrInitRequest(
+    event.params.requestId.toString(),
+    event.params.requestId,
+    event,
+  )
   request.status = 'CANCELLED'
   // Amount of assets the user will receive back. This should match the
   // request's amountIn, but the contract overwrites this field, so we
@@ -73,10 +127,11 @@ export function handleRequestCancelled(event: RequestCancelledEvent): void {
 }
 
 export function handleRequestRecovered(event: RequestRecoveredEvent): void {
-  const request = Request.load(event.params.requestId.toString())
-  if (request == null) {
-    return
-  }
+  const request = loadOrInitRequest(
+    event.params.requestId.toString(),
+    event.params.requestId,
+    event,
+  )
   request.status = 'RECOVERED'
   request.recoverTxHash = event.transaction.hash
   request.save()

--- a/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
+++ b/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
@@ -1,4 +1,4 @@
-import { BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
+import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts'
 
 import {
   DepositRequested as DepositRequestedEvent,
@@ -36,10 +36,14 @@ function loadOrInitRequest(
     request.requestId = requestId
     // Sentinels for required fields — overwritten by Deposit/Redeem when the
     // request-creation event arrives (later in same tx, or never if missed).
+    // `asset` and `receiver` are address-shaped in practice (the schema types
+    // them as `Bytes!` for storage); use the 20-byte zero address so that
+    // downstream consumers (e.g. portal calls to `getAddress(asset)`) keep
+    // working on placeholder rows instead of choking on `0x`.
     request.kind = 'DEPOSIT'
-    request.asset = Bytes.empty()
+    request.asset = Address.zero()
     request.amountIn = BigInt.zero()
-    request.receiver = Bytes.empty()
+    request.receiver = Address.zero()
     request.automatic = false
     request.initiatedAt = event.block.timestamp
     request.initiateTxHash = event.transaction.hash

--- a/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
+++ b/subgraphs/hemi-earn-router-subgraph/src/mappings/router.ts
@@ -10,37 +10,44 @@ import {
 } from '../../generated/Router/Router'
 import { Request } from '../../generated/schema'
 
-// Loads the Request entity, or creates one with sentinel field values when a
-// lifecycle event (Fulfilled / Claimed / Cancelled / Recovered) arrives
-// BEFORE the originating DepositRequested / RedeemRequested. This happens:
-//   1. When graph-node processes events in an order where the lifecycle event
-//      precedes the request-creation event in the same tx (e.g. the local
-//      anvil mock that collapses the cross-chain hop into one transaction
-//      emits RequestFulfilled inside the requestDeposit call, ahead of the
-//      final `emit DepositRequested(...)`); production cross-chain timing
-//      naturally separates these into different blocks.
+// Lifecycle handlers (Fulfilled / Claimed / Cancelled / Recovered) don't
+// know the request `kind` — that information only lives in the originating
+// Deposit/Redeem event. When those handlers have to create a placeholder
+// (see `loadOrInitRequest` below), they pass this value as a best-guess
+// sentinel. In the anvil mock the Deposit/Redeem event always arrives later
+// in the same tx and overwrites it; the bias only surfaces if the subgraph
+// is (re)indexed past the creation block and the placeholder persists.
+const FALLBACK_KIND = 'DEPOSIT'
+
+// Loads the Request entity, or creates one with sentinel field values when
+// the originating Deposit/Redeem hasn't been observed yet. This happens:
+//   1. When graph-node processes events in an order where a lifecycle event
+//      (Fulfilled / Claimed / Cancelled / Recovered) precedes the request-
+//      creation event in the same tx — the local anvil mock collapses the
+//      cross-chain hop into one transaction and emits RequestFulfilled
+//      inside `requestDeposit`, ahead of the final `emit DepositRequested`;
+//      production cross-chain timing naturally separates these into
+//      different blocks.
 //   2. When the subgraph is (re)indexed with `startBlock` past a request's
-//      creation block, so DepositRequested was never observed locally.
+//      creation block, so the creation event was never observed locally.
 // Sentinels are placeholders for the required (non-null) fields. When (and
-// if) the corresponding DepositRequested / RedeemRequested arrives later, it
-// overwrites them with the real values — but does NOT touch `status`, which
-// is owned by the lifecycle handlers.
+// if) the corresponding Deposit/Redeem arrives later, it overwrites them
+// with the real values; lifecycle handlers overwrite `status`/`amountOut`/
+// `*TxHash`. Address-shaped fields use the 20-byte zero address so
+// downstream consumers (e.g. portal calls to `getAddress(asset)`) keep
+// working on placeholder rows instead of choking on `0x`. `kind` is taken
+// from the caller — Deposit/Redeem pass their own kind; lifecycle handlers
+// pass `FALLBACK_KIND` since they have no way to know.
 function loadOrInitRequest(
   id: string,
-  requestId: BigInt,
+  kind: string,
   event: ethereum.Event,
 ): Request {
   let request = Request.load(id)
   if (request == null) {
     request = new Request(id)
-    request.requestId = requestId
-    // Sentinels for required fields — overwritten by Deposit/Redeem when the
-    // request-creation event arrives (later in same tx, or never if missed).
-    // `asset` and `receiver` are address-shaped in practice (the schema types
-    // them as `Bytes!` for storage); use the 20-byte zero address so that
-    // downstream consumers (e.g. portal calls to `getAddress(asset)`) keep
-    // working on placeholder rows instead of choking on `0x`.
-    request.kind = 'DEPOSIT'
+    request.requestId = BigInt.fromString(id)
+    request.kind = kind
     request.asset = Address.zero()
     request.amountIn = BigInt.zero()
     request.receiver = Address.zero()
@@ -53,17 +60,16 @@ function loadOrInitRequest(
 }
 
 export function handleDepositRequested(event: DepositRequestedEvent): void {
-  const id = event.params.requestId.toString()
-  let request = Request.load(id)
-  if (request == null) {
-    request = new Request(id)
-    request.status = 'PENDING'
-  }
+  const request = loadOrInitRequest(
+    event.params.requestId.toString(),
+    'DEPOSIT',
+    event,
+  )
   // Populate request-time fields. `status` is intentionally NOT reassigned
   // when the entity pre-exists — a lifecycle handler (Fulfilled / Claimed /
-  // Cancelled / Recovered) already wrote the current status and resetting to
-  // PENDING here would clobber it. The `new Request(...)` branch above seeds
-  // PENDING for the fresh-entity case.
+  // Cancelled / Recovered) already wrote the current status and resetting
+  // to PENDING here would clobber it. `loadOrInitRequest` seeds PENDING for
+  // the fresh-entity case.
   request.requestId = event.params.requestId
   request.kind = 'DEPOSIT'
   request.asset = event.params.asset
@@ -76,12 +82,11 @@ export function handleDepositRequested(event: DepositRequestedEvent): void {
 }
 
 export function handleRedeemRequested(event: RedeemRequestedEvent): void {
-  const id = event.params.requestId.toString()
-  let request = Request.load(id)
-  if (request == null) {
-    request = new Request(id)
-    request.status = 'PENDING'
-  }
+  const request = loadOrInitRequest(
+    event.params.requestId.toString(),
+    'REDEEM',
+    event,
+  )
   request.requestId = event.params.requestId
   request.kind = 'REDEEM'
   request.asset = event.params.asset
@@ -96,7 +101,7 @@ export function handleRedeemRequested(event: RedeemRequestedEvent): void {
 export function handleRequestFulfilled(event: RequestFulfilledEvent): void {
   const request = loadOrInitRequest(
     event.params.requestId.toString(),
-    event.params.requestId,
+    FALLBACK_KIND,
     event,
   )
   request.status = 'FULFILLED'
@@ -108,7 +113,7 @@ export function handleRequestFulfilled(event: RequestFulfilledEvent): void {
 export function handleRequestClaimed(event: RequestClaimedEvent): void {
   const request = loadOrInitRequest(
     event.params.requestId.toString(),
-    event.params.requestId,
+    FALLBACK_KIND,
     event,
   )
   request.status = 'CLAIMED'
@@ -119,7 +124,7 @@ export function handleRequestClaimed(event: RequestClaimedEvent): void {
 export function handleRequestCancelled(event: RequestCancelledEvent): void {
   const request = loadOrInitRequest(
     event.params.requestId.toString(),
-    event.params.requestId,
+    FALLBACK_KIND,
     event,
   )
   request.status = 'CANCELLED'
@@ -133,7 +138,7 @@ export function handleRequestCancelled(event: RequestCancelledEvent): void {
 export function handleRequestRecovered(event: RequestRecoveredEvent): void {
   const request = loadOrInitRequest(
     event.params.requestId.toString(),
-    event.params.requestId,
+    FALLBACK_KIND,
     event,
   )
   request.status = 'RECOVERED'

--- a/subgraphs/hemi-earn-router-subgraph/tests/router.test.ts
+++ b/subgraphs/hemi-earn-router-subgraph/tests/router.test.ts
@@ -221,12 +221,18 @@ describe('Router subgraph', function () {
     // same placeholder, so we end with one entity reflecting the final
     // lifecycle state.
     const id = unknownId.toString()
+    const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
     assert.entityCount(ENTITY, 1)
     assert.fieldEquals(ENTITY, id, 'requestId', unknownId.toString())
     assert.fieldEquals(ENTITY, id, 'status', 'RECOVERED')
     assert.fieldEquals(ENTITY, id, 'amountOut', assetsReturned.toString())
     assert.fieldEquals(ENTITY, id, 'claimTxHash', claimTxHash.toHexString())
     assert.fieldEquals(ENTITY, id, 'recoverTxHash', recoverTxHash.toHexString())
+    // The placeholder must use a 20-byte zero address for the address-shaped
+    // fields (asset / receiver) — `0x` (Bytes.empty) is not parseable as an
+    // address downstream.
+    assert.fieldEquals(ENTITY, id, 'asset', ZERO_ADDRESS)
+    assert.fieldEquals(ENTITY, id, 'receiver', ZERO_ADDRESS)
   })
 
   test('RedeemRequested creates a Request with kind=REDEEM and status=PENDING', function () {

--- a/subgraphs/hemi-earn-router-subgraph/tests/router.test.ts
+++ b/subgraphs/hemi-earn-router-subgraph/tests/router.test.ts
@@ -198,7 +198,7 @@ describe('Router subgraph', function () {
     )
   })
 
-  test('Shared events for an unknown requestId are no-ops', function () {
+  test('Lifecycle events for an unknown requestId create a placeholder Request', function () {
     const unknownId = BigInt.fromI32(9999)
 
     handleRequestFulfilled(
@@ -214,7 +214,19 @@ describe('Router subgraph', function () {
       createRequestRecoveredEvent(unknownId, receiver, recoverTxHash),
     )
 
-    assert.entityCount(ENTITY, 0)
+    // Defensive mapping: lifecycle handlers create a placeholder Request when
+    // the originating DepositRequested/RedeemRequested hasn't been observed
+    // (event ordering inverted by the local anvil mock, or subgraph reindexed
+    // past the request's creation block). Each subsequent handler updates the
+    // same placeholder, so we end with one entity reflecting the final
+    // lifecycle state.
+    const id = unknownId.toString()
+    assert.entityCount(ENTITY, 1)
+    assert.fieldEquals(ENTITY, id, 'requestId', unknownId.toString())
+    assert.fieldEquals(ENTITY, id, 'status', 'RECOVERED')
+    assert.fieldEquals(ENTITY, id, 'amountOut', assetsReturned.toString())
+    assert.fieldEquals(ENTITY, id, 'claimTxHash', claimTxHash.toHexString())
+    assert.fieldEquals(ENTITY, id, 'recoverTxHash', recoverTxHash.toHexString())
   })
 
   test('RedeemRequested creates a Request with kind=REDEEM and status=PENDING', function () {


### PR DESCRIPTION
### Description

This PR fixes a bug where Hemi Earn deposits and redeems showed up as PENDING in the subgraph even after the on-chain fulfillment landed.

  The lifecycle handlers (Fulfilled / Claimed / Cancelled / Recovered) used to early-return when the originating DepositRequested or RedeemRequested hadn't been processed yet. That implicit
  assumption breaks in two real scenarios: the local anvil mock collapses the cross-chain round-trip into a single tx and emits RequestFulfilled inside requestDeposit before the final emit
  DepositRequested, and a subgraph (re)indexed with a startBlock past a request's creation block never sees the original Deposit event. In both cases the lifecycle event got silently dropped and
  the request was stranded in PENDING forever.

  The mapping is now order-agnostic. Lifecycle handlers create a placeholder Request on demand with sentinel values for the required fields, and the request-creation handlers
  (DepositRequested/RedeemRequested) populate the remaining fields when they arrive. The status field is owned exclusively by the lifecycle handlers, so the request-creation path never clobbers a
  more advanced state.

### Screenshots

<img width="909" height="467" alt="Captura de Tela 2026-05-27 às 00 18 11" src="https://github.com/user-attachments/assets/ffcc70de-38ef-4ee0-a3c9-29d17ad8fb92" />

### Related issue(s)

Related to #1848

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
