### PR TITLE
Build portal-backend crons from repo root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # Used by the images that build from the repo root (portal-backend/api and the
-# portal-backend/cron/\* services). subgraph-api still builds from its own folder
-# and uses its own .dockerignore. until it gets removed
+# portal-backend/cron/* services). subgraph-api still builds from its own folder
+# and uses its own .dockerignore until it gets removed.
 # See https://github.com/hemilabs/ui-monorepo/issues/1425
 # Keep all package.json, pnpm-lock.yaml, pnpm-workspace.yaml and patches/
 # pnpm needs them to resolve the workspace.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,19 @@
-# Used only by the portal-backend/api image, which builds from the repo root.
-# Other images (crons, subgraph-api) build from their own folders and read their
-# own .dockerignore. Keep all package.json, pnpm-lock.yaml, pnpm-workspace.yaml
-# and patches/ — pnpm needs them to resolve the workspace.
+# Used by the images that build from the repo root (portal-backend/api and the
+# portal-backend/cron/\* services). subgraph-api still builds from its own folder
+# and uses its own .dockerignore. until it gets removed
+# See https://github.com/hemilabs/ui-monorepo/issues/1425
+# Keep all package.json, pnpm-lock.yaml, pnpm-workspace.yaml and patches/
+# pnpm needs them to resolve the workspace.
 **/node_modules
 **/.next
 **/dist
 **/out
 **/coverage
 **/.turbo
-**/*.tsbuildinfo
-**/*.log
+**/\*.tsbuildinfo
+**/_.log
 **/.DS_Store
+**/.env_
 .git
 .github
+portal-backend/api/scripts

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,10 +10,10 @@
 **/out
 **/coverage
 **/.turbo
-**/\*.tsbuildinfo
-**/_.log
+**/*.tsbuildinfo
+**/*.log
 **/.DS_Store
-**/.env_
+**/.env*
 .git
 .github
 portal-backend/api/scripts

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -40,11 +40,18 @@ jobs:
             dockerfile: portal-backend/api/Dockerfile
             versionFile: portal-backend/api/package.json
             image: hemilabs/portal-backend-api
-          - context: portal-backend/cron/hemi-supply
+          - context: .
+            dockerfile: portal-backend/cron/hemi-supply/Dockerfile
+            versionFile: portal-backend/cron/hemi-supply/package.json
             image: hemilabs/hemi-supply-cron
-          - context: portal-backend/cron/token-prices
+          - context: .
+            dockerfile: portal-backend/cron/token-prices/Dockerfile
+            versionFile: portal-backend/cron/token-prices/package.json
             image: hemilabs/token-prices-cron
-          - context: portal-backend/cron/vaults-monitor
+          - context: .
+            dockerfile: portal-backend/cron/vaults-monitor/Dockerfile
+            versionFile: portal-backend/cron/vaults-monitor/package.json
             image: hemilabs/vaults-monitor-cron
+          # Kept as is, as it will be removed - See https://github.com/hemilabs/ui-monorepo/issues/1425
           - context: subgraph-api
             image: hemilabs/subgraph-api

--- a/.github/workflows/docker-checks.yml
+++ b/.github/workflows/docker-checks.yml
@@ -51,11 +51,15 @@ jobs:
           - context: .
             dockerfile: portal-backend/api/Dockerfile
             image: hemilabs/portal-backend-api
-          - context: portal-backend/cron/hemi-supply
+          - context: .
+            dockerfile: portal-backend/cron/hemi-supply/Dockerfile
             image: hemilabs/hemi-supply-cron
-          - context: portal-backend/cron/token-prices
+          - context: .
+            dockerfile: portal-backend/cron/token-prices/Dockerfile
             image: hemilabs/token-prices-cron
-          - context: portal-backend/cron/vaults-monitor
+          - context: .
+            dockerfile: portal-backend/cron/vaults-monitor/Dockerfile
             image: hemilabs/vaults-monitor-cron
+          # Kept as is, as it will be removed - See https://github.com/hemilabs/ui-monorepo/issues/1425
           - context: subgraph-api
             image: hemilabs/subgraph-api

--- a/portal-backend/api/.dockerignore
+++ b/portal-backend/api/.dockerignore
@@ -1,2 +1,0 @@
-node_modules
-scripts

--- a/portal-backend/cron/hemi-supply/.dockerignore
+++ b/portal-backend/cron/hemi-supply/.dockerignore
@@ -1,1 +1,0 @@
-node_modules

--- a/portal-backend/cron/hemi-supply/Dockerfile
+++ b/portal-backend/cron/hemi-supply/Dockerfile
@@ -1,8 +1,26 @@
+# Build context is the repo root (see docker-compose.yml / the CI workflows).
+# Every image in this repo follows the same multi-stage `pnpm deploy` shape so
+# that any service can pull workspace packages without changing build wiring.
+# Multi-stage keeps the runtime image slim: only the self-contained `pnpm deploy`
+# output ships, not the workspace source or dev tooling.
+
+# ---- build: install the workspace, deploy ----
+FROM node:24.14.0-alpine3.23 AS build
+RUN corepack enable
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+WORKDIR /repo
+COPY . .
+RUN pnpm install --frozen-lockfile --filter hemi-supply-cron...
+# --legacy: this workspace doesn't set inject-workspace-packages, which pnpm v10's
+# default deploy now requires.
+RUN pnpm deploy --filter=hemi-supply-cron --prod --legacy /app
+
+# ---- runtime: minimal patched image running the deployed app ----
 FROM node:24.14.0-alpine3.23
 
 # Patch vulnerabilities
 RUN apk update
-RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23 
+RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
 RUN apk add --upgrade openssl=3.5.6-r0
 RUN npm install --global npm@11.12.0
 RUN corepack enable
@@ -14,11 +32,8 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-COPY package.json .
-RUN pnpm install --prod
+COPY --from=build --chown=node:node /app .
 
 USER node
-
-COPY . .
 
 CMD ["pnpm", "run", "start"]

--- a/portal-backend/cron/token-prices/.dockerignore
+++ b/portal-backend/cron/token-prices/.dockerignore
@@ -1,1 +1,0 @@
-node_modules

--- a/portal-backend/cron/token-prices/Dockerfile
+++ b/portal-backend/cron/token-prices/Dockerfile
@@ -1,8 +1,26 @@
+# Build context is the repo root (see docker-compose.yml / the CI workflows).
+# Every image in this repo follows the same multi-stage `pnpm deploy` shape so
+# that any service can pull workspace packages without changing build wiring.
+# Multi-stage keeps the runtime image slim: only the self-contained `pnpm deploy`
+# output ships, not the workspace source or dev tooling.
+
+# ---- build: install the workspace, deploy ----
+FROM node:24.14.0-alpine3.23 AS build
+RUN corepack enable
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+WORKDIR /repo
+COPY . .
+RUN pnpm install --frozen-lockfile --filter token-prices-cron...
+# --legacy: this workspace doesn't set inject-workspace-packages, which pnpm v10's
+# default deploy now requires.
+RUN pnpm deploy --filter=token-prices-cron --prod --legacy /app
+
+# ---- runtime: minimal patched image running the deployed app ----
 FROM node:24.14.0-alpine3.23
 
 # Patch vulnerabilities
 RUN apk update
-RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23 
+RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
 RUN apk add --upgrade openssl=3.5.6-r0
 RUN npm install --global npm@11.12.0
 RUN corepack enable
@@ -14,11 +32,8 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-COPY package.json .
-RUN pnpm install --prod
+COPY --from=build --chown=node:node /app .
 
 USER node
-
-COPY . .
 
 CMD ["pnpm", "run", "start"]

--- a/portal-backend/cron/vaults-monitor/.dockerignore
+++ b/portal-backend/cron/vaults-monitor/.dockerignore
@@ -1,1 +1,0 @@
-node_modules

--- a/portal-backend/cron/vaults-monitor/Dockerfile
+++ b/portal-backend/cron/vaults-monitor/Dockerfile
@@ -1,8 +1,26 @@
+# Build context is the repo root (see docker-compose.yml / the CI workflows).
+# Every image in this repo follows the same multi-stage `pnpm deploy` shape so
+# that any service can pull workspace packages without changing build wiring.
+# Multi-stage keeps the runtime image slim: only the self-contained `pnpm deploy`
+# output ships, not the workspace source or dev tooling.
+
+# ---- build: install the workspace, deploy ----
+FROM node:24.14.0-alpine3.23 AS build
+RUN corepack enable
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+WORKDIR /repo
+COPY . .
+RUN pnpm install --frozen-lockfile --filter vaults-monitor-cron...
+# --legacy: this workspace doesn't set inject-workspace-packages, which pnpm v10's
+# default deploy now requires.
+RUN pnpm deploy --filter=vaults-monitor-cron --prod --legacy /app
+
+# ---- runtime: minimal patched image running the deployed app ----
 FROM node:24.14.0-alpine3.23
 
 # Patch vulnerabilities
 RUN apk update
-RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23 
+RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
 RUN apk add --upgrade openssl=3.5.6-r0
 RUN npm install --global npm@11.12.0
 RUN corepack enable
@@ -14,11 +32,8 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-COPY package.json .
-RUN pnpm install --prod
+COPY --from=build --chown=node:node /app .
 
 USER node
-
-COPY . .
 
 CMD ["pnpm", "run", "start"]

--- a/portal-backend/docker-compose.yml
+++ b/portal-backend/docker-compose.yml
@@ -1,9 +1,12 @@
+# Every service builds from the repo root with an explicit dockerfile path, so
+# any image can pull workspace packages via `pnpm deploy` if it needs them.
 services:
   cache:
     image: redis:7.2.7-alpine
   hemi-supply-cron:
     build:
-      context: cron/hemi-supply
+      context: ..
+      dockerfile: portal-backend/cron/hemi-supply/Dockerfile
     depends_on:
       - cache
     environment:
@@ -21,7 +24,6 @@ services:
     restart: always
   portal-api:
     build:
-      # Repo root, because the api bundles workspace packages via pnpm deploy.
       context: ..
       dockerfile: portal-backend/api/Dockerfile
     depends_on:
@@ -42,7 +44,8 @@ services:
     restart: always
   token-prices-cron:
     build:
-      context: cron/token-prices
+      context: ..
+      dockerfile: portal-backend/cron/token-prices/Dockerfile
     depends_on:
       - cache
     environment:
@@ -55,7 +58,8 @@ services:
     restart: always
   vaults-monitor-cron:
     build:
-      context: cron/vaults-monitor
+      context: ..
+      dockerfile: portal-backend/cron/vaults-monitor/Dockerfile
     depends_on:
       - portal-api
     environment:


### PR DESCRIPTION
### Description

Follow-up to #1950. The three cron images (`hemi-supply`, `token-prices`, `vaults-monitor`) now build from the repo root with the same multi-stage `pnpm deploy` shape as `portal-backend/api`: the build stage runs `pnpm install --frozen-lockfile --filter <cron>...` against the workspace lockfile, then `pnpm deploy --filter=<cron> --prod --legacy /app` produces a slim self-contained `/app` that the runtime stage ships. `docker-compose.yml` and both CI workflows (`build-push-images`, `docker-checks`) pass the repo root as context with an explicit `dockerfile:`/`versionFile:` per image.

The four orphan per-service `.dockerignore` files (api + the three crons) are removed — the repo-root `.dockerignore` now covers them. It gains `**/.env*` so dotenvs in the broader context never enter the build, and `portal-backend/api/scripts` to keep the api's operator-only `.cjs` helpers out of the runtime image (the intent of api's old per-folder `.dockerignore`, which the api root-context move in #1950 dropped).

`subgraph-api` stays on its own per-folder context — it's slated for removal in #1425, so changing it now is wasted churn.

### Screenshots

N/A — Docker/CI plumbing only, no UI.

### Related issue(s)

Closes #1951

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.