### PR TITLE
Add share token to pool info bar

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
@@ -3,6 +3,7 @@
 import { ButtonLink } from 'components/button'
 import { ExternalLink } from 'components/externalLink'
 import { RenderFiatBalance } from 'components/fiatBalance'
+import { TokenLogo } from 'components/tokenLogo'
 import { getStakingVaultForShare } from 'hemi-earn-actions'
 import { useChain } from 'hooks/useChain'
 import { mainnet } from 'networks/mainnet'
@@ -56,6 +57,16 @@ export const PoolInfoBar = function ({ pool }: Props) {
               formattedAddress
             )}
           </span>
+        </PoolInfoItem>
+        <PoolInfoItem label={t('share-token')}>
+          <div className="flex items-center gap-x-1.5">
+            <div className="flex items-center justify-center rounded-full border border-gray-200">
+              <TokenLogo size="small" token={pool.shareToken} version="L1" />
+            </div>
+            <span className="body-text-medium text-neutral-950">
+              {pool.shareToken.symbol}
+            </span>
+          </div>
         </PoolInfoItem>
         <PoolInfoItem label={t('total-deposits')}>
           <span className="body-text-medium text-neutral-950">

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -60,6 +60,7 @@
       "manage": "Manage",
       "pool-contract": "Pool Contract",
       "potential-rewards": "Potential rewards",
+      "share-token": "Share token",
       "total-deposits": "Total deposits"
     }
   },

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -60,6 +60,7 @@
       "manage": "Gestionar",
       "pool-contract": "Contrato del fondo",
       "potential-rewards": "Recompensas potenciales",
+      "share-token": "Token de participación",
       "total-deposits": "Depósitos totales"
     }
   },

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -60,6 +60,7 @@
       "manage": "Gerenciar",
       "pool-contract": "Contrato do fundo",
       "potential-rewards": "Recompensas potenciais",
+      "share-token": "Token de participação",
       "total-deposits": "Depósitos totais"
     }
   },


### PR DESCRIPTION
### Description

Adds a new **Share token** item to the Hemi Earn pool info bar, shown between **Pool Contract** and **Total deposits**. It renders the share token's L1 logo (via the existing `TokenLogo` component, `version="L1"`) followed by its symbol, reusing the already-resolved `pool.shareToken`. The logo sits inside a `gray-200` circular border so the otherwise-white logo has a visible outline. The `share-token` label was added to the `en`, `es` and `pt` message files.

### Screenshots

<img width="813" height="181" alt="image" src="https://github.com/user-attachments/assets/f76531b4-4195-4532-8b9e-fb13f02bb3e1" />

Note: The rest of the bar is using default values because I had mocked data as the contracts are not deployed.

### Related issue(s)

Closes #1960

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.