### PR TITLE
Invalidate cached reward-token balances after claim

### DIFF
--- a/portal/app/[locale]/btc-yield/_hooks/useDeposit.ts
+++ b/portal/app/[locale]/btc-yield/_hooks/useDeposit.ts
@@ -4,7 +4,7 @@ import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpd
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { getBtcStakingVaultContractAddress } from 'hemi-btc-staking-actions'
 import { depositToken } from 'hemi-btc-staking-actions/actions'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { buildAllowanceQueryKey } from 'utils/allowanceQueryKey'
@@ -38,10 +38,11 @@ export const useDeposit = function ({
   const vaultAddress = getBtcStakingVaultContractAddress(token.chainId)
   const queryClient = useQueryClient()
 
-  const { queryKey: tokenBalanceQueryKey } = useTokenBalance(
-    token.chainId,
-    token.address,
-  )
+  const tokenBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: token.chainId,
+    tokenAddress: token.address,
+  })
 
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
     token.chainId,

--- a/portal/app/[locale]/btc-yield/_hooks/useWithdraw.ts
+++ b/portal/app/[locale]/btc-yield/_hooks/useWithdraw.ts
@@ -4,7 +4,7 @@ import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpd
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { getBtcStakingVaultContractAddress } from 'hemi-btc-staking-actions'
 import { withdraw } from 'hemi-btc-staking-actions/actions'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { parseTokenUnits } from 'utils/token'
@@ -38,10 +38,11 @@ export const useWithdraw = function ({
   const ensureConnectedTo = useEnsureConnectedTo()
   const queryClient = useQueryClient()
 
-  const { queryKey: tokenBalanceQueryKey } = useTokenBalance(
-    token.chainId,
-    token.address,
-  )
+  const tokenBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: token.chainId,
+    tokenAddress: token.address,
+  })
 
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
     token.chainId,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDeposit.ts
@@ -8,7 +8,7 @@ import {
   getHemiEarnRouterAddress,
 } from 'hemi-earn-actions'
 import { requestDeposit } from 'hemi-earn-actions/actions'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { buildAllowanceQueryKey } from 'utils/allowanceQueryKey'
 import { parseTokenUnits } from 'utils/token'
 import { type Hash } from 'viem'
@@ -56,10 +56,11 @@ export const useDeposit = function ({
   const { deleteLocalOperationByInitiateTxHash, upsertLocalOperation } =
     useLocalEarnOperations()
 
-  const { queryKey: tokenBalanceQueryKey } = useTokenBalance(
+  const tokenBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
     chainId,
-    selectedAsset.address,
-  )
+    tokenAddress: selectedAsset.address,
+  })
 
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(chainId)
 

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdraw.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdraw.ts
@@ -8,7 +8,7 @@ import {
   getHemiEarnRouterAddress,
 } from 'hemi-earn-actions'
 import { requestRedeem } from 'hemi-earn-actions/actions'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { buildAllowanceQueryKey } from 'utils/allowanceQueryKey'
 import { useAccount, useConfig } from 'wagmi'
@@ -62,15 +62,17 @@ export const useWithdraw = function ({
   const [networkType] = useNetworkType()
   const routerAddress = getHemiEarnRouterAddress()
 
-  const { queryKey: tokenBalanceQueryKey } = useTokenBalance(
+  const tokenBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
     chainId,
-    selectedAsset.address,
-  )
+    tokenAddress: selectedAsset.address,
+  })
 
-  const { queryKey: shareBalanceQueryKey } = useTokenBalance(
+  const shareBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
     chainId,
-    pool.shareAddress,
-  )
+    tokenAddress: pool.shareAddress,
+  })
 
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(chainId)
 

--- a/portal/app/[locale]/stake/_hooks/useStake.ts
+++ b/portal/app/[locale]/stake/_hooks/useStake.ts
@@ -2,7 +2,7 @@ import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { stakeManagerAddresses } from 'hemi-viem-stake-actions'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemiClient, useHemiWalletClient } from 'hooks/useHemiClient'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useUmami } from 'hooks/useUmami'
@@ -35,10 +35,11 @@ export const useStake = function (token: StakeToken) {
   const [networkType] = useNetworkType()
   const hemiPublicClient = useHemiClient()
   const { hemiWalletClient } = useHemiWalletClient()
-  const { queryKey: erc20BalanceQueryKey } = useTokenBalance(
-    token.chainId,
-    token.address,
-  )
+  const erc20BalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: token.chainId,
+    tokenAddress: token.address,
+  })
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
     token.chainId,
   )

--- a/portal/app/[locale]/stake/_hooks/useUnstake.ts
+++ b/portal/app/[locale]/stake/_hooks/useUnstake.ts
@@ -1,6 +1,6 @@
 import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemiClient, useHemiWalletClient } from 'hooks/useHemiClient'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useUmami } from 'hooks/useUmami'
@@ -24,10 +24,11 @@ export const useUnstake = function (token: StakeToken) {
   const hemiPublicClient = useHemiClient()
   const { hemiWalletClient } = useHemiWalletClient()
   const [networkType] = useNetworkType()
-  const { queryKey: balanceQueryKey } = useTokenBalance(
-    token.chainId,
-    token.address,
-  )
+  const balanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: token.chainId,
+    tokenAddress: token.address,
+  })
   const t = useTranslations()
 
   // Use this state to prevent multiple submissions, and force the animation to run

--- a/portal/app/[locale]/staking-dashboard/_hooks/useCollectAllRewards.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useCollectAllRewards.ts
@@ -3,6 +3,7 @@ import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { EventEmitter } from 'events'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { useUmami } from 'hooks/useUmami'
@@ -122,14 +123,28 @@ export const useCollectRewards = function ({
       return promise
     },
     onSettled() {
-      // Invalidate rewards queries in the background
+      // Invalidate per-reward-token queries in the background.
       rewardTokens.forEach(function ({ address: rewardsAddress }) {
-        const queryKey = getCalculateRewardsQueryKey({
-          chainId: hemi.id,
-          rewardToken: rewardsAddress,
-          tokenId,
+        // The claimable amount counter.
+        queryClient.invalidateQueries({
+          queryKey: getCalculateRewardsQueryKey({
+            chainId: hemi.id,
+            rewardToken: rewardsAddress,
+            tokenId,
+          }),
         })
-        queryClient.invalidateQueries({ queryKey })
+
+        // The wallet ERC-20 balance of the collected reward token,
+        // so the balances shown in the UI reflect the just-claimed amounts.
+        if (address) {
+          queryClient.invalidateQueries({
+            queryKey: getTokenBalanceQueryKey({
+              account: address,
+              chainId: hemi.id,
+              tokenAddress: rewardsAddress,
+            }),
+          })
+        }
       })
 
       // Invalidate native token balance in the background

--- a/portal/app/[locale]/staking-dashboard/_hooks/useIncreaseAmount.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useIncreaseAmount.ts
@@ -3,7 +3,7 @@ import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { EventEmitter } from 'events'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { useUmami } from 'hooks/useUmami'
 import {
@@ -44,10 +44,11 @@ export const useIncreaseAmount = function ({
   const ensureConnectedTo = useEnsureConnectedTo()
   const veHemiAddress = getVeHemiContractAddress(token.chainId)
   const queryClient = useQueryClient()
-  const { queryKey: hemiBalanceQueryKey } = useTokenBalance(
-    token.chainId,
-    token.address,
-  )
+  const hemiBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: token.chainId,
+    tokenAddress: token.address,
+  })
 
   const amount = parseTokenUnits(input, token)
 

--- a/portal/app/[locale]/staking-dashboard/_hooks/useStake.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useStake.ts
@@ -3,7 +3,7 @@ import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { EventEmitter } from 'events'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { useUmami } from 'hooks/useUmami'
 import {
@@ -52,10 +52,11 @@ export const useStake = function ({
   const ensureConnectedTo = useEnsureConnectedTo()
   const veHemiAddress = getVeHemiContractAddress(token.chainId)
   const queryClient = useQueryClient()
-  const { queryKey: hemiBalanceQueryKey } = useTokenBalance(
-    token.chainId,
-    token.address,
-  )
+  const hemiBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: token.chainId,
+    tokenAddress: token.address,
+  })
 
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
     token.chainId,

--- a/portal/app/[locale]/staking-dashboard/_hooks/useUnlock.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useUnlock.ts
@@ -3,7 +3,7 @@ import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { EventEmitter } from 'events'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemiWalletClient } from 'hooks/useHemiClient'
 import { useUmami } from 'hooks/useUmami'
 import {
@@ -44,10 +44,11 @@ export const useUnlock = function ({
   const { address } = useAccount()
   const ensureConnectedTo = useEnsureConnectedTo()
   const queryClient = useQueryClient()
-  const { queryKey: hemiBalanceQueryKey } = useTokenBalance(
-    token.chainId,
-    token.address,
-  )
+  const hemiBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: token.chainId,
+    tokenAddress: token.address,
+  })
 
   const stakingPositionQueryKey = getStakingPositionsQueryKey({
     address,

--- a/portal/app/[locale]/tunnel/_components/challengeBtcWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/challengeBtcWithdrawal.tsx
@@ -1,13 +1,14 @@
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from 'components/button'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useChallengeBitcoinWithdrawal } from 'hooks/useBtcTunnel'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useUmami } from 'hooks/useUmami'
 import { useTranslations } from 'next-intl'
-import { type FormEvent, useEffect, useState } from 'react'
+import { type FormEvent, useEffect, useMemo, useState } from 'react'
 import { BtcWithdrawStatus, ToBtcWithdrawOperation } from 'types/tunnel'
+import { useAccount } from 'wagmi'
 
 import { DrawerCallToAction } from './reviewOperation/drawerCallToAction'
 
@@ -30,9 +31,15 @@ export const ChallengeBtcWithdrawal = function ({ withdrawal }: Props) {
 
   const t = useTranslations('tunnel-page')
   const { track } = useUmami()
-  const { queryKey: erc20BalanceQueryKey } = useTokenBalance(
-    withdrawal.l2ChainId,
-    withdrawal.l2Token,
+  const { address } = useAccount()
+  const erc20BalanceQueryKey = useMemo(
+    () =>
+      getTokenBalanceQueryKey({
+        account: address,
+        chainId: withdrawal.l2ChainId,
+        tokenAddress: withdrawal.l2Token,
+      }),
+    [address, withdrawal.l2ChainId, withdrawal.l2Token],
   )
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
     withdrawal.l2ChainId,

--- a/portal/app/[locale]/tunnel/_hooks/useClaimTransaction.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useClaimTransaction.ts
@@ -4,7 +4,7 @@ import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpd
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import EventEmitter from 'events'
 import { type FinalizeEvents, finalizeWithdrawal } from 'hemi-tunnel-actions'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemiClient } from 'hooks/useHemiClient'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useUmami } from 'hooks/useUmami'
@@ -26,10 +26,11 @@ export const useClaimTransaction = function ({
     withdrawal.l1ChainId,
   )
   const queryClient = useQueryClient()
-  const { queryKey: erc20BalanceQueryKey } = useTokenBalance(
-    withdrawal.l1ChainId,
-    withdrawal.l1Token,
-  )
+  const erc20BalanceQueryKey = getTokenBalanceQueryKey({
+    account,
+    chainId: withdrawal.l1ChainId,
+    tokenAddress: withdrawal.l1Token,
+  })
   const { updateWithdrawal } = useTunnelHistory()
   const { track } = useUmami()
   const updateNativeBalanceAfterFees = useUpdateNativeBalanceAfterReceipt(

--- a/portal/app/[locale]/tunnel/_hooks/useDeposit.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useDeposit.ts
@@ -9,7 +9,7 @@ import {
   depositErc20,
   depositEth,
 } from 'hemi-tunnel-actions'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useL1StandardBridgeAddress } from 'hooks/useL1StandardBridgeAddress'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useUmami } from 'hooks/useUmami'
@@ -60,10 +60,11 @@ export const useDeposit = function ({
   )
   const l1StandardBridgeAddress = useL1StandardBridgeAddress(fromToken.chainId)
   const queryClient = useQueryClient()
-  const { queryKey: erc20BalanceQueryKey } = useTokenBalance(
-    fromToken.chainId,
-    fromToken.address,
-  )
+  const erc20BalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: fromToken.chainId,
+    tokenAddress: fromToken.address,
+  })
 
   const { addDepositToTunnelHistory, updateDeposit } = useTunnelHistory()
   const { txHash: currentTxHash, updateTxHash } = useTunnelOperation()

--- a/portal/app/[locale]/tunnel/_hooks/useWithdraw.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useWithdraw.ts
@@ -8,7 +8,7 @@ import {
   initiateWithdrawEth,
   type WithdrawEvents,
 } from 'hemi-tunnel-actions'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useHemiClient, useHemiWalletClient } from 'hooks/useHemiClient'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useUmami } from 'hooks/useUmami'
@@ -50,10 +50,11 @@ export const useWithdraw = function ({
     fromToken.chainId,
   )
   const queryClient = useQueryClient()
-  const { queryKey: erc20BalanceQueryKey } = useTokenBalance(
-    fromToken.chainId,
-    fromToken.address,
-  )
+  const erc20BalanceQueryKey = getTokenBalanceQueryKey({
+    account,
+    chainId: fromToken.chainId,
+    tokenAddress: fromToken.address,
+  })
   const { addWithdrawalToTunnelHistory, updateWithdrawal } = useTunnelHistory()
   const { updateTxHash } = useTunnelOperation()
   const updateNativeBalanceAfterFees = useUpdateNativeBalanceAfterReceipt(

--- a/portal/components/tunnelStatusUpdaters/evmDepositsStatusUpdater.tsx
+++ b/portal/components/tunnelStatusUpdaters/evmDepositsStatusUpdater.tsx
@@ -1,12 +1,12 @@
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useQueryClient } from '@tanstack/react-query'
 import { WithWorker } from 'components/withWorker'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
 import { useEvmDeposits } from 'hooks/useEvmDeposits'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useSearchParams } from 'next/navigation'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { EvmDepositOperation, EvmDepositStatus } from 'types/tunnel'
 import { isNativeAddress } from 'utils/nativeToken'
 import { isPendingOperation } from 'utils/tunnel'
@@ -24,9 +24,15 @@ const WatchEvmDeposit = function ({
   worker: AppToWorker
 }) {
   const { updateDeposit } = useTunnelHistory()
-  const { queryKey: erc20BalanceQueryKey } = useTokenBalance(
-    deposit.l2ChainId,
-    deposit.l2Token,
+  const { address } = useAccount()
+  const erc20BalanceQueryKey = useMemo(
+    () =>
+      getTokenBalanceQueryKey({
+        account: address,
+        chainId: deposit.l2ChainId,
+        tokenAddress: deposit.l2Token,
+      }),
+    [address, deposit.l2ChainId, deposit.l2Token],
   )
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
     deposit.l2ChainId,

--- a/portal/components/tunnelStatusUpdaters/evmWithdrawalsStateUpdater.tsx
+++ b/portal/components/tunnelStatusUpdaters/evmWithdrawalsStateUpdater.tsx
@@ -1,12 +1,12 @@
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useQueryClient } from '@tanstack/react-query'
 import { WithWorker } from 'components/withWorker'
-import { useTokenBalance } from 'hooks/useBalance'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useConnectedToUnsupportedEvmChain } from 'hooks/useConnectedToUnsupportedChain'
 import { useToEvmWithdrawals } from 'hooks/useToEvmWithdrawals'
 import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useSearchParams } from 'next/navigation'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { MessageStatus, ToEvmWithdrawOperation } from 'types/tunnel'
 import { isNativeAddress } from 'utils/nativeToken'
 import {
@@ -30,9 +30,15 @@ const WatchEvmWithdrawal = function ({
   worker: AppToWorker
 }) {
   const { updateWithdrawal } = useTunnelHistory()
-  const { queryKey: erc20BalanceQueryKey } = useTokenBalance(
-    withdrawal.l1ChainId,
-    withdrawal.l1Token,
+  const { address } = useAccount()
+  const erc20BalanceQueryKey = useMemo(
+    () =>
+      getTokenBalanceQueryKey({
+        account: address,
+        chainId: withdrawal.l1ChainId,
+        tokenAddress: withdrawal.l1Token,
+      }),
+    [address, withdrawal.l1ChainId, withdrawal.l1Token],
   )
   const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(
     withdrawal.l1ChainId,

--- a/portal/hooks/useBalance.ts
+++ b/portal/hooks/useBalance.ts
@@ -1,26 +1,41 @@
+import {
+  tokenBalanceQueryKey,
+  tokenBalanceQueryOptions,
+} from '@hemilabs/react-hooks/useTokenBalance'
+import { useQuery } from '@tanstack/react-query'
 import { EvmToken } from 'types/token'
 import { isNativeAddress } from 'utils/nativeToken'
-import { type Address, erc20Abi, isAddress } from 'viem'
-import { useAccount, useReadContract } from 'wagmi'
+import { type Address, isAddress } from 'viem'
+import { useAccount, usePublicClient } from 'wagmi'
+
+export const getTokenBalanceQueryKey = ({
+  account,
+  chainId,
+  tokenAddress,
+}: {
+  account: Address | undefined
+  chainId: EvmToken['chainId']
+  tokenAddress: string
+}) =>
+  tokenBalanceQueryKey({ address: tokenAddress as Address, chainId }, account)
 
 export const useTokenBalance = function (
   chainId: EvmToken['chainId'],
   tokenAddress: string,
 ) {
   const { address, isConnected } = useAccount()
-  return useReadContract({
-    abi: erc20Abi,
-    address: tokenAddress as Address,
-    args: address ? [address] : undefined,
-    chainId,
-    functionName: 'balanceOf',
-    query: {
-      enabled:
-        isConnected &&
-        !!address &&
-        isAddress(address) &&
-        isAddress(tokenAddress) &&
-        !isNativeAddress(tokenAddress),
-    },
+  const client = usePublicClient({ chainId })
+  return useQuery({
+    ...tokenBalanceQueryOptions({
+      account: address!,
+      client: client!,
+      token: { address: tokenAddress as Address, chainId },
+    }),
+    enabled:
+      isConnected &&
+      !!address &&
+      isAddress(tokenAddress) &&
+      !isNativeAddress(tokenAddress) &&
+      !!client,
   })
 }


### PR DESCRIPTION
### Description

When a user collects rewards on a veHEMI staking position, the claimed ERC-20 reward tokens (e.g. HEMI, hemiBTC) are credited on-chain, but their cached `balanceOf` queries were never invalidated — so the UI kept showing stale (lower) balances until something else triggered a refetch. This is especially visible for HEMI, since the same balance feeds the create-lockup form's "how much can I lock" calculation.

The straightforward fix (invalidate each collected reward token's balance in `onSettled`) ran into a wrinkle: `useCollectAllRewards` works over a **dynamic** list of reward tokens, so the existing pattern — read `.queryKey` off a top-level `useTokenBalance()` call — can't be used (hooks can't run in a loop). We needed a way to build a token's balance query key imperatively.

**Why `useTokenBalance` was refactored:** it was re-backed by the shared lib query `@hemilabs/react-hooks/useTokenBalance` (via `tokenBalanceQueryOptions` + a plain `useQuery`) instead of wagmi's `useReadContract`. The lib exposes a plain, rebuildable key tuple (`tokenBalanceQueryKey`), so a new `getTokenBalanceQueryKey` helper can construct the exact same key **without rendering the hook** — enabling synchronous/imperative invalidation rather than hook-based invalidation, and reusing the shared lib instead of a local wagmi wrapper.

Because a plain `useQuery` result doesn't expose `.queryKey` (only wagmi's `useReadContract` did), every consumer that read `.queryKey` off the hook now builds it via `getTokenBalanceQueryKey`. The two tunnel updater components gain a memoized key + `useAccount` so their effect deps stay stable. Data-only consumers (reading `data`/`status`) are untouched.

With that in place, the actual fix invalidates each collected reward token's balance in `onSettled`, folded into the existing per-reward-token loop. Plain invalidation (no optimistic update) is enough — it's a no-op when a balance isn't cached.

**Commits:**

- d6292c7f Back useTokenBalance with shared lib query
- 08bce7d9 Invalidate reward token balances on claim

### Screenshots

N/A — no visual changes.

### Related issue(s)

Closes #1969

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A. — N/A (no unit tests cover these hooks; full `vitest` suite still passes: 453/453)
- [x] Documentation updated, or N/A. — N/A
- [x] Environment variables set in CI, or N/A. — N/A