### PR TITLE
Restructure Hemi Earn deposit summary

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: 3.13.24
         version: 3.13.24(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@vetro-protocol/earn':
+        specifier: 1.0.0
+        version: 1.0.0(viem@2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@vetro-protocol/gateway':
         specifier: 1.0.0
         version: 1.0.0(viem@2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))

--- a/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
@@ -3,9 +3,9 @@ import { getCooldownDuration } from '@vetro-protocol/earn/actions'
 import { getStakingVaultForShare } from 'hemi-earn-actions'
 import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'
+import { secondsToDays } from 'utils/time'
 import { type Address } from 'viem'
 
-const SECONDS_IN_DAY = 86_400
 // `cooldownDuration` is governance-controlled and rarely changes. Caching
 // for a few hours avoids refetching on every window focus / wallet
 // reconnect.
@@ -22,7 +22,7 @@ export const useCooldownDuration = ({
         getEvmL1PublicClient(mainnet.id),
         { address: getStakingVaultForShare(shareAddress) },
       )
-      return Math.round(Number(seconds) / SECONDS_IN_DAY)
+      return Math.round(secondsToDays(Number(seconds)))
     },
     queryKey: ['hemi-earn', 'cooldown-duration', shareAddress],
     staleTime: STALE_TIME_MS,

--- a/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query'
+import { getCooldownDuration } from '@vetro-protocol/earn/actions'
+import { getStakingVaultForShare } from 'hemi-earn-actions'
+import { mainnet } from 'networks/mainnet'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { type Address } from 'viem'
+
+const SECONDS_IN_DAY = 86_400
+// `cooldownDuration` is governance-controlled and rarely changes. Caching
+// for a few hours avoids refetching on every window focus / wallet
+// reconnect.
+const STALE_TIME_MS = 4 * 60 * 60 * 1000
+
+export const useCooldownDuration = ({
+  shareAddress,
+}: {
+  shareAddress: Address
+}) =>
+  useQuery({
+    async queryFn() {
+      const seconds = await getCooldownDuration(
+        getEvmL1PublicClient(mainnet.id),
+        { address: getStakingVaultForShare(shareAddress) },
+      )
+      return Math.round(Number(seconds) / SECONDS_IN_DAY)
+    },
+    queryKey: ['hemi-earn', 'cooldown-duration', shareAddress],
+    staleTime: STALE_TIME_MS,
+  })

--- a/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
@@ -5,6 +5,11 @@ import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 
+// Underlying reads (`cooldownEnabled`, `instantWithdrawWhitelist`) are
+// governance/admin-controlled and change infrequently. Caching for a few
+// hours avoids refetching on every window focus / wallet reconnect.
+const STALE_TIME_MS = 4 * 60 * 60 * 1000
+
 // Resolves whether the caller is subject to the vault's 7-day withdraw cooldown
 // (i.e. cooldown is enabled AND the caller is not on the instant-withdraw
 // whitelist). Mirrors `resolveIsInstant` and inverts it so the consumer can
@@ -27,4 +32,5 @@ export const useIsCooldownEligible = ({
       return !isInstant
     },
     queryKey: ['hemi-earn', 'cooldown-eligible', shareAddress, account],
+    staleTime: STALE_TIME_MS,
   })

--- a/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query'
+import { getStakingVaultForShare } from 'hemi-earn-actions'
+import { resolveIsInstant } from 'hemi-earn-actions/actions'
+import { mainnet } from 'networks/mainnet'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { type Address } from 'viem'
+
+// Resolves whether the caller is subject to the vault's 7-day withdraw cooldown
+// (i.e. cooldown is enabled AND the caller is not on the instant-withdraw
+// whitelist). Mirrors `resolveIsInstant` and inverts it so the consumer can
+// gate UI like "withdraw takes 7 days" on a single boolean.
+export const useIsCooldownEligible = ({
+  account,
+  shareAddress,
+}: {
+  account: Address | undefined
+  shareAddress: Address
+}) =>
+  useQuery({
+    enabled: !!account,
+    async queryFn() {
+      const isInstant = await resolveIsInstant({
+        caller: account!,
+        client: getEvmL1PublicClient(mainnet.id),
+        stakingVault: getStakingVaultForShare(shareAddress),
+      })
+      return !isInstant
+    },
+    queryKey: ['hemi-earn', 'cooldown-eligible', shareAddress, account],
+  })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
@@ -1,14 +1,19 @@
 import { WarningIcon } from 'components/icons/warningIcon'
 import { useTranslations } from 'next-intl'
 import Skeleton from 'react-loading-skeleton'
+import { type Address } from 'viem'
+
+import { useCooldownDuration } from '../../../_hooks/useCooldownDuration'
 
 type Props = {
-  days: number | undefined
-  isLoading: boolean
+  shareAddress: Address
 }
 
-export const CooldownWarning = function ({ days, isLoading }: Props) {
+export const CooldownWarning = function ({ shareAddress }: Props) {
   const t = useTranslations()
+  const { data: days, isPending: isLoading } = useCooldownDuration({
+    shareAddress,
+  })
   return (
     <div className="flex items-center gap-x-1 rounded-lg bg-neutral-100 p-4 text-sm font-medium text-neutral-900">
       <WarningIcon />

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
@@ -1,12 +1,26 @@
 import { WarningIcon } from 'components/icons/warningIcon'
 import { useTranslations } from 'next-intl'
+import Skeleton from 'react-loading-skeleton'
 
-export const CooldownWarning = function () {
+type Props = {
+  days: number | undefined
+  isLoading: boolean
+}
+
+export const CooldownWarning = function ({ days, isLoading }: Props) {
   const t = useTranslations()
   return (
     <div className="flex items-center gap-x-1 rounded-lg bg-neutral-100 p-4 text-sm font-medium text-neutral-900">
       <WarningIcon />
-      <p>{t('hemi-earn.pool.form.cooldown-warning')}</p>
+      {isLoading ? (
+        <Skeleton className="h-4 w-64" />
+      ) : (
+        <p>
+          {days !== undefined
+            ? t('hemi-earn.pool.form.cooldown-warning', { days })
+            : t('hemi-earn.pool.form.cooldown-warning-fallback')}
+        </p>
+      )}
     </div>
   )
 }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
@@ -1,0 +1,12 @@
+import { WarningIcon } from 'components/icons/warningIcon'
+import { useTranslations } from 'next-intl'
+
+export const CooldownWarning = function () {
+  const t = useTranslations()
+  return (
+    <div className="flex items-center gap-x-1 rounded-lg bg-neutral-100 p-4 text-sm font-medium text-neutral-900">
+      <WarningIcon />
+      <p>{t('hemi-earn.pool.form.cooldown-warning')}</p>
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -18,6 +18,7 @@ import { useIsCooldownEligible } from '../../../_hooks/useIsCooldownEligible'
 import { usePoolForm } from '../_context/poolFormContext'
 import { useDeposit } from '../_hooks/useDeposit'
 import { useDepositFees } from '../_hooks/useDepositFees'
+import { useDepositShares } from '../_hooks/useDepositShares'
 import { useDrawerQueryString } from '../_hooks/useDrawerQueryString'
 import { type DepositOperationRunning } from '../_types/operations'
 
@@ -145,6 +146,11 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
     shareAddress: pool.shareAddress,
   })
 
+  const { data: shares } = useDepositShares({
+    peggedAmount: quote?.peggedAmount,
+    shareAddress: pool.shareAddress,
+  })
+
   const { setDrawerQueryString } = useDrawerQueryString()
 
   const { isPending: isRunningOperation, mutate: deposit } = useDeposit({
@@ -199,7 +205,7 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
             nativeToken={nativeToken}
             networkFee={networkFee}
             shareToken={pool.shareToken}
-            shares={quote?.shares}
+            shares={shares}
             totalFees={totalFees}
           />
         )

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -36,13 +36,13 @@ const SetMaxEvmBalance = dynamic(
 
 type BelowFormProps = {
   account: Address | undefined
+  bridgingFee: bigint
   cooldownDays: number | undefined
-  ethereumGasFee: bigint
+  hemiGasFee: bigint
   isCooldownDaysLoading: boolean
   isCooldownEligible: boolean
   isFeesError: boolean
   nativeToken: EvmToken
-  networkFee: bigint
   shareToken: EvmToken
   shares: bigint | undefined
   totalFees: bigint
@@ -50,13 +50,13 @@ type BelowFormProps = {
 
 const BelowForm = ({
   account,
+  bridgingFee,
   cooldownDays,
-  ethereumGasFee,
+  hemiGasFee,
   isCooldownDaysLoading,
   isCooldownEligible,
   isFeesError,
   nativeToken,
-  networkFee,
   shares,
   shareToken,
   totalFees,
@@ -64,10 +64,10 @@ const BelowForm = ({
   <div className="flex flex-col gap-y-4">
     <div className="px-4">
       <DepositSummary
-        ethereumGasFee={ethereumGasFee}
+        bridgingFee={bridgingFee}
+        hemiGasFee={hemiGasFee}
         isFeesError={isFeesError}
         nativeToken={nativeToken}
-        networkFee={networkFee}
         shareToken={shareToken}
         shares={shares}
         totalFees={totalFees}
@@ -202,7 +202,7 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
   }
 
   const nativeToken = getNativeToken(selectedAsset.token.chainId) as EvmToken
-  const networkFee =
+  const hemiGasFee =
     depositGasFees + (needsApproval ? approvalGasFees : BigInt(0))
 
   return (
@@ -211,13 +211,13 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
         canDeposit && (
           <BelowForm
             account={address}
+            bridgingFee={layerZeroFee}
             cooldownDays={cooldownDays}
-            ethereumGasFee={layerZeroFee}
+            hemiGasFee={hemiGasFee}
             isCooldownDaysLoading={isCooldownDaysLoading}
             isCooldownEligible={isCooldownEligible}
             isFeesError={isFeesError}
             nativeToken={nativeToken}
-            networkFee={networkFee}
             shareToken={pool.shareToken}
             shares={shares}
             totalFees={totalFees}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -1,26 +1,28 @@
 'use client'
 
-import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
 import { useTokenBalance } from 'hooks/useBalance'
-import { useChain } from 'hooks/useChain'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
+import { type EvmToken } from 'types/token'
 import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
 import { validateSubmit } from 'utils/validateSubmit'
 import { walletIsConnected } from 'utils/wallet'
-import { formatUnits } from 'viem'
+import { type Address } from 'viem'
 import { useAccount as useEvmAccount } from 'wagmi'
 
+import { useIsCooldownEligible } from '../../../_hooks/useIsCooldownEligible'
 import { usePoolForm } from '../_context/poolFormContext'
 import { useDeposit } from '../_hooks/useDeposit'
 import { useDepositFees } from '../_hooks/useDepositFees'
 import { useDrawerQueryString } from '../_hooks/useDrawerQueryString'
 import { type DepositOperationRunning } from '../_types/operations'
 
+import { CooldownWarning } from './cooldownWarning'
+import { DepositSummary } from './depositSummary'
 import { VaultFormLayout } from './form'
 import { PoolFormContent } from './poolFormContent'
 import { SubmitDeposit } from './submitDeposit'
@@ -28,6 +30,45 @@ import { SubmitDeposit } from './submitDeposit'
 const SetMaxEvmBalance = dynamic(
   () => import('components/setMaxBalance').then(mod => mod.SetMaxEvmBalance),
   { ssr: false },
+)
+
+type BelowFormProps = {
+  account: Address | undefined
+  ethereumGasFee: bigint
+  isCooldownEligible: boolean
+  isFeesError: boolean
+  nativeToken: EvmToken
+  networkFee: bigint
+  shareToken: EvmToken
+  shares: bigint | undefined
+  totalFees: bigint
+}
+
+const BelowForm = ({
+  account,
+  ethereumGasFee,
+  isCooldownEligible,
+  isFeesError,
+  nativeToken,
+  networkFee,
+  shares,
+  shareToken,
+  totalFees,
+}: BelowFormProps) => (
+  <div className="flex flex-col gap-y-4">
+    <div className="px-4">
+      <DepositSummary
+        ethereumGasFee={ethereumGasFee}
+        isFeesError={isFeesError}
+        nativeToken={nativeToken}
+        networkFee={networkFee}
+        shareToken={shareToken}
+        shares={shares}
+        totalFees={totalFees}
+      />
+    </div>
+    {account && isCooldownEligible && <CooldownWarning />}
+  </div>
 )
 
 type Props = {
@@ -78,17 +119,31 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
 
   const canDeposit = validInput
 
-  const { depositGasFees, isFeesError, layerZeroFee, quote, totalFees } =
-    useDepositFees({
-      amount,
-      asset: selectedAsset.address,
-      canDeposit,
-      needsApproval,
-      receiver: address,
-      shareAddress: pool.shareAddress,
-      spender: routerAddress,
-      token: selectedAsset.token,
-    })
+  const {
+    approvalGasFees,
+    depositGasFees,
+    isFeesError,
+    layerZeroFee,
+    quote,
+    totalFees,
+  } = useDepositFees({
+    amount,
+    asset: selectedAsset.address,
+    canDeposit,
+    needsApproval,
+    receiver: address,
+    shareAddress: pool.shareAddress,
+    spender: routerAddress,
+    token: selectedAsset.token,
+  })
+
+  // Fail safe: when the eligibility read on Ethereum is in-flight or errors,
+  // assume the cooldown applies so the warning shows. Silently hiding it
+  // would let the user sign a deposit thinking instant withdraw is available.
+  const { data: isCooldownEligible = true } = useIsCooldownEligible({
+    account: address,
+    shareAddress: pool.shareAddress,
+  })
 
   const { setDrawerQueryString } = useDrawerQueryString()
 
@@ -128,34 +183,27 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
     setOperationRunning(needsApproval ? 'approving' : 'depositing')
   }
 
-  const chain = useChain(selectedAsset.token.chainId)
-  const nativeToken = getNativeToken(selectedAsset.token.chainId)
-
-  function RenderBelowForm() {
-    if (!canDeposit) {
-      return null
-    }
-    return (
-      <div className="px-4">
-        <EvmFeesSummary
-          gas={{
-            amount: formatUnits(
-              totalFees,
-              chain?.nativeCurrency.decimals ?? 18,
-            ),
-            isError: isFeesError,
-            label: t('hemi-earn.pool.form.total-fee'),
-            token: nativeToken,
-          }}
-          operationToken={nativeToken}
-        />
-      </div>
-    )
-  }
+  const nativeToken = getNativeToken(selectedAsset.token.chainId) as EvmToken
+  const networkFee =
+    depositGasFees + (needsApproval ? approvalGasFees : BigInt(0))
 
   return (
     <VaultFormLayout
-      belowForm={<RenderBelowForm />}
+      belowForm={
+        canDeposit && (
+          <BelowForm
+            account={address}
+            ethereumGasFee={layerZeroFee}
+            isCooldownEligible={isCooldownEligible}
+            isFeesError={isFeesError}
+            nativeToken={nativeToken}
+            networkFee={networkFee}
+            shareToken={pool.shareToken}
+            shares={quote?.shares}
+            totalFees={totalFees}
+          />
+        )
+      }
       formContent={
         <PoolFormContent
           activeTab="deposit"

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -14,7 +14,6 @@ import { walletIsConnected } from 'utils/wallet'
 import { type Address } from 'viem'
 import { useAccount as useEvmAccount } from 'wagmi'
 
-import { useCooldownDuration } from '../../../_hooks/useCooldownDuration'
 import { useIsCooldownEligible } from '../../../_hooks/useIsCooldownEligible'
 import { usePoolForm } from '../_context/poolFormContext'
 import { useDeposit } from '../_hooks/useDeposit'
@@ -37,12 +36,11 @@ const SetMaxEvmBalance = dynamic(
 type BelowFormProps = {
   account: Address | undefined
   bridgingFee: bigint
-  cooldownDays: number | undefined
   hemiGasFee: bigint
-  isCooldownDaysLoading: boolean
   isCooldownEligible: boolean
   isFeesError: boolean
   nativeToken: EvmToken
+  shareAddress: Address
   shareToken: EvmToken
   shares: bigint | undefined
   totalFees: bigint
@@ -51,12 +49,11 @@ type BelowFormProps = {
 const BelowForm = ({
   account,
   bridgingFee,
-  cooldownDays,
   hemiGasFee,
-  isCooldownDaysLoading,
   isCooldownEligible,
   isFeesError,
   nativeToken,
+  shareAddress,
   shares,
   shareToken,
   totalFees,
@@ -74,7 +71,7 @@ const BelowForm = ({
       />
     </div>
     {account && isCooldownEligible && (
-      <CooldownWarning days={cooldownDays} isLoading={isCooldownDaysLoading} />
+      <CooldownWarning shareAddress={shareAddress} />
     )}
   </div>
 )
@@ -153,11 +150,6 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
     shareAddress: pool.shareAddress,
   })
 
-  const { data: cooldownDays, isPending: isCooldownDaysLoading } =
-    useCooldownDuration({
-      shareAddress: pool.shareAddress,
-    })
-
   const { data: shares } = useDepositShares({
     peggedAmount: quote?.peggedAmount,
     shareAddress: pool.shareAddress,
@@ -212,12 +204,11 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
           <BelowForm
             account={address}
             bridgingFee={layerZeroFee}
-            cooldownDays={cooldownDays}
             hemiGasFee={hemiGasFee}
-            isCooldownDaysLoading={isCooldownDaysLoading}
             isCooldownEligible={isCooldownEligible}
             isFeesError={isFeesError}
             nativeToken={nativeToken}
+            shareAddress={pool.shareAddress}
             shareToken={pool.shareToken}
             shares={shares}
             totalFees={totalFees}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -14,6 +14,7 @@ import { walletIsConnected } from 'utils/wallet'
 import { type Address } from 'viem'
 import { useAccount as useEvmAccount } from 'wagmi'
 
+import { useCooldownDuration } from '../../../_hooks/useCooldownDuration'
 import { useIsCooldownEligible } from '../../../_hooks/useIsCooldownEligible'
 import { usePoolForm } from '../_context/poolFormContext'
 import { useDeposit } from '../_hooks/useDeposit'
@@ -35,7 +36,9 @@ const SetMaxEvmBalance = dynamic(
 
 type BelowFormProps = {
   account: Address | undefined
+  cooldownDays: number | undefined
   ethereumGasFee: bigint
+  isCooldownDaysLoading: boolean
   isCooldownEligible: boolean
   isFeesError: boolean
   nativeToken: EvmToken
@@ -47,7 +50,9 @@ type BelowFormProps = {
 
 const BelowForm = ({
   account,
+  cooldownDays,
   ethereumGasFee,
+  isCooldownDaysLoading,
   isCooldownEligible,
   isFeesError,
   nativeToken,
@@ -68,7 +73,9 @@ const BelowForm = ({
         totalFees={totalFees}
       />
     </div>
-    {account && isCooldownEligible && <CooldownWarning />}
+    {account && isCooldownEligible && (
+      <CooldownWarning days={cooldownDays} isLoading={isCooldownDaysLoading} />
+    )}
   </div>
 )
 
@@ -146,6 +153,11 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
     shareAddress: pool.shareAddress,
   })
 
+  const { data: cooldownDays, isPending: isCooldownDaysLoading } =
+    useCooldownDuration({
+      shareAddress: pool.shareAddress,
+    })
+
   const { data: shares } = useDepositShares({
     peggedAmount: quote?.peggedAmount,
     shareAddress: pool.shareAddress,
@@ -199,7 +211,9 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
         canDeposit && (
           <BelowForm
             account={address}
+            cooldownDays={cooldownDays}
             ethereumGasFee={layerZeroFee}
+            isCooldownDaysLoading={isCooldownDaysLoading}
             isCooldownEligible={isCooldownEligible}
             isFeesError={isFeesError}
             nativeToken={nativeToken}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/depositSummary.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/depositSummary.tsx
@@ -1,0 +1,123 @@
+import { DisplayAmount } from 'components/displayAmount'
+import { TokenLogo } from 'components/tokenLogo'
+import { useTranslations } from 'next-intl'
+import { type ReactNode } from 'react'
+import Skeleton from 'react-loading-skeleton'
+import { type EvmToken } from 'types/token'
+import { formatUnits } from 'viem'
+
+const Row = ({ children, label }: { children: ReactNode; label: string }) => (
+  <div className="flex items-center justify-between text-sm font-medium">
+    <span className="text-neutral-500">{label}</span>
+    {children}
+  </div>
+)
+
+type FeeRowProps = {
+  amount: bigint
+  isError: boolean
+  label: string
+  token: EvmToken
+}
+
+const FeeRow = function ({ amount, isError, label, token }: FeeRowProps) {
+  const formatted = formatUnits(amount, token.decimals)
+
+  if (!isError && formatted !== '0') {
+    return (
+      <Row label={label}>
+        <DisplayAmount amount={formatted} showTokenLogo={false} token={token} />
+      </Row>
+    )
+  }
+  if (isError) {
+    return (
+      <Row label={label}>
+        <span className="text-neutral-950">-</span>
+      </Row>
+    )
+  }
+  return (
+    <Row label={label}>
+      <Skeleton className="w-12" />
+    </Row>
+  )
+}
+
+type SharesRowProps = {
+  shareToken: EvmToken
+  shares: bigint | undefined
+}
+
+const SharesRow = function ({ shares, shareToken }: SharesRowProps) {
+  const t = useTranslations()
+  const label = t('hemi-earn.pool.form.you-will-receive')
+
+  if (shares !== undefined) {
+    return (
+      <Row label={label}>
+        <div className="flex items-center gap-x-1 text-neutral-950">
+          <DisplayAmount
+            amount={formatUnits(shares, shareToken.decimals)}
+            showTokenLogo={false}
+            token={shareToken}
+          />
+          <div className="shadow-bs rounded-full">
+            <TokenLogo size="small" token={shareToken} />
+          </div>
+        </div>
+      </Row>
+    )
+  }
+  return (
+    <Row label={label}>
+      <Skeleton className="w-16" />
+    </Row>
+  )
+}
+
+type Props = {
+  ethereumGasFee: bigint
+  isFeesError: boolean
+  nativeToken: EvmToken
+  networkFee: bigint
+  shareToken: EvmToken
+  shares: bigint | undefined
+  totalFees: bigint
+}
+
+export const DepositSummary = function ({
+  ethereumGasFee,
+  isFeesError,
+  nativeToken,
+  networkFee,
+  shares,
+  shareToken,
+  totalFees,
+}: Props) {
+  const t = useTranslations()
+  return (
+    <div className="flex flex-col gap-y-2.5">
+      <SharesRow shareToken={shareToken} shares={shares} />
+      <div className="h-px w-full bg-neutral-200" />
+      <FeeRow
+        amount={networkFee}
+        isError={isFeesError}
+        label={t('hemi-earn.pool.form.network-fee')}
+        token={nativeToken}
+      />
+      <FeeRow
+        amount={ethereumGasFee}
+        isError={isFeesError}
+        label={t('hemi-earn.pool.form.ethereum-gas-fee')}
+        token={nativeToken}
+      />
+      <FeeRow
+        amount={totalFees}
+        isError={isFeesError}
+        label={t('common.total')}
+        token={nativeToken}
+      />
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/depositSummary.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/depositSummary.tsx
@@ -1,6 +1,6 @@
 import { DisplayAmount } from 'components/displayAmount'
 import { TokenLogo } from 'components/tokenLogo'
-import { hemi } from 'hemi-viem'
+import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
@@ -97,6 +97,7 @@ export const DepositSummary = function ({
   totalFees,
 }: Props) {
   const t = useTranslations()
+  const hemi = useHemi()
   return (
     <div className="flex flex-col gap-y-2.5">
       <SharesRow shareToken={shareToken} shares={shares} />

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/depositSummary.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/depositSummary.tsx
@@ -1,5 +1,6 @@
 import { DisplayAmount } from 'components/displayAmount'
 import { TokenLogo } from 'components/tokenLogo'
+import { hemi } from 'hemi-viem'
 import { useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
@@ -77,20 +78,20 @@ const SharesRow = function ({ shares, shareToken }: SharesRowProps) {
 }
 
 type Props = {
-  ethereumGasFee: bigint
+  bridgingFee: bigint
+  hemiGasFee: bigint
   isFeesError: boolean
   nativeToken: EvmToken
-  networkFee: bigint
   shareToken: EvmToken
   shares: bigint | undefined
   totalFees: bigint
 }
 
 export const DepositSummary = function ({
-  ethereumGasFee,
+  bridgingFee,
+  hemiGasFee,
   isFeesError,
   nativeToken,
-  networkFee,
   shares,
   shareToken,
   totalFees,
@@ -101,15 +102,15 @@ export const DepositSummary = function ({
       <SharesRow shareToken={shareToken} shares={shares} />
       <div className="h-px w-full bg-neutral-200" />
       <FeeRow
-        amount={networkFee}
+        amount={hemiGasFee}
         isError={isFeesError}
-        label={t('hemi-earn.pool.form.network-fee')}
+        label={t('common.network-gas-fee', { network: hemi.name })}
         token={nativeToken}
       />
       <FeeRow
-        amount={ethereumGasFee}
+        amount={bridgingFee}
         isError={isFeesError}
-        label={t('hemi-earn.pool.form.ethereum-gas-fee')}
+        label={t('hemi-earn.pool.form.bridging-fees')}
         token={nativeToken}
       />
       <FeeRow

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositFees.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositFees.ts
@@ -114,6 +114,7 @@ export const useDepositFees = function ({
   const layerZeroFee = quote?.nativeFee ?? BigInt(0)
 
   return {
+    approvalGasFees,
     depositGasFees,
     isFeesError: computeIsFeesError({
       isApprovalGasFeesError,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositShares.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositShares.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+import { getStakingVaultForShare } from 'hemi-earn-actions'
+import { mainnet } from 'networks/mainnet'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { type Address } from 'viem'
+import { convertToShares } from 'viem-erc4626/actions'
+
+export const useDepositShares = ({
+  peggedAmount,
+  shareAddress,
+}: {
+  peggedAmount: bigint | undefined
+  shareAddress: Address
+}) =>
+  useQuery({
+    enabled: peggedAmount !== undefined && peggedAmount > BigInt(0),
+    queryFn: () =>
+      convertToShares(getEvmL1PublicClient(mainnet.id), {
+        address: getStakingVaultForShare(shareAddress),
+        assets: peggedAmount!,
+      }),
+    queryKey: [
+      'hemi-earn',
+      'deposit-shares',
+      shareAddress,
+      peggedAmount?.toString(),
+    ],
+  })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteDeposit.ts
@@ -15,7 +15,6 @@ import { hemi } from 'hemi-viem'
 import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient, getHemiClient } from 'utils/chainClients'
 import { type Address } from 'viem'
-import { convertToShares } from 'viem-erc4626/actions'
 
 type QuoteDeposit = {
   callbackFee: bigint
@@ -24,10 +23,6 @@ type QuoteDeposit = {
   // (`Gateway.previewDeposit(remoteAsset, amount)`). Used by `useDeposit` to
   // optimistically bump `totalAssets()` in its native unit.
   peggedAmount: bigint
-  // Share-token amount the user will receive for this deposit
-  // (`StakingVault.convertToShares(peggedAmount)`). Drives the "You'll receive"
-  // preview in the deposit form.
-  shares: bigint
 }
 
 // Chains the contract reads needed to know the user's true cost on Hemi
@@ -87,14 +82,7 @@ export const useQuoteDeposit = ({
           tokenIn: assetData.remoteAsset,
         }),
       ])
-      const shares =
-        peggedAmount > BigInt(0)
-          ? await convertToShares(ethereumClient, {
-              address: getStakingVaultForShare(shareAddress),
-              assets: peggedAmount,
-            })
-          : BigInt(0)
-      return { callbackFee, nativeFee, peggedAmount, shares }
+      return { callbackFee, nativeFee, peggedAmount }
     },
     queryKey: [
       'hemi-earn',

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteDeposit.ts
@@ -15,6 +15,7 @@ import { hemi } from 'hemi-viem'
 import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient, getHemiClient } from 'utils/chainClients'
 import { type Address } from 'viem'
+import { convertToShares } from 'viem-erc4626/actions'
 
 type QuoteDeposit = {
   callbackFee: bigint
@@ -23,6 +24,10 @@ type QuoteDeposit = {
   // (`Gateway.previewDeposit(remoteAsset, amount)`). Used by `useDeposit` to
   // optimistically bump `totalAssets()` in its native unit.
   peggedAmount: bigint
+  // Share-token amount the user will receive for this deposit
+  // (`StakingVault.convertToShares(peggedAmount)`). Drives the "You'll receive"
+  // preview in the deposit form.
+  shares: bigint
 }
 
 // Chains the contract reads needed to know the user's true cost on Hemi
@@ -82,7 +87,14 @@ export const useQuoteDeposit = ({
           tokenIn: assetData.remoteAsset,
         }),
       ])
-      return { callbackFee, nativeFee, peggedAmount }
+      const shares =
+        peggedAmount > BigInt(0)
+          ? await convertToShares(ethereumClient, {
+              address: getStakingVaultForShare(shareAddress),
+              assets: peggedAmount,
+            })
+          : BigInt(0)
+      return { callbackFee, nativeFee, peggedAmount, shares }
     },
     queryKey: [
       'hemi-earn',

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -39,7 +39,8 @@
         "withdraw-token": "Withdraw {symbol}"
       },
       "form": {
-        "cooldown-warning": "Withdrawing funds takes 7 days to complete.",
+        "cooldown-warning": "Withdrawing funds takes {days, plural, one {# day} other {# days}} to complete.",
+        "cooldown-warning-fallback": "Withdrawing funds takes several days to complete.",
         "ethereum-gas-fee": "Ethereum gas fee",
         "network-fee": "Network fee",
         "total-fee": "Total gas fee",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -39,10 +39,9 @@
         "withdraw-token": "Withdraw {symbol}"
       },
       "form": {
+        "bridging-fees": "Bridging fees",
         "cooldown-warning": "Withdrawing funds takes {days, plural, one {# day} other {# days}} to complete.",
         "cooldown-warning-fallback": "Withdrawing funds takes several days to complete.",
-        "ethereum-gas-fee": "Ethereum gas fee",
-        "network-fee": "Network fee",
         "total-fee": "Total gas fee",
         "withdrawing": "Withdrawing...",
         "you-will-receive": "You'll receive"

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -39,8 +39,12 @@
         "withdraw-token": "Withdraw {symbol}"
       },
       "form": {
+        "cooldown-warning": "Withdrawing funds takes 7 days to complete.",
+        "ethereum-gas-fee": "Ethereum gas fee",
+        "network-fee": "Network fee",
         "total-fee": "Total gas fee",
-        "withdrawing": "Withdrawing..."
+        "withdrawing": "Withdrawing...",
+        "you-will-receive": "You'll receive"
       },
       "here-is-your-tx": "Here's your transaction:",
       "historical-metrics": {

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -44,7 +44,7 @@
         "cooldown-warning-fallback": "Retirar fondos tarda algunos días en completarse.",
         "total-fee": "Costo total de gas",
         "withdrawing": "Retirando...",
-        "you-will-receive": "Recibirás"
+        "you-will-receive": "Recibirá"
       },
       "here-is-your-tx": "Aquí está su transacción:",
       "historical-metrics": {

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -39,8 +39,12 @@
         "withdraw-token": "Retirar {symbol}"
       },
       "form": {
+        "cooldown-warning": "Retirar fondos tarda 7 días en completarse.",
+        "ethereum-gas-fee": "Costo de gas en Ethereum",
+        "network-fee": "Costo de red",
         "total-fee": "Costo total de gas",
-        "withdrawing": "Retirando..."
+        "withdrawing": "Retirando...",
+        "you-will-receive": "Recibirás"
       },
       "here-is-your-tx": "Aquí está su transacción:",
       "historical-metrics": {

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -39,7 +39,8 @@
         "withdraw-token": "Retirar {symbol}"
       },
       "form": {
-        "cooldown-warning": "Retirar fondos tarda 7 días en completarse.",
+        "cooldown-warning": "Retirar fondos tarda {days, plural, one {# día} other {# días}} en completarse.",
+        "cooldown-warning-fallback": "Retirar fondos tarda algunos días en completarse.",
         "ethereum-gas-fee": "Costo de gas en Ethereum",
         "network-fee": "Costo de red",
         "total-fee": "Costo total de gas",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -39,10 +39,9 @@
         "withdraw-token": "Retirar {symbol}"
       },
       "form": {
+        "bridging-fees": "Tarifas de bridge",
         "cooldown-warning": "Retirar fondos tarda {days, plural, one {# día} other {# días}} en completarse.",
         "cooldown-warning-fallback": "Retirar fondos tarda algunos días en completarse.",
-        "ethereum-gas-fee": "Costo de gas en Ethereum",
-        "network-fee": "Costo de red",
         "total-fee": "Costo total de gas",
         "withdrawing": "Retirando...",
         "you-will-receive": "Recibirás"

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -40,9 +40,9 @@
       },
       "form": {
         "cooldown-warning": "Sacar fundos leva 7 dias para concluir.",
-        "ethereum-gas-fee": "Taxa de gas no Ethereum",
+        "ethereum-gas-fee": "Taxa de gás no Ethereum",
         "network-fee": "Taxa de rede",
-        "total-fee": "Custo total de gas",
+        "total-fee": "Custo total de gás",
         "withdrawing": "Sacando...",
         "you-will-receive": "Você vai receber"
       },

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -39,8 +39,12 @@
         "withdraw-token": "Sacar {symbol}"
       },
       "form": {
+        "cooldown-warning": "Sacar fundos leva 7 dias para concluir.",
+        "ethereum-gas-fee": "Taxa de gas no Ethereum",
+        "network-fee": "Taxa de rede",
         "total-fee": "Custo total de gas",
-        "withdrawing": "Sacando..."
+        "withdrawing": "Sacando...",
+        "you-will-receive": "Você vai receber"
       },
       "here-is-your-tx": "Aqui está sua transação:",
       "historical-metrics": {

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -39,7 +39,8 @@
         "withdraw-token": "Sacar {symbol}"
       },
       "form": {
-        "cooldown-warning": "Sacar fundos leva 7 dias para concluir.",
+        "cooldown-warning": "Sacar fundos leva {days, plural, one {# dia} other {# dias}} para concluir.",
+        "cooldown-warning-fallback": "Sacar fundos leva alguns dias para concluir.",
         "ethereum-gas-fee": "Taxa de gás no Ethereum",
         "network-fee": "Taxa de rede",
         "total-fee": "Custo total de gás",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -39,10 +39,9 @@
         "withdraw-token": "Sacar {symbol}"
       },
       "form": {
+        "bridging-fees": "Taxas de bridge",
         "cooldown-warning": "Sacar fundos leva {days, plural, one {# dia} other {# dias}} para concluir.",
         "cooldown-warning-fallback": "Sacar fundos leva alguns dias para concluir.",
-        "ethereum-gas-fee": "Taxa de gás no Ethereum",
-        "network-fee": "Taxa de rede",
         "total-fee": "Custo total de gás",
         "withdrawing": "Sacando...",
         "you-will-receive": "Você vai receber"

--- a/portal/package.json
+++ b/portal/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "5.100.9",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.24",
+    "@vetro-protocol/earn": "1.0.0",
     "@vetro-protocol/gateway": "1.0.0",
     "@wagmi/core": "2.17.3",
     "big.js": "7.0.1",

--- a/portal/utils/time.ts
+++ b/portal/utils/time.ts
@@ -1,3 +1,5 @@
+export const secondsToDays = (seconds: number) => seconds / 60 / 60 / 24
+
 export const secondsToHours = (seconds: number) => seconds / 60 / 60
 
 export const secondsToMinutes = (seconds: number) => seconds / 60


### PR DESCRIPTION
### Description

This PR restructures the Hemi Earn deposit summary to match the new design. The single "Total gas fee" line under the deposit form is replaced by a "You'll receive {shares} svetBTC" row, a Network fee + Ethereum gas fee + Total breakdown, and a cooldown warning banner that reads "Withdrawing funds takes 7 days to complete."

  The shares preview reuses the same two-step pattern already in `useAssetsToShares` on the withdraw side: `Gateway.previewDeposit` to get the pegged amount, then `StakingVault.convertToShares` to get the user-facing share count. A new `useIsCooldownEligible` hook wraps `resolveIsInstant` and lives in the shared hemi-earn `_hooks` folder so other surfaces can reuse it.

  The warning is intentionally **fail-safe**: it shows whenever the Ethereum eligibility read is pending or errors, so the user never signs a deposit under the wrong assumption that withdraw is instant. It's also gated on a connected wallet so it doesn't render pre-connect.

Note: Withdraw is untouched in this PR

### Screenshots

Desktop

https://github.com/user-attachments/assets/908cd94d-90fc-4ab0-9e4c-327776819ff6



Mobile


https://github.com/user-attachments/assets/09626143-fe6f-4b3c-b660-5903d3c9bffc


### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
