### PR TITLE
Bump file-existence-action to v3.1.0

### DIFF
--- a/.github/actions/deploy-portal/action.yml
+++ b/.github/actions/deploy-portal/action.yml
@@ -148,7 +148,7 @@ runs:
         SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
     - name: Check portal build
       id: portal_build
-      uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+      uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
       with:
         files: ./portal/out/
     # folder should only exist if portal was built


### PR DESCRIPTION
### Description

The portal deploy workflow pins `andstor/file-existence-action` at v3.0.0, which runs on Node.js 20. GitHub Actions has deprecated Node.js 20 and will remove it from runners in September 2026, so the deploy logs a deprecation warning. This bumps the action to v3.1.0 (pinned to commit `558493d`), which upgrades it to Node.js 24 and clears the warning. The `files` input is unchanged and still supported.

### Screenshots

N/A

### Related issue(s)

Fixes #1979

### Checklist

- [ ] Manual testing passed, or N/A. N/A — CI-only change.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.