### PR TITLE
Drop wagmi config from token reads, add getPublicClient

### DIFF
--- a/portal/app/[locale]/btc-yield/_components/usdRewards.tsx
+++ b/portal/app/[locale]/btc-yield/_components/usdRewards.tsx
@@ -7,13 +7,11 @@ import { TokenWithBalance } from 'types/token'
 import { formatFiatNumber } from 'utils/format'
 import { type MerklRewards } from 'utils/merkl'
 import { calculateUsdValue } from 'utils/prices'
-import { useConfig } from 'wagmi'
 
 type Props = {
   merklRewards: MerklRewards
 }
 export const UsdRewards = function ({ merklRewards }: Props) {
-  const config = useConfig()
   const hemi = useHemi()
   const { data: prices, isError: isPricesError } = useTokenPrices()
 
@@ -24,7 +22,6 @@ export const UsdRewards = function ({ merklRewards }: Props) {
       tokenQueryOptions({
         address,
         chainId: hemi.id,
-        config,
       }),
     ),
   })

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnPositions.ts
@@ -1,6 +1,6 @@
 import { type QueryClient, queryOptions } from '@tanstack/react-query'
 import { hemi } from 'hemi-viem'
-import { getHemiClient } from 'utils/chainClients'
+import { getPublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 import { balanceOf } from 'viem-erc20/actions'
 
@@ -21,7 +21,7 @@ const shareBalanceQueryOptions = ({
 }) =>
   queryOptions({
     queryFn: () =>
-      balanceOf(getHemiClient(hemi.id), {
+      balanceOf(getPublicClient(hemi.id), {
         account,
         address: shareAddress,
       }),

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteDeposit.ts
@@ -13,7 +13,7 @@ import {
 } from 'hemi-earn-actions/actions'
 import { hemi } from 'hemi-viem'
 import { mainnet } from 'networks/mainnet'
-import { getEvmL1PublicClient, getHemiClient } from 'utils/chainClients'
+import { getEvmL1PublicClient, getPublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 
 type QuoteDeposit = {
@@ -55,7 +55,7 @@ export const useQuoteDeposit = ({
     enabled: amount > BigInt(0),
     async queryFn() {
       const ethereumClient = getEvmL1PublicClient(mainnet.id)
-      const hemiClient = getHemiClient(hemi.id)
+      const hemiClient = getPublicClient(hemi.id)
       const [callbackFee, assetData] = await Promise.all([
         quoteDepositFulfillment({
           agentAddress: getHemiEarnAgentAddress(),

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteRedeem.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteRedeem.ts
@@ -12,7 +12,7 @@ import {
 } from 'hemi-earn-actions/actions'
 import { hemi } from 'hemi-viem'
 import { mainnet } from 'networks/mainnet'
-import { getEvmL1PublicClient, getHemiClient } from 'utils/chainClients'
+import { getEvmL1PublicClient, getPublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 
 type QuoteRedeem = {
@@ -45,7 +45,7 @@ export const useQuoteRedeem = ({
     enabled: shares > BigInt(0) && !!account,
     async queryFn() {
       const ethereumClient = getEvmL1PublicClient(mainnet.id)
-      const hemiClient = getHemiClient(hemi.id)
+      const hemiClient = getPublicClient(hemi.id)
       // `Agent.quoteRedeemFulfillment` lives on Ethereum and needs the
       // *remote* asset address (the OFT registered on the Agent), not the
       // Hemi-side asset OFT the user holds. Resolve via the Router's

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useUserPoolBalance.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useUserPoolBalance.ts
@@ -3,7 +3,7 @@ import { previewRedeem } from '@vetro-protocol/gateway/actions'
 import { getGatewayForShare, getStakingVaultForShare } from 'hemi-earn-actions'
 import { hemi } from 'hemi-viem'
 import { mainnet } from 'networks/mainnet'
-import { getEvmL1PublicClient, getHemiClient } from 'utils/chainClients'
+import { getEvmL1PublicClient, getPublicClient } from 'utils/chainClients'
 import { type Address, type Chain } from 'viem'
 import { balanceOf } from 'viem-erc20/actions'
 import { convertToAssets } from 'viem-erc4626/actions'
@@ -60,7 +60,7 @@ export const useUserPoolBalance = function ({
   return useQuery<UserPoolBalance>({
     enabled: !!address,
     async queryFn() {
-      const shares = await balanceOf(getHemiClient(chainId), {
+      const shares = await balanceOf(getPublicClient(chainId), {
         account: address!,
         address: shareAddress,
       })

--- a/portal/app/[locale]/staking-dashboard/_hooks/useRewardTokens.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useRewardTokens.ts
@@ -5,13 +5,11 @@ import { useMemo } from 'react'
 import { EvmToken } from 'types/token'
 import { getErc20Token, getTokenByAddress } from 'utils/token'
 import type { Address } from 'viem'
-import { useConfig } from 'wagmi'
 
 import { useRewardTokensAddresses as useRewardTokensQuery } from './useRewardTokensAddresses'
 
 export const useRewardTokens = function () {
   const { id } = useHemi()
-  const config = useConfig()
   const {
     data: rewardTokenAddresses = [],
     isLoading: isLoadingTokenAddresses,
@@ -22,7 +20,7 @@ export const useRewardTokens = function () {
       enabled: !!address,
       queryFn: async () =>
         getTokenByAddress(address, id) ??
-        getErc20Token({ address, chainId: id, config }),
+        getErc20Token({ address, chainId: id }),
       queryKey: getUseTokenQueryKey(address, id),
     })),
   })

--- a/portal/hooks/useL2Token.ts
+++ b/portal/hooks/useL2Token.ts
@@ -2,7 +2,6 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { L2Token } from 'types/token'
 import { getL2Erc20Token } from 'utils/token'
 import { isAddress, type Address, type Chain } from 'viem'
-import { useConfig } from 'wagmi'
 
 type Params = {
   address: string
@@ -15,21 +14,14 @@ type Params = {
  * For most scenarios, prefer useToken hook instead. This token should be used if
  * the info from the RemoteToken (L1) is needed
  */
-export const useL2Token = function ({
-  address,
-  chainId,
-  options = {},
-}: Params) {
-  const config = useConfig()
-  return useQuery({
+export const useL2Token = ({ address, chainId, options = {} }: Params) =>
+  useQuery({
     ...options,
     enabled: (options.enabled ?? true) && isAddress(address),
     queryFn: () =>
       getL2Erc20Token({
         address: address as Address,
         chainId,
-        config,
       }) as Promise<L2Token>,
     queryKey: ['l2-erc20-token-complete', address, chainId],
   })
-}

--- a/portal/hooks/useToken.ts
+++ b/portal/hooks/useToken.ts
@@ -5,7 +5,6 @@ import { toChecksumAddress } from 'utils/address'
 import { isNativeAddress } from 'utils/nativeToken'
 import { getErc20Token, getTokenByAddress } from 'utils/token'
 import { type Address, type Chain, isAddress } from 'viem'
-import { type Config, useConfig } from 'wagmi'
 
 type Params = {
   address: string | undefined
@@ -21,12 +20,10 @@ export const getUseTokenQueryKey = (
 export const tokenQueryOptions = ({
   address,
   chainId,
-  config,
   options = {},
 }: {
   address: Params['address']
   chainId: Params['chainId']
-  config: Config
   options?: Omit<UseQueryOptions<Token, Error>, 'queryKey' | 'queryFn'>
 }) =>
   queryOptions({
@@ -44,17 +41,11 @@ export const tokenQueryOptions = ({
         (getErc20Token({
           address: checksumAddress as Address,
           chainId: chainId as Chain['id'],
-          config,
         }) satisfies Promise<Token>)
       )
     },
     queryKey: getUseTokenQueryKey(address, chainId),
   })
 
-export const useToken = function ({ address, chainId, options = {} }: Params) {
-  const config = useConfig()
-
-  return useQuery<Token, Error>(
-    tokenQueryOptions({ address, chainId, config, options }),
-  )
-}
+export const useToken = ({ address, chainId, options = {} }: Params) =>
+  useQuery<Token, Error>(tokenQueryOptions({ address, chainId, options }))

--- a/portal/test/[locale]/staking-dashboard/_utils/aprCalculations.test.ts
+++ b/portal/test/[locale]/staking-dashboard/_utils/aprCalculations.test.ts
@@ -5,7 +5,11 @@ import {
 import { EvmToken } from 'types/token'
 import { SixDaysSeconds } from 've-hemi-actions'
 import { zeroAddress } from 'viem'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('utils/chainClients', () => ({
+  getPublicClient: vi.fn(),
+}))
 
 const token = { address: zeroAddress, decimals: 18, symbol: 'HEMI' } as EvmToken
 

--- a/portal/test/[locale]/tunnel/_utils/index.test.ts
+++ b/portal/test/[locale]/tunnel/_utils/index.test.ts
@@ -2,6 +2,10 @@ import * as tokenInputUtils from 'components/tokenInput/utils'
 import { validateSubmit } from 'utils/validateSubmit'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 
+vi.mock('utils/chainClients', () => ({
+  getPublicClient: vi.fn(),
+}))
+
 // Minimal mock for t, matching only the required signature for the test
 const t = (key: string) => key
 

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchEarnPositions.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchEarnPositions.test.ts
@@ -15,7 +15,7 @@ import { createTestQueryClient } from '../../../../createTestQueryClient'
 // through the chainClients → transport import chain.
 vi.mock('utils/chainClients', () => ({
   getEvmL1PublicClient: vi.fn(),
-  getHemiClient: vi.fn(),
+  getPublicClient: vi.fn(),
 }))
 
 // `fetchEarnPositions` calls `queryClient.fetchQuery(shareBalanceQueryOptions)`

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.test.ts
@@ -17,7 +17,7 @@ import { createTestQueryClient } from '../../../../createTestQueryClient'
 // use the client is never invoked here because the cache is seeded.
 vi.mock('utils/chainClients', () => ({
   getEvmL1PublicClient: vi.fn(),
-  getHemiClient: vi.fn(),
+  getPublicClient: vi.fn(),
 }))
 
 // Override only the registry getters — leave addresses/`getPeggedTokenForShare`

--- a/portal/test/components/tokenInput/utils.test.ts
+++ b/portal/test/components/tokenInput/utils.test.ts
@@ -1,7 +1,11 @@
 import { validateInput } from 'components/tokenInput/utils'
 import { parseTokenUnits } from 'utils/token'
 import { zeroAddress } from 'viem'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('utils/chainClients', () => ({
+  getPublicClient: vi.fn(),
+}))
 
 // Minimal valid Token mock for tests
 const mockToken = (overrides = {}) => ({

--- a/portal/test/utils/prices.test.ts
+++ b/portal/test/utils/prices.test.ts
@@ -1,7 +1,11 @@
 import { TokenWithBalance } from 'types/token'
 import { calculateUsdValue } from 'utils/prices'
 import { parseUnits } from 'viem'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('utils/chainClients', () => ({
+  getPublicClient: vi.fn(),
+}))
 
 describe('utils/prices', function () {
   describe('calculateUsdValue', function () {

--- a/portal/test/utils/sortTokens.test.ts
+++ b/portal/test/utils/sortTokens.test.ts
@@ -1,7 +1,11 @@
 import { priorityStakeTokensToSort, StakeToken } from 'types/stake'
 import { sortTokens } from 'utils/sortTokens'
 import { zeroAddress } from 'viem'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('utils/chainClients', () => ({
+  getPublicClient: vi.fn(),
+}))
 
 const createMockToken = function (params: {
   symbol: string

--- a/portal/test/utils/stake.test.ts
+++ b/portal/test/utils/stake.test.ts
@@ -15,6 +15,10 @@ vi.mock('viem-erc20/actions', () => ({
   balanceOf: vi.fn(),
 }))
 
+vi.mock('utils/chainClients', () => ({
+  getPublicClient: vi.fn(),
+}))
+
 vi.mock('hemi-viem-stake-actions/actions', () => ({
   stakedBalance: vi.fn(),
   unstakeToken: vi.fn(),

--- a/portal/test/utils/token.test.ts
+++ b/portal/test/utils/token.test.ts
@@ -8,7 +8,11 @@ import {
   isCustomToken,
 } from 'utils/token'
 import { parseUnits as viemParseUnits } from 'viem'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('utils/chainClients', () => ({
+  getPublicClient: vi.fn(),
+}))
 
 const baseToken = {
   address: '0x123',

--- a/portal/test/utils/watch/bitcoinDeposit.test.ts
+++ b/portal/test/utils/watch/bitcoinDeposit.test.ts
@@ -34,7 +34,7 @@ vi.mock(import('utils/btcApi'), async function (importOriginal) {
 })
 
 vi.mock('utils/chainClients', () => ({
-  getHemiClient: vi.fn(),
+  getPublicClient: vi.fn(),
 }))
 
 vi.mock('utils/hemi', () => ({

--- a/portal/test/utils/watch/bitcoinWithdrawals.test.ts
+++ b/portal/test/utils/watch/bitcoinWithdrawals.test.ts
@@ -30,7 +30,7 @@ const block = {
 const uuid = BigInt(1)
 
 vi.mock('utils/chainClients', () => ({
-  getHemiClient: vi.fn(),
+  getPublicClient: vi.fn(),
 }))
 
 vi.mock('utils/evmApi', () => ({

--- a/portal/utils/chainClients.ts
+++ b/portal/utils/chainClients.ts
@@ -3,6 +3,14 @@ import { buildTransport } from 'utils/transport'
 import { type Chain, createPublicClient, type PublicClient } from 'viem'
 import { publicActionsL1, PublicActionsL1 } from 'viem/op-stack'
 
+export const getPublicClient = function (chainId: Chain['id']) {
+  const chain = findChainById(chainId) as Chain
+  return createPublicClient({
+    chain,
+    transport: buildTransport(chain),
+  })
+}
+
 export const getHemiClient = function (chainId: Chain['id']) {
   // L2 are always EVM
   const l2Chain = findChainById(chainId) as Chain

--- a/portal/utils/chainClients.ts
+++ b/portal/utils/chainClients.ts
@@ -11,15 +11,6 @@ export const getPublicClient = function (chainId: Chain['id']) {
   })
 }
 
-export const getHemiClient = function (chainId: Chain['id']) {
-  // L2 are always EVM
-  const l2Chain = findChainById(chainId) as Chain
-  return createPublicClient({
-    chain: l2Chain,
-    transport: buildTransport(l2Chain),
-  })
-}
-
 export const getEvmL1PublicClient = function (chainId: Chain['id']) {
   const l1Chain = findChainById(chainId) as Chain
   return createPublicClient({

--- a/portal/utils/sync-history/bitcoin.ts
+++ b/portal/utils/sync-history/bitcoin.ts
@@ -20,7 +20,7 @@ import {
   mapBitcoinNetwork,
   type MempoolJsBitcoinTransaction,
 } from 'utils/btcApi'
-import { getHemiClient } from 'utils/chainClients'
+import { getPublicClient } from 'utils/chainClients'
 import {
   getBitcoinDepositFee,
   getHemiStatusOfBtcDeposit,
@@ -160,7 +160,7 @@ export const createBitcoinSync = function ({
 > & {
   l1Chain: BtcChain
 } & Pick<HistorySyncer<BlockSyncType>, 'withdrawalsSyncInfo'>) {
-  const hemiClient = getHemiClient(l2Chain.id)
+  const hemiClient = getPublicClient(l2Chain.id)
 
   const syncDeposits = async function () {
     let localDepositSyncInfo: TransactionListSyncType = {

--- a/portal/utils/token.ts
+++ b/portal/utils/token.ts
@@ -1,18 +1,23 @@
-import { type Config, readContract } from '@wagmi/core'
 import pMemoize from 'promise-mem'
 import { tokenList } from 'tokenList'
 import { stakeProtocols, type StakeProtocols, StakeToken } from 'types/stake'
 import { EvmToken, L2Token, Token } from 'types/token'
 import { Token as TokenType } from 'types/token'
+import { getPublicClient } from 'utils/chainClients'
 import {
   type Address,
   type Chain,
-  erc20Abi,
   isAddress,
   isAddressEqual,
   checksumAddress as toChecksum,
   parseUnits as viemParseUnits,
 } from 'viem'
+import { readContract } from 'viem/actions'
+import {
+  decimals as getDecimals,
+  name as getName,
+  symbol as getSymbol,
+} from 'viem-erc20/actions'
 
 import { getNativeToken, isNativeAddress } from './nativeToken'
 import { opErc20Abi } from './opErc20Abi'
@@ -72,21 +77,17 @@ export const getErc20Token = pMemoize(
   async function ({
     address,
     chainId,
-    config,
   }: {
     address: Address
     chainId: Chain['id']
-    config: Config
   }) {
-    const read = <T extends 'decimals' | 'name' | 'symbol'>(functionName: T) =>
-      readContract(config, {
-        abi: erc20Abi,
-        address,
-        chainId,
-        functionName,
-      })
+    const client = getPublicClient(chainId)
 
-    return Promise.all([read('decimals'), read('name'), read('symbol')]).then(
+    return Promise.all([
+      getDecimals(client, { address }),
+      getName(client, { address }),
+      getSymbol(client, { address }),
+    ]).then(
       ([decimals, name, symbol]) =>
         ({
           address: toChecksum(address),
@@ -101,21 +102,12 @@ export const getErc20Token = pMemoize(
 )
 
 export const getL2Erc20Token = pMemoize(
-  async ({
-    address,
-    chainId,
-    config,
-  }: {
-    address: Address
-    chainId: Chain['id']
-    config: Config
-  }) =>
+  async ({ address, chainId }: { address: Address; chainId: Chain['id'] }) =>
     Promise.all([
-      getErc20Token({ address, chainId, config }),
-      readContract(config, {
+      getErc20Token({ address, chainId }),
+      readContract(getPublicClient(chainId), {
         abi: opErc20Abi,
         address,
-        chainId,
         functionName: 'l1Token',
         // The token may not have an l1 counter part
       }).catch(() => undefined),

--- a/portal/utils/wait-times/evmWithdrawals.ts
+++ b/portal/utils/wait-times/evmWithdrawals.ts
@@ -1,11 +1,11 @@
 import { ToEvmWithdrawOperation } from 'types/tunnel'
-import { getEvmL1PublicClient, getHemiClient } from 'utils/chainClients'
+import { getEvmL1PublicClient, getPublicClient } from 'utils/chainClients'
 import { getWithdrawals } from 'viem/op-stack'
 
 export const getTimeToProveInSeconds = async function (
   withdrawal: ToEvmWithdrawOperation,
 ): Promise<number> {
-  const hemiClient = getHemiClient(withdrawal.l2ChainId)
+  const hemiClient = getPublicClient(withdrawal.l2ChainId)
   const publicClientL1 = getEvmL1PublicClient(withdrawal.l1ChainId)
 
   const receipt = await hemiClient.getTransactionReceipt({
@@ -26,7 +26,7 @@ export const getTimeToProveInSeconds = async function (
 export const getTimeToFinalizeInSeconds = async function (
   withdrawal: ToEvmWithdrawOperation,
 ): Promise<number> {
-  const hemiClient = getHemiClient(withdrawal.l2ChainId)
+  const hemiClient = getPublicClient(withdrawal.l2ChainId)
   const publicClientL1 = getEvmL1PublicClient(withdrawal.l1ChainId)
 
   const receipt = await hemiClient.getTransactionReceipt({

--- a/portal/utils/watch/bitcoinDeposits.ts
+++ b/portal/utils/watch/bitcoinDeposits.ts
@@ -2,7 +2,7 @@ import debugConstructor from 'debug'
 import { type BtcDepositOperation, BtcDepositStatus } from 'types/tunnel'
 import { getBitcoinTimestamp } from 'utils/bitcoin'
 import { createBtcApi, mapBitcoinNetwork } from 'utils/btcApi'
-import { getHemiClient } from 'utils/chainClients'
+import { getPublicClient } from 'utils/chainClients'
 import { getHemiStatusOfBtcDeposit, getVaultAddressByDeposit } from 'utils/hemi'
 import { getBtcDepositInfo } from 'utils/subgraph'
 import { isPendingOperation } from 'utils/tunnel'
@@ -59,7 +59,7 @@ export const watchDepositOnHemi = async function (
 ) {
   const updates: Partial<BtcDepositOperation> = {}
 
-  const hemiClient = getHemiClient(deposit.l2ChainId)
+  const hemiClient = getPublicClient(deposit.l2ChainId)
 
   const newStatus = isPendingOperation(deposit)
     ? await getVaultAddressByDeposit(hemiClient, deposit).then(vaultAddress =>

--- a/portal/utils/watch/bitcoinWithdrawals.ts
+++ b/portal/utils/watch/bitcoinWithdrawals.ts
@@ -1,5 +1,5 @@
 import { type ToBtcWithdrawOperation, BtcWithdrawStatus } from 'types/tunnel'
-import { getHemiClient } from 'utils/chainClients'
+import { getPublicClient } from 'utils/chainClients'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import {
   getBitcoinWithdrawalUuid,
@@ -38,7 +38,7 @@ export const watchBitcoinWithdrawal = async function (
 ) {
   const updates: Partial<ToBtcWithdrawOperation> = {}
 
-  const hemiClient = getHemiClient(withdrawal.l2ChainId)
+  const hemiClient = getPublicClient(withdrawal.l2ChainId)
 
   // if the withdrawal is on a final state, it won't change, so there's no need to re-check it
   const newStatus = isPendingOperation(withdrawal)


### PR DESCRIPTION
### Description

Small refactor extracted from the hemi-earn composition work (#1966).

`getErc20Token` / `getL2Erc20Token` no longer take a `@wagmi/core` `config`. They build a public client from `chainId` and read erc20 metadata via `viem-erc20` actions (and viem's `readContract` for the OP-stack `l1Token`), instead of `@wagmi/core`'s `readContract`. A generic `getPublicClient` helper is added to `utils/chainClients`, and the now-redundant `getHemiClient` — which was identical to it — is dropped in favor of it across the codebase. `getEvmL1PublicClient` stays, since it extends the client with op-stack L1 actions.

`config` is removed from every caller (`tokenQueryOptions`, `useToken`, `useL2Token`, `useRewardTokens`, `UsdRewards`). The affected test suites now mock `utils/chainClients`, since importing the token utils pulls in the transport stack (whose `eth-rpc-cache` dependency can't load under vitest). The full portal test suite passes (469 tests).

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #1966

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.