### PR TITLE
Render pool composition from the Vetro treasury

### DIFF
--- a/packages/hemi-earn-actions/index.ts
+++ b/packages/hemi-earn-actions/index.ts
@@ -7,7 +7,6 @@ export {
   type HemiEarnAsset,
   type HemiEarnShareEntry,
   SVETBTC_OFT_ADDRESS,
-  getGatewayForShare,
   getHemiEarnAgentAddress,
   getHemiEarnRouterAddress,
   getHemiEarnShares,

--- a/packages/hemi-earn-actions/src/actions/public/getAssetData.ts
+++ b/packages/hemi-earn-actions/src/actions/public/getAssetData.ts
@@ -1,4 +1,10 @@
-import { type Address, type Client, isAddressEqual, zeroAddress } from 'viem'
+import {
+  type Address,
+  type Client,
+  isAddress,
+  isAddressEqual,
+  zeroAddress,
+} from 'viem'
 import { readContract } from 'viem/actions'
 
 import { getHemiEarnRouterAddress } from '../../constants'
@@ -24,15 +30,25 @@ export type AssetData = {
 // Per-key lookup of the Router's asset registry: given a Hemi-side deposit
 // asset (e.g. the hemiBTC OFT), returns the share OFT it settles into plus
 // the Ethereum-side asset the Agent uses on fulfillment.
-export const getAssetData = async function ({
-  asset,
-  client,
-  routerAddress = getHemiEarnRouterAddress(),
-}: {
-  asset: Address
-  client: Client
-  routerAddress?: Address
-}): Promise<AssetData> {
+export const getAssetData = async function (
+  client: Client,
+  {
+    asset,
+    routerAddress = getHemiEarnRouterAddress(),
+  }: {
+    asset: Address
+    routerAddress?: Address
+  },
+): Promise<AssetData> {
+  if (!client) {
+    throw new Error('getAssetData: `client` is not defined')
+  }
+  if (!isAddress(asset, { strict: false })) {
+    throw new Error('getAssetData: `asset` is not a valid address')
+  }
+  if (!isAddress(routerAddress, { strict: false })) {
+    throw new Error('getAssetData: `routerAddress` is not a valid address')
+  }
   if (isAddressEqual(asset, zeroAddress)) {
     throw new Error('getAssetData: `asset` cannot be the zero address')
   }

--- a/packages/hemi-earn-actions/src/constants.ts
+++ b/packages/hemi-earn-actions/src/constants.ts
@@ -128,10 +128,6 @@ function findShareEntry(shareOft: Address) {
 export const getStakingVaultForShare = (shareOft: Address) =>
   findShareEntry(shareOft).stakingVault
 
-// Ethereum-side Vetro Gateway for a Hemi-side share OFT.
-export const getGatewayForShare = (shareOft: Address) =>
-  findShareEntry(shareOft).gateway
-
 // Ethereum-side pegged token (vBTC, vUSD) for a Hemi-side share OFT.
 // Resolved on-chain via the gateway's `PEGGED_TOKEN()` view — callers
 // should wrap in `useQuery` / `useQueries` and cache the result (the

--- a/packages/hemi-earn-actions/test/actions/public/getAssetData.test.ts
+++ b/packages/hemi-earn-actions/test/actions/public/getAssetData.test.ts
@@ -24,7 +24,7 @@ describe('getAssetData', function () {
       share,
     })
 
-    const result = await getAssetData({ asset, client, routerAddress })
+    const result = await getAssetData(client, { asset, routerAddress })
 
     expect(result).toEqual({
       enabled: true,
@@ -50,14 +50,32 @@ describe('getAssetData', function () {
       share,
     })
 
-    const result = await getAssetData({ asset, client, routerAddress })
+    const result = await getAssetData(client, { asset, routerAddress })
 
     expect(result.enabled).toBe(false)
   })
 
   it('rejects a zero `asset`', async function () {
     await expect(
-      getAssetData({ asset: zeroAddress, client, routerAddress }),
+      getAssetData(client, { asset: zeroAddress, routerAddress }),
     ).rejects.toThrow(/`asset` cannot be the zero address/)
+  })
+
+  it('rejects an undefined `client`', async function () {
+    await expect(
+      getAssetData(undefined as unknown as Client, { asset, routerAddress }),
+    ).rejects.toThrow(/`client` is not defined/)
+  })
+
+  it('rejects an invalid `asset`', async function () {
+    await expect(
+      getAssetData(client, { asset: '0xnope', routerAddress }),
+    ).rejects.toThrow(/`asset` is not a valid address/)
+  })
+
+  it('rejects an invalid `routerAddress`', async function () {
+    await expect(
+      getAssetData(client, { asset, routerAddress: '0xnope' as Address }),
+    ).rejects.toThrow(/`routerAddress` is not a valid address/)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5561,15 +5561,6 @@ packages:
     peerDependencies:
       viem: ^2.x
 
-  '@vetro-protocol/gateway@1.2.0':
-    resolution:
-      {
-        integrity: sha512-s1rpaQey1WdKyvq1JuTNyLWXOGz6jMi2/GPvw7m0Ez+A/b/MJ+Auvfzon5bazUpLGbLEIUAO74izqFeUCl9v5Q==,
-      }
-    engines: { node: '>=20' }
-    peerDependencies:
-      viem: ^2.x
-
   '@vitest/eslint-plugin@1.6.16':
     resolution:
       {
@@ -17982,12 +17973,6 @@ snapshots:
       '@vanilla-extract/css': 1.17.3
 
   '@vetro-protocol/earn@1.0.0(viem@2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
-    dependencies:
-      to-promise-event: 1.0.0
-      viem: 2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      viem-erc20: 2.1.0(viem@2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-
-  '@vetro-protocol/gateway@1.2.0(viem@2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       to-promise-event: 1.0.0
       viem: 2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5561,6 +5561,15 @@ packages:
     peerDependencies:
       viem: ^2.x
 
+  '@vetro-protocol/gateway@1.2.0':
+    resolution:
+      {
+        integrity: sha512-s1rpaQey1WdKyvq1JuTNyLWXOGz6jMi2/GPvw7m0Ez+A/b/MJ+Auvfzon5bazUpLGbLEIUAO74izqFeUCl9v5Q==,
+      }
+    engines: { node: '>=20' }
+    peerDependencies:
+      viem: ^2.x
+
   '@vitest/eslint-plugin@1.6.16':
     resolution:
       {
@@ -17973,6 +17982,12 @@ snapshots:
       '@vanilla-extract/css': 1.17.3
 
   '@vetro-protocol/earn@1.0.0(viem@2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+    dependencies:
+      to-promise-event: 1.0.0
+      viem: 2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem-erc20: 2.1.0(viem@2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+
+  '@vetro-protocol/gateway@1.2.0(viem@2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       to-promise-event: 1.0.0
       viem: 2.28.4(patch_hash=2c103b691bf333d47e3036fd621d41c27c78e3ed367384b389fd6518dfd67846)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchComposition.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchComposition.ts
@@ -1,0 +1,185 @@
+import { type QueryClient } from '@tanstack/react-query'
+import { gateways } from '@vetro-protocol/gateway'
+import fetch from 'fetch-plus-plus'
+import { tokenQueryOptions } from 'hooks/useToken'
+import { tokenPricesQueryOptions } from 'hooks/useTokenPrices'
+import { mainnet } from 'networks/mainnet'
+import { type Token } from 'types/token'
+import { type Address, formatUnits, isAddressEqual } from 'viem'
+
+import {
+  gatewayForAssetQueryOptions,
+  getAssetForShare,
+} from '../_hooks/gatewayForAsset'
+
+// Shape of each entry returned by `GET /analytics/treasury/:gatewayAddress`.
+// Token amounts (`totalDebt`, `withdrawable`, a strategy's `totalDebt`) are
+// denominated in the token's erc20 minimal units. `latestPrice` is the token's
+// oracle price denominated in the gateway's peg unit (e.g. BTC for the vetBTC
+// gateway), so converting to USD only needs the peg's USD price on top — see
+// `toCompositionData`.
+type TreasuryToken = {
+  activeStrategies: { name: string; totalDebt: string }[]
+  latestPrice: string
+  priceDecimals: number
+  tokenAddress: Address
+  totalDebt: string
+  withdrawable: string
+}
+
+// Raw, locale-free and grouping-agnostic data cached by the composition query:
+// per whitelisted token, the USD value of each active strategy plus the
+// token's deployed (`totalDebt`) and total (`withdrawable`, deployed + idle)
+// USD values. Grouping into display items happens in `toCompositionItems`.
+export type CompositionData = {
+  strategies: { amount: number; name: string }[]
+  symbol: string
+  totalDebt: number
+  withdrawable: number
+}[]
+
+// Turns the treasury response into the composition data. Each token's oracle
+// `latestPrice` is denominated in the gateway's peg unit, so its USD price is
+// `latestPrice × pegPrice` (the peg's USD price). `tokens` holds the resolved
+// metadata (symbol, decimals) to scale the token amounts.
+const toCompositionData = function (
+  treasury: TreasuryToken[],
+  tokens: Token[],
+  pegPrice: number,
+): CompositionData {
+  const data: CompositionData = []
+
+  for (const {
+    activeStrategies,
+    latestPrice,
+    priceDecimals,
+    tokenAddress,
+    totalDebt,
+    withdrawable,
+  } of treasury) {
+    const token = tokens.find(t =>
+      isAddressEqual(t.address as Address, tokenAddress),
+    )
+    if (token === undefined) {
+      continue
+    }
+    const price =
+      Number(formatUnits(BigInt(latestPrice), priceDecimals)) * pegPrice
+    const toUsd = (value: string) =>
+      Number(formatUnits(BigInt(value), token.decimals)) * price
+
+    data.push({
+      strategies: activeStrategies.map(strategy => ({
+        amount: toUsd(strategy.totalDebt),
+        name: strategy.name,
+      })),
+      symbol: token.symbol,
+      totalDebt: toUsd(totalDebt),
+      withdrawable: toUsd(withdrawable),
+    })
+  }
+
+  return data
+}
+
+// Groups the cached composition data into display items. 'protocol' lists the
+// individual strategies and appends the idle funds (`withdrawable` minus
+// `totalDebt`, across tokens) as a reserve-buffer entry. 'token' lists each
+// whitelisted token by its `withdrawable` value, which already contains the
+// token's idle share — so no separate buffer entry. Shares are percentages of
+// the grouped total.
+export const toCompositionItems = function ({
+  data,
+  reserveBufferLabel,
+  viewMode,
+}: {
+  data: CompositionData
+  reserveBufferLabel: string
+  viewMode: 'protocol' | 'token'
+}) {
+  const items: { amount: number; isReserveBuffer?: boolean; name: string }[] =
+    viewMode === 'token'
+      ? data.map(({ symbol, withdrawable }) => ({
+          amount: withdrawable,
+          name: symbol,
+        }))
+      : data.flatMap(token => token.strategies)
+
+  if (viewMode === 'protocol') {
+    const reserveBuffer = Math.max(
+      0,
+      data.reduce(
+        (sum, token) => sum + token.withdrawable - token.totalDebt,
+        0,
+      ),
+    )
+    if (reserveBuffer > 0) {
+      items.push({
+        amount: reserveBuffer,
+        isReserveBuffer: true,
+        name: reserveBufferLabel,
+      })
+    }
+  }
+
+  const visible = items.filter(item => item.amount > 0)
+  const total = visible.reduce((sum, item) => sum + item.amount, 0)
+  return visible.map(item => ({
+    amount: item.amount,
+    apy: 1.01,
+    // Lets consumers exclude the buffer row from e.g. position counts
+    isReserveBuffer: item.isReserveBuffer === true,
+    name: item.name,
+    share: total > 0 ? (item.amount / total) * 100 : 0,
+  }))
+}
+
+export const fetchComposition = async function ({
+  apiUrl,
+  queryClient,
+  shareAddress,
+}: {
+  apiUrl: string
+  queryClient: QueryClient
+  shareAddress: Address
+}): Promise<CompositionData> {
+  const gatewayAddress = await queryClient.ensureQueryData(
+    gatewayForAssetQueryOptions(getAssetForShare(shareAddress)),
+  )
+  // Whitelisted-token oracles are denominated in the gateway's peg unit, so a
+  // single feed lookup for the peg symbol prices every token. "USD" pegs are
+  // the identity (no conversion needed).
+  const pegBaseSymbol = gateways.find(gateway =>
+    isAddressEqual(gateway.address, gatewayAddress),
+  )?.pegBaseSymbol
+  if (pegBaseSymbol === undefined) {
+    throw new Error(`No peg base symbol for gateway ${gatewayAddress}`)
+  }
+
+  const treasury = (await fetch(
+    `${apiUrl}/analytics/treasury/${gatewayAddress}`,
+  )) as TreasuryToken[]
+
+  // The endpoint returns the token addresses but not their metadata, so
+  // resolve each one through the shared token query (token list + erc20
+  // fallback). Both lookups are cached and shared across reloads and other
+  // consumers.
+  const uniqueAddresses = [
+    ...new Set(treasury.map(token => token.tokenAddress)),
+  ]
+
+  const [tokens, prices] = await Promise.all([
+    Promise.all(
+      uniqueAddresses.map(address =>
+        queryClient.ensureQueryData(
+          tokenQueryOptions({ address, chainId: mainnet.id }),
+        ),
+      ),
+    ),
+    queryClient.ensureQueryData(tokenPricesQueryOptions()),
+  ])
+  // The feed quotes prices in USD, so the USD peg itself is 1
+  const pegPrice = Number({ USD: '1', ...prices }[pegBaseSymbol] ?? '0')
+
+  return toCompositionData(treasury, tokens, pegPrice)
+}

--- a/portal/app/[locale]/hemi-earn/_hooks/gatewayForAsset.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/gatewayForAsset.ts
@@ -1,0 +1,38 @@
+import { queryOptions } from '@tanstack/react-query'
+import { getHemiEarnSupportedAssets } from 'hemi-earn-actions'
+import { type Address, isAddressEqual } from 'viem'
+
+import { gatewayForRemoteShareQueryOptions } from './gatewayForRemoteShare'
+import { assetDataQueryOptions } from './useAssetData'
+
+// Resolves the gateway for a Hemi-side deposit asset dynamically:
+//   Router.assetsData(asset).remoteShare (Hemi)
+//     → StakingVault.asset() (Ethereum)
+//     → PeggedToken.gateway() (Ethereum)
+// Composes the asset-data and remote-share lookups through the query cache so
+// each is shared (e.g. `useQuoteDeposit` reuses the same asset-data entry).
+export const gatewayForAssetQueryOptions = (asset: Address) =>
+  queryOptions({
+    async queryFn({ client }) {
+      const { remoteShare } = await client.ensureQueryData(
+        assetDataQueryOptions(asset),
+      )
+      return client.ensureQueryData(
+        gatewayForRemoteShareQueryOptions(remoteShare),
+      )
+    },
+    queryKey: ['hemi-earn', 'gateway-for-asset', asset],
+  })
+
+// The gateway is identical across all of a share's deposit assets, so callers
+// that only have a share OFT (e.g. composition) resolve any registered asset
+// for that share to feed the asset-keyed gateway lookup.
+export const getAssetForShare = function (shareAddress: Address) {
+  const entry = getHemiEarnSupportedAssets().find(supported =>
+    isAddressEqual(supported.share, shareAddress),
+  )
+  if (!entry) {
+    throw new Error(`No supported asset registered for share ${shareAddress}`)
+  }
+  return entry.asset
+}

--- a/portal/app/[locale]/hemi-earn/_hooks/gatewayForRemoteShare.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/gatewayForRemoteShare.ts
@@ -1,0 +1,27 @@
+import { queryOptions } from '@tanstack/react-query'
+import { getGateway } from '@vetro-protocol/gateway/actions'
+import { mainnet } from 'networks/mainnet'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { type Address, type Client } from 'viem'
+import { asset as getVaultAsset } from 'viem-erc4626/actions'
+
+// Resolves the Ethereum-side Vetro Gateway from the Ethereum-side StakingVault
+// (the Router's `remoteShare`), following the chain the Agent walks:
+// `StakingVault.asset()` → pegged token, then `PeggedToken.gateway()` → gateway.
+// Both reads hit Ethereum.
+const getGatewayFromRemoteShare = async function (
+  ethereumClient: Client,
+  remoteShare: Address,
+): Promise<Address> {
+  const peggedToken = await getVaultAsset(ethereumClient, {
+    address: remoteShare,
+  })
+  return getGateway(ethereumClient, { address: peggedToken })
+}
+
+export const gatewayForRemoteShareQueryOptions = (remoteShare: Address) =>
+  queryOptions({
+    queryFn: () =>
+      getGatewayFromRemoteShare(getEvmL1PublicClient(mainnet.id), remoteShare),
+    queryKey: ['hemi-earn', 'gateway-for-remote-share', remoteShare],
+  })

--- a/portal/app/[locale]/hemi-earn/_hooks/useAssetData.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useAssetData.ts
@@ -1,0 +1,18 @@
+import { queryOptions } from '@tanstack/react-query'
+import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
+import { getAssetData } from 'hemi-earn-actions/actions'
+import { getPublicClient } from 'utils/chainClients'
+import { type Address } from 'viem'
+import { hemi } from 'viem/chains'
+
+// `Router.assetsData(asset)` on Hemi — resolves a Hemi-side asset to its
+// Ethereum-side counterparts (`remoteShare` = staking vault, `remoteAsset`).
+export const assetDataQueryOptions = (asset: Address) =>
+  queryOptions({
+    queryFn: () =>
+      getAssetData(getPublicClient(hemi.id), {
+        asset,
+        routerAddress: getHemiEarnRouterAddress(),
+      }),
+    queryKey: ['hemi-earn', 'asset-data', asset],
+  })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionChart.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Skeleton from 'react-loading-skeleton'
+import { formatPercentage } from 'utils/format'
 import { VictoryPie } from 'victory'
 
 import { type CompositionItemWithColor } from './compositionColumns'
@@ -61,7 +62,7 @@ export const CompositionChart = function ({
         </svg>
         {hoveredItem !== null && (
           <span className="text-mid-md pointer-events-none absolute font-semibold text-orange-500">
-            {`${hoveredItem.share}%`}
+            {formatPercentage(hoveredItem.share)}
           </span>
         )}
       </div>

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionColumns.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionColumns.tsx
@@ -53,7 +53,7 @@ export const useGetCompositionColumns = function () {
         {
           cell: ({ row }) => (
             <span className="text-sm font-medium text-neutral-950">
-              {row.original.share}%
+              {formatPercentage(row.original.share)}
             </span>
           ),
           header: () => <Header text={t('share')} />,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/index.tsx
@@ -16,20 +16,16 @@ import { SegmentedControlItem } from '../segmentedControlItem'
 import { CompositionChart } from './compositionChart'
 import { CompositionTable } from './compositionTable'
 
-// Orange gradient palette supporting up to 12 items (dark to light)
+// Orange palette (dark to light); items beyond the palette wrap around
 const compositionColors = [
-  '#FF4600',
-  '#FF570D',
-  '#FF6A1A',
-  '#FF7B2E',
-  '#FF8C42',
-  '#FF9C5E',
-  '#FFB07A',
-  '#FFC299',
-  '#FFD4B8',
-  '#FFDEC7',
-  '#FFE8D6',
-  '#FFF3EB',
+  '#CC2F02', // orange-700
+  '#FF4600', // orange-600
+  '#FF600A', // orange-500
+  '#FF8332', // orange-400
+  '#FFB06D', // orange-300
+  '#FFD1A5', // orange-200
+  '#FFEAD3', // orange-100
+  '#FFF6EC', // orange-50
 ]
 
 type Props = {
@@ -42,11 +38,7 @@ export const Composition = function ({ chainId, shareAddress }: Props) {
   const [viewMode, setViewMode] = useState<CompositionViewMode>('token')
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
 
-  const {
-    data = [],
-    isError,
-    isPending,
-  } = useComposition({
+  const { data, isError, isPending } = useComposition({
     chainId,
     shareAddress,
     viewMode,
@@ -54,7 +46,7 @@ export const Composition = function ({ chainId, shareAddress }: Props) {
 
   const dataWithColors = useMemo(
     () =>
-      data.map((item, index) => ({
+      (data ?? []).map((item, index) => ({
         ...item,
         color: compositionColors[index % compositionColors.length],
       })),
@@ -63,9 +55,11 @@ export const Composition = function ({ chainId, shareAddress }: Props) {
 
   const renderHeadline = function () {
     if (dataWithColors.length > 0) {
+      // The reserve buffer row is not a position, so keep it out of the count
+      const count = dataWithColors.filter(item => !item.isReserveBuffer).length
       return viewMode === 'token'
-        ? t('tokens-count', { count: dataWithColors.length })
-        : t('protocols-count', { count: dataWithColors.length })
+        ? t('tokens-count', { count })
+        : t('protocols-count', { count })
     }
     if (isError) {
       return '-'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchAssetsToShares.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchAssetsToShares.ts
@@ -1,10 +1,15 @@
-import { type UseQueryOptions } from '@tanstack/react-query'
+import { type QueryClient, type UseQueryOptions } from '@tanstack/react-query'
 import { previewWithdraw } from '@vetro-protocol/gateway/actions'
-import { getGatewayForShare, getStakingVaultForShare } from 'hemi-earn-actions'
+import { getStakingVaultForShare } from 'hemi-earn-actions'
 import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 import { convertToShares } from 'viem-erc4626/actions'
+
+import {
+  gatewayForAssetQueryOptions,
+  getAssetForShare,
+} from '../../../_hooks/gatewayForAsset'
 
 export type AssetsToShares = {
   peggedAmount: bigint
@@ -14,6 +19,7 @@ export type AssetsToShares = {
 export type AssetsToSharesParams = {
   amount: bigint
   assetAddress: Address
+  queryClient: QueryClient
   shareAddress: Address
 }
 
@@ -29,11 +35,17 @@ export type AssetsToSharesParams = {
 export async function fetchAssetsToShares({
   amount,
   assetAddress,
+  queryClient,
   shareAddress,
 }: AssetsToSharesParams): Promise<AssetsToShares> {
   const ethereumClient = getEvmL1PublicClient(mainnet.id)
+  // Resolve the gateway on-chain from the share's deposit asset, reusing the
+  // shared asset-data/remote-share cache entries instead of a static lookup.
+  const gateway = await queryClient.ensureQueryData(
+    gatewayForAssetQueryOptions(getAssetForShare(shareAddress)),
+  )
   const peggedAmount = await previewWithdraw(ethereumClient, {
-    address: getGatewayForShare(shareAddress),
+    address: gateway,
     amountOut: amount,
     tokenOut: assetAddress,
   })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchDepositShares.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchDepositShares.ts
@@ -5,7 +5,7 @@ import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 import { convertToShares } from 'viem-erc4626/actions'
 
-import { fetchQuoteDeposit, getQuoteDepositQueryKey } from './fetchQuoteDeposit'
+import { quoteDepositOptions } from './fetchQuoteDeposit'
 
 export type DepositSharesParams = {
   amount: bigint
@@ -21,11 +21,16 @@ export async function fetchDepositShares(
   queryClient: QueryClient,
   { amount, asset, shareAddress }: DepositSharesParams,
 ): Promise<bigint> {
-  const quote = await queryClient.fetchQuery({
-    queryFn: () => fetchQuoteDeposit({ amount, asset, shareAddress }),
-    queryKey: getQuoteDepositQueryKey({ amount, asset, shareAddress }),
+  const { queryFn, queryKey } = quoteDepositOptions({
+    amount,
+    asset,
+    queryClient,
+    shareAddress,
   })
-  if (quote.peggedAmount <= BigInt(0)) return BigInt(0)
+  const quote = await queryClient.fetchQuery({ queryFn, queryKey })
+  if (quote.peggedAmount <= BigInt(0)) {
+    return BigInt(0)
+  }
   return convertToShares(getEvmL1PublicClient(mainnet.id), {
     address: getStakingVaultForShare(shareAddress),
     assets: quote.peggedAmount,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.ts
@@ -1,13 +1,11 @@
-import { type UseQueryOptions } from '@tanstack/react-query'
+import { type QueryClient, type UseQueryOptions } from '@tanstack/react-query'
 import { previewDeposit } from '@vetro-protocol/gateway/actions'
 import {
-  getGatewayForShare,
   getHemiEarnAgentAddress,
   getHemiEarnRouterAddress,
   getStakingVaultForShare,
 } from 'hemi-earn-actions'
 import {
-  getAssetData,
   quoteDeposit,
   quoteDepositFulfillment,
 } from 'hemi-earn-actions/actions'
@@ -15,6 +13,9 @@ import { hemi } from 'hemi-viem'
 import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient, getPublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
+
+import { gatewayForAssetQueryOptions } from '../../../_hooks/gatewayForAsset'
+import { assetDataQueryOptions } from '../../../_hooks/useAssetData'
 
 export type QuoteDeposit = {
   callbackFee: bigint
@@ -25,6 +26,7 @@ export type QuoteDeposit = {
 export type QuoteDepositParams = {
   amount: bigint
   asset: Address
+  queryClient: QueryClient
   shareAddress: Address
 }
 
@@ -35,36 +37,43 @@ export type QuoteDepositParams = {
 export async function fetchQuoteDeposit({
   amount,
   asset,
+  queryClient,
   shareAddress,
 }: QuoteDepositParams): Promise<QuoteDeposit> {
   const ethereumClient = getEvmL1PublicClient(mainnet.id)
   const hemiClient = getPublicClient(hemi.id)
-  const [callbackFee, assetData] = await Promise.all([
-    quoteDepositFulfillment({
-      agentAddress: getHemiEarnAgentAddress(),
-      client: ethereumClient,
-      share: getStakingVaultForShare(shareAddress),
-    }),
-    getAssetData({
-      asset,
-      client: hemiClient,
-      routerAddress: getHemiEarnRouterAddress(),
-    }),
-  ])
-  const [nativeFee, peggedAmount] = await Promise.all([
-    quoteDeposit({
-      asset,
-      assets: amount,
-      callbackFee,
-      client: hemiClient,
-      routerAddress: getHemiEarnRouterAddress(),
-    }),
+
+  const peggedAmountPromise = Promise.all([
+    queryClient.ensureQueryData(gatewayForAssetQueryOptions(asset)),
+    queryClient.ensureQueryData(assetDataQueryOptions(asset)),
+  ]).then(([gateway, assetData]) =>
     previewDeposit(ethereumClient, {
-      address: getGatewayForShare(shareAddress),
+      address: gateway,
       amountIn: amount,
       tokenIn: assetData.remoteAsset,
     }),
+  )
+
+  const callbackFeePromise = quoteDepositFulfillment({
+    agentAddress: getHemiEarnAgentAddress(),
+    client: ethereumClient,
+    share: getStakingVaultForShare(shareAddress),
+  })
+
+  const [callbackFee, nativeFee, peggedAmount] = await Promise.all([
+    callbackFeePromise,
+    callbackFeePromise.then(cbFee =>
+      quoteDeposit({
+        asset,
+        assets: amount,
+        callbackFee: cbFee,
+        client: hemiClient,
+        routerAddress: getHemiEarnRouterAddress(),
+      }),
+    ),
+    peggedAmountPromise,
   ])
+
   return { callbackFee, nativeFee, peggedAmount }
 }
 

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.ts
@@ -77,7 +77,7 @@ export async function fetchQuoteDeposit({
   return { callbackFee, nativeFee, peggedAmount }
 }
 
-export const getQuoteDepositQueryKey = ({
+const getQuoteDepositQueryKey = ({
   amount,
   asset,
   shareAddress,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.ts
@@ -46,9 +46,8 @@ export async function fetchQuoteRedeem({
       client: ethereumClient,
       stakingVault: getStakingVaultForShare(shareAddress),
     }),
-    getAssetData({
+    getAssetData(hemiClient, {
       asset,
-      client: hemiClient,
       routerAddress: getHemiEarnRouterAddress(),
     }),
   ])

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useAssetsToShares.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useAssetsToShares.ts
@@ -1,9 +1,11 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import {
   type AssetsToSharesParams,
   assetsToSharesOptions,
 } from '../_fetchers/fetchAssetsToShares'
 
-export const useAssetsToShares = (params: AssetsToSharesParams) =>
-  useQuery(assetsToSharesOptions(params))
+export const useAssetsToShares = (
+  params: Omit<AssetsToSharesParams, 'queryClient'>,
+) =>
+  useQuery(assetsToSharesOptions({ ...params, queryClient: useQueryClient() }))

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useComposition.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useComposition.ts
@@ -1,55 +1,56 @@
-import { useQuery } from '@tanstack/react-query'
+'use client'
+
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { useTranslations } from 'next-intl'
+import { isValidUrl } from 'utils/url'
 import { type Address, type Chain } from 'viem'
+
+import {
+  type CompositionData,
+  fetchComposition,
+  toCompositionItems,
+} from '../../../_fetchers/fetchComposition'
 
 export type CompositionViewMode = 'token' | 'protocol'
 
 export type CompositionItem = {
   amount: number
   apy: number
+  isReserveBuffer: boolean
   name: string
   share: number
 }
 
-// Simple seeded pseudo-random for deterministic mock data
-const seededRandom = function (seed: number) {
-  const x = Math.sin(seed) * 10000
-  return x - Math.floor(x)
+const apiUrl = process.env.NEXT_PUBLIC_VETRO_API_URL
+const isVetroApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
+
+type CompositionQueryOptions = {
+  chainId: Chain['id']
+  queryClient: QueryClient
+  shareAddress: Address
 }
 
-const tokenMockData: CompositionItem[] = [
-  { amount: 6_342_160, apy: 1.01, name: 'Other positions', share: 32 },
-  { amount: 5_556_931, apy: 1.01, name: 'Morphoblue - Steakhouse', share: 28 },
-  { amount: 2_849_340, apy: 1.01, name: 'Spark - eth', share: 14.4 },
-  { amount: 2_697_935, apy: 1.01, name: 'Lagoon - Vault', share: 13.6 },
-  {
-    amount: 2_160_089,
-    apy: 1.01,
-    name: 'Originstory - ARM-WETH-stETH',
-    share: 10.9,
-  },
-  { amount: 219_361, apy: 1.01, name: 'Wallet', share: 1.1 },
-]
-
-const generateMockData = function (viewMode: CompositionViewMode) {
-  if (viewMode === 'token') {
-    return tokenMockData
-  }
-  // For protocol view, generate slightly different data
-  return [
-    { amount: 7_100_000, apy: 1.02, name: 'Morpho', share: 35.8 },
-    { amount: 4_200_000, apy: 0.98, name: 'Spark', share: 21.2 },
-    { amount: 3_500_000, apy: 1.01, name: 'Lagoon', share: 17.6 },
-    { amount: 2_800_000, apy: 1.05, name: 'Originstory', share: 14.1 },
-    {
-      amount: 2_225_816,
-      apy: seededRandom(42) * 2,
-      name: 'Other',
-      share: 11.3,
-    },
-  ]
-}
-
-const mockDelay = 2000
+// The cached data is grouping-agnostic, so both view modes share one entry —
+// `viewMode` only drives the `select` below and is kept out of the query key.
+const compositionQueryOptions = ({
+  chainId,
+  queryClient,
+  shareAddress,
+}: CompositionQueryOptions) =>
+  queryOptions({
+    enabled: isVetroApiConfigured,
+    // `enabled` guarantees the query only runs with a valid api url
+    queryFn: () =>
+      fetchComposition({ apiUrl: apiUrl!, queryClient, shareAddress }),
+    queryKey: ['hemi-earn', 'composition', chainId, shareAddress],
+    refetchInterval: 5 * 60 * 1000,
+    retry: 2,
+  })
 
 type UseComposition = {
   chainId: Chain['id']
@@ -57,16 +58,28 @@ type UseComposition = {
   viewMode: CompositionViewMode
 }
 
-// TODO: replace mocked data with real API call once the backend endpoint is available.
-export const useComposition = ({
+export const useComposition = function ({
   chainId,
   shareAddress,
   viewMode,
-}: UseComposition) =>
-  useQuery({
-    queryFn: () =>
-      new Promise<CompositionItem[]>(resolve =>
-        setTimeout(() => resolve(generateMockData(viewMode)), mockDelay),
-      ),
-    queryKey: ['composition', chainId, shareAddress, viewMode],
+}: UseComposition) {
+  const queryClient = useQueryClient()
+  const t = useTranslations('hemi-earn.pool.composition')
+
+  return useQuery({
+    ...compositionQueryOptions({
+      chainId,
+      queryClient,
+      shareAddress,
+    }),
+    // The cached data is locale-free and ungrouped — the translated
+    // reserve-buffer label, the per-mode grouping and the derived share
+    // percentages are applied at render time.
+    select: (data: CompositionData): CompositionItem[] =>
+      toCompositionItems({
+        data,
+        reserveBufferLabel: t('reserve-buffer'),
+        viewMode,
+      }),
   })
+}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteDeposit.ts
@@ -1,9 +1,10 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import {
   type QuoteDepositParams,
   quoteDepositOptions,
 } from '../_fetchers/fetchQuoteDeposit'
 
-export const useQuoteDeposit = (params: QuoteDepositParams) =>
-  useQuery(quoteDepositOptions(params))
+export const useQuoteDeposit = (
+  params: Omit<QuoteDepositParams, 'queryClient'>,
+) => useQuery(quoteDepositOptions({ ...params, queryClient: useQueryClient() }))

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useUserPoolBalance.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useUserPoolBalance.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { previewRedeem } from '@vetro-protocol/gateway/actions'
-import { getGatewayForShare, getStakingVaultForShare } from 'hemi-earn-actions'
+import { getStakingVaultForShare } from 'hemi-earn-actions'
 import { hemi } from 'hemi-viem'
 import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient, getPublicClient } from 'utils/chainClients'
@@ -8,6 +8,8 @@ import { type Address, type Chain } from 'viem'
 import { balanceOf } from 'viem-erc20/actions'
 import { convertToAssets } from 'viem-erc4626/actions'
 import { useAccount } from 'wagmi'
+
+import { gatewayForAssetQueryOptions } from '../../../_hooks/gatewayForAsset'
 
 export function getUserPoolBalanceQueryKey({
   account,
@@ -56,6 +58,7 @@ export const useUserPoolBalance = function ({
 }) {
   const chainId = hemi.id
   const { address } = useAccount()
+  const queryClient = useQueryClient()
 
   return useQuery<UserPoolBalance>({
     enabled: !!address,
@@ -75,8 +78,11 @@ export const useUserPoolBalance = function ({
       if (peggedAmount <= BigInt(0)) {
         return { assetOut: BigInt(0), shares }
       }
+      const gateway = await queryClient.ensureQueryData(
+        gatewayForAssetQueryOptions(assetAddress),
+      )
       const assetOut = await previewRedeem(ethereumClient, {
-        address: getGatewayForShare(shareAddress),
+        address: gateway,
         peggedTokenIn: peggedAmount,
         tokenOut: assetAddress,
       })

--- a/portal/hooks/useToken.ts
+++ b/portal/hooks/useToken.ts
@@ -15,7 +15,12 @@ type Params = {
 export const getUseTokenQueryKey = (
   address: Params['address'],
   chainId: Params['chainId'],
-) => ['erc20-token-complete', address, chainId]
+) => [
+  'erc20-token-complete',
+  // Normalize to the canonical EIP-55 form so callers dedup regardless of casing
+  address === undefined ? address : toChecksumAddress(address),
+  chainId,
+]
 
 export const tokenQueryOptions = ({
   address,

--- a/portal/hooks/useTokenPrices.ts
+++ b/portal/hooks/useTokenPrices.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { queryOptions, useQuery, UseQueryOptions } from '@tanstack/react-query'
 import fetch from 'fetch-plus-plus'
 import { isValidUrl } from 'utils/url'
 
@@ -6,10 +6,10 @@ const portalApiUrl = process.env.NEXT_PUBLIC_PORTAL_API_URL
 
 type Prices = Record<string, string>
 
-export const useTokenPrices = (
+export const tokenPricesQueryOptions = (
   options: Omit<UseQueryOptions<Prices, Error>, 'queryKey' | 'queryFn'> = {},
 ) =>
-  useQuery({
+  queryOptions({
     // If the URL is not set, prices are not returned. Consumers of the hook
     // should consider this scenario
     enabled: portalApiUrl !== undefined && isValidUrl(portalApiUrl),
@@ -23,3 +23,7 @@ export const useTokenPrices = (
     retry: 2,
     ...options,
   })
+
+export const useTokenPrices = (
+  options: Omit<UseQueryOptions<Prices, Error>, 'queryKey' | 'queryFn'> = {},
+) => useQuery(tokenPricesQueryOptions(options))

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -20,6 +20,7 @@
         "by-token": "By token",
         "position": "Position",
         "protocols-count": "{count, plural, one {# protocol} other {# protocols}}",
+        "reserve-buffer": "Reserve Buffer",
         "share": "Share",
         "title": "Composition",
         "tokens-count": "{count, plural, one {# token} other {# tokens}}"

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -20,6 +20,7 @@
         "by-token": "Por token",
         "position": "Posición",
         "protocols-count": "{count, plural, one {# protocolo} other {# protocolos}}",
+        "reserve-buffer": "Reserva de liquidez",
         "share": "Participación",
         "title": "Composición",
         "tokens-count": "{count, plural, one {# token} other {# tokens}}"

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -20,6 +20,7 @@
         "by-token": "Por token",
         "position": "Posição",
         "protocols-count": "{count, plural, one {# protocolo} other {# protocolos}}",
+        "reserve-buffer": "Reserva de liquidez",
         "share": "Participação",
         "title": "Composição",
         "tokens-count": "{count, plural, one {# token} other {# tokens}}"

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchComposition.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchComposition.test.ts
@@ -9,7 +9,6 @@ import {
   getAssetForShare,
 } from 'app/[locale]/hemi-earn/_hooks/gatewayForAsset'
 import fetch from 'fetch-plus-plus'
-import { SVETBTC_OFT_ADDRESS } from 'hemi-earn-actions'
 import { tokenQueryOptions } from 'hooks/useToken'
 import { tokenPricesQueryOptions } from 'hooks/useTokenPrices'
 import { mainnet } from 'networks/mainnet'
@@ -30,9 +29,23 @@ vi.mock('utils/chainClients', () => ({
 // The treasury endpoint call — the only direct network request of the fetcher.
 vi.mock('fetch-plus-plus', () => ({ default: vi.fn() }))
 
+const { assetAddress, shareAddress } = vi.hoisted(() => ({
+  assetAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Address,
+  shareAddress: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Address,
+}))
+
+// The committed hemi-earn registry ships placeholder (zero) addresses until
+// the production deployment is configured, so the test registers its own
+// share/asset entry instead of relying on the real data.
+vi.mock('hemi-earn-actions', async importOriginal => ({
+  ...(await importOriginal<typeof import('hemi-earn-actions')>()),
+  getHemiEarnSupportedAssets: () => [
+    { asset: assetAddress, share: shareAddress },
+  ],
+}))
+
 const apiUrl = 'https://vetro.test'
-// Real registry entry: the svetBTC share and its registered deposit asset.
-const shareAddress = SVETBTC_OFT_ADDRESS
+// Resolves through the real lookup, against the mocked registry entry
 const asset = getAssetForShare(shareAddress)
 // Real gateway configs, so the peg-base lookup exercises the production data.
 const btcGateway = gateways.find(g => g.pegBaseSymbol === 'BTC')!.address

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchComposition.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchComposition.test.ts
@@ -1,0 +1,376 @@
+import { gateways } from '@vetro-protocol/gateway'
+import {
+  type CompositionData,
+  fetchComposition,
+  toCompositionItems,
+} from 'app/[locale]/hemi-earn/_fetchers/fetchComposition'
+import {
+  gatewayForAssetQueryOptions,
+  getAssetForShare,
+} from 'app/[locale]/hemi-earn/_hooks/gatewayForAsset'
+import fetch from 'fetch-plus-plus'
+import { SVETBTC_OFT_ADDRESS } from 'hemi-earn-actions'
+import { tokenQueryOptions } from 'hooks/useToken'
+import { tokenPricesQueryOptions } from 'hooks/useTokenPrices'
+import { mainnet } from 'networks/mainnet'
+import { type Token } from 'types/token'
+import { type Address } from 'viem'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createTestQueryClient } from '../../../../createTestQueryClient'
+
+// Avoid pulling `eth-rpc-cache` (and its broken ESM resolution under vitest)
+// through the chainClients → transport import chain. The clients are never
+// used because every nested query is seeded.
+vi.mock('utils/chainClients', () => ({
+  getEvmL1PublicClient: vi.fn(),
+  getPublicClient: vi.fn(),
+}))
+
+// The treasury endpoint call — the only direct network request of the fetcher.
+vi.mock('fetch-plus-plus', () => ({ default: vi.fn() }))
+
+const apiUrl = 'https://vetro.test'
+// Real registry entry: the svetBTC share and its registered deposit asset.
+const shareAddress = SVETBTC_OFT_ADDRESS
+const asset = getAssetForShare(shareAddress)
+// Real gateway configs, so the peg-base lookup exercises the production data.
+const btcGateway = gateways.find(g => g.pegBaseSymbol === 'BTC')!.address
+const usdGateway = gateways.find(g => g.pegBaseSymbol === 'USD')!.address
+
+const tokenA = '0x1111111111111111111111111111111111111111' as Address
+const tokenB = '0x2222222222222222222222222222222222222222' as Address
+
+const makeToken = (
+  address: Address,
+  decimals: number,
+  symbol: string,
+): Token => ({
+  address,
+  chainId: mainnet.id,
+  decimals,
+  logoURI: '',
+  name: symbol,
+  symbol,
+})
+
+const seedQueryClient = function ({
+  gateway,
+  prices,
+  tokens,
+}: {
+  gateway: Address
+  prices: Record<string, string>
+  tokens: Token[]
+}) {
+  const queryClient = createTestQueryClient()
+  queryClient.setQueryData(gatewayForAssetQueryOptions(asset).queryKey, gateway)
+  queryClient.setQueryData(tokenPricesQueryOptions().queryKey, prices)
+  tokens.forEach(token =>
+    queryClient.setQueryData(
+      tokenQueryOptions({ address: token.address, chainId: mainnet.id })
+        .queryKey,
+      token,
+    ),
+  )
+  return queryClient
+}
+
+describe('app/[locale]/hemi-earn/_fetchers/fetchComposition', function () {
+  describe('fetchComposition', function () {
+    it('prices each token and strategy via the peg', async function () {
+      const queryClient = seedQueryClient({
+        gateway: btcGateway,
+        prices: { BTC: '100000' },
+        tokens: [makeToken(tokenA, 8, 'WBTC'), makeToken(tokenB, 18, 'cbBTC')],
+      })
+      vi.mocked(fetch).mockResolvedValue([
+        {
+          activeStrategies: [
+            // 1.0 and 0.5 tokens, oracle 1.0 BTC each
+            { name: 'Strategy A1', totalDebt: '100000000' },
+            { name: 'Strategy A2', totalDebt: '50000000' },
+          ],
+          latestPrice: '100000000',
+          priceDecimals: 8,
+          tokenAddress: tokenA,
+          totalDebt: '150000000',
+          // 0.25 tokens sit idle
+          withdrawable: '175000000',
+        },
+        {
+          // 0.5 tokens, oracle 2.0 BTC, nothing idle
+          activeStrategies: [
+            { name: 'Strategy B1', totalDebt: '500000000000000000' },
+          ],
+          latestPrice: '2000000000000000000',
+          priceDecimals: 18,
+          tokenAddress: tokenB,
+          totalDebt: '500000000000000000',
+          withdrawable: '500000000000000000',
+        },
+      ])
+
+      const result = await fetchComposition({
+        apiUrl,
+        queryClient,
+        shareAddress,
+      })
+
+      expect(result).toEqual([
+        {
+          strategies: [
+            { amount: 100_000, name: 'Strategy A1' },
+            { amount: 50_000, name: 'Strategy A2' },
+          ],
+          symbol: 'WBTC',
+          totalDebt: 150_000,
+          withdrawable: 175_000,
+        },
+        {
+          strategies: [{ amount: 100_000, name: 'Strategy B1' }],
+          symbol: 'cbBTC',
+          totalDebt: 100_000,
+          withdrawable: 100_000,
+        },
+      ])
+      expect(fetch).toHaveBeenCalledWith(
+        `${apiUrl}/analytics/treasury/${btcGateway}`,
+      )
+    })
+
+    it('treats USD pegs as the identity, without a feed entry', async function () {
+      const queryClient = seedQueryClient({
+        gateway: usdGateway,
+        prices: {},
+        tokens: [makeToken(tokenA, 6, 'satUSD')],
+      })
+      vi.mocked(fetch).mockResolvedValue([
+        {
+          // 1.0 tokens at an oracle price of 1.0 USD
+          activeStrategies: [{ name: 'Strategy', totalDebt: '1000000' }],
+          latestPrice: '100000000',
+          priceDecimals: 8,
+          tokenAddress: tokenA,
+          totalDebt: '1000000',
+          withdrawable: '1000000',
+        },
+      ])
+
+      const result = await fetchComposition({
+        apiUrl,
+        queryClient,
+        shareAddress,
+      })
+
+      expect(result).toEqual([
+        {
+          strategies: [{ amount: 1, name: 'Strategy' }],
+          symbol: 'satUSD',
+          totalDebt: 1,
+          withdrawable: 1,
+        },
+      ])
+    })
+
+    it('rejects when the gateway has no peg configuration', async function () {
+      const queryClient = seedQueryClient({
+        gateway: '0x00000000000000000000000000000000000000aa' as Address,
+        prices: {},
+        tokens: [],
+      })
+
+      await expect(
+        fetchComposition({ apiUrl, queryClient, shareAddress }),
+      ).rejects.toThrow(/No peg base symbol for gateway/)
+      expect(fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('toCompositionItems', function () {
+    const reserveBufferLabel = 'Reserve Buffer'
+    const data: CompositionData = [
+      {
+        strategies: [
+          { amount: 75, name: 'Strategy A1' },
+          { amount: 50, name: 'Strategy A2' },
+        ],
+        symbol: 'WBTC',
+        totalDebt: 125,
+        withdrawable: 150, // 25 idle
+      },
+      {
+        strategies: [{ amount: 25, name: 'Strategy B1' }],
+        symbol: 'cbBTC',
+        totalDebt: 25,
+        withdrawable: 50, // 25 idle
+      },
+    ]
+
+    it('groups by strategy and appends the reserve buffer in protocol mode', function () {
+      const items = toCompositionItems({
+        data,
+        reserveBufferLabel,
+        viewMode: 'protocol',
+      })
+
+      expect(items).toEqual([
+        {
+          amount: 75,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'Strategy A1',
+          share: 37.5,
+        },
+        {
+          amount: 50,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'Strategy A2',
+          share: 25,
+        },
+        {
+          amount: 25,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'Strategy B1',
+          share: 12.5,
+        },
+        {
+          amount: 50,
+          apy: 1.01,
+          isReserveBuffer: true,
+          name: reserveBufferLabel,
+          share: 25,
+        },
+      ])
+    })
+
+    it('groups by token, with idle funds folded into each token', function () {
+      const items = toCompositionItems({
+        data,
+        reserveBufferLabel,
+        viewMode: 'token',
+      })
+
+      expect(items).toEqual([
+        {
+          amount: 150,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'WBTC',
+          share: 75,
+        },
+        {
+          amount: 50,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'cbBTC',
+          share: 25,
+        },
+      ])
+    })
+
+    it('omits the reserve buffer when nothing is idle', function () {
+      const items = toCompositionItems({
+        data: [
+          {
+            strategies: [{ amount: 100, name: 'Strategy' }],
+            symbol: 'WBTC',
+            totalDebt: 100,
+            withdrawable: 100,
+          },
+        ],
+        reserveBufferLabel,
+        viewMode: 'protocol',
+      })
+
+      expect(items).toEqual([
+        {
+          amount: 100,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'Strategy',
+          share: 100,
+        },
+      ])
+    })
+
+    it('clamps a negative reserve buffer to zero', function () {
+      const items = toCompositionItems({
+        data: [
+          {
+            // strategies report more debt than is withdrawable
+            strategies: [{ amount: 150, name: 'Strategy' }],
+            symbol: 'WBTC',
+            totalDebt: 150,
+            withdrawable: 100,
+          },
+        ],
+        reserveBufferLabel,
+        viewMode: 'protocol',
+      })
+
+      expect(items).toEqual([
+        {
+          amount: 150,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'Strategy',
+          share: 100,
+        },
+      ])
+    })
+
+    it('drops zero amounts in both modes', function () {
+      const zeroed: CompositionData = [
+        {
+          strategies: [
+            { amount: 0, name: 'Empty' },
+            { amount: 100, name: 'Active' },
+          ],
+          symbol: 'WBTC',
+          totalDebt: 100,
+          withdrawable: 100,
+        },
+        {
+          strategies: [],
+          symbol: 'cbBTC',
+          totalDebt: 0,
+          withdrawable: 0,
+        },
+      ]
+
+      expect(
+        toCompositionItems({
+          data: zeroed,
+          reserveBufferLabel,
+          viewMode: 'protocol',
+        }),
+      ).toEqual([
+        {
+          amount: 100,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'Active',
+          share: 100,
+        },
+      ])
+      expect(
+        toCompositionItems({
+          data: zeroed,
+          reserveBufferLabel,
+          viewMode: 'token',
+        }),
+      ).toEqual([
+        {
+          amount: 100,
+          apy: 1.01,
+          isReserveBuffer: false,
+          name: 'WBTC',
+          share: 100,
+        },
+      ])
+    })
+  })
+})

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchAssetsToShares.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchAssetsToShares.test.ts
@@ -13,8 +13,14 @@ vi.mock('viem-erc4626/actions', () => ({
   convertToShares: vi.fn(),
 }))
 
+const assetAddress = '0x1111111111111111111111111111111111111111' as Address
+const shareAddress = '0x2222222222222222222222222222222222222222' as Address
+const gateway = '0x6666666666666666666666666666666666666666' as Address
+
 vi.mock('hemi-earn-actions', () => ({
-  getGatewayForShare: () => '0xGateway',
+  getHemiEarnSupportedAssets: () => [
+    { asset: assetAddress, share: shareAddress },
+  ],
   getStakingVaultForShare: () => '0xStakingVault',
 }))
 
@@ -22,8 +28,18 @@ vi.mock('utils/chainClients', () => ({
   getEvmL1PublicClient: () => ({ chain: 'mainnet' }),
 }))
 
-const assetAddress = '0x1111111111111111111111111111111111111111' as Address
-const shareAddress = '0x2222222222222222222222222222222222222222' as Address
+// Fake query client that resolves the gateway the fetcher maps from the
+// share's asset through the cache, branching on the query's key.
+const createQueryClient = () => ({
+  ensureQueryData: vi.fn(function ({ queryKey }) {
+    switch (queryKey[1]) {
+      case 'gateway-for-asset':
+        return Promise.resolve(gateway)
+      default:
+        return Promise.reject(new Error(`unexpected query ${queryKey[1]}`))
+    }
+  }),
+})
 
 describe('fetchAssetsToShares', function () {
   beforeEach(function () {
@@ -35,6 +51,7 @@ describe('fetchAssetsToShares', function () {
     const result = await fetchAssetsToShares({
       amount: BigInt(1000),
       assetAddress,
+      queryClient: createQueryClient() as never,
       shareAddress,
     })
 
@@ -45,6 +62,7 @@ describe('fetchAssetsToShares', function () {
     expect(previewWithdraw).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
+        address: gateway,
         amountOut: BigInt(1000),
         tokenOut: assetAddress,
       }),
@@ -61,6 +79,7 @@ describe('fetchAssetsToShares', function () {
     const result = await fetchAssetsToShares({
       amount: BigInt(1000),
       assetAddress,
+      queryClient: createQueryClient() as never,
       shareAddress,
     })
 
@@ -74,6 +93,7 @@ describe('fetchAssetsToShares', function () {
     const result = await fetchAssetsToShares({
       amount: BigInt(1000),
       assetAddress,
+      queryClient: createQueryClient() as never,
       shareAddress,
     })
 
@@ -88,6 +108,7 @@ describe('fetchAssetsToShares', function () {
       fetchAssetsToShares({
         amount: BigInt(1000),
         assetAddress,
+        queryClient: createQueryClient() as never,
         shareAddress,
       }),
     ).rejects.toThrow('Gateway down')

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.test.ts
@@ -1,6 +1,5 @@
 import { previewDeposit } from '@vetro-protocol/gateway/actions'
 import {
-  getAssetData,
   quoteDeposit,
   quoteDepositFulfillment,
 } from 'hemi-earn-actions/actions'
@@ -20,9 +19,9 @@ vi.mock('@vetro-protocol/gateway/actions', () => ({
 }))
 
 vi.mock('hemi-earn-actions', () => ({
-  getGatewayForShare: () => '0xGateway',
   getHemiEarnAgentAddress: () => '0xAgent',
   getHemiEarnRouterAddress: () => '0xRouter',
+  getHemiEarnSupportedAssets: () => [],
   getStakingVaultForShare: () => '0xStakingVault',
 }))
 
@@ -34,15 +33,32 @@ vi.mock('utils/chainClients', () => ({
 const asset = '0x1111111111111111111111111111111111111111' as Address
 const shareAddress = '0x2222222222222222222222222222222222222222' as Address
 const remoteAsset = '0x3333333333333333333333333333333333333333' as Address
+const gateway = '0x6666666666666666666666666666666666666666' as Address
+
+const assetData = {
+  enabled: true,
+  remoteAsset,
+  remoteShare: '0x4444444444444444444444444444444444444444' as Address,
+  share: '0x5555555555555555555555555555555555555555' as Address,
+}
+
+// Fake query client that resolves the gateway and asset-data lookups the
+// fetcher threads through the cache, branching on each query's key.
+const createQueryClient = () => ({
+  ensureQueryData: vi.fn(function ({ queryKey }) {
+    switch (queryKey[1]) {
+      case 'gateway-for-asset':
+        return Promise.resolve(gateway)
+      case 'asset-data':
+        return Promise.resolve(assetData)
+      default:
+        return Promise.reject(new Error(`unexpected query ${queryKey[1]}`))
+    }
+  }),
+})
 
 describe('fetchQuoteDeposit', function () {
   beforeEach(function () {
-    vi.mocked(getAssetData).mockResolvedValue({
-      enabled: true,
-      remoteAsset,
-      remoteShare: '0x4444444444444444444444444444444444444444',
-      share: '0x5555555555555555555555555555555555555555',
-    })
     vi.mocked(quoteDepositFulfillment).mockResolvedValue(BigInt(11))
     vi.mocked(quoteDeposit).mockResolvedValue(BigInt(22))
     vi.mocked(previewDeposit).mockResolvedValue(BigInt(33))
@@ -52,6 +68,7 @@ describe('fetchQuoteDeposit', function () {
     const result = await fetchQuoteDeposit({
       amount: BigInt(1000),
       asset,
+      queryClient: createQueryClient() as never,
       shareAddress,
     })
 
@@ -63,7 +80,12 @@ describe('fetchQuoteDeposit', function () {
   })
 
   it('threads the resolved remoteAsset through previewDeposit', async function () {
-    await fetchQuoteDeposit({ amount: BigInt(1000), asset, shareAddress })
+    await fetchQuoteDeposit({
+      amount: BigInt(1000),
+      asset,
+      queryClient: createQueryClient() as never,
+      shareAddress,
+    })
 
     expect(previewDeposit).toHaveBeenCalledWith(
       expect.anything(),
@@ -74,7 +96,12 @@ describe('fetchQuoteDeposit', function () {
   it('threads the resolved callbackFee through quoteDeposit', async function () {
     vi.mocked(quoteDepositFulfillment).mockResolvedValue(BigInt(99))
 
-    await fetchQuoteDeposit({ amount: BigInt(1000), asset, shareAddress })
+    await fetchQuoteDeposit({
+      amount: BigInt(1000),
+      asset,
+      queryClient: createQueryClient() as never,
+      shareAddress,
+    })
 
     expect(quoteDeposit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -88,7 +115,12 @@ describe('fetchQuoteDeposit', function () {
     vi.mocked(quoteDepositFulfillment).mockRejectedValue(new Error('RPC down'))
 
     await expect(
-      fetchQuoteDeposit({ amount: BigInt(1000), asset, shareAddress }),
+      fetchQuoteDeposit({
+        amount: BigInt(1000),
+        asset,
+        queryClient: createQueryClient() as never,
+        shareAddress,
+      }),
     ).rejects.toThrow('RPC down')
   })
 })


### PR DESCRIPTION
### Description

This replaces the mocked pool composition with the real strategy breakdown from the Vetro `/analytics/treasury/:gateway` endpoint.

A new `fetchComposition` fetcher resolves the pool's gateway dynamically on-chain (`Router.assetsData` → `StakingVault.asset()` → `PeggedToken.gateway()`, replacing the hardcoded registry lookup) and prices every whitelisted token through its peg-unit oracle price times the peg's USD price from the portal feed — so tokens missing from the feed (e.g. the Ethereum-side hemiBTC OFT) are priced correctly too. The query caches locale-free, grouping-agnostic per-token data; the hook's `select` groups it **by protocol** (individual strategies plus an idle-funds "Reserve Buffer" row, excluded from the position count) or **by token** (idle funds folded into each token), so toggling the view re-groups instantly without refetching.

Supporting changes: `useTokenPrices` exposes `tokenPricesQueryOptions`, `@vetro-protocol/gateway` is bumped to 1.2.0 (ships `getGateway`), the `useToken` cache key is normalized to EIP-55 so consumers dedup regardless of address casing, and `getAssetData` now follows the viem action signature with input validation.

> [!NOTE]
> The Router/Agent and some tokens are not configured in staging, so this feature won't run there — it currently only works against mainnet configuration.

**Commits:**
- 5d7e948e Extract queryOptions from useTokenPrices
- b5d48889 Bump @vetro-protocol/gateway to 1.2.0
- 2120c917 Normalize address in useToken cache key
- 956ec936 Align getAssetData with viem action format
- ecf9c13a Resolve gateways on-chain instead of registry
- 54637a64 Render pool composition from the Vetro treasury
- 8f05c11f Decouple composition test from the registry
- 7e59eb32 Fix conflicts

> [!NOTE]
> No UI changes, except for the colors, were made. If anything, we can update details in a future issue once this lands on staging and Nahuel is able to test it

### Screenshots

https://github.com/user-attachments/assets/5b35e9e0-cfb5-463d-8809-0d15810423d5

### Related issue(s)

Closes #1966

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
