### PR TITLE
Iterate withdraw drawer to 3-step with cooldown

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/earnStatusUpdaters.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnStatusUpdaters.tsx
@@ -1,19 +1,25 @@
 'use client'
 
+import { useTranslations } from 'next-intl'
+
 import { useEarnDeliveryWatcher } from '../_hooks/useEarnDeliveryWatcher'
 
-import { DepositSuccessToast } from './depositSuccessToast'
+import { EarnSuccessToast } from './earnSuccessToast'
 
 // Mounted in the hemi-earn layout. Drives cross-route polling and Vetro-
 // side cache invalidation off a single subscription — `useEarnDeliveryWatcher`
-// removes local entries once the subgraph indexes them and invalidates
-// pool TVL, user pool position, and the staked-balance card when a deposit
-// transitions to CLAIMED/RECOVERED. The same layout slot renders the
-// success toast so it survives navigation between the pool page and home.
-//
-// When withdraw lands, add a `useWithdrawDeliveryWatcher()` call (and a
-// sibling toast if needed) right alongside.
+// soft-settles local entries once the subgraph indexes them and invalidates
+// pool TVL, user pool position, and the staked-balance card when a request
+// transitions to CLAIMED/RECOVERED. The same layout slot renders one
+// success toast per kind so they survive navigation between the pool page
+// and home.
 export const EarnStatusUpdaters = function () {
+  const t = useTranslations('hemi-earn.pool')
   useEarnDeliveryWatcher()
-  return <DepositSuccessToast />
+  return (
+    <>
+      <EarnSuccessToast kind="DEPOSIT" title={t('deposit-successful')} />
+      <EarnSuccessToast kind="REDEEM" title={t('withdraw-successful')} />
+    </>
+  )
 }

--- a/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
@@ -22,10 +22,11 @@ type Props = {
 }
 
 // Fires when a request reaches the subgraph `CLAIMED` state — the moment
-// the full cross-chain flow completes (shares on Ethereum for deposits,
-// underlying back on Hemi for redeems). Mounted once per kind at the
-// hemi-earn layout level so it survives navigation between the pool page
-// and the home page.
+// the full cross-chain flow completes (share OFTs landing on the user's
+// Hemi wallet for deposits, underlying tokens landing on the user's Hemi
+// wallet for redeems). Mounted once per kind at the hemi-earn layout
+// level so it survives navigation between the pool page and the home
+// page.
 //
 // To avoid noise on first mount (a session with historical CLAIMED rows),
 // the component snapshots the already-claimed hashes on the first non-

--- a/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
@@ -1,31 +1,39 @@
 'use client'
 
 import { hemi } from 'hemi-viem'
-import { useTranslations } from 'next-intl'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { type Address, type Hash } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { useEarnTransactionsQuery } from '../_hooks/useEarnTransactionsQuery'
 import { PoolToast } from '../pool/[shareAddress]/_components/poolToast'
+import { type EarnTransactionKindType } from '../types'
 
 // Visible window before the toast unmounts. Matches the `<Toast>` primitive's
 // own auto-close (10s) so the inner close-animation isn't cut short.
 const TOAST_MS = 10_000
 
-// Fires when a deposit reaches the subgraph `CLAIMED` state — the moment
-// the full cross-chain flow completes and the shares actually land on the
-// user's wallet. Mounted once at the hemi-earn layout level so it survives
-// navigation between the pool page and the home page.
+type Props = {
+  // Subgraph kind to watch — `DEPOSIT` for the shares-landing toast,
+  // `REDEEM` for the underlying-received toast. Each consumer mounts its
+  // own instance with the matching kind + title.
+  kind: EarnTransactionKindType
+  title: string
+}
+
+// Fires when a request reaches the subgraph `CLAIMED` state — the moment
+// the full cross-chain flow completes (shares on Ethereum for deposits,
+// underlying back on Hemi for redeems). Mounted once per kind at the
+// hemi-earn layout level so it survives navigation between the pool page
+// and the home page.
 //
 // To avoid noise on first mount (a session with historical CLAIMED rows),
 // the component snapshots the already-claimed hashes on the first non-
 // empty render and only latches the toast for rows that become CLAIMED
 // after that.
-export const DepositSuccessToast = function () {
+export const EarnSuccessToast = function ({ kind, title }: Props) {
   const { address } = useAccount()
   const { data } = useEarnTransactionsQuery()
-  const t = useTranslations('hemi-earn.pool')
 
   const seenClaimedOnMountRef = useRef<Set<string> | null>(null)
   // Hashes already surfaced this session. Without this ref the toast would
@@ -47,7 +55,7 @@ export const DepositSuccessToast = function () {
   if (seenClaimedOnMountRef.current === null && data !== undefined) {
     seenClaimedOnMountRef.current = new Set(
       data
-        .filter(tx => tx.kind === 'DEPOSIT' && tx.status === 'CLAIMED')
+        .filter(tx => tx.kind === kind && tx.status === 'CLAIMED')
         .map(tx => tx.initiateTxHash.toLowerCase()),
     )
   }
@@ -59,7 +67,7 @@ export const DepositSuccessToast = function () {
       const fresh = data
         .filter(
           tx =>
-            tx.kind === 'DEPOSIT' &&
+            tx.kind === kind &&
             tx.status === 'CLAIMED' &&
             !!tx.claimTxHash &&
             !snapshot.has(tx.initiateTxHash.toLowerCase()),
@@ -67,7 +75,7 @@ export const DepositSuccessToast = function () {
         .sort((a, b) => Number(b.initiatedAt) - Number(a.initiatedAt))
       return fresh[0]
     },
-    [data],
+    [data, kind],
   )
 
   const [latched, setLatched] = useState<{
@@ -105,7 +113,7 @@ export const DepositSuccessToast = function () {
     <PoolToast
       chainId={hemi.id}
       key={latched.initiateTxHash}
-      title={t('deposit-successful')}
+      title={title}
       transactionHash={latched.claimTxHash}
     />
   )

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchRequestDetails.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchRequestDetails.ts
@@ -1,0 +1,37 @@
+import { getRequestDetails } from '@vetro-protocol/earn/actions'
+import { getStakingVaultForShare } from 'hemi-earn-actions'
+import { mainnet } from 'networks/mainnet'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { type Address } from 'viem'
+
+export const requestDetailsKeyPrefix = ['hemi-earn', 'request-details'] as const
+
+export type RequestDetails = {
+  owner: Address
+  assets: bigint
+  // Unix-seconds timestamp at which the Vetro Agent (Ethereum-side) will
+  // allow the auto/manual claim to fire. Set the moment the Agent
+  // observes the LayerZero request and never changes afterward —
+  // preferring this over a local `initiatedAt + cooldownDuration`
+  // calculation removes the LayerZero-delay drift between when the user
+  // signed on Hemi and when the cooldown actually started ticking on
+  // Ethereum.
+  claimableAt: bigint
+}
+
+// Reads Vetro-side details for a redeem request. The Hemi subgraph
+// exposes `requestId` + `initiatedAt`, but the cooldown timer actually
+// starts on Ethereum at Agent-observation time — `claimableAt` is the
+// only authoritative source. Cached forever (Infinity) by the consuming
+// hook since the value is immutable after observation.
+export const fetchRequestDetails = ({
+  requestId,
+  shareAddress,
+}: {
+  requestId: bigint | string
+  shareAddress: Address
+}): Promise<RequestDetails> =>
+  getRequestDetails(getEvmL1PublicClient(mainnet.id), {
+    address: getStakingVaultForShare(shareAddress),
+    requestId: BigInt(requestId),
+  })

--- a/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
@@ -3,7 +3,6 @@ import { getCooldownDuration } from '@vetro-protocol/earn/actions'
 import { getStakingVaultForShare } from 'hemi-earn-actions'
 import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'
-import { secondsToDays } from 'utils/time'
 import { type Address } from 'viem'
 
 // `cooldownDuration` is governance-controlled and rarely changes. Caching
@@ -11,6 +10,10 @@ import { type Address } from 'viem'
 // reconnect.
 const STALE_TIME_MS = 4 * 60 * 60 * 1000
 
+// Returns the raw on-chain cooldown duration in seconds. Callers that just
+// need the day count (e.g. the warning banner) convert with
+// `secondsToDays`; the withdraw drawer's live countdown needs the raw
+// seconds to tick at minute resolution.
 export const useCooldownDuration = ({
   shareAddress,
 }: {
@@ -22,7 +25,7 @@ export const useCooldownDuration = ({
         getEvmL1PublicClient(mainnet.id),
         { address: getStakingVaultForShare(shareAddress) },
       )
-      return Math.round(secondsToDays(Number(seconds)))
+      return Number(seconds)
     },
     queryKey: ['hemi-earn', 'cooldown-duration', shareAddress],
     staleTime: STALE_TIME_MS,

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
@@ -1,12 +1,17 @@
 'use client'
 
 import { useQueryClient } from '@tanstack/react-query'
-import { tokenBalanceQueryKeyPrefix } from 'hooks/useBalance'
+import { getHemiEarnSupportedAssets } from 'hemi-earn-actions'
+import { hemi } from 'hemi-viem'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useEffect, useRef } from 'react'
+import { type Address, isAddressEqual } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { earnPositionsKeyPrefix } from '../_fetchers/fetchEarnPositions'
 import {
+  type EarnTransaction,
+  type EarnTransactionKindType,
   type EarnTransactionStatusType,
   type LocalEarnOperation,
 } from '../types'
@@ -47,30 +52,67 @@ function reconcileLocals({
 const isInFlightStatus = (status: EarnTransactionStatusType) =>
   status !== 'CLAIMED' && status !== 'CANCELLED' && status !== 'RECOVERED'
 
-// Walks the previous-vs-current subgraph status maps and reports whether any
-// request hash transitioned from an in-flight state into a terminal delivery
-// state (CLAIMED / RECOVERED) since the last poll. Applies to both deposits
-// (share OFTs landing on the user's Hemi wallet) and redeems (underlying
-// tokens landing on the user's Hemi wallet) — both move the user's pool
-// position and TVL. First-time observations of already-terminal hashes
-// (page reload after CLAIMED) do NOT count — those rows are historical
-// and don't move balances.
-function detectCrossChainDelivery(
-  previous: Map<string, EarnTransactionStatusType>,
-  current: Map<string, EarnTransactionStatusType>,
-) {
-  for (const [hash, status] of current) {
-    if (status !== 'CLAIMED' && status !== 'RECOVERED') continue
-    const prev = previous.get(hash)
-    if (prev !== undefined && isInFlightStatus(prev)) return true
-  }
-  return false
+type DeliveredEvent = {
+  asset: Address
+  kind: EarnTransactionKindType
+  receiver: Address
 }
 
-function invalidateOnDelivery(queryClient: ReturnType<typeof useQueryClient>) {
+// Walks the subgraph rows and reports every request that transitioned from
+// an in-flight state into a terminal delivery state (CLAIMED / RECOVERED)
+// since the previous poll. Returns the delivered events with enough metadata
+// (kind, asset, receiver) for the caller to build the exact cache keys
+// that actually moved — deposits make the share OFT land on the user's
+// Hemi wallet, redeems make the underlying land on the user's Hemi wallet.
+// First-time observations of already-terminal hashes (page reload after
+// CLAIMED) do NOT count — those rows are historical and don't move
+// balances.
+function detectCrossChainDeliveries(
+  previous: Map<string, EarnTransactionStatusType>,
+  rows: EarnTransaction[],
+) {
+  const events: DeliveredEvent[] = []
+  for (const row of rows) {
+    if (row.status !== 'CLAIMED' && row.status !== 'RECOVERED') continue
+    const prev = previous.get(row.initiateTxHash.toLowerCase())
+    if (prev === undefined || !isInFlightStatus(prev)) continue
+    events.push({
+      asset: row.asset,
+      kind: row.kind,
+      receiver: row.receiver,
+    })
+  }
+  return events
+}
+
+// Resolves the share OFT registered against a deposit asset. The deposit
+// pulls the underlying in, but the cache that moves at CLAIMED time is
+// the share's balance — so for DEPOSIT events we invalidate that key
+// instead of `event.asset`.
+const findShareForAsset = (asset: Address) =>
+  getHemiEarnSupportedAssets().find(entry => isAddressEqual(entry.asset, asset))
+    ?.share
+
+const tokenAddressForEvent = (event: DeliveredEvent) =>
+  event.kind === 'DEPOSIT' ? findShareForAsset(event.asset) : event.asset
+
+function invalidateOnDelivery(
+  queryClient: ReturnType<typeof useQueryClient>,
+  events: DeliveredEvent[],
+) {
   queryClient.invalidateQueries({ queryKey: vetroPoolsPrefix })
   queryClient.invalidateQueries({ queryKey: vetroUserPoolBalancePrefix })
-  queryClient.invalidateQueries({ queryKey: tokenBalanceQueryKeyPrefix })
+  for (const event of events) {
+    const tokenAddress = tokenAddressForEvent(event)
+    if (tokenAddress === undefined) continue
+    queryClient.invalidateQueries({
+      queryKey: getTokenBalanceQueryKey({
+        account: event.receiver,
+        chainId: hemi.id,
+        tokenAddress,
+      }),
+    })
+  }
   // `resetQueries` is the only single-call primitive that does both halves
   // of what we need: it removes every matching cache entry (so the inner
   // `ensureQueryData` reads inside `fetchEarnPositions` go to the network
@@ -114,9 +156,9 @@ export const useEarnDeliveryWatcher = function () {
       const subgraphHashToStatus = new Map<string, EarnTransactionStatusType>(
         data.map(t => [t.initiateTxHash.toLowerCase(), t.status]),
       )
-      const crossChainDelivered = detectCrossChainDelivery(
+      const deliveries = detectCrossChainDeliveries(
         previousSubgraphStatusRef.current,
-        subgraphHashToStatus,
+        data,
       )
       previousSubgraphStatusRef.current = subgraphHashToStatus
       reconcileLocals({
@@ -124,8 +166,8 @@ export const useEarnDeliveryWatcher = function () {
         markSettledByInitiateTxHash,
         subgraphHashes: new Set(subgraphHashToStatus.keys()),
       })
-      if (crossChainDelivered) {
-        invalidateOnDelivery(queryClient)
+      if (deliveries.length > 0) {
+        invalidateOnDelivery(queryClient, deliveries)
       }
     },
     [address, data, localOperations, markSettledByInitiateTxHash, queryClient],

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
@@ -47,10 +47,12 @@ const isInFlightStatus = (status: EarnTransactionStatusType) =>
   status !== 'CLAIMED' && status !== 'CANCELLED' && status !== 'RECOVERED'
 
 // Walks the previous-vs-current subgraph status maps and reports whether any
-// deposit hash transitioned from an in-flight state into a terminal delivery
-// state (CLAIMED / RECOVERED) since the last poll. First-time observations
-// of already-terminal hashes (page reload after CLAIMED) do NOT count —
-// those rows are historical and don't move balances.
+// request hash transitioned from an in-flight state into a terminal delivery
+// state (CLAIMED / RECOVERED) since the last poll. Applies to both deposits
+// (shares landing on Ethereum) and redeems (underlying tokens landing on
+// Hemi) — both move the user's pool position and TVL. First-time
+// observations of already-terminal hashes (page reload after CLAIMED) do
+// NOT count — those rows are historical and don't move balances.
 function detectCrossChainDelivery(
   previous: Map<string, EarnTransactionStatusType>,
   current: Map<string, EarnTransactionStatusType>,
@@ -63,11 +65,10 @@ function detectCrossChainDelivery(
   return false
 }
 
-function invalidateVetroBalances(
-  queryClient: ReturnType<typeof useQueryClient>,
-) {
+function invalidateOnDelivery(queryClient: ReturnType<typeof useQueryClient>) {
   queryClient.invalidateQueries({ queryKey: vetroPoolsPrefix })
   queryClient.invalidateQueries({ queryKey: vetroUserPoolBalancePrefix })
+  queryClient.invalidateQueries({ queryKey: ['tokenBalance'] })
   // `resetQueries` is the only single-call primitive that does both halves
   // of what we need: it removes every matching cache entry (so the inner
   // `ensureQueryData` reads inside `fetchEarnPositions` go to the network
@@ -109,9 +110,7 @@ export const useEarnDeliveryWatcher = function () {
     function reconcileAndInvalidate() {
       if (!data || data.length === 0 || !address) return
       const subgraphHashToStatus = new Map<string, EarnTransactionStatusType>(
-        data
-          .filter(t => t.kind === 'DEPOSIT')
-          .map(t => [t.initiateTxHash.toLowerCase(), t.status]),
+        data.map(t => [t.initiateTxHash.toLowerCase(), t.status]),
       )
       const crossChainDelivered = detectCrossChainDelivery(
         previousSubgraphStatusRef.current,
@@ -124,7 +123,7 @@ export const useEarnDeliveryWatcher = function () {
         subgraphHashes: new Set(subgraphHashToStatus.keys()),
       })
       if (crossChainDelivered) {
-        invalidateVetroBalances(queryClient)
+        invalidateOnDelivery(queryClient)
       }
     },
     [address, data, localOperations, markSettledByInitiateTxHash, queryClient],

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useQueryClient } from '@tanstack/react-query'
+import { tokenBalanceQueryKeyPrefix } from 'hooks/useBalance'
 import { useEffect, useRef } from 'react'
 import { useAccount } from 'wagmi'
 
@@ -69,7 +70,7 @@ function detectCrossChainDelivery(
 function invalidateOnDelivery(queryClient: ReturnType<typeof useQueryClient>) {
   queryClient.invalidateQueries({ queryKey: vetroPoolsPrefix })
   queryClient.invalidateQueries({ queryKey: vetroUserPoolBalancePrefix })
-  queryClient.invalidateQueries({ queryKey: ['tokenBalance'] })
+  queryClient.invalidateQueries({ queryKey: tokenBalanceQueryKeyPrefix })
   // `resetQueries` is the only single-call primitive that does both halves
   // of what we need: it removes every matching cache entry (so the inner
   // `ensureQueryData` reads inside `fetchEarnPositions` go to the network

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
@@ -49,10 +49,11 @@ const isInFlightStatus = (status: EarnTransactionStatusType) =>
 // Walks the previous-vs-current subgraph status maps and reports whether any
 // request hash transitioned from an in-flight state into a terminal delivery
 // state (CLAIMED / RECOVERED) since the last poll. Applies to both deposits
-// (shares landing on Ethereum) and redeems (underlying tokens landing on
-// Hemi) — both move the user's pool position and TVL. First-time
-// observations of already-terminal hashes (page reload after CLAIMED) do
-// NOT count — those rows are historical and don't move balances.
+// (share OFTs landing on the user's Hemi wallet) and redeems (underlying
+// tokens landing on the user's Hemi wallet) — both move the user's pool
+// position and TVL. First-time observations of already-terminal hashes
+// (page reload after CLAIMED) do NOT count — those rows are historical
+// and don't move balances.
 function detectCrossChainDelivery(
   previous: Map<string, EarnTransactionStatusType>,
   current: Map<string, EarnTransactionStatusType>,

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
@@ -19,22 +19,20 @@ import { useLocalEarnOperations } from './useLocalEarnOperations'
 // consumers — a single network call per interval drives every subscriber.
 //
 // Polling: every 10s while there's at least one row we're actively waiting
-// on — either a subgraph entry stuck on PENDING / FULFILLED (cross-chain
-// in flight, or auto-claim still pending) or a local entry whose
-// initiateTxHash hasn't shown up in the subgraph yet (indexer lag). Stops
-// once all rows are terminal (CLAIMED / CANCELLED / RECOVERED).
-//
-// TODO(withdraw): redeem will need to also poll on FULFILLED-without-claim
-// (cooldown maturity) — the predicate below stays the same shape, the
-// status check just gains another branch.
+// on — either a subgraph entry stuck on a non-terminal status (cross-chain
+// in flight, auto-claim still pending, cooldown maturing for a redeem) or a
+// local entry whose initiateTxHash hasn't shown up in the subgraph yet
+// (indexer lag). Stops once all rows are terminal (CLAIMED / CANCELLED /
+// RECOVERED). Both deposits and redeems contribute to the predicate — the
+// drawer's third step depends on this polling to flip its status once the
+// subgraph catches up.
 export const useEarnTransactionsQuery = function () {
   const [networkType] = useNetworkType()
   const { address } = useAccount()
   const { localOperations } = useLocalEarnOperations()
 
   const inFlightLocalsExist = localOperations.some(
-    op =>
-      op.kind === 'DEPOSIT' && op.initiateTxHash !== undefined && !op.settled,
+    op => op.initiateTxHash !== undefined && !op.settled,
   )
 
   return useQuery({
@@ -45,7 +43,6 @@ export const useEarnTransactionsQuery = function () {
       const subgraphData = (query.state.data ?? []) as EarnTransaction[]
       const hasSubgraphInFlight = subgraphData.some(
         t =>
-          t.kind === 'DEPOSIT' &&
           t.status !== 'CLAIMED' &&
           t.status !== 'CANCELLED' &&
           t.status !== 'RECOVERED',

--- a/portal/app/[locale]/hemi-earn/_hooks/useRequestDetails.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRequestDetails.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+import { type Address } from 'viem'
+
+import {
+  fetchRequestDetails,
+  requestDetailsKeyPrefix,
+} from '../_fetchers/fetchRequestDetails'
+
+// `claimableAt` is set by the Vetro Agent the moment it observes the
+// LayerZero request and never changes after that, so caching forever is
+// safe. Pass `requestId === undefined` (e.g. before the subgraph has
+// indexed the request) to leave the query disabled.
+export const useRequestDetails = ({
+  requestId,
+  shareAddress,
+}: {
+  requestId: bigint | string | undefined
+  shareAddress: Address
+}) =>
+  useQuery({
+    enabled: requestId !== undefined,
+    queryFn: () => fetchRequestDetails({ requestId: requestId!, shareAddress }),
+    queryKey: [...requestDetailsKeyPrefix, shareAddress, requestId?.toString()],
+    staleTime: Infinity,
+  })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
@@ -1,6 +1,7 @@
 import { WarningIcon } from 'components/icons/warningIcon'
 import { useTranslations } from 'next-intl'
 import Skeleton from 'react-loading-skeleton'
+import { secondsToDays } from 'utils/time'
 import { type Address } from 'viem'
 
 import { useCooldownDuration } from '../../../_hooks/useCooldownDuration'
@@ -11,9 +12,13 @@ type Props = {
 
 export const CooldownWarning = function ({ shareAddress }: Props) {
   const t = useTranslations()
-  const { data: days, isPending: isLoading } = useCooldownDuration({
+  const { data: durationSec, isPending: isLoading } = useCooldownDuration({
     shareAddress,
   })
+  const days =
+    durationSec !== undefined
+      ? Math.round(secondsToDays(durationSec))
+      : undefined
   return (
     <div className="flex items-center gap-x-1 rounded-lg bg-neutral-100 p-4 text-sm font-medium text-neutral-900">
       <WarningIcon />

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/cooldownWarning.tsx
@@ -1,7 +1,7 @@
 import { WarningIcon } from 'components/icons/warningIcon'
 import { useTranslations } from 'next-intl'
 import Skeleton from 'react-loading-skeleton'
-import { secondsToDays } from 'utils/time'
+import { secondsToWholeDays } from 'utils/time'
 import { type Address } from 'viem'
 
 import { useCooldownDuration } from '../../../_hooks/useCooldownDuration'
@@ -16,9 +16,7 @@ export const CooldownWarning = function ({ shareAddress }: Props) {
     shareAddress,
   })
   const days =
-    durationSec !== undefined
-      ? Math.round(secondsToDays(durationSec))
-      : undefined
+    durationSec !== undefined ? secondsToWholeDays(durationSec) : undefined
   return (
     <div className="flex items-center gap-x-1 rounded-lg bg-neutral-100 p-4 text-sm font-medium text-neutral-900">
       <WarningIcon />

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolForm.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolForm.tsx
@@ -1,26 +1,14 @@
 'use client'
 
-import { ToastLoader } from 'components/toast/toastLoader'
-import dynamic from 'next/dynamic'
-import { useTranslations } from 'next-intl'
 import { Suspense, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import { usePoolForm } from '../_context/poolFormContext'
 import { useDrawerQueryString } from '../_hooks/useDrawerQueryString'
-import { WithdrawStatus } from '../_types/operations'
 
 import { Deposit } from './deposit'
 import { PoolReview } from './poolReview'
 import { Withdraw } from './withdraw'
-
-const PoolToast = dynamic(
-  () => import('./poolToast').then(mod => mod.PoolToast),
-  {
-    loading: () => <ToastLoader />,
-    ssr: false,
-  },
-)
 
 type ActiveTab = 'deposit' | 'withdraw'
 
@@ -36,8 +24,7 @@ const SideDrawer = function () {
 }
 
 export const PoolForm = function () {
-  const { pool, updateInput, withdrawOperation } = usePoolForm()
-  const t = useTranslations('hemi-earn.pool')
+  const { pool, updateInput } = usePoolForm()
   const [activeTab, setActiveTab] = useState<ActiveTab>('deposit')
 
   const switchToDeposit = function () {
@@ -59,22 +46,8 @@ export const PoolForm = function () {
     )
   }
 
-  // Deposit success toast is rendered at the hemi-earn layout level via
-  // `<DepositSuccessToast>` so it fires off the subgraph CLAIMED transition
-  // (the full cross-chain flow's completion), not at request-deposit mined.
-  const showWithdrawToast =
-    withdrawOperation?.status === WithdrawStatus.WITHDRAW_TX_CONFIRMED &&
-    withdrawOperation.transactionHash
-
   return (
     <>
-      {showWithdrawToast && (
-        <PoolToast
-          chainId={pool.shareToken.chainId}
-          title={t('withdraw-successful')}
-          transactionHash={withdrawOperation.transactionHash!}
-        />
-      )}
       {activeTab === 'deposit' ? (
         <Deposit onSwitchToWithdraw={switchToWithdraw} />
       ) : (

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/retryWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/retryWithdraw.tsx
@@ -25,6 +25,7 @@ export const RetryWithdraw = function () {
     resetStateAfterOperation,
     selectedAsset,
     updateWithdrawOperation,
+    withdrawOperation,
   } = usePoolForm()
 
   const t = useTranslations()
@@ -77,8 +78,13 @@ export const RetryWithdraw = function () {
     },
     peggedAmount,
     pool,
+    priorApprovalTxHash: withdrawOperation?.approvalTxHash,
     selectedAsset,
     shares,
+    // Hide the specific failed row from the table when the user commits to
+    // this retry. `withdrawOperation.transactionHash` is the failed redeem's
+    // hash (set on `user-signed-withdraw` and not cleared by the revert).
+    supersedesInitiateTxHash: withdrawOperation?.transactionHash,
     updateWithdrawOperation,
   })
 

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -284,9 +284,9 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
       : undefined,
     shareAddress: pool.shareAddress,
   })
-  const cooldownRemainingSec = useEarnCooldownRemaining({
-    claimableAt: requestDetails?.claimableAt,
-  })
+  const cooldownRemainingSec = useEarnCooldownRemaining(
+    requestDetails?.claimableAt,
+  )
 
   const withdrawStatus =
     withdrawOperation?.status ?? WithdrawStatus.APPROVAL_TX_COMPLETED

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -7,6 +7,7 @@ import {
   type ProgressStatusType,
 } from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
+import { TokenLogo } from 'components/tokenLogo'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
 import { encodeRequestRedeem } from 'hemi-earn-actions/actions'
 import { useChain } from 'hooks/useChain'
@@ -14,7 +15,10 @@ import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useEstimateFees } from 'hooks/useEstimateFees'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import { useTranslations } from 'next-intl'
+import { type ReactNode } from 'react'
+import { type EvmToken } from 'types/token'
 import { getNativeToken } from 'utils/nativeToken'
+import { secondsToDays, secondsToHours } from 'utils/time'
 import { parseTokenUnits } from 'utils/token'
 import { type Address, formatUnits } from 'viem'
 import { useAccount, useEstimateGas } from 'wagmi'
@@ -23,8 +27,14 @@ import {
   REDEEM_SLIPPAGE_BPS,
   applySlippage,
 } from '../../../../_constants/slippage'
+import { useCooldownDuration } from '../../../../_hooks/useCooldownDuration'
+import { useEarnTransactionsQuery } from '../../../../_hooks/useEarnTransactionsQuery'
+import { useIsCooldownEligible } from '../../../../_hooks/useIsCooldownEligible'
+import { useRequestDetails } from '../../../../_hooks/useRequestDetails'
+import { hashesMatch } from '../../../../_utils'
 import { usePoolForm } from '../../_context/poolFormContext'
 import { useAssetsToShares } from '../../_hooks/useAssetsToShares'
+import { useEarnCooldownRemaining } from '../../_hooks/useEarnCooldownRemaining'
 import { useQuoteRedeem } from '../../_hooks/useQuoteRedeem'
 import {
   WithdrawStatus,
@@ -37,12 +47,246 @@ type Props = {
   onClose: VoidFunction
 }
 
+type CooldownPostAction = {
+  description: ReactNode
+  status: ProgressStatusType
+}
+
+type CooldownInputs = {
+  cooldownDurationSec: number | undefined
+  cooldownRemainingSec: number | undefined
+  isCooldownEligible: boolean | undefined
+  subgraphStatus: string | undefined
+  t: ReturnType<typeof useTranslations<'hemi-earn.pool.drawer'>>
+  unstakeMined: boolean
+}
+
+// Maps the local withdraw status, subgraph row, and cooldown state to the
+// receive step's progress + terminal hash. Module-level so the component
+// stays under the complexity threshold.
+//
+// The step only flips to PROGRESS once the user is actually waiting on the
+// remote claim — either because they're whitelisted (no cooldown) or
+// because the cooldown timer has elapsed. Otherwise it stays NOT_READY so
+// the drawer doesn't show two simultaneous spinners (one on the cooldown
+// sub-step, one here).
+function buildReceiveStep({
+  cooldownRemainingSec,
+  isCooldownEligible,
+  receiveToken,
+  subgraphRow,
+  t,
+  withdrawStatus,
+}: {
+  cooldownRemainingSec: number | undefined
+  isCooldownEligible: boolean | undefined
+  receiveToken: EvmToken
+  subgraphRow:
+    | {
+        claimTxHash: string | null
+        recoverTxHash: string | null
+        status: string
+      }
+    | undefined
+  t: ReturnType<typeof useTranslations<'hemi-earn.pool.drawer'>>
+  withdrawStatus: WithdrawStatusType
+}): StepPropsWithoutPosition {
+  // Only CLAIMED actually delivers the underlying. RECOVERED returns
+  // shares to the user (not the asset this step is labeled with), so the
+  // step never flips COMPLETED in that case — recovery UX is handled
+  // outside this drawer (tracked in its own follow-up).
+  const claimTxHash =
+    subgraphRow?.status === 'CLAIMED'
+      ? subgraphRow.claimTxHash ?? undefined
+      : undefined
+  const unstakeMined = withdrawStatus === WithdrawStatus.WITHDRAW_TX_CONFIRMED
+  // Two distinct questions, kept as separate predicates so each reads
+  // for what it actually asks:
+  //   - `needsCooldown`: does this user have to wait at all? Defaults
+  //     to true while `useIsCooldownEligible` is loading — cooldown
+  //     active is the normal case; whitelist / disabled-cooldown are
+  //     the exception.
+  //   - `cooldownElapsed`: for users that DO wait, has the timer
+  //     finished?
+  const needsCooldown = isCooldownEligible !== false
+  const cooldownElapsed = cooldownRemainingSec === 0
+  const status: ProgressStatusType = claimTxHash
+    ? ProgressStatus.COMPLETED
+    : unstakeMined && (!needsCooldown || cooldownElapsed)
+      ? ProgressStatus.PROGRESS
+      : ProgressStatus.NOT_READY
+  return {
+    description: (
+      <div className="flex items-center gap-x-2">
+        <TokenLogo size="small" token={receiveToken} />
+        <span>{t('receive-token', { symbol: receiveToken.symbol })}</span>
+      </div>
+    ),
+    status,
+    txHash: claimTxHash,
+  }
+}
+
+const FAILED_STATUSES: WithdrawStatusType[] = [
+  WithdrawStatus.APPROVAL_TX_FAILED,
+  WithdrawStatus.WITHDRAW_TX_FAILED,
+]
+
+const renderRetryCta = (status: WithdrawStatusType) =>
+  FAILED_STATUSES.includes(status) ? <RetryWithdraw /> : null
+
+// Subgraph statuses past the cross-chain handoff — the Vetro Agent has
+// acted on the request, so per-request reads like `getRequestDetails`
+// have valid data to return. PENDING is excluded because the Agent
+// hasn't observed yet, and the contract may revert or return zeros.
+const AGENT_OBSERVED_STATUSES = ['FULFILLED', 'CLAIMED', 'RECOVERED'] as const
+
+const hasAgentObserved = (subgraphStatus: string | undefined) =>
+  subgraphStatus !== undefined &&
+  (AGENT_OBSERVED_STATUSES as readonly string[]).includes(subgraphStatus)
+
+// Builds the `data:` argument for `useEstimateGas`. Module-level so the
+// component doesn't pay the branching tax for this conditional encode.
+function encodeRedeemForGasEstimate({
+  account,
+  assetAddress,
+  assetsOutMin,
+  quote,
+  shares,
+}: {
+  account: Address | undefined
+  assetAddress: Address
+  assetsOutMin: bigint
+  quote:
+    | { callbackFee: bigint; isInstant: boolean; nativeFee: bigint }
+    | undefined
+  shares: bigint
+}) {
+  if (!account || !quote || shares <= BigInt(0)) return undefined
+  return encodeRequestRedeem({
+    asset: assetAddress,
+    assetsOutMin,
+    callbackFee: quote.callbackFee,
+    isInstant: quote.isInstant,
+    operator: account,
+    receiver: account,
+    shares,
+  })
+}
+
+// Decides what (if anything) to render under the Unstake step as a clock
+// sub-step. Pure function so the component's complexity stays low.
+//
+// Mirrors the tunnel's wait-step pattern (e.g. `reviewEvmWithdrawal`):
+// the sub-step stays mounted across its whole lifecycle (NOT_READY →
+// PROGRESS → COMPLETED) so the user keeps a visible milestone even
+// after the wait period elapses. The only case we hide it entirely is
+// when the user simply doesn't have a cooldown (whitelist / disabled).
+function deriveCooldownPostAction({
+  cooldownDurationSec,
+  cooldownRemainingSec,
+  isCooldownEligible,
+  subgraphStatus,
+  t,
+  unstakeMined,
+}: CooldownInputs): CooldownPostAction | undefined {
+  if (isCooldownEligible === false) return undefined
+  // The cooldown is effectively over once any of:
+  //   - the local timer elapsed
+  //   - the subgraph row reached CLAIMED (auto-claim fired the moment
+  //     the cooldown matured)
+  //   - the subgraph row reached RECOVERED (cancel/recovery ended the
+  //     cooldown early)
+  // Keep the sub-step visible as a COMPLETED milestone — without this,
+  // an auto-claim landing seconds after the timer hits zero would make
+  // the sub-step disappear right when the user expects to see it tick
+  // over to "done".
+  const cooldownOver =
+    cooldownRemainingSec === 0 ||
+    subgraphStatus === 'CLAIMED' ||
+    subgraphStatus === 'RECOVERED'
+  if (cooldownOver) {
+    return {
+      description: t('cooldown-ended'),
+      status: ProgressStatus.COMPLETED,
+    }
+  }
+  // Duration still loading — render nothing for now; the postAction
+  // shows up once the on-chain read settles.
+  if (cooldownDurationSec === undefined) return undefined
+
+  const days = Math.round(secondsToDays(cooldownDurationSec))
+
+  if (!unstakeMined) {
+    return {
+      description: t('wait-cooldown-pending', { days }),
+      status: ProgressStatus.NOT_READY,
+    }
+  }
+
+  if (cooldownRemainingSec === undefined) {
+    return {
+      description: t('wait-cooldown-pending', { days }),
+      status: ProgressStatus.PROGRESS,
+    }
+  }
+
+  const remainingDays = Math.floor(secondsToDays(cooldownRemainingSec))
+  const remainingHours = Math.floor(
+    secondsToHours(cooldownRemainingSec - remainingDays * 86400),
+  )
+  return {
+    description: t('wait-cooldown-countdown', {
+      days: remainingDays,
+      hours: remainingHours,
+    }),
+    status: ProgressStatus.PROGRESS,
+  }
+}
+
+// Drawer opens after the user signs the first wallet prompt (approval if
+// needed, otherwise the redeem).
 export const ReviewWithdraw = function ({ onClose }: Props) {
   const { input, pool, selectedAsset, withdrawOperation } = usePoolForm()
   const t = useTranslations('hemi-earn.pool.drawer')
   const chainId = selectedAsset.token.chainId
   const chain = useChain(chainId)
   const { address } = useAccount()
+
+  // Shared subscription with the layout-mounted watcher; lets the new
+  // receive step flip to COMPLETED off the subgraph status.
+  const { data: subgraphRows = [] } = useEarnTransactionsQuery()
+  const subgraphRow = subgraphRows.find(
+    r =>
+      r.kind === 'REDEEM' &&
+      hashesMatch(r.initiateTxHash, withdrawOperation?.transactionHash),
+  )
+
+  const { data: isCooldownEligible } = useIsCooldownEligible({
+    account: address,
+    shareAddress: pool.shareAddress,
+  })
+  // Pool-level cooldown duration drives the static "Wait for the N-day
+  // cooldown period" copy while we don't yet have a request to query
+  // (pre-sign / pre-indexed).
+  const { data: cooldownDurationSec } = useCooldownDuration({
+    shareAddress: pool.shareAddress,
+  })
+  // Per-request `claimableAt` from Ethereum is the authoritative cooldown
+  // maturity timestamp — set by the Vetro Agent at LayerZero-observation
+  // time, never drifts after that. We only query it once the subgraph
+  // confirms the Agent has acted (FULFILLED+); before that the Vetro
+  // contract may revert or return a zero struct, and caching either
+  // outcome under `staleTime: Infinity` would poison the countdown.
+  const { data: requestDetails } = useRequestDetails({
+    requestId: hasAgentObserved(subgraphRow?.status)
+      ? subgraphRow?.requestId
+      : undefined,
+    shareAddress: pool.shareAddress,
+  })
+  const cooldownRemainingSec = useEarnCooldownRemaining({
+    claimableAt: requestDetails?.claimableAt,
+  })
 
   const withdrawStatus =
     withdrawOperation?.status ?? WithdrawStatus.APPROVAL_TX_COMPLETED
@@ -85,18 +329,13 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
 
   const { data: withdrawGasUnits, isError: isWithdrawGasUnitsError } =
     useEstimateGas({
-      data:
-        address && quote && shares > BigInt(0)
-          ? encodeRequestRedeem({
-              asset: selectedAsset.address,
-              assetsOutMin,
-              callbackFee: quote.callbackFee,
-              isInstant: quote.isInstant,
-              operator: address,
-              receiver: address,
-              shares,
-            })
-          : undefined,
+      data: encodeRedeemForGasEstimate({
+        account: address,
+        assetAddress: selectedAsset.address,
+        assetsOutMin,
+        quote,
+        shares,
+      }),
       query: { enabled: !!address && shares > BigInt(0) && !!quote },
       to: routerAddress as Address,
       value: quote?.nativeFee,
@@ -140,13 +379,6 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
       [WithdrawStatus.APPROVAL_TX_PENDING]: ProgressStatus.PROGRESS,
     }
 
-    const getStatus = function () {
-      if (withdrawStatus === undefined) {
-        return ProgressStatus.COMPLETED
-      }
-      return statusMap[withdrawStatus] ?? ProgressStatus.COMPLETED
-    }
-
     return {
       description: (
         <ChainLabel
@@ -161,12 +393,12 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
         isError: isApprovalGasFeesError,
         show: showFees,
       }),
-      status: getStatus(),
+      status: statusMap[withdrawStatus] ?? ProgressStatus.COMPLETED,
       txHash: withdrawOperation?.approvalTxHash,
     }
   }
 
-  const addWithdrawStep = function (): StepPropsWithoutPosition {
+  const addUnstakeStep = function (): StepPropsWithoutPosition {
     const statusMap: Record<WithdrawStatusType, ProgressStatusType> = {
       [WithdrawStatus.APPROVAL_TX_PENDING]: ProgressStatus.NOT_READY,
       [WithdrawStatus.APPROVAL_TX_FAILED]: ProgressStatus.NOT_READY,
@@ -189,17 +421,24 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
 
     return {
       description: (
-        <ChainLabel
-          active={withdrawStatus === WithdrawStatus.WITHDRAW_TX_PENDING}
-          chainId={chainId}
-          label={t('withdraw-token', { symbol: selectedAsset.token.symbol })}
-        />
+        <div className="flex items-center gap-x-2">
+          <TokenLogo size="small" token={pool.shareToken} />
+          <span>{t('unstake-token', { symbol: pool.shareToken.symbol })}</span>
+        </div>
       ),
       explorerChainId: chainId,
       fees: getStepFees({
         fee: withdrawLineTotal,
         isError: isWithdrawGasFeesError,
         show: showFees,
+      }),
+      postAction: deriveCooldownPostAction({
+        cooldownDurationSec,
+        cooldownRemainingSec,
+        isCooldownEligible,
+        subgraphStatus: subgraphRow?.status,
+        t,
+        unstakeMined: withdrawStatus === WithdrawStatus.WITHDRAW_TX_CONFIRMED,
       }),
       status: statusMap[withdrawStatus] ?? ProgressStatus.NOT_READY,
       txHash: withdrawOperation?.transactionHash,
@@ -211,27 +450,29 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
     if (needsApproval || withdrawOperation?.approvalTxHash) {
       steps.push(addApprovalStep())
     }
-    steps.push(addWithdrawStep())
+    steps.push(addUnstakeStep())
+    steps.push(
+      buildReceiveStep({
+        cooldownRemainingSec,
+        isCooldownEligible,
+        receiveToken: selectedAsset.token,
+        subgraphRow,
+        t,
+        withdrawStatus,
+      }),
+    )
     return steps
   }
 
-  const getCallToAction = (status: WithdrawStatusType) =>
-    [
-      WithdrawStatus.APPROVAL_TX_FAILED,
-      WithdrawStatus.WITHDRAW_TX_FAILED,
-    ].includes(status) ? (
-      <RetryWithdraw />
-    ) : null
-
   return (
     <Operation
-      amount={amount.toString()}
-      callToAction={getCallToAction(withdrawStatus)}
+      amount={withdrawOperation?.amountIn ?? shares.toString()}
+      callToAction={renderRetryCta(withdrawStatus)}
       heading={t('withdraw.heading')}
       onClose={onClose}
       steps={getSteps()}
       subheading={t('withdraw.subheading')}
-      token={selectedAsset.token}
+      token={pool.shareToken}
     />
   )
 }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -231,6 +231,17 @@ function deriveCooldownPostAction({
     }
   }
 
+  // Sub-hour remaining: avoid the misleading "0h" by collapsing to a
+  // generic "less than an hour" copy. Tick interval is at minute
+  // resolution, so showing a precise minute countdown would lie about
+  // freshness; the shorter copy is honest about where we are.
+  if (cooldownRemainingSec < 3600) {
+    return {
+      description: t('wait-cooldown-countdown-soon'),
+      status: ProgressStatus.PROGRESS,
+    }
+  }
+
   const remainingDays = Math.floor(secondsToDays(cooldownRemainingSec))
   const remainingHours = Math.floor(
     secondsToHours(cooldownRemainingSec - remainingDays * 86400),

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -18,9 +18,9 @@ import { useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
 import { type EvmToken } from 'types/token'
 import { getNativeToken } from 'utils/nativeToken'
-import { secondsToDays, secondsToHours } from 'utils/time'
+import { secondsToDays, secondsToHours, secondsToWholeDays } from 'utils/time'
 import { parseTokenUnits } from 'utils/token'
-import { type Address, formatUnits } from 'viem'
+import { type Address, type Hash, formatUnits } from 'viem'
 import { useAccount, useEstimateGas } from 'wagmi'
 
 import {
@@ -83,8 +83,8 @@ function buildReceiveStep({
   receiveToken: EvmToken
   subgraphRow:
     | {
-        claimTxHash: string | null
-        recoverTxHash: string | null
+        claimTxHash: Hash | null
+        recoverTxHash: Hash | null
         status: string
       }
     | undefined
@@ -215,7 +215,7 @@ function deriveCooldownPostAction({
   // shows up once the on-chain read settles.
   if (cooldownDurationSec === undefined) return undefined
 
-  const days = Math.round(secondsToDays(cooldownDurationSec))
+  const days = secondsToWholeDays(cooldownDurationSec)
 
   if (!unstakeMined) {
     return {

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDeposit.ts
@@ -10,6 +10,7 @@ import {
 import { requestDeposit } from 'hemi-earn-actions/actions'
 import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { buildAllowanceQueryKey } from 'utils/allowanceQueryKey'
+import { unixNowTimestamp } from 'utils/time'
 import { parseTokenUnits } from 'utils/token'
 import { type Hash } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
@@ -102,7 +103,7 @@ export const useDeposit = function ({
       //   2. `user-signed-deposit` — adds `initiateTxHash`, which is the
       //      key the merge in `useEarnTransactions` uses to dedupe against
       //      the subgraph row.
-      const startedAt = Math.floor(Date.now() / 1000)
+      const startedAt = Number(unixNowTimestamp())
       const baseLocalPayload = {
         account: address,
         amountIn: amount.toString(),

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
@@ -20,11 +20,9 @@ const TICK_MS = 60_000
 
 const nowInSeconds = () => Number(unixNowTimestamp())
 
-export function useEarnCooldownRemaining({
-  claimableAt,
-}: {
-  claimableAt: bigint | number | undefined
-}) {
+export function useEarnCooldownRemaining(
+  claimableAt: bigint | number | undefined,
+) {
   const [nowSec, setNowSec] = useState(nowInSeconds)
 
   const claimableAtSec =

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { unixNowTimestamp } from 'utils/time'
+
+// Local-only countdown driven by the on-chain `claimableAt` timestamp
+// (read via `useRequestDetails`). Ticks every 60s so the drawer's
+// cooldown sub-step copy (and any future table column) updates without
+// round-tripping through react-query.
+//
+// `claimableAt` is the unix-seconds timestamp at which the Vetro Agent
+// will allow the claim to fire (set on Ethereum at observation time —
+// the authoritative source for cooldown maturity, free of the
+// LayerZero-delay drift a local `initiatedAt + duration` calculation
+// would carry).
+//
+// Returns `undefined` while the input is missing, otherwise the
+// remaining seconds (clamped at 0).
+const TICK_MS = 60_000
+
+const nowInSeconds = () => Number(unixNowTimestamp())
+
+export function useEarnCooldownRemaining({
+  claimableAt,
+}: {
+  claimableAt: bigint | number | undefined
+}) {
+  const [nowSec, setNowSec] = useState(nowInSeconds)
+
+  const claimableAtSec =
+    claimableAt === undefined ? undefined : Number(claimableAt)
+
+  useEffect(
+    function tick() {
+      if (claimableAtSec === undefined) return undefined
+      const id = setInterval(() => setNowSec(nowInSeconds()), TICK_MS)
+      return () => clearInterval(id)
+    },
+    [claimableAtSec],
+  )
+
+  if (claimableAtSec === undefined) return undefined
+  const remaining = claimableAtSec - nowSec
+  return remaining > 0 ? remaining : 0
+}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
@@ -20,24 +20,28 @@ const TICK_MS = 60_000
 
 const nowInSeconds = () => Number(unixNowTimestamp())
 
+export function computeCooldownRemaining(
+  claimableAt: bigint | number | undefined,
+  nowSec: number,
+) {
+  if (claimableAt === undefined) return undefined
+  const remaining = Number(claimableAt) - nowSec
+  return remaining > 0 ? remaining : 0
+}
+
 export function useEarnCooldownRemaining(
   claimableAt: bigint | number | undefined,
 ) {
   const [nowSec, setNowSec] = useState(nowInSeconds)
 
-  const claimableAtSec =
-    claimableAt === undefined ? undefined : Number(claimableAt)
-
   useEffect(
     function tick() {
-      if (claimableAtSec === undefined) return undefined
+      if (claimableAt === undefined) return undefined
       const id = setInterval(() => setNowSec(nowInSeconds()), TICK_MS)
       return () => clearInterval(id)
     },
-    [claimableAtSec],
+    [claimableAt],
   )
 
-  if (claimableAtSec === undefined) return undefined
-  const remaining = claimableAtSec - nowSec
-  return remaining > 0 ? remaining : 0
+  return computeCooldownRemaining(claimableAt, nowSec)
 }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdraw.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdraw.ts
@@ -11,11 +11,14 @@ import { requestRedeem } from 'hemi-earn-actions/actions'
 import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { buildAllowanceQueryKey } from 'utils/allowanceQueryKey'
+import { unixNowTimestamp } from 'utils/time'
+import { type Hash } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 import { getWalletClient } from 'wagmi/actions'
 
 import { earnPositionsKeyPrefix } from '../../../_fetchers/fetchEarnPositions'
 import { earnTvlQueryKey } from '../../../_hooks/useEarnTvl'
+import { useLocalEarnOperations } from '../../../_hooks/useLocalEarnOperations'
 import { type EarnAsset, type EarnPool } from '../../../types'
 import { type WithdrawOperation, WithdrawStatus } from '../_types/operations'
 
@@ -43,12 +46,22 @@ type UseWithdraw = {
   // the preview is pending; `onSettled` invalidation reconciles.
   peggedAmount: bigint
   pool: EarnPool
+  // Set by retry callers when the prior attempt had a successful approval
+  // (allowance is still on-chain, so `requestRedeem` won't emit
+  // `user-signed-approval` again). Carried forward into the new local-store
+  // entry so the historical drawer keeps surfacing the approval step.
+  priorApprovalTxHash?: Hash
   selectedAsset: EarnAsset
   // Pre-converted share amount in shareToken units. Computed by the caller
   // (the withdraw drawer) via `convertToShares` so the off-chain input flow
   // stays close to the asset-unit UX while this hook stays focused on the
   // on-chain submission.
   shares: bigint
+  // Set by retry callers: the `initiateTxHash` of the specific prior FAILED
+  // attempt being replaced. Once the new withdraw is signed, that entry is
+  // flagged `settled` so the table doesn't show the old failure alongside
+  // the new attempt.
+  supersedesInitiateTxHash?: Hash
   updateWithdrawOperation: (payload?: WithdrawOperation) => void
 }
 
@@ -60,8 +73,10 @@ export const useWithdraw = function ({
   on,
   peggedAmount,
   pool,
+  priorApprovalTxHash,
   selectedAsset,
   shares,
+  supersedesInitiateTxHash,
   updateWithdrawOperation,
 }: UseWithdraw) {
   const { setDrawerQueryString } = useDrawerQueryString()
@@ -72,6 +87,10 @@ export const useWithdraw = function ({
   const queryClient = useQueryClient()
   const [networkType] = useNetworkType()
   const routerAddress = getHemiEarnRouterAddress()
+  // Requires <LocalEarnOperationsProvider> upstream (mounted in the
+  // hemi-earn layout). Hook throws at runtime if used outside it.
+  const { markSettledByInitiateTxHash, upsertLocalOperation } =
+    useLocalEarnOperations()
 
   const tokenBalanceQueryKey = getTokenBalanceQueryKey({
     account: address,
@@ -125,6 +144,38 @@ export const useWithdraw = function ({
 
       const walletClient = await getWalletClient(config, { chainId })
 
+      // Local-store entries are created at two points:
+      //   1. `user-signed-approval` — captures `approvalTxHash` so a future
+      //      historical drawer can later render the approval step (the
+      //      indexer has no way to link an approval tx to a request).
+      //   2. `user-signed-withdraw` — adds `initiateTxHash`, which is the
+      //      key the merge would use to dedupe against the subgraph row.
+      // REDEEM rows aren't surfaced in the table yet, but the local entries
+      // still drive `useEarnTransactionsQuery` polling and the cooldown
+      // sub-step's reactivity.
+      const startedAt = Number(unixNowTimestamp())
+      // `amountIn` for REDEEM stores the share amount being burned (raw
+      // share-token units). The drawer displays this directly as "X
+      // {shareSymbol}" — survives `resetStateAfterOperation()` clearing
+      // the form input. DEPOSIT stores the asset amount instead; the
+      // difference reflects what each kind actually puts in on-chain.
+      const baseLocalPayload = {
+        account: address,
+        amountIn: shares.toString(),
+        asset: selectedAsset.address,
+        chainId,
+        kind: 'REDEEM' as const,
+        operator: address,
+        shareAddress: pool.shareAddress,
+        startedAt,
+      }
+
+      // Tracks the approval hash for this specific attempt. Seeded from
+      // `priorApprovalTxHash` so retries (where allowance is still on-chain
+      // and `user-signed-approval` won't fire) keep showing the original
+      // approval step. Overwritten when a fresh approval is signed.
+      let observedApprovalTxHash: Hash | undefined = priorApprovalTxHash
+
       const { emitter, promise } = requestRedeem({
         account: address,
         asset: selectedAsset.address,
@@ -140,10 +191,22 @@ export const useWithdraw = function ({
       })
 
       emitter.on('user-signed-approval', function (approvalTxHash) {
+        observedApprovalTxHash = approvalTxHash
         updateWithdrawOperation({
+          amountIn: shares.toString(),
           approvalTxHash,
           status: WithdrawStatus.APPROVAL_TX_PENDING,
           transactionHash: undefined,
+        })
+        // Persist the approval hash to the local store so the drawer can
+        // surface the approval step across route changes — the indexer
+        // never sees this association.
+        upsertLocalOperation({
+          ...baseLocalPayload,
+          approvalTxHash,
+          operation: {
+            status: WithdrawStatus.APPROVAL_TX_PENDING,
+          },
         })
         setDrawerQueryString('withdrawing')
       })
@@ -171,9 +234,25 @@ export const useWithdraw = function ({
 
       emitter.on('user-signed-withdraw', function (transactionHash) {
         updateWithdrawOperation({
+          amountIn: shares.toString(),
           status: WithdrawStatus.WITHDRAW_TX_PENDING,
           transactionHash,
         })
+        upsertLocalOperation({
+          ...baseLocalPayload,
+          approvalTxHash: observedApprovalTxHash,
+          initiateTxHash: transactionHash,
+          operation: {
+            status: WithdrawStatus.WITHDRAW_TX_PENDING,
+            transactionHash,
+          },
+        })
+        // Hide the specific prior FAILED entry the user is replacing. Done
+        // here (and not on retry click) so the row only disappears once the
+        // user actually commits to the new attempt by signing.
+        if (supersedesInitiateTxHash) {
+          markSettledByInitiateTxHash(supersedesInitiateTxHash)
+        }
         setDrawerQueryString('withdrawing')
       })
 
@@ -188,6 +267,12 @@ export const useWithdraw = function ({
         // requestId so the UI can track cross-chain fulfillment.
         updateWithdrawOperation({
           status: WithdrawStatus.WITHDRAW_TX_CONFIRMED,
+        })
+        upsertLocalOperation({
+          ...baseLocalPayload,
+          approvalTxHash: observedApprovalTxHash,
+          initiateTxHash: receipt.transactionHash,
+          operation: { status: WithdrawStatus.WITHDRAW_TX_CONFIRMED },
         })
         updateNativeBalanceAfterFees(receipt)
         // Optimistic bumps. Invalidation in `onSettled` reconciles, but the
@@ -227,6 +312,12 @@ export const useWithdraw = function ({
       emitter.on('withdraw-transaction-reverted', function (receipt) {
         updateWithdrawOperation({
           status: WithdrawStatus.WITHDRAW_TX_FAILED,
+        })
+        upsertLocalOperation({
+          ...baseLocalPayload,
+          approvalTxHash: observedApprovalTxHash,
+          initiateTxHash: receipt.transactionHash,
+          operation: { status: WithdrawStatus.WITHDRAW_TX_FAILED },
         })
         updateNativeBalanceAfterFees(receipt)
       })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_types/operations.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_types/operations.ts
@@ -57,6 +57,7 @@ export type WithdrawStatusType =
   (typeof WithdrawStatus)[keyof typeof WithdrawStatus]
 
 export type WithdrawOperation = {
+  amountIn?: string
   approvalTxHash?: Hash
   status: WithdrawStatusType
   transactionHash?: Hash

--- a/portal/hooks/useBalance.ts
+++ b/portal/hooks/useBalance.ts
@@ -8,10 +8,6 @@ import { isNativeAddress } from 'utils/nativeToken'
 import { type Address, isAddress } from 'viem'
 import { useAccount, usePublicClient } from 'wagmi'
 
-export const tokenBalanceQueryKeyPrefix = [
-  'tokenBalance' satisfies ReturnType<typeof tokenBalanceQueryKey>[0],
-] as const
-
 export const getTokenBalanceQueryKey = ({
   account,
   chainId,

--- a/portal/hooks/useBalance.ts
+++ b/portal/hooks/useBalance.ts
@@ -8,6 +8,8 @@ import { isNativeAddress } from 'utils/nativeToken'
 import { type Address, isAddress } from 'viem'
 import { useAccount, usePublicClient } from 'wagmi'
 
+export const tokenBalanceQueryKeyPrefix = ['tokenBalance'] as const
+
 export const getTokenBalanceQueryKey = ({
   account,
   chainId,

--- a/portal/hooks/useBalance.ts
+++ b/portal/hooks/useBalance.ts
@@ -8,7 +8,9 @@ import { isNativeAddress } from 'utils/nativeToken'
 import { type Address, isAddress } from 'viem'
 import { useAccount, usePublicClient } from 'wagmi'
 
-export const tokenBalanceQueryKeyPrefix = ['tokenBalance'] as const
+export const tokenBalanceQueryKeyPrefix = [
+  'tokenBalance' satisfies ReturnType<typeof tokenBalanceQueryKey>[0],
+] as const
 
 export const getTokenBalanceQueryKey = ({
   account,

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -37,7 +37,7 @@
         "get-share-tokens": "Get share tokens",
         "receive-token": "Receive {symbol}",
         "unstake-token": "Unstake {symbol}",
-        "wait-cooldown-countdown": "Cooldown ends in {days}d {hours}h",
+        "wait-cooldown-countdown": "{days, plural, =0 {Cooldown ends in {hours}h} other {Cooldown ends in #d {hours}h}}",
         "wait-cooldown-pending": "Wait for the {days, plural, one {# day} other {# days}} cooldown period",
         "withdraw": {
           "heading": "Review stake withdrawal",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -38,6 +38,7 @@
         "receive-token": "Receive {symbol}",
         "unstake-token": "Unstake {symbol}",
         "wait-cooldown-countdown": "{days, plural, =0 {Cooldown ends in {hours}h} other {Cooldown ends in #d {hours}h}}",
+        "wait-cooldown-countdown-soon": "Cooldown ends in less than an hour",
         "wait-cooldown-pending": "Wait for the {days, plural, one {# day} other {# days}} cooldown period",
         "withdraw": {
           "heading": "Review stake withdrawal",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -32,11 +32,16 @@
           "heading": "Review stake deposit",
           "subheading": "Your transaction has been submitted and is awaiting confirmation on the blockchain."
         },
+        "cooldown-ended": "Cooldown period complete",
         "stake-token": "Stake {symbol}",
         "get-share-tokens": "Get share tokens",
+        "receive-token": "Receive {symbol}",
+        "unstake-token": "Unstake {symbol}",
+        "wait-cooldown-countdown": "Cooldown ends in {days}d {hours}h",
+        "wait-cooldown-pending": "Wait for the {days, plural, one {# day} other {# days}} cooldown period",
         "withdraw": {
-          "heading": "Review Withdrawal",
-          "subheading": "Complete the remaining steps to withdraw your tokens."
+          "heading": "Review stake withdrawal",
+          "subheading": "Your transaction has been submitted and is awaiting confirmation on the blockchain."
         },
         "withdraw-token": "Withdraw {symbol}"
       },

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -42,8 +42,7 @@
         "withdraw": {
           "heading": "Review stake withdrawal",
           "subheading": "Your transaction has been submitted and is awaiting confirmation on the blockchain."
-        },
-        "withdraw-token": "Withdraw {symbol}"
+        }
       },
       "form": {
         "amount-too-small": "Amount too small",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -37,7 +37,7 @@
         "get-share-tokens": "Recibir share tokens",
         "receive-token": "Recibir {symbol}",
         "unstake-token": "Hacer unstake de {symbol}",
-        "wait-cooldown-countdown": "Cooldown termina en {days}d {hours}h",
+        "wait-cooldown-countdown": "{days, plural, =0 {Cooldown termina en {hours}h} other {Cooldown termina en #d {hours}h}}",
         "wait-cooldown-pending": "Espere el período de cooldown de {days, plural, one {# día} other {# días}}",
         "withdraw": {
           "heading": "Revisar retiro de stake",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -32,11 +32,16 @@
           "heading": "Revisar depósito de stake",
           "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."
         },
+        "cooldown-ended": "Período de cooldown completado",
         "stake-token": "Hacer stake de {symbol}",
         "get-share-tokens": "Recibir share tokens",
+        "receive-token": "Recibir {symbol}",
+        "unstake-token": "Hacer unstake de {symbol}",
+        "wait-cooldown-countdown": "Cooldown termina en {days}d {hours}h",
+        "wait-cooldown-pending": "Espere el período de cooldown de {days, plural, one {# día} other {# días}}",
         "withdraw": {
-          "heading": "Revisar Retiro",
-          "subheading": "Complete los pasos restantes para retirar sus tokens."
+          "heading": "Revisar retiro de stake",
+          "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."
         },
         "withdraw-token": "Retirar {symbol}"
       },

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -32,14 +32,14 @@
           "heading": "Revisar depósito de stake",
           "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."
         },
-        "cooldown-ended": "Período de cooldown completado",
+        "cooldown-ended": "Período de espera completado",
         "stake-token": "Hacer stake de {symbol}",
         "get-share-tokens": "Recibir share tokens",
         "receive-token": "Recibir {symbol}",
         "unstake-token": "Hacer unstake de {symbol}",
-        "wait-cooldown-countdown": "{days, plural, =0 {Cooldown termina en {hours}h} other {Cooldown termina en #d {hours}h}}",
-        "wait-cooldown-countdown-soon": "Cooldown termina en menos de una hora",
-        "wait-cooldown-pending": "Espere el período de cooldown de {days, plural, one {# día} other {# días}}",
+        "wait-cooldown-countdown": "{days, plural, =0 {El período de espera termina en {hours}h} other {El período de espera termina en #d {hours}h}}",
+        "wait-cooldown-countdown-soon": "El período de espera termina en menos de una hora",
+        "wait-cooldown-pending": "El período de espera es de {days, plural, one {# día} other {# días}}",
         "withdraw": {
           "heading": "Revisar retiro de stake",
           "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -38,6 +38,7 @@
         "receive-token": "Recibir {symbol}",
         "unstake-token": "Hacer unstake de {symbol}",
         "wait-cooldown-countdown": "{days, plural, =0 {Cooldown termina en {hours}h} other {Cooldown termina en #d {hours}h}}",
+        "wait-cooldown-countdown-soon": "Cooldown termina en menos de una hora",
         "wait-cooldown-pending": "Espere el período de cooldown de {days, plural, one {# día} other {# días}}",
         "withdraw": {
           "heading": "Revisar retiro de stake",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -42,8 +42,7 @@
         "withdraw": {
           "heading": "Revisar retiro de stake",
           "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."
-        },
-        "withdraw-token": "Retirar {symbol}"
+        }
       },
       "form": {
         "amount-too-small": "Monto demasiado pequeño",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -42,8 +42,7 @@
         "withdraw": {
           "heading": "Revisar saque de stake",
           "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."
-        },
-        "withdraw-token": "Sacar {symbol}"
+        }
       },
       "form": {
         "amount-too-small": "Valor muito pequeno",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -37,7 +37,7 @@
         "get-share-tokens": "Receber share tokens",
         "receive-token": "Receber {symbol}",
         "unstake-token": "Fazer unstake de {symbol}",
-        "wait-cooldown-countdown": "Cooldown termina em {days}d {hours}h",
+        "wait-cooldown-countdown": "{days, plural, =0 {Cooldown termina em {hours}h} other {Cooldown termina em #d {hours}h}}",
         "wait-cooldown-pending": "Aguarde o período de cooldown de {days, plural, one {# dia} other {# dias}}",
         "withdraw": {
           "heading": "Revisar saque de stake",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -32,11 +32,16 @@
           "heading": "Revisar depósito de stake",
           "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."
         },
+        "cooldown-ended": "Período de cooldown concluído",
         "stake-token": "Fazer stake de {symbol}",
         "get-share-tokens": "Receber share tokens",
+        "receive-token": "Receber {symbol}",
+        "unstake-token": "Fazer unstake de {symbol}",
+        "wait-cooldown-countdown": "Cooldown termina em {days}d {hours}h",
+        "wait-cooldown-pending": "Aguarde o período de cooldown de {days, plural, one {# dia} other {# dias}}",
         "withdraw": {
-          "heading": "Revisar Saque",
-          "subheading": "Complete as etapas restantes para sacar seus tokens."
+          "heading": "Revisar saque de stake",
+          "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."
         },
         "withdraw-token": "Sacar {symbol}"
       },

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -32,14 +32,14 @@
           "heading": "Revisar depósito de stake",
           "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."
         },
-        "cooldown-ended": "Período de cooldown concluído",
+        "cooldown-ended": "Período de espera concluído",
         "stake-token": "Fazer stake de {symbol}",
         "get-share-tokens": "Receber share tokens",
         "receive-token": "Receber {symbol}",
         "unstake-token": "Fazer unstake de {symbol}",
-        "wait-cooldown-countdown": "{days, plural, =0 {Cooldown termina em {hours}h} other {Cooldown termina em #d {hours}h}}",
-        "wait-cooldown-countdown-soon": "Cooldown termina em menos de uma hora",
-        "wait-cooldown-pending": "Aguarde o período de cooldown de {days, plural, one {# dia} other {# dias}}",
+        "wait-cooldown-countdown": "{days, plural, =0 {O período de espera termina em {hours}h} other {O período de espera termina em #d {hours}h}}",
+        "wait-cooldown-countdown-soon": "O período de espera termina em menos de uma hora",
+        "wait-cooldown-pending": "O período de espera é de {days, plural, one {# dia} other {# dias}}",
         "withdraw": {
           "heading": "Revisar saque de stake",
           "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -38,6 +38,7 @@
         "receive-token": "Receber {symbol}",
         "unstake-token": "Fazer unstake de {symbol}",
         "wait-cooldown-countdown": "{days, plural, =0 {Cooldown termina em {hours}h} other {Cooldown termina em #d {hours}h}}",
+        "wait-cooldown-countdown-soon": "Cooldown termina em menos de uma hora",
         "wait-cooldown-pending": "Aguarde o período de cooldown de {days, plural, one {# dia} other {# dias}}",
         "withdraw": {
           "heading": "Revisar saque de stake",

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchRequestDetails.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchRequestDetails.test.ts
@@ -1,0 +1,85 @@
+import { getRequestDetails } from '@vetro-protocol/earn/actions'
+import { fetchRequestDetails } from 'app/[locale]/hemi-earn/_fetchers/fetchRequestDetails'
+import { getStakingVaultForShare } from 'hemi-earn-actions'
+import { type Address } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Avoid pulling `eth-rpc-cache` (and its broken ESM resolution under
+// vitest) through the chainClients → transport import chain. The
+// returned client is opaque to `fetchRequestDetails` — it just hands it
+// to the Vetro action which we're mocking as well.
+vi.mock('utils/chainClients', () => ({
+  getEvmL1PublicClient: vi.fn(() => ({}) as never),
+  getPublicClient: vi.fn(),
+}))
+
+vi.mock('@vetro-protocol/earn/actions', () => ({
+  getRequestDetails: vi.fn(),
+}))
+
+vi.mock('hemi-earn-actions', async function (importOriginal) {
+  const actual = await importOriginal<typeof import('hemi-earn-actions')>()
+  return {
+    ...actual,
+    getStakingVaultForShare: vi.fn(),
+  }
+})
+
+const shareAddress = '0x1111111111111111111111111111111111111111' as Address
+const vaultAddress = '0x2222222222222222222222222222222222222222' as Address
+const ownerAddress = '0x3333333333333333333333333333333333333333' as Address
+
+const sampleResult = {
+  assets: BigInt('1000000000000000000'),
+  claimableAt: BigInt(1781534321),
+  owner: ownerAddress,
+}
+
+describe('app/[locale]/hemi-earn/_fetchers/fetchRequestDetails', function () {
+  beforeEach(function () {
+    vi.mocked(getStakingVaultForShare).mockReturnValue(vaultAddress)
+    vi.mocked(getRequestDetails).mockResolvedValue(sampleResult)
+  })
+
+  it('resolves the Vetro vault address for the share + forwards bigint requestId', async function () {
+    const requestId = BigInt(42)
+    const result = await fetchRequestDetails({ requestId, shareAddress })
+
+    expect(getStakingVaultForShare).toHaveBeenCalledWith(shareAddress)
+    expect(getRequestDetails).toHaveBeenCalledWith(expect.anything(), {
+      address: vaultAddress,
+      requestId,
+    })
+    expect(result).toEqual(sampleResult)
+  })
+
+  it('coerces a string requestId to bigint before calling the action', async function () {
+    await fetchRequestDetails({ requestId: '42', shareAddress })
+
+    expect(getRequestDetails).toHaveBeenCalledWith(expect.anything(), {
+      address: vaultAddress,
+      requestId: BigInt(42),
+    })
+  })
+
+  it('propagates the action result unchanged', async function () {
+    const result = await fetchRequestDetails({
+      requestId: BigInt(7),
+      shareAddress,
+    })
+
+    expect(result.owner).toBe(ownerAddress)
+    expect(result.assets).toBe(sampleResult.assets)
+    expect(result.claimableAt).toBe(sampleResult.claimableAt)
+  })
+
+  it('propagates action errors', async function () {
+    vi.mocked(getRequestDetails).mockRejectedValueOnce(
+      new Error('reverted: unknown request'),
+    )
+
+    await expect(
+      fetchRequestDetails({ requestId: BigInt(99), shareAddress }),
+    ).rejects.toThrow('reverted: unknown request')
+  })
+})

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.test.ts
@@ -1,0 +1,40 @@
+import { computeCooldownRemaining } from 'app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining'
+import { describe, expect, it } from 'vitest'
+
+const now = 1_781_534_321
+
+describe('computeCooldownRemaining', function () {
+  it('returns undefined when claimableAt is undefined', function () {
+    expect(computeCooldownRemaining(undefined, now)).toBeUndefined()
+  })
+
+  it('returns positive remaining seconds when claimableAt is ahead of now', function () {
+    expect(computeCooldownRemaining(now + 3600, now)).toBe(3600)
+  })
+
+  it('clamps to 0 when claimableAt equals now', function () {
+    expect(computeCooldownRemaining(now, now)).toBe(0)
+  })
+
+  it('clamps to 0 when claimableAt is in the past', function () {
+    expect(computeCooldownRemaining(now - 1, now)).toBe(0)
+  })
+
+  it('accepts bigint inputs', function () {
+    expect(computeCooldownRemaining(BigInt(now + 600), now)).toBe(600)
+  })
+
+  it('accepts number inputs', function () {
+    expect(computeCooldownRemaining(now + 600, now)).toBe(600)
+  })
+
+  it('coerces bigint inputs above Number.MAX_SAFE_INTEGER without crashing', function () {
+    // Realistic unix-seconds never approach this range, but the coerce
+    // should not throw — the result becomes imprecise floating-point,
+    // but the function returns a number rather than crashing.
+    const huge = BigInt('9999999999999999')
+    const result = computeCooldownRemaining(huge, now)
+    expect(typeof result).toBe('number')
+    expect(result).toBeGreaterThan(0)
+  })
+})

--- a/portal/test/utils/time.test.ts
+++ b/portal/test/utils/time.test.ts
@@ -1,4 +1,4 @@
-import { secondsToHours } from 'utils/time'
+import { secondsToHours, secondsToWholeDays } from 'utils/time'
 import { describe, expect, it } from 'vitest'
 
 describe('utils/time', function () {
@@ -6,6 +6,24 @@ describe('utils/time', function () {
     it('should convert seconds to hours correctly', function () {
       const result = secondsToHours(43200)
       expect(result).toBe(12)
+    })
+  })
+
+  describe('secondsToWholeDays', function () {
+    it('should return the exact day count when seconds is a whole-day multiple', function () {
+      expect(secondsToWholeDays(7 * 86400)).toBe(7)
+    })
+
+    it('should round up when the fractional part is >= 0.5 day', function () {
+      expect(secondsToWholeDays(7 * 86400 + 43200)).toBe(8)
+    })
+
+    it('should round down when the fractional part is < 0.5 day', function () {
+      expect(secondsToWholeDays(7 * 86400 + 43199)).toBe(7)
+    })
+
+    it('should return 0 for zero seconds', function () {
+      expect(secondsToWholeDays(0)).toBe(0)
     })
   })
 })

--- a/portal/utils/time.ts
+++ b/portal/utils/time.ts
@@ -1,5 +1,8 @@
 export const secondsToDays = (seconds: number) => seconds / 60 / 60 / 24
 
+export const secondsToWholeDays = (seconds: number) =>
+  Math.round(secondsToDays(seconds))
+
 export const secondsToHours = (seconds: number) => seconds / 60 / 60
 
 export const secondsToMinutes = (seconds: number) => seconds / 60


### PR DESCRIPTION
### Description

This PR iterates the Hemi Earn withdraw drawer to match the deposit drawer's 3-step shape: Approve / Unstake / Receive. A cooldown sub-step under Unstake ticks down toward zero before the underlying lands on the user's Hemi wallet.

  The cooldown timer reads `claimableAt` from `getRequestDetails` on Ethereum (the Vetro Agent's observation timestamp), gated on the subgraph reporting the Agent has acted (FULFILLED+) to avoid querying before the request exists on chain. New hooks: `useRequestDetails` (thin RPC reader with unit tests) and `useEarnCooldownRemaining` (local interval ticker over `claimableAt`).

  `useWithdraw` mirrors the deposit hook's local-store + retry mechanics: persists `approvalTxHash`/`initiateTxHash` to the per-browser store, accepts `priorApprovalTxHash` and `supersedesInitiateTxHash` for retry callers, and soft-settles superseded entries. The withdraw success toast moves from inline (firing on `WITHDRAW_TX_CONFIRMED`) to the hemi-earn layout via a generalized `EarnSuccessToast({ kind, title })` shared with deposit — both kinds now fire on subgraph CLAIMED, matching the full cross-chain completion instead of just the Hemi-side mine.

  The cross-chain delivery watcher also invalidates the user's Hemi token balances on CLAIMED/RECOVERED, so a redeem's underlying arriving back actually refreshes the wallet card immediately. The watcher's kind filter and the polling predicate dropped their `kind === 'DEPOSIT'` checks so REDEEM gets the same treatment.

  ## Notes

  - The countdown shows "0d 0h" in my local test because my dev cooldown is configured to 30 seconds — well below the day/hour granularity of the display. The `claimableAt` itself is read straight
  from the Vetro contract, so in production with a 7-day cooldown the countdown ticks normally ("Cooldown ends in 6d 22h").
  - Recovery UX (RECOVERED for REDEEM returns shares, not the asset) is intentionally not handled here — tracked in a separate follow-up issue.

### Screenshots

https://github.com/user-attachments/assets/04de43af-9a48-4c4d-a908-d95620b0ffb8

Retry:

https://github.com/user-attachments/assets/c1d55307-dfb6-490d-aedd-aa5cfc3c99cc

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
