### PR TITLE
Wire total deposits chart to Vetro API

### DIFF
--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/headlineValue.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/headlineValue.tsx
@@ -23,8 +23,9 @@ export const HeadlineValue = function ({
   const { number, suffix } = formatCompactFiatParts(value, locale)
   return (
     <>
-      <span>{`${number} ${peggedToken.symbol}`}</span>
+      <span>{number}</span>
       <span className="text-neutral-400">{suffix}</span>
+      <span>{` ${peggedToken.symbol}`}</span>
     </>
   )
 }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/headlineValue.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/headlineValue.tsx
@@ -1,14 +1,20 @@
 import { useLocale } from 'next-intl'
+import { EvmToken } from 'types/token'
 import { formatCompactFiatParts, formatPercentage } from 'utils/format'
 
 import { type MetricType } from '../../../../types'
 
 type Props = {
   metricType: MetricType
+  peggedToken: EvmToken
   value: number
 }
 
-export const HeadlineValue = function ({ metricType, value }: Props) {
+export const HeadlineValue = function ({
+  metricType,
+  peggedToken,
+  value,
+}: Props) {
   const locale = useLocale()
 
   if (metricType === 'apy') {
@@ -17,7 +23,7 @@ export const HeadlineValue = function ({ metricType, value }: Props) {
   const { number, suffix } = formatCompactFiatParts(value, locale)
   return (
     <>
-      <span>{number}</span>
+      <span>{`${number} ${peggedToken.symbol}`}</span>
       <span className="text-neutral-400">{suffix}</span>
     </>
   )

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
@@ -4,8 +4,9 @@ import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
 import { useLocale } from 'next-intl'
 import Skeleton from 'react-loading-skeleton'
 import { screenBreakpoints } from 'styles'
+import { EvmToken } from 'types/token'
 import {
-  formatCompactFiat,
+  formatCompactFiatParts,
   formatDate,
   formatPercentage,
   formatShortDate,
@@ -27,10 +28,10 @@ import {
 
 const getChartPadding = (metricType: MetricType) => ({
   bottom: 24,
-  // APY labels are short ("4%"), but deposits labels can be longer since
-  // locales like es/pt render compact notation with a space (eg. "$400 M"
-  // instead of the en "$400M"), so we reserve extra room for them.
-  left: metricType === 'apy' ? 28 : 51,
+  // APY labels are short ("4%"), but deposits labels carry the token symbol
+  // ("400M vetBTC") and locales like es/pt add a space in compact notation
+  // ("400 M" instead of the en "400M"), so we reserve extra room for them.
+  left: metricType === 'apy' ? 28 : 80,
   right: 0,
   top: 4,
 })
@@ -38,7 +39,7 @@ const getChartPadding = (metricType: MetricType) => ({
 const tickLabelStyle = {
   fill: '#737373',
   fontFamily: 'Geist, sans-serif',
-  fontSize: 11,
+  fontSize: 9,
   fontWeight: 500,
   letterSpacing: 0.22,
   lineHeight: '16px',
@@ -91,30 +92,40 @@ const formatFullTimestamp = (timestampMs: number, locale: string) =>
 // is explicitly asking for detail.
 type FormatPrecision = 'compact' | 'full'
 
-const formatYAxis = function (
-  value: number,
-  metricType: MetricType,
-  locale: string,
-  precision: FormatPrecision = 'compact',
-) {
+const formatYAxis = function ({
+  locale,
+  metricType,
+  peggedToken,
+  precision = 'compact',
+  value,
+}: {
+  locale: string
+  metricType: MetricType
+  peggedToken: EvmToken
+  precision?: FormatPrecision
+  value: number
+}) {
   if (metricType === 'apy') {
     return precision === 'full'
       ? formatPercentage(value)
       : `${Math.round(value)}%`
   }
-  return formatCompactFiat(value, locale)
+  const { number, suffix } = formatCompactFiatParts(value, locale)
+  return `${number}${suffix} ${peggedToken.symbol}`
 }
 
 function ChartTooltipLabel({
   datum,
   locale,
   metricType,
+  peggedToken,
   x,
   y,
 }: {
   datum?: MetricDataPoint
   locale: string
   metricType: MetricType
+  peggedToken: EvmToken
   x?: number
   y?: number
 }) {
@@ -123,12 +134,18 @@ function ChartTooltipLabel({
   }
 
   const dateText = formatFullTimestamp(datum.x, locale)
-  const valueText = formatYAxis(datum.y, metricType, locale, 'full')
+  const valueText = formatYAxis({
+    locale,
+    metricType,
+    peggedToken,
+    precision: 'full',
+    value: datum.y,
+  })
 
   return (
     <text
       dominantBaseline="central"
-      style={{ fontSize: 11 }}
+      style={{ fontSize: 9 }}
       textAnchor="middle"
       x={x}
       y={y}
@@ -165,11 +182,13 @@ const getChartWidth = (windowWidth: number) =>
 const EmptyChart = ({
   locale,
   metricType,
+  peggedToken,
   period,
   width,
 }: {
   locale: string
   metricType: MetricType
+  peggedToken: EvmToken
   period: MetricPeriod
   width: number
 }) => (
@@ -186,7 +205,9 @@ const EmptyChart = ({
     <VictoryAxis
       dependentAxis
       style={yAxisStyle}
-      tickFormat={(v: number) => formatYAxis(v, metricType, locale)}
+      tickFormat={(v: number) =>
+        formatYAxis({ locale, metricType, peggedToken, value: v })
+      }
       tickValues={metricType === 'apy' ? [0, 2, 4, 6] : undefined}
     />
   </VictoryChart>
@@ -197,6 +218,7 @@ type Props = {
   isError: boolean
   isPending: boolean
   metricType: MetricType
+  peggedToken: EvmToken
   period: MetricPeriod
 }
 
@@ -205,6 +227,7 @@ export const HistoricalMetricsChart = function ({
   isError,
   isPending,
   metricType,
+  peggedToken,
   period,
 }: Props) {
   const locale = useLocale()
@@ -230,6 +253,7 @@ export const HistoricalMetricsChart = function ({
                     <ChartTooltipLabel
                       locale={locale}
                       metricType={metricType}
+                      peggedToken={peggedToken}
                     />
                   }
                   pointerLength={0}
@@ -237,12 +261,13 @@ export const HistoricalMetricsChart = function ({
                 />
               }
               labels={({ datum }: { datum: MetricDataPoint }) =>
-                `${formatFullTimestamp(datum.x, locale)}  ${formatYAxis(
-                  datum.y,
-                  metricType,
+                `${formatFullTimestamp(datum.x, locale)}  ${formatYAxis({
                   locale,
-                  'full',
-                )}`
+                  metricType,
+                  peggedToken,
+                  precision: 'full',
+                  value: datum.y,
+                })}`
               }
               voronoiBlacklist={['area']}
             />
@@ -259,7 +284,9 @@ export const HistoricalMetricsChart = function ({
           <VictoryAxis
             dependentAxis
             style={yAxisStyle}
-            tickFormat={(v: number) => formatYAxis(v, metricType, locale)}
+            tickFormat={(v: number) =>
+              formatYAxis({ locale, metricType, peggedToken, value: v })
+            }
           />
           <AreaGradient />
           <VictoryArea
@@ -294,6 +321,7 @@ export const HistoricalMetricsChart = function ({
         <EmptyChart
           locale={locale}
           metricType={metricType}
+          peggedToken={peggedToken}
           period={period}
           width={chartWidth}
         />
@@ -306,6 +334,7 @@ export const HistoricalMetricsChart = function ({
       <EmptyChart
         locale={locale}
         metricType={metricType}
+        peggedToken={peggedToken}
         period={period}
         width={chartWidth}
       />
@@ -318,6 +347,7 @@ export const HistoricalMetricsChart = function ({
         <EmptyChart
           locale={locale}
           metricType={metricType}
+          peggedToken={peggedToken}
           period={period}
           width={chartWidth}
         />

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/index.tsx
@@ -15,31 +15,39 @@ import { HeadlineValue } from './headlineValue'
 import { HistoricalMetricsChart } from './historicalMetricsChart'
 
 type Props = {
+  peggedToken: EvmToken
   shareToken: EvmToken
 }
 
-export const HistoricalMetrics = function ({ shareToken }: Props) {
+export const HistoricalMetrics = function ({ peggedToken, shareToken }: Props) {
   const t = useTranslations('hemi-earn.pool.historical-metrics')
   const [period, setPeriod] = useState<MetricPeriod>('1w')
   const [metricType, setMetricType] = useState<MetricType>('deposits')
 
   const { data, isError, isPending } = useHistoricalMetrics({
     metricType,
+    peggedToken,
     period,
     shareToken,
   })
 
-  const lastValue =
-    data && data.length > 0 ? data[data.length - 1].y : undefined
-
   const renderHeadline = function () {
-    if (isPending) {
-      return <Skeleton className="h-7 w-28" />
+    const lastValue =
+      data && data.length > 0 ? data[data.length - 1].y : undefined
+
+    if (lastValue !== undefined) {
+      return (
+        <HeadlineValue
+          metricType={metricType}
+          peggedToken={peggedToken}
+          value={lastValue}
+        />
+      )
     }
-    if (isError || lastValue === undefined) {
+    if (isError) {
       return '-'
     }
-    return <HeadlineValue metricType={metricType} value={lastValue} />
+    return <Skeleton className="h-7 w-28" />
   }
 
   return (
@@ -121,6 +129,7 @@ export const HistoricalMetrics = function ({ shareToken }: Props) {
             isError={isError}
             isPending={isPending}
             metricType={metricType}
+            peggedToken={peggedToken}
             period={period}
           />
         </div>

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/index.tsx
@@ -32,22 +32,21 @@ export const HistoricalMetrics = function ({ peggedToken, shareToken }: Props) {
   })
 
   const renderHeadline = function () {
+    if (isPending) {
+      return <Skeleton className="h-7 w-28" />
+    }
     const lastValue =
       data && data.length > 0 ? data[data.length - 1].y : undefined
-
-    if (lastValue !== undefined) {
-      return (
-        <HeadlineValue
-          metricType={metricType}
-          peggedToken={peggedToken}
-          value={lastValue}
-        />
-      )
-    }
-    if (isError) {
+    if (isError || lastValue === undefined) {
       return '-'
     }
-    return <Skeleton className="h-7 w-28" />
+    return (
+      <HeadlineValue
+        metricType={metricType}
+        peggedToken={peggedToken}
+        value={lastValue}
+      />
+    )
   }
 
   return (

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolPageContent.tsx
@@ -81,7 +81,10 @@ export const PoolPageContent = function ({ shareAddress }: Props) {
         <div className="mt-6 flex flex-col gap-3 md:gap-5 lg:flex-row">
           <div className="order-2 flex flex-col gap-4 md:gap-5 lg:order-1 lg:basis-2/3">
             <PoolInfoCards pool={pool} />
-            <HistoricalMetrics shareToken={pool.shareToken} />
+            <HistoricalMetrics
+              peggedToken={pool.peggedToken}
+              shareToken={pool.shareToken}
+            />
             <Composition
               chainId={pool.shareToken.chainId}
               shareAddress={pool.shareAddress}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useHistoricalMetrics.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useHistoricalMetrics.ts
@@ -1,6 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
+import fetch from 'fetch-plus-plus'
+import { getStakingVaultForShare } from 'hemi-earn-actions'
 import { type EvmToken } from 'types/token'
-import { type Address } from 'viem'
+import { isValidUrl } from 'utils/url'
+import { type Address, formatUnits } from 'viem'
 
 import {
   type MetricDataPoint,
@@ -8,9 +11,11 @@ import {
   type MetricType,
 } from '../../../types'
 
-// Temporary stub: the previous subgraph endpoint was removed in #1917.
-// Returns mocked MetricDataPoint[] directly so the chart still renders;
-// re-wire to the new data source once it's available.
+const apiUrl = process.env.NEXT_PUBLIC_VETRO_API_URL
+const isVetroApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
+
+// Temporary stub: there's no APY-history endpoint yet, so the `apy` metric still
+// renders mocked MetricDataPoint[]. Re-wire it once a time series is available.
 
 const periodToMs: Record<MetricPeriod, number> = {
   '1m': 30 * 24 * 60 * 60 * 1000,
@@ -36,24 +41,47 @@ const generateMockMetric = function (
   })
 }
 
+type TotalDepositsHistory = { timestamp: number; totalDeposits: string }[]
+
+const fetchTotalDeposits = async function (
+  shareToken: EvmToken,
+  peggedToken: EvmToken,
+  period: MetricPeriod,
+): Promise<MetricDataPoint[]> {
+  const stakingVault = getStakingVaultForShare(shareToken.address as Address)
+  const history = (await fetch(
+    `${apiUrl}/variable-stake/total-deposits-history/${stakingVault}/${period}`,
+  )) as TotalDepositsHistory
+  return history.map(({ timestamp, totalDeposits }) => ({
+    x: timestamp,
+    y: Number(formatUnits(BigInt(totalDeposits), peggedToken.decimals)),
+  }))
+}
+
 type UseHistoricalMetrics = {
   metricType: MetricType
+  peggedToken: EvmToken
   period: MetricPeriod
   shareToken: EvmToken
 }
 
 export const useHistoricalMetrics = ({
   metricType,
+  peggedToken,
   period,
   shareToken,
 }: UseHistoricalMetrics) =>
   useQuery({
+    enabled: metricType === 'apy' || isVetroApiConfigured,
     queryFn: (): Promise<MetricDataPoint[]> =>
-      Promise.resolve(generateMockMetric(period, metricType)),
+      metricType === 'apy'
+        ? Promise.resolve(generateMockMetric(period, metricType))
+        : fetchTotalDeposits(shareToken, peggedToken, period),
     queryKey: [
       'historical-metrics',
       metricType,
       period,
+      peggedToken.address,
       shareToken.chainId,
       shareToken.address as Address,
     ],

--- a/portal/test/utils/format.test.ts
+++ b/portal/test/utils/format.test.ts
@@ -243,49 +243,49 @@ describe('utils/format', function () {
 
     it('should split number and suffix for millions in en locale', function () {
       expect(formatCompactFiatParts(420_170_000, 'en')).toEqual({
-        number: '$420.17',
+        number: '420.17',
         suffix: 'M',
       })
     })
 
     it('should split number and suffix for billions in en locale', function () {
       expect(formatCompactFiatParts(1_234_567_890, 'en')).toEqual({
-        number: '$1.23',
+        number: '1.23',
         suffix: 'B',
       })
     })
 
     it('should return an empty suffix for small numbers', function () {
       expect(formatCompactFiatParts(999, 'en')).toEqual({
-        number: '$999',
+        number: '999',
         suffix: '',
       })
     })
 
     it('should return an empty suffix for zero', function () {
       expect(formatCompactFiatParts(0, 'en')).toEqual({
-        number: '$0',
+        number: '0',
         suffix: '',
       })
     })
 
     it('should honor an explicit maximumFractionDigits', function () {
       expect(formatCompactFiatParts(420_170_000, 'en', 0)).toEqual({
-        number: '$420',
+        number: '420',
         suffix: 'M',
       })
     })
 
     it('should use comma decimals in es locale', function () {
       expect(formatCompactFiatParts(420_170_000, 'es')).toEqual({
-        number: `$420,17${nbsp}`,
+        number: `420,17${nbsp}`,
         suffix: 'M',
       })
     })
 
     it('should use "mi" suffix in pt locale', function () {
       expect(formatCompactFiatParts(420_170_000, 'pt')).toEqual({
-        number: `$420,17${nbsp}`,
+        number: `420,17${nbsp}`,
         suffix: 'mi',
       })
     })

--- a/portal/utils/format.ts
+++ b/portal/utils/format.ts
@@ -125,7 +125,7 @@ export const formatCompactFiatParts = function (
     .filter(p => p.type !== 'compact')
     .map(p => p.value)
     .join('')
-  return { number: `$${number}`, suffix }
+  return { number, suffix }
 }
 
 export const formatDate = (date: Date, locale: string) =>


### PR DESCRIPTION
### Description

Wires the pool page's historical "deposits" (TVL) chart to real data from the Vetro API, replacing the previous mock. The series is fetched from \`/variable-stake/total-deposits-history/<stakingVault>/<period>\`, resolving the staking vault from the share token, and amounts are scaled by the pegged token's decimals.

The APY metric still renders mocked data — there's no APY time-series endpoint yet, so it stays stubbed until one is available.

Deposits values now render in compact notation with the pegged token symbol (eg. "420M vetBTC") across the headline, y-axis and tooltip. As a result \`formatCompactFiatParts\` no longer hardcodes a "$" prefix, and the y-axis reserves extra left padding for the longer labels.

Also fixes \`renderHeadline\` so a zero last value renders correctly instead of falling through to the loading skeleton.

Note: this depends on the \`NEXT_PUBLIC_VETRO_API_URL\` env var; when it's unset the deposits query stays disabled and only the (mocked) APY metric works.

### Screenshots

<img width="2210" height="748" alt="image" src="https://github.com/user-attachments/assets/6c46a8d1-eb08-40c0-9e60-453cbb666a5a" />

<img width="1058" height="363" alt="image" src="https://github.com/user-attachments/assets/141beb99-e98f-4796-b551-4966a8019577" />

<img width="1075" height="333" alt="image" src="https://github.com/user-attachments/assets/d2d1c83c-fd1f-40da-a0db-d49869fc93be" />

Just wiring, and a tiny update on the axis' labels styles

### Related issue(s)

Related to #1967

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.