### PR TITLE
Return upstream errors as 502

### DIFF
--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "scripts": {
     "build": "tsc",
     "start": "node --import=./src/instrument.ts server.ts"

--- a/portal-backend/api/server.ts
+++ b/portal-backend/api/server.ts
@@ -9,6 +9,7 @@ import { createDune, type DuneOptions } from './src/dune.ts'
 import { globToRegExp } from './src/glob-to-regexp.ts'
 import { createNetStats, type NetStatsOptions } from './src/net-stats.ts'
 import { createRedisCache, type RedisOptions } from './src/redis.ts'
+import { UpstreamGraphQLError } from './src/subgraphs/errors.ts'
 import { createSubgraphsRouter } from './src/subgraphs/router.ts'
 import { toJsonMiddleware, toTextMiddleware } from './src/to-middleware.ts'
 import { createVeHemi } from './src/ve-hemi/index.ts'
@@ -90,6 +91,13 @@ app.use(notFoundHandler)
 setupExpressErrorHandler(app)
 
 const errorHandler: ErrorRequestHandler = function (error, _req, res, _next) {
+  if (error instanceof UpstreamGraphQLError) {
+    // Intentionally not filtered from Sentry — upstream issues are still
+    // tracked there
+    console.warn('Upstream GraphQL error:', error)
+    res.status(502).send({ error: 'Bad Gateway' })
+    return
+  }
   console.error('Internal Server Error:', error)
   res.status(500).send({ error: 'Internal Server Error' })
 }

--- a/portal-backend/api/src/subgraphs/errors.ts
+++ b/portal-backend/api/src/subgraphs/errors.ts
@@ -1,0 +1,6 @@
+export class UpstreamGraphQLError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'UpstreamGraphQLError'
+  }
+}

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -79,7 +79,7 @@ const getTunnelSubgraphUrl = function (chainId: Chain['id']) {
 /**
  * Helper function to check for errors in GraphQL responses
  * @param response The GraphQL response to check
- * @throws Error if the response contains errors
+ * @throws UpstreamGraphQLError if the response contains errors
  */
 function checkGraphQLErrors<T>(
   response: GraphResponse<T>,

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -12,6 +12,7 @@ import { hemi, hemiSepolia, mainnet, sepolia } from 'viem/chains'
 
 import { postJson } from '../post-json.ts'
 
+import { UpstreamGraphQLError } from './errors.ts'
 import type {
   BtcDepositOperation,
   EvmDepositOperation,
@@ -54,6 +55,8 @@ const getSubgraphUrl = function ({
 const request = <TResponse>(url: string, schema: Schema): Promise<TResponse> =>
   postJson(url, schema, {
     headers: { Origin: subgraphConfig.origin },
+  }).catch(function (err) {
+    throw new UpstreamGraphQLError(err.message, { cause: err })
   }) as Promise<TResponse>
 
 const getTunnelSubgraphUrl = function (chainId: Chain['id']) {
@@ -85,7 +88,7 @@ function checkGraphQLErrors<T>(
   if ('errors' in response && response.errors.length > 0) {
     // Extract error messages and join them
     const errorMessages = response.errors.map(e => e.message).join(', ')
-    throw new Error(`GraphQL Error: ${errorMessages}`)
+    throw new UpstreamGraphQLError(`GraphQL Error: ${errorMessages}`)
   }
 }
 

--- a/portal-backend/api/src/to-middleware.ts
+++ b/portal-backend/api/src/to-middleware.ts
@@ -37,11 +37,9 @@ function toJsonMiddleware(
   return async function (req, res) {
     const [err, data] = await wrapped(...Object.values(req.params))
     if (err) {
-      console.error(`Failed to handle request to ${req.path}: ${err.stack}`)
-      res.status(500).json({ error: 'Internal Server Error' })
-    } else {
-      res.status(200).json(data)
+      throw err
     }
+    res.status(200).json(data)
   }
 }
 
@@ -53,11 +51,11 @@ function toTextMiddleware(
   return async function (req, res) {
     const [err, data] = await wrapped(...Object.values(req.params))
     if (err) {
-      console.error(`Failed to handle request to ${req.path}: ${err.stack}`)
-      res.status(500).type('text').send('Internal Server Error')
-    } else {
-      res.status(200).type('text').send(data.toString())
+      // Errors are rethrown to the global error handler, which responds with
+      // JSON regardless of the route's content type. This is ok for now.
+      throw err
     }
+    res.status(200).type('text').send(data.toString())
   }
 }
 


### PR DESCRIPTION
### Summary

The Graph infrastructure and API are failing too often. It is better to return these errors as 502 instead of taking the blame by returning plain 500s.

— The real Gabi

### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request introduces improved error handling for upstream GraphQL errors in the subgraph integration. The main changes include defining a custom `UpstreamGraphQLError` class, ensuring all upstream GraphQL errors are wrapped in this class, and updating the Express error handler to respond with a 502 Bad Gateway for these errors.

**Error handling improvements:**

* Added a new `UpstreamGraphQLError` class in `errors.ts` to represent errors originating from upstream GraphQL services.
* Updated the `request` and `checkGraphQLErrors` functions in `subgraph.ts` to throw `UpstreamGraphQLError` instead of generic errors when upstream issues occur. [[1]](diffhunk://#diff-663006409f3f251a3a30d6d149ce3b48bdab165e7725912157e4530ecf6a9fbbR58-R59) [[2]](diffhunk://#diff-663006409f3f251a3a30d6d149ce3b48bdab165e7725912157e4530ecf6a9fbbL88-R91)
* Modified the Express error handler in `server.ts` to catch `UpstreamGraphQLError` and return a 502 Bad Gateway response, while logging the error for monitoring.

**Codebase integration:**

* Imported `UpstreamGraphQLError` where needed in `server.ts` and `subgraph.ts` to support the new error handling logic. [[1]](diffhunk://#diff-3dd6c4f79045e7e5cf0edb3a924d407c1af02753ce346c694e36823fe68cf63bR12) [[2]](diffhunk://#diff-663006409f3f251a3a30d6d149ce3b48bdab165e7725912157e4530ecf6a9fbbR15)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
