### PR TITLE
Derive Hemi Earn agent address on-chain (drop hardcoded constant)

### DIFF
--- a/packages/hemi-earn-actions/index.ts
+++ b/packages/hemi-earn-actions/index.ts
@@ -1,5 +1,4 @@
 export {
-  HEMI_EARN_AGENT_ADDRESS,
   HEMI_EARN_ROUTER_ADDRESS,
   HEMI_EARN_SHARES,
   HEMI_EARN_SHARES_REGISTRY,
@@ -7,7 +6,6 @@ export {
   type HemiEarnAsset,
   type HemiEarnShareEntry,
   SVETBTC_OFT_ADDRESS,
-  getHemiEarnAgentAddress,
   getHemiEarnRouterAddress,
   getHemiEarnShares,
   getHemiEarnSupportedAssets,

--- a/packages/hemi-earn-actions/src/actions/index.ts
+++ b/packages/hemi-earn-actions/src/actions/index.ts
@@ -1,6 +1,7 @@
 export {
   type AssetData,
   type Request,
+  getAgentAddress,
   getAssetData,
   getRequest,
   quoteDeposit,

--- a/packages/hemi-earn-actions/src/actions/public/getAgentAddress.ts
+++ b/packages/hemi-earn-actions/src/actions/public/getAgentAddress.ts
@@ -1,0 +1,45 @@
+import {
+  type Address,
+  type Client,
+  getAddress,
+  isAddress,
+  isAddressEqual,
+  slice,
+  zeroAddress,
+} from 'viem'
+import { readContract } from 'viem/actions'
+
+import { getHemiEarnRouterAddress } from '../../constants'
+import { routerAbi } from '../../routerAbi'
+
+// Reads the LayerZero peer stored on the Router (Hemi-side) and decodes it into
+// the Agent's address on Ethereum. The peer is stored as a left-padded bytes32,
+// so the address is the trailing 20 bytes.
+export const getAgentAddress = async function (
+  client: Client,
+  {
+    routerAddress = getHemiEarnRouterAddress(),
+  }: {
+    routerAddress?: Address
+  } = {},
+): Promise<Address> {
+  if (!client) {
+    throw new Error('getAgentAddress: `client` is not defined')
+  }
+  if (!isAddress(routerAddress, { strict: false })) {
+    throw new Error('getAgentAddress: `routerAddress` is not a valid address')
+  }
+  if (isAddressEqual(routerAddress, zeroAddress)) {
+    throw new Error(
+      'getAgentAddress: `routerAddress` cannot be the zero address',
+    )
+  }
+
+  const peer = await readContract(client, {
+    abi: routerAbi,
+    address: routerAddress,
+    functionName: 'peerAddress',
+  })
+
+  return getAddress(slice(peer, 12))
+}

--- a/packages/hemi-earn-actions/src/actions/public/index.ts
+++ b/packages/hemi-earn-actions/src/actions/public/index.ts
@@ -1,3 +1,4 @@
+export { getAgentAddress } from './getAgentAddress'
 export { type AssetData, getAssetData } from './getAssetData'
 export { type Request, getRequest } from './getRequest'
 export { quoteDeposit } from './quoteDeposit'

--- a/packages/hemi-earn-actions/src/actions/public/quoteDepositFulfillment.ts
+++ b/packages/hemi-earn-actions/src/actions/public/quoteDepositFulfillment.ts
@@ -1,8 +1,13 @@
-import { type Address, type Client, isAddressEqual, zeroAddress } from 'viem'
+import {
+  type Address,
+  type Client,
+  isAddress,
+  isAddressEqual,
+  zeroAddress,
+} from 'viem'
 import { readContract } from 'viem/actions'
 
 import { agentAbi } from '../../agentAbi'
-import { getHemiEarnAgentAddress } from '../../constants'
 
 // Reads the LayerZero native fee the Agent on Ethereum needs to send the
 // fulfillment response (sVetToken OFT) back to the Router on Hemi. The
@@ -15,14 +20,24 @@ import { getHemiEarnAgentAddress } from '../../constants'
 // `assetsData(asset)` mapping; the share has to be supplied directly.
 // Resolve via `getStakingVaultForShare(shareOft)` on the portal.
 export const quoteDepositFulfillment = async function ({
-  agentAddress = getHemiEarnAgentAddress(),
+  agentAddress,
   client,
   share,
 }: {
-  agentAddress?: Address
+  agentAddress: Address
   client: Client
   share: Address
 }): Promise<bigint> {
+  if (!isAddress(agentAddress, { strict: false })) {
+    throw new Error(
+      'quoteDepositFulfillment: `agentAddress` is not a valid address',
+    )
+  }
+  if (isAddressEqual(agentAddress, zeroAddress)) {
+    throw new Error(
+      'quoteDepositFulfillment: `agentAddress` cannot be the zero address',
+    )
+  }
   if (isAddressEqual(share, zeroAddress)) {
     throw new Error(
       'quoteDepositFulfillment: `share` cannot be the zero address',

--- a/packages/hemi-earn-actions/src/actions/public/quoteRedeemFulfillment.ts
+++ b/packages/hemi-earn-actions/src/actions/public/quoteRedeemFulfillment.ts
@@ -1,8 +1,13 @@
-import { type Address, type Client, isAddressEqual, zeroAddress } from 'viem'
+import {
+  type Address,
+  type Client,
+  isAddress,
+  isAddressEqual,
+  zeroAddress,
+} from 'viem'
 import { readContract } from 'viem/actions'
 
 import { agentAbi } from '../../agentAbi'
-import { getHemiEarnAgentAddress } from '../../constants'
 
 // Reads the LayerZero native fee the Agent on Ethereum needs to send the
 // fulfillment response back to the Router on Hemi for a redeem. Caller passes
@@ -10,14 +15,24 @@ import { getHemiEarnAgentAddress } from '../../constants'
 // `requestRedeem`. The Agent looks up the share OFT internally from the asset
 // address — the portal only needs to supply the asset.
 export const quoteRedeemFulfillment = async function ({
-  agentAddress = getHemiEarnAgentAddress(),
+  agentAddress,
   asset,
   client,
 }: {
-  agentAddress?: Address
+  agentAddress: Address
   asset: Address
   client: Client
 }): Promise<bigint> {
+  if (!isAddress(agentAddress, { strict: false })) {
+    throw new Error(
+      'quoteRedeemFulfillment: `agentAddress` is not a valid address',
+    )
+  }
+  if (isAddressEqual(agentAddress, zeroAddress)) {
+    throw new Error(
+      'quoteRedeemFulfillment: `agentAddress` cannot be the zero address',
+    )
+  }
   if (isAddressEqual(asset, zeroAddress)) {
     throw new Error(
       'quoteRedeemFulfillment: `asset` cannot be the zero address',

--- a/packages/hemi-earn-actions/src/constants.ts
+++ b/packages/hemi-earn-actions/src/constants.ts
@@ -7,11 +7,6 @@ import { type Address, type Client, isAddressEqual, zeroAddress } from 'viem'
 // the addresses are confirmed.
 export const HEMI_EARN_ROUTER_ADDRESS: Address = zeroAddress
 
-// TODO: placeholder — replace with the deployed Agent on Ethereum mainnet
-// once the addresses are confirmed. Used by the portal to quote the
-// LayerZero fulfillment fee from the remote chain.
-export const HEMI_EARN_AGENT_ADDRESS: Address = zeroAddress
-
 // Named address constants for each share OFT registered on the Router.
 // Exported individually so the portal (and other consumers) can import the
 // canonical address without re-declaring it. Mirrors Vetro's pattern
@@ -97,8 +92,6 @@ export type HemiEarnAsset = {
 export const HEMI_EARN_SUPPORTED_ASSETS: readonly HemiEarnAsset[] = [] as const
 
 export const getHemiEarnRouterAddress = () => HEMI_EARN_ROUTER_ADDRESS
-
-export const getHemiEarnAgentAddress = () => HEMI_EARN_AGENT_ADDRESS
 
 export const getHemiEarnShares = () =>
   HEMI_EARN_SHARES.filter(s => !isAddressEqual(s, zeroAddress))

--- a/packages/hemi-earn-actions/src/routerAbi.ts
+++ b/packages/hemi-earn-actions/src/routerAbi.ts
@@ -358,4 +358,11 @@ export const routerAbi = [
     name: 'AssetDataUpdated',
     type: 'event',
   },
+  {
+    inputs: [],
+    name: 'peerAddress',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
 ] as const

--- a/packages/hemi-earn-actions/test/actions/public/getAgentAddress.test.ts
+++ b/packages/hemi-earn-actions/test/actions/public/getAgentAddress.test.ts
@@ -9,6 +9,17 @@ vi.mock('viem/actions', () => ({
   readContract: vi.fn(),
 }))
 
+// The real Router address is still a TBD placeholder (zeroAddress) in
+// constants, which would trip the zero-address guard on the default-router
+// path. Mock a non-zero default until the deployed address lands.
+const { defaultRouterAddress } = vi.hoisted(() => ({
+  defaultRouterAddress: '0x000000000000000000000000000000000000cAFe',
+}))
+
+vi.mock('../../../src/constants', () => ({
+  getHemiEarnRouterAddress: () => defaultRouterAddress,
+}))
+
 const client = {} as Client
 const routerAddress = '0x000000000000000000000000000000000000bEEf' as Address
 // A full 20-byte agent address left-padded into a bytes32, so the test

--- a/packages/hemi-earn-actions/test/actions/public/getAgentAddress.test.ts
+++ b/packages/hemi-earn-actions/test/actions/public/getAgentAddress.test.ts
@@ -1,0 +1,67 @@
+import { type Address, type Client, getAddress, zeroAddress } from 'viem'
+import { readContract } from 'viem/actions'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getAgentAddress } from '../../../src/actions/public/getAgentAddress'
+import { getHemiEarnRouterAddress } from '../../../src/constants'
+
+vi.mock('viem/actions', () => ({
+  readContract: vi.fn(),
+}))
+
+const client = {} as Client
+const routerAddress = '0x000000000000000000000000000000000000bEEf' as Address
+// A full 20-byte agent address left-padded into a bytes32, so the test
+// exercises the slicing across the whole address (not just trailing zeros).
+const agentAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+const peer = `0x000000000000000000000000${agentAddress.slice(2)}`
+const expectedAgent = getAddress(agentAddress)
+
+describe('getAgentAddress', function () {
+  it('reads `peerAddress` from the Router and decodes it into an address', async function () {
+    vi.mocked(readContract).mockResolvedValue(peer)
+
+    const result = await getAgentAddress(client, { routerAddress })
+
+    expect(result).toBe(expectedAgent)
+    expect(readContract).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        address: routerAddress,
+        functionName: 'peerAddress',
+      }),
+    )
+  })
+
+  it('falls back to the default router address', async function () {
+    vi.mocked(readContract).mockResolvedValue(peer)
+
+    await getAgentAddress(client)
+
+    expect(readContract).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        address: getHemiEarnRouterAddress(),
+        functionName: 'peerAddress',
+      }),
+    )
+  })
+
+  it('rejects a missing `client`', async function () {
+    await expect(
+      getAgentAddress(undefined as unknown as Client, { routerAddress }),
+    ).rejects.toThrow(/`client` is not defined/)
+  })
+
+  it('rejects a zero `routerAddress`', async function () {
+    await expect(
+      getAgentAddress(client, { routerAddress: zeroAddress }),
+    ).rejects.toThrow(/`routerAddress` cannot be the zero address/)
+  })
+
+  it('rejects an invalid `routerAddress`', async function () {
+    await expect(
+      getAgentAddress(client, { routerAddress: '0xnotanaddress' as Address }),
+    ).rejects.toThrow(/`routerAddress` is not a valid address/)
+  })
+})

--- a/packages/hemi-earn-actions/test/actions/public/quoteDepositFulfillment.test.ts
+++ b/packages/hemi-earn-actions/test/actions/public/quoteDepositFulfillment.test.ts
@@ -42,4 +42,24 @@ describe('quoteDepositFulfillment', function () {
       }),
     ).rejects.toThrow(/`share` cannot be the zero address/)
   })
+
+  it('rejects the zero address as agentAddress', async function () {
+    await expect(
+      quoteDepositFulfillment({
+        agentAddress: zeroAddress,
+        client,
+        share,
+      }),
+    ).rejects.toThrow(/`agentAddress` cannot be the zero address/)
+  })
+
+  it('rejects an invalid agentAddress', async function () {
+    await expect(
+      quoteDepositFulfillment({
+        agentAddress: '0xnotanaddress' as Address,
+        client,
+        share,
+      }),
+    ).rejects.toThrow(/`agentAddress` is not a valid address/)
+  })
 })

--- a/packages/hemi-earn-actions/test/actions/public/quoteRedeemFulfillment.test.ts
+++ b/packages/hemi-earn-actions/test/actions/public/quoteRedeemFulfillment.test.ts
@@ -42,4 +42,24 @@ describe('quoteRedeemFulfillment', function () {
       }),
     ).rejects.toThrow(/`asset` cannot be the zero address/)
   })
+
+  it('rejects the zero address as agentAddress', async function () {
+    await expect(
+      quoteRedeemFulfillment({
+        agentAddress: zeroAddress,
+        asset,
+        client,
+      }),
+    ).rejects.toThrow(/`agentAddress` cannot be the zero address/)
+  })
+
+  it('rejects an invalid agentAddress', async function () {
+    await expect(
+      quoteRedeemFulfillment({
+        agentAddress: '0xnotanaddress' as Address,
+        asset,
+        client,
+      }),
+    ).rejects.toThrow(/`agentAddress` is not a valid address/)
+  })
 })

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnAgentAddress.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnAgentAddress.ts
@@ -1,0 +1,16 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import { getAgentAddress } from 'hemi-earn-actions/actions'
+import { getPublicClient } from 'utils/chainClients'
+import { hemi } from 'viem/chains'
+
+export const agentAddressQueryOptions = () =>
+  queryOptions({
+    queryFn: () => getAgentAddress(getPublicClient(hemi.id)),
+    queryKey: ['hemi-earn', 'agent-address'],
+    // `Router.peerAddress()` on Hemi, decoded to the Agent address on Ethereum.
+    // Immutable once the peer is set, so cache it indefinitely.
+    staleTime: Infinity,
+  })
+
+export const useHemiEarnAgentAddress = () =>
+  useQuery(agentAddressQueryOptions())

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnAgentAddress.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnAgentAddress.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery } from '@tanstack/react-query'
+import { queryOptions } from '@tanstack/react-query'
 import { getAgentAddress } from 'hemi-earn-actions/actions'
 import { getPublicClient } from 'utils/chainClients'
 import { hemi } from 'viem/chains'
@@ -11,6 +11,3 @@ export const agentAddressQueryOptions = () =>
     // Immutable once the peer is set, so cache it indefinitely.
     staleTime: Infinity,
   })
-
-export const useHemiEarnAgentAddress = () =>
-  useQuery(agentAddressQueryOptions())

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnAgentAddress.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnAgentAddress.ts
@@ -5,6 +5,7 @@ import { hemi } from 'viem/chains'
 
 export const agentAddressQueryOptions = () =>
   queryOptions({
+    gcTime: Infinity,
     queryFn: () => getAgentAddress(getPublicClient(hemi.id)),
     queryKey: ['hemi-earn', 'agent-address'],
     // `Router.peerAddress()` on Hemi, decoded to the Agent address on Ethereum.

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.ts
@@ -1,7 +1,6 @@
 import { type QueryClient, type UseQueryOptions } from '@tanstack/react-query'
 import { previewDeposit } from '@vetro-protocol/gateway/actions'
 import {
-  getHemiEarnAgentAddress,
   getHemiEarnRouterAddress,
   getStakingVaultForShare,
 } from 'hemi-earn-actions'
@@ -16,6 +15,7 @@ import { type Address } from 'viem'
 
 import { gatewayForAssetQueryOptions } from '../../../_hooks/gatewayForAsset'
 import { assetDataQueryOptions } from '../../../_hooks/useAssetData'
+import { agentAddressQueryOptions } from '../../../_hooks/useHemiEarnAgentAddress'
 
 export type QuoteDeposit = {
   callbackFee: bigint
@@ -54,11 +54,15 @@ export async function fetchQuoteDeposit({
     }),
   )
 
-  const callbackFeePromise = quoteDepositFulfillment({
-    agentAddress: getHemiEarnAgentAddress(),
-    client: ethereumClient,
-    share: getStakingVaultForShare(shareAddress),
-  })
+  const callbackFeePromise = queryClient
+    .ensureQueryData(agentAddressQueryOptions())
+    .then(agentAddress =>
+      quoteDepositFulfillment({
+        agentAddress,
+        client: ethereumClient,
+        share: getStakingVaultForShare(shareAddress),
+      }),
+    )
 
   const [callbackFee, nativeFee, peggedAmount] = await Promise.all([
     callbackFeePromise,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.ts
@@ -1,6 +1,5 @@
-import { type UseQueryOptions } from '@tanstack/react-query'
+import { type QueryClient, type UseQueryOptions } from '@tanstack/react-query'
 import {
-  getHemiEarnAgentAddress,
   getHemiEarnRouterAddress,
   getStakingVaultForShare,
 } from 'hemi-earn-actions'
@@ -15,6 +14,8 @@ import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient, getPublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 
+import { agentAddressQueryOptions } from '../../../_hooks/useHemiEarnAgentAddress'
+
 export type QuoteRedeem = {
   callbackFee: bigint
   isInstant: boolean
@@ -24,6 +25,7 @@ export type QuoteRedeem = {
 export type QuoteRedeemParams = {
   account: Address
   asset: Address
+  queryClient: QueryClient
   shareAddress: Address
   shares: bigint
 }
@@ -35,12 +37,13 @@ export type QuoteRedeemParams = {
 export async function fetchQuoteRedeem({
   account,
   asset,
+  queryClient,
   shareAddress,
   shares,
 }: QuoteRedeemParams): Promise<QuoteRedeem> {
   const ethereumClient = getEvmL1PublicClient(mainnet.id)
   const hemiClient = getPublicClient(hemi.id)
-  const [isInstant, assetData] = await Promise.all([
+  const [isInstant, assetData, agentAddress] = await Promise.all([
     resolveIsInstant({
       caller: account,
       client: ethereumClient,
@@ -50,9 +53,10 @@ export async function fetchQuoteRedeem({
       asset,
       routerAddress: getHemiEarnRouterAddress(),
     }),
+    queryClient.ensureQueryData(agentAddressQueryOptions()),
   ])
   const callbackFee = await quoteRedeemFulfillment({
-    agentAddress: getHemiEarnAgentAddress(),
+    agentAddress,
     asset: assetData.remoteAsset,
     client: ethereumClient,
   })
@@ -76,7 +80,7 @@ const getQuoteRedeemQueryKey = ({
   asset,
   shareAddress,
   shares,
-}: QuoteRedeemHookParams) =>
+}: Omit<QuoteRedeemHookParams, 'queryClient'>) =>
   [
     'hemi-earn',
     'quote-redeem',
@@ -89,12 +93,19 @@ const getQuoteRedeemQueryKey = ({
 export const quoteRedeemOptions = ({
   account,
   asset,
+  queryClient,
   shareAddress,
   shares,
 }: QuoteRedeemHookParams): UseQueryOptions<QuoteRedeem> => ({
   enabled: shares > BigInt(0) && !!account,
   // The `enabled` flag above guarantees `account` is defined when this runs.
   queryFn: () =>
-    fetchQuoteRedeem({ account: account!, asset, shareAddress, shares }),
+    fetchQuoteRedeem({
+      account: account!,
+      asset,
+      queryClient,
+      shareAddress,
+      shares,
+    }),
   queryKey: getQuoteRedeemQueryKey({ account, asset, shareAddress, shares }),
 })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteRedeem.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteRedeem.ts
@@ -1,9 +1,10 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import {
   type QuoteRedeemHookParams,
   quoteRedeemOptions,
 } from '../_fetchers/fetchQuoteRedeem'
 
-export const useQuoteRedeem = (params: QuoteRedeemHookParams) =>
-  useQuery(quoteRedeemOptions(params))
+export const useQuoteRedeem = (
+  params: Omit<QuoteRedeemHookParams, 'queryClient'>,
+) => useQuery(quoteRedeemOptions({ ...params, queryClient: useQueryClient() }))

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchQuoteDeposit } from '../../../../../../../app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit'
 
 vi.mock('hemi-earn-actions/actions', () => ({
+  getAgentAddress: vi.fn(),
   getAssetData: vi.fn(),
   quoteDeposit: vi.fn(),
   quoteDepositFulfillment: vi.fn(),
@@ -19,7 +20,6 @@ vi.mock('@vetro-protocol/gateway/actions', () => ({
 }))
 
 vi.mock('hemi-earn-actions', () => ({
-  getHemiEarnAgentAddress: () => '0xAgent',
   getHemiEarnRouterAddress: () => '0xRouter',
   getHemiEarnSupportedAssets: () => [],
   getStakingVaultForShare: () => '0xStakingVault',
@@ -47,6 +47,8 @@ const assetData = {
 const createQueryClient = () => ({
   ensureQueryData: vi.fn(function ({ queryKey }) {
     switch (queryKey[1]) {
+      case 'agent-address':
+        return Promise.resolve('0xAgent')
       case 'gateway-for-asset':
         return Promise.resolve(gateway)
       case 'asset-data':
@@ -90,6 +92,19 @@ describe('fetchQuoteDeposit', function () {
     expect(previewDeposit).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ amountIn: BigInt(1000), tokenIn: remoteAsset }),
+    )
+  })
+
+  it('threads the resolved agentAddress through quoteDepositFulfillment', async function () {
+    await fetchQuoteDeposit({
+      amount: BigInt(1000),
+      asset,
+      queryClient: createQueryClient() as never,
+      shareAddress,
+    })
+
+    expect(quoteDepositFulfillment).toHaveBeenCalledWith(
+      expect.objectContaining({ agentAddress: '0xAgent' }),
     )
   })
 

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.test.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchQuoteRedeem } from '../../../../../../../app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem'
 
 vi.mock('hemi-earn-actions/actions', () => ({
+  getAgentAddress: vi.fn(),
   getAssetData: vi.fn(),
   quoteRedeem: vi.fn(),
   quoteRedeemFulfillment: vi.fn(),
@@ -17,7 +18,6 @@ vi.mock('hemi-earn-actions/actions', () => ({
 }))
 
 vi.mock('hemi-earn-actions', () => ({
-  getHemiEarnAgentAddress: () => '0xAgent',
   getHemiEarnRouterAddress: () => '0xRouter',
   getStakingVaultForShare: () => '0xStakingVault',
 }))
@@ -31,6 +31,19 @@ const account = '0x9999999999999999999999999999999999999999' as Address
 const asset = '0x1111111111111111111111111111111111111111' as Address
 const shareAddress = '0x2222222222222222222222222222222222222222' as Address
 const remoteAsset = '0x3333333333333333333333333333333333333333' as Address
+
+// Fake query client that resolves the agent-address lookup the fetcher threads
+// through the cache, branching on the query's key.
+const createQueryClient = () => ({
+  ensureQueryData: vi.fn(function ({ queryKey }) {
+    switch (queryKey[1]) {
+      case 'agent-address':
+        return Promise.resolve('0xAgent')
+      default:
+        return Promise.reject(new Error(`unexpected query ${queryKey[1]}`))
+    }
+  }),
+})
 
 describe('fetchQuoteRedeem', function () {
   beforeEach(function () {
@@ -49,6 +62,7 @@ describe('fetchQuoteRedeem', function () {
     const result = await fetchQuoteRedeem({
       account,
       asset,
+      queryClient: createQueryClient() as never,
       shareAddress,
       shares: BigInt(500),
     })
@@ -64,12 +78,13 @@ describe('fetchQuoteRedeem', function () {
     await fetchQuoteRedeem({
       account,
       asset,
+      queryClient: createQueryClient() as never,
       shareAddress,
       shares: BigInt(500),
     })
 
     expect(quoteRedeemFulfillment).toHaveBeenCalledWith(
-      expect.objectContaining({ asset: remoteAsset }),
+      expect.objectContaining({ agentAddress: '0xAgent', asset: remoteAsset }),
     )
   })
 
@@ -80,6 +95,7 @@ describe('fetchQuoteRedeem', function () {
     await fetchQuoteRedeem({
       account,
       asset,
+      queryClient: createQueryClient() as never,
       shareAddress,
       shares: BigInt(500),
     })
@@ -99,7 +115,13 @@ describe('fetchQuoteRedeem', function () {
     )
 
     await expect(
-      fetchQuoteRedeem({ account, asset, shareAddress, shares: BigInt(500) }),
+      fetchQuoteRedeem({
+        account,
+        asset,
+        queryClient: createQueryClient() as never,
+        shareAddress,
+        shares: BigInt(500),
+      }),
     ).rejects.toThrow('Vault unreachable')
   })
 })


### PR DESCRIPTION
### Description

Replaces the hardcoded `HEMI_EARN_AGENT_ADDRESS` placeholder with an on-chain lookup, so the Ethereum-side Agent address is derived from the deployed contracts instead of being maintained by hand.

A new public action `getAgentAddress` reads `Router.peerAddress()` on Hemi (the LayerZero peer, stored as a left-padded `bytes32`) and decodes it to the Agent's address. A `useHemiEarnAgentAddress` hook + `agentAddressQueryOptions` wrap it (cached indefinitely, since the peer is immutable once set). The deposit and redeem quote fetchers now resolve the agent address through that query, and `quoteDepositFulfillment` / `quoteRedeemFulfillment` take `agentAddress` as a required, validated argument. The `HEMI_EARN_AGENT_ADDRESS` constant and `getHemiEarnAgentAddress` getter are removed; the Router address remains the single hardcoded anchor.

**Commits:**
3f8026b5 Add getAgentAddress public earn action
8009deeb Resolve Hemi Earn agent address on-chain

### Screenshots

N/A — data/logic layer only, no UI changes.

### Related issue(s)

Related to #1973

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
