### PR TITLE
Bump openssl pin to 3.5.7-r0 in Dockerfiles

### DIFF
--- a/portal-backend/api/Dockerfile
+++ b/portal-backend/api/Dockerfile
@@ -30,7 +30,7 @@ FROM node:24.14.0-alpine3.23
 # Patch vulnerabilities
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
-RUN apk add --upgrade openssl=3.5.6-r0
+RUN apk add --upgrade openssl=3.5.7-r0
 RUN npm install --global npm@11.12.0
 RUN corepack enable
 # Skip corepack's interactive download prompt so the `node` user can fetch

--- a/portal-backend/cron/hemi-supply/Dockerfile
+++ b/portal-backend/cron/hemi-supply/Dockerfile
@@ -21,7 +21,7 @@ FROM node:24.14.0-alpine3.23
 # Patch vulnerabilities
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
-RUN apk add --upgrade openssl=3.5.6-r0
+RUN apk add --upgrade openssl=3.5.7-r0
 RUN npm install --global npm@11.12.0
 RUN corepack enable
 # Skip corepack's interactive download prompt so the `node` user can fetch

--- a/portal-backend/cron/token-prices/Dockerfile
+++ b/portal-backend/cron/token-prices/Dockerfile
@@ -21,7 +21,7 @@ FROM node:24.14.0-alpine3.23
 # Patch vulnerabilities
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
-RUN apk add --upgrade openssl=3.5.6-r0
+RUN apk add --upgrade openssl=3.5.7-r0
 RUN npm install --global npm@11.12.0
 RUN corepack enable
 # Skip corepack's interactive download prompt so the `node` user can fetch

--- a/portal-backend/cron/vaults-monitor/Dockerfile
+++ b/portal-backend/cron/vaults-monitor/Dockerfile
@@ -21,7 +21,7 @@ FROM node:24.14.0-alpine3.23
 # Patch vulnerabilities
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
-RUN apk add --upgrade openssl=3.5.6-r0
+RUN apk add --upgrade openssl=3.5.7-r0
 RUN npm install --global npm@11.12.0
 RUN corepack enable
 # Skip corepack's interactive download prompt so the `node` user can fetch


### PR DESCRIPTION
### Description

This PR fixes the portal-backend Docker builds, which started failing in CI because the Alpine 3.23 package index dropped `openssl=3.5.6-r0` and now only publishes `3.5.7-r0`. The old pin can no longer be resolved, so `apk add --upgrade openssl=3.5.6-r0` aborts with `breaks: world[openssl=3.5.6-r0]` and every image build dies at that step.

  The fix just moves the pin forward to the version the index exposes. apk takes care of pulling `libcrypto3=3.5.7-r0` and `libssl3=3.5.7-r0` as transitive deps, so the rest of the Dockerfile stays the same. The exact same line was duplicated across all four portal-backend images, so the change is applied uniformly.

  Files touched:
  - `portal-backend/api/Dockerfile`
  - `portal-backend/cron/hemi-supply/Dockerfile`
  - `portal-backend/cron/token-prices/Dockerfile`
  - `portal-backend/cron/vaults-monitor/Dockerfile`

### Screenshots

N/A.

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
