### PR TITLE
Add Envio earn-requests endpoint

### DIFF
--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -163,6 +163,15 @@ $ curl http://localhost:3006/subgraphs/43111/locks/0x000000000000000000000000000
 {"positions":[]}
 ```
 
+##### `GET /subgraphs/:chain-id/earn-requests/:address`
+
+Returns the Hemi Earn cross-chain requests (deposits and redeems) initiated by the given address. Hemi mainnet only. Powered by the Envio multichain indexer (`hemi-earn-requests-subgraph`); rows are filtered by `initiator` (`msg.sender` on the Router call).
+
+```console
+$ curl http://localhost:3006/subgraphs/43111/earn-requests/0x0000000000000000000000000000000000000001
+{"requests":[{"amountIn":"1000000000000000000","amountOut":"1000000000000000000","asset":"0x...","automatic":true,"claimableAt":"1759162804","claimTxHash":"0xabc...","failed":false,"failureReason":null,"kind":"DEPOSIT","receiver":"0x1234...","recoverTxHash":null,"requestedAt":"1759162804","requestId":"6","requestTxHash":"0xdef...","status":"FINALIZED"}]}
+```
+
 ### Configuration
 
 These environment variables control how the cache works:

--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -172,6 +172,11 @@ $ curl http://localhost:3006/subgraphs/43111/earn-requests/0x0000000000000000000
 {"requests":[{"amountIn":"1000000000000000000","amountOut":"1000000000000000000","asset":"0x...","automatic":true,"claimableAt":"1759162804","claimTxHash":"0xabc...","failed":false,"failureReason":null,"kind":"DEPOSIT","receiver":"0x1234...","recoverTxHash":null,"requestedAt":"1759162804","requestId":"6","requestTxHash":"0xdef...","status":"FINALIZED"}]}
 ```
 
+Requires the following env vars to be set on the backend:
+
+- `SUBGRAPH_HEMI_EARN_REQUESTS_API_URL` — the full GraphQL URL of the Envio `hemi-earn-requests` indexer.
+- `SUBGRAPH_HEMI_EARN_REQUESTS_API_KEY` — Bearer token for the Envio indexer (only sent when set; can be left empty against an unauthenticated local Envio).
+
 ### Configuration
 
 These environment variables control how the cache works:

--- a/portal-backend/api/config/custom-environment-variables.json
+++ b/portal-backend/api/config/custom-environment-variables.json
@@ -26,6 +26,10 @@
   "subgraph": {
     "apiKey": "SUBGRAPH_API_KEY",
     "apiUrl": "SUBGRAPH_API_URL",
+    "hemiEarnRequests": {
+      "apiKey": "SUBGRAPH_HEMI_EARN_REQUESTS_API_KEY",
+      "apiUrl": "SUBGRAPH_HEMI_EARN_REQUESTS_API_URL"
+    },
     "origin": "SUBGRAPH_ORIGIN",
     "veHemi": {
       "testnet": "SUBGRAPH_VE_HEMI_TESTNET"

--- a/portal-backend/api/config/default.json
+++ b/portal-backend/api/config/default.json
@@ -16,6 +16,10 @@
   "subgraph": {
     "apiKey": "",
     "apiUrl": "https://gateway.thegraph.com/api",
+    "hemiEarnRequests": {
+      "apiKey": "",
+      "apiUrl": ""
+    },
     "origin": "https://app.hemi.xyz",
     "stake": {
       "mainnet": "7qiewFZ7UyDpj3gyNaCDUk55NqHLdbjWQLduS5dcYfQ4",

--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "scripts": {
     "build": "tsc",
     "start": "node --import=./src/instrument.ts server.ts"

--- a/portal-backend/api/src/subgraphs/route-handlers/get-earn-requests.ts
+++ b/portal-backend/api/src/subgraphs/route-handlers/get-earn-requests.ts
@@ -1,0 +1,21 @@
+import type { Request, Response } from 'express'
+import { type Address } from 'viem'
+
+import type { ChainIdPathParams } from '../../types.ts'
+import { getEarnRequests } from '../subgraph.ts'
+
+export async function getEarnRequestsHandler(
+  req: Request<ChainIdPathParams & { address: Address }>,
+  res: Response,
+) {
+  const { chainId } = req.data
+  const { address } = req.params
+
+  const requests = await getEarnRequests({
+    address,
+    // @ts-expect-error chainId is validated by validateChainIsHemiMainnet
+    chainId,
+  })
+
+  res.status(200).json({ requests })
+}

--- a/portal-backend/api/src/subgraphs/route-handlers/get-earn-requests.ts
+++ b/portal-backend/api/src/subgraphs/route-handlers/get-earn-requests.ts
@@ -8,14 +8,9 @@ export async function getEarnRequestsHandler(
   req: Request<ChainIdPathParams & { address: Address }>,
   res: Response,
 ) {
-  const { chainId } = req.data
   const { address } = req.params
 
-  const requests = await getEarnRequests({
-    address,
-    // @ts-expect-error chainId is validated by validateChainIsHemiMainnet
-    chainId,
-  })
+  const requests = await getEarnRequests({ address })
 
   res.status(200).json({ requests })
 }

--- a/portal-backend/api/src/subgraphs/router.ts
+++ b/portal-backend/api/src/subgraphs/router.ts
@@ -8,6 +8,7 @@ import type { ChainIdPathParams, ReqData } from '../types.ts'
 
 import { getBtcDepositOnHemi } from './route-handlers/get-btc-deposit-on-hemi.ts'
 import { getClaimTransactionHandler } from './route-handlers/get-claim-transaction-hash.ts'
+import { getEarnRequestsHandler } from './route-handlers/get-earn-requests.ts'
 import { getLockedPositionsHandler } from './route-handlers/get-locked-positions.ts'
 import { getWithdrawalProofAndClaimHandler } from './route-handlers/get-withdrawal-proof-and-claim.ts'
 import {
@@ -55,6 +56,18 @@ function validateChainIsHemi(
     req.data.chainId &&
     [hemi.id, hemiSepolia.id].includes(req.data.chainId)
   ) {
+    next()
+  } else {
+    next('route')
+  }
+}
+
+function validateChainIsHemiMainnet(
+  req: Request & ReqData,
+  res: Response,
+  next: NextFunction,
+) {
+  if (req.data.chainId === hemi.id) {
     next()
   } else {
     next('route')
@@ -251,6 +264,14 @@ export function createSubgraphsRouter() {
     validateAddress,
     validateChainIsHemi,
     getLockedPositionsHandler,
+  )
+
+  router.get(
+    '/:chainIdStr/earn-requests/:address',
+    parseChainId,
+    validateAddress,
+    validateChainIsHemiMainnet,
+    getEarnRequestsHandler,
   )
 
   return router

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -13,6 +13,7 @@ import { hemi, hemiSepolia, mainnet, sepolia } from 'viem/chains'
 import { postJson } from '../post-json.ts'
 
 import { UpstreamGraphQLError } from './errors.ts'
+import type { EarnRequestRow, EarnRequestStatus } from './types/earn.ts'
 import type {
   BtcDepositOperation,
   EvmDepositOperation,
@@ -697,4 +698,150 @@ export const getLockedPositions = function ({
       }))
     },
   )
+}
+
+type SubgraphRequest = {
+  amountIn: string
+  amountOut: string | null
+  asset: string
+  automatic: boolean | null
+  claimableAt: string | null
+  claimTxHash: string | null
+  failed: boolean
+  failureReason: string | null
+  kind: 'DEPOSIT' | 'REDEEM'
+  receiver: string
+  recoverTxHash: string | null
+  requestedAt: string
+  requestId: string
+  requestTxHash: string
+  status: 'PENDING' | 'FULFILLED' | 'FINALIZED' | 'CANCELLED' | 'RECOVERED'
+}
+
+// The indexer clears `failed` on `RequestRetried`, so a successful retry
+// won't be mis-labeled.
+const deriveStatus = (row: SubgraphRequest): EarnRequestStatus =>
+  row.failed ? 'FAILED' : row.status
+
+const toEarnRequestRow = (row: SubgraphRequest): EarnRequestRow => ({
+  amountIn: row.amountIn,
+  amountOut: row.amountOut,
+  // @ts-expect-error address comes lowercased from the indexer
+  asset: row.asset,
+  automatic: row.automatic ?? true,
+  claimableAt: row.claimableAt,
+  claimTxHash: row.claimTxHash as Hash | null,
+  failed: row.failed,
+  failureReason: row.failureReason,
+  kind: row.kind,
+  receiver: toChecksum(row.receiver as `0x${string}`),
+  recoverTxHash: row.recoverTxHash as Hash | null,
+  requestedAt: row.requestedAt,
+  requestId: row.requestId,
+  requestTxHash: row.requestTxHash as Hash,
+  status: deriveStatus(row),
+})
+
+// Envio HyperIndex uses Bearer-token auth. Header is only added when an
+// API key is configured so local dev against an unauthenticated indexer
+// (Hasura at `localhost:8080`) keeps working.
+function requestHemiEarn<TResponse>(schema: Schema): Promise<TResponse> {
+  const { apiKey, apiUrl } = subgraphConfig.hemiEarnRequests
+  const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined
+  return postJson(apiUrl, schema, { headers }).catch(function (err) {
+    throw new UpstreamGraphQLError(err.message, { cause: err })
+  }) as Promise<TResponse>
+}
+
+/**
+ * Hasura-style paginator for the Envio indexer.
+ *
+ * Envio runs on Postgres so it doesn't carry graph-node's `skip` cap that
+ * `paginateSubgraph` works around — pagination is plain `limit`/`offset`
+ * until a short page (fewer rows than `pageSize`) ends the loop.
+ *
+ * The caller owns the query, including the `order_by` clause and any
+ * `where` filter; this helper only drives `offset` and aggregates the
+ * pages.
+ *
+ * @param fetchPage Runs one request given the page window, returning that
+ * page's rows.
+ * @param pageSize Rows to request per page. Defaults to 100.
+ */
+const paginateHemiEarnSubgraph = async function <TRow>({
+  fetchPage,
+  pageSize = 100,
+}: {
+  fetchPage: (window: { limit: number; offset: number }) => Promise<TRow[]>
+  pageSize?: number
+}) {
+  const rows: TRow[] = []
+  let offset = 0
+  let page: TRow[]
+
+  do {
+    page = await fetchPage({ limit: pageSize, offset })
+    rows.push(...page)
+    offset += pageSize
+  } while (page.length === pageSize)
+
+  return rows
+}
+
+type GetEarnRequestsQueryResponse = GraphResponse<{
+  Request: SubgraphRequest[]
+}>
+
+/**
+ * Retrieves the Hemi Earn cross-chain requests (deposits and redeems)
+ * initiated by the given address. Filtered by `initiator` (msg.sender on
+ * the Router call), not `receiver` — those can differ for smart-account
+ * wallets, and the portal's "my transactions" view follows the signer.
+ */
+export const getEarnRequests = async function ({
+  address,
+}: {
+  address: Address
+  chainId: Chain['id']
+}) {
+  const initiator = address.toLowerCase()
+
+  const rows = await paginateHemiEarnSubgraph<SubgraphRequest>({
+    async fetchPage({ limit, offset }) {
+      const schema = {
+        query: `query GetEarnRequests($initiator: String!, $limit: Int!, $offset: Int!) {
+          Request(
+            where: { initiator: { _eq: $initiator } }
+            order_by: { requestedAt: desc }
+            limit: $limit
+            offset: $offset
+          ) {
+            amountIn
+            amountOut
+            asset
+            automatic
+            claimableAt
+            claimTxHash
+            failed
+            failureReason
+            kind
+            receiver
+            recoverTxHash
+            requestedAt
+            requestId
+            requestTxHash
+            status
+          }
+        }`,
+        variables: { initiator, limit, offset },
+      }
+
+      const response =
+        await requestHemiEarn<GetEarnRequestsQueryResponse>(schema)
+      checkGraphQLErrors(response)
+      return response.data.Request
+    },
+  })
+
+  return rows.map(toEarnRequestRow)
 }

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -704,10 +704,13 @@ export const getLockedPositions = function ({
   )
 }
 
-// The indexer clears `failed` on `RequestRetried`, so a successful retry
-// won't be mis-labeled.
+// `failed` is an Agent-side flag the indexer clears on `RequestRetried` but not
+// on cancel, so it lingers through CANCELLED/RECOVERED. A terminal Router status
+// wins over it: only a still-PENDING request surfaces as FAILED, otherwise a
+// failed-then-cancelled deposit would be masked as a failure and the portal's
+// recover path would never show.
 const deriveStatus = (row: SubgraphRequest): EarnRequestStatus =>
-  row.failed ? 'FAILED' : row.status
+  row.failed && row.status === 'PENDING' ? 'FAILED' : row.status
 
 const toEarnRequestRow = (row: SubgraphRequest): EarnRequestRow => ({
   // Spread the fields that flow through unchanged (see

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -726,8 +726,9 @@ const deriveStatus = (row: SubgraphRequest): EarnRequestStatus =>
 const toEarnRequestRow = (row: SubgraphRequest): EarnRequestRow => ({
   amountIn: row.amountIn,
   amountOut: row.amountOut,
-  // @ts-expect-error address comes lowercased from the indexer
-  asset: row.asset,
+  // Kept lowercase on purpose so it matches the portal-side tokens
+  // registry; only `receiver` is normalized to checksum below.
+  asset: row.asset as Address,
   automatic: row.automatic ?? true,
   claimableAt: row.claimableAt,
   claimTxHash: row.claimTxHash as Hash | null,
@@ -747,6 +748,11 @@ const toEarnRequestRow = (row: SubgraphRequest): EarnRequestRow => ({
 // (Hasura at `localhost:8080`) keeps working.
 function requestHemiEarn<TResponse>(schema: Schema): Promise<TResponse> {
   const { apiKey, apiUrl } = subgraphConfig.hemiEarnRequests
+  if (!apiUrl) {
+    throw new UpstreamGraphQLError(
+      'hemi-earn-requests indexer URL is not configured (set SUBGRAPH_HEMI_EARN_REQUESTS_API_URL)',
+    )
+  }
   const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined
   return postJson(apiUrl, schema, { headers }).catch(function (err) {
     throw new UpstreamGraphQLError(err.message, { cause: err })
@@ -797,12 +803,14 @@ type GetEarnRequestsQueryResponse = GraphResponse<{
  * initiated by the given address. Filtered by `initiator` (msg.sender on
  * the Router call), not `receiver` — those can differ for smart-account
  * wallets, and the portal's "my transactions" view follows the signer.
+ *
+ * No `chainId` parameter: the `hemi-earn-requests-subgraph` is Hemi-mainnet
+ * only and the route gates that via `validateChainIsHemiMainnet`.
  */
 export const getEarnRequests = async function ({
   address,
 }: {
   address: Address
-  chainId: Chain['id']
 }) {
   const initiator = address.toLowerCase()
 

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -13,7 +13,11 @@ import { hemi, hemiSepolia, mainnet, sepolia } from 'viem/chains'
 import { postJson } from '../post-json.ts'
 
 import { UpstreamGraphQLError } from './errors.ts'
-import type { EarnRequestRow, EarnRequestStatus } from './types/earn.ts'
+import type {
+  EarnRequestRow,
+  EarnRequestStatus,
+  SubgraphRequest,
+} from './types/earn.ts'
 import type {
   BtcDepositOperation,
   EvmDepositOperation,
@@ -700,45 +704,24 @@ export const getLockedPositions = function ({
   )
 }
 
-type SubgraphRequest = {
-  amountIn: string
-  amountOut: string | null
-  asset: string
-  automatic: boolean | null
-  claimableAt: string | null
-  claimTxHash: string | null
-  failed: boolean
-  failureReason: string | null
-  kind: 'DEPOSIT' | 'REDEEM'
-  receiver: string
-  recoverTxHash: string | null
-  requestedAt: string
-  requestId: string
-  requestTxHash: string
-  status: 'PENDING' | 'FULFILLED' | 'FINALIZED' | 'CANCELLED' | 'RECOVERED'
-}
-
 // The indexer clears `failed` on `RequestRetried`, so a successful retry
 // won't be mis-labeled.
 const deriveStatus = (row: SubgraphRequest): EarnRequestStatus =>
   row.failed ? 'FAILED' : row.status
 
 const toEarnRequestRow = (row: SubgraphRequest): EarnRequestRow => ({
-  amountIn: row.amountIn,
-  amountOut: row.amountOut,
+  // Spread the fields that flow through unchanged (see
+  // `EarnRequestCommonFields` in `types/earn.ts`); the explicit
+  // overrides below transform the addresses, hashes, status and the
+  // nullable `automatic` flag.
+  ...row,
   // Kept lowercase on purpose so it matches the portal-side tokens
   // registry; only `receiver` is normalized to checksum below.
   asset: row.asset as Address,
   automatic: row.automatic ?? true,
-  claimableAt: row.claimableAt,
   claimTxHash: row.claimTxHash as Hash | null,
-  failed: row.failed,
-  failureReason: row.failureReason,
-  kind: row.kind,
   receiver: toChecksum(row.receiver as `0x${string}`),
   recoverTxHash: row.recoverTxHash as Hash | null,
-  requestedAt: row.requestedAt,
-  requestId: row.requestId,
   requestTxHash: row.requestTxHash as Hash,
   status: deriveStatus(row),
 })

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -1,0 +1,36 @@
+import { type Address, type Hash } from 'viem'
+
+// Portal-facing status. `'FAILED'` is synthetic — derived at the helper
+// boundary from the subgraph's `failed` flag (the indexer keeps `status`
+// Router-authoritative).
+export type EarnRequestStatus =
+  | 'PENDING'
+  | 'FULFILLED'
+  | 'FINALIZED'
+  | 'CANCELLED'
+  | 'RECOVERED'
+  | 'FAILED'
+
+// One Hemi Earn cross-chain request, as returned by
+// `GET /subgraphs/:chainId/earn-requests/:address`. Shape mirrors the
+// portal's `EarnTransaction` type (minus the localStorage-only fields).
+// BigInt values arrive as strings. `failed` is redundant with
+// `status === 'FAILED'` but exposed for debug; `failureReason` carries the
+// raw revert reason for any future UI that surfaces it.
+export type EarnRequestRow = {
+  amountIn: string
+  amountOut: string | null
+  asset: Address
+  automatic: boolean
+  claimableAt: string | null
+  claimTxHash: Hash | null
+  failed: boolean
+  failureReason: string | null
+  kind: 'DEPOSIT' | 'REDEEM'
+  receiver: Address
+  recoverTxHash: Hash | null
+  requestedAt: string
+  requestId: string
+  requestTxHash: Hash
+  status: EarnRequestStatus
+}

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -1,15 +1,45 @@
 import { type Address, type Hash } from 'viem'
 
-// Portal-facing status. `'FAILED'` is synthetic — derived at the helper
-// boundary from the subgraph's `failed` flag (the indexer keeps `status`
-// Router-authoritative).
-export type EarnRequestStatus =
+// Subgraph-side status from the Envio indexer (Router-authoritative).
+type SubgraphRequestStatus =
   | 'PENDING'
   | 'FULFILLED'
   | 'FINALIZED'
   | 'CANCELLED'
   | 'RECOVERED'
-  | 'FAILED'
+
+// Portal-facing status. `'FAILED'` is synthetic — derived at the helper
+// boundary from the subgraph's `failed` flag (the indexer keeps `status`
+// Router-authoritative).
+export type EarnRequestStatus = SubgraphRequestStatus | 'FAILED'
+
+// Fields that flow through the boundary unchanged. Keeping the shared
+// shape in one place so the two types below stay in sync when the
+// subgraph schema evolves.
+type EarnRequestCommonFields = {
+  amountIn: string
+  amountOut: string | null
+  claimableAt: string | null
+  failed: boolean
+  failureReason: string | null
+  kind: 'DEPOSIT' | 'REDEEM'
+  requestedAt: string
+  requestId: string
+}
+
+// Raw `Request` entity from the Envio `hemi-earn-requests-subgraph`. The
+// indexer lowercases addresses/hashes and emits BigInts as strings;
+// `automatic` is nullable because the entity can be created from an
+// Agent-side event before the Router fires its `*Requested` event.
+export type SubgraphRequest = EarnRequestCommonFields & {
+  asset: string
+  automatic: boolean | null
+  claimTxHash: string | null
+  receiver: string
+  recoverTxHash: string | null
+  requestTxHash: string
+  status: SubgraphRequestStatus
+}
 
 // One Hemi Earn cross-chain request, as returned by
 // `GET /subgraphs/:chainId/earn-requests/:address`. Shape mirrors the
@@ -17,20 +47,12 @@ export type EarnRequestStatus =
 // BigInt values arrive as strings. `failed` is redundant with
 // `status === 'FAILED'` but exposed for debug; `failureReason` carries the
 // raw revert reason for any future UI that surfaces it.
-export type EarnRequestRow = {
-  amountIn: string
-  amountOut: string | null
+export type EarnRequestRow = EarnRequestCommonFields & {
   asset: Address
   automatic: boolean
-  claimableAt: string | null
   claimTxHash: Hash | null
-  failed: boolean
-  failureReason: string | null
-  kind: 'DEPOSIT' | 'REDEEM'
   receiver: Address
   recoverTxHash: Hash | null
-  requestedAt: string
-  requestId: string
   requestTxHash: Hash
   status: EarnRequestStatus
 }

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -44,9 +44,11 @@ export type SubgraphRequest = EarnRequestCommonFields & {
 // One Hemi Earn cross-chain request, as returned by
 // `GET /subgraphs/:chainId/earn-requests/:address`. Shape mirrors the
 // portal's `EarnTransaction` type (minus the localStorage-only fields).
-// BigInt values arrive as strings. `failed` is redundant with
-// `status === 'FAILED'` but exposed for debug; `failureReason` carries the
-// raw revert reason for any future UI that surfaces it.
+// BigInt values arrive as strings. `failed` is the raw Agent-side flag and is
+// NOT redundant with `status === 'FAILED'`: a terminal status (CANCELLED /
+// RECOVERED) can carry `failed: true`, while the synthetic FAILED status only
+// applies to a still-PENDING request. `failureReason` carries the raw revert
+// reason for any future UI that surfaces it.
 export type EarnRequestRow = EarnRequestCommonFields & {
   asset: Address
   automatic: boolean

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTransactions.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTransactions.ts
@@ -13,7 +13,6 @@ export const fetchEarnTransactions = async function ({
   account,
 }: {
   account: Address
-  networkType: string
 }): Promise<EarnTransaction[]> {
   const { requests } = (await fetchPlusPlus(getEarnRequestsUrl(account), {
     method: 'GET',

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTransactions.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTransactions.ts
@@ -1,104 +1,13 @@
-import { type Address, type Hash, getAddress, zeroAddress } from 'viem'
+import fetchPlusPlus from 'fetch-plus-plus'
+import { hemi } from 'hemi-viem'
+import { type Address } from 'viem'
 
-import { type EarnTransaction, type EarnTransactionStatusType } from '../types'
+import { type EarnTransaction } from '../types'
 
 export const earnTransactionsKeyPrefix = ['hemi-earn', 'transactions'] as const
 
-// `receiver` checksum matches `useAccount()` in balance cache keys;
-// `asset` stays lowercase to match `tokens.ts`.
-const normalizeEarnTransaction = (row: EarnTransaction): EarnTransaction => ({
-  ...row,
-  receiver: getAddress(row.receiver),
-})
-
-// Raw `Request` entity shape from `hemi-earn-requests-subgraph` (Envio).
-type SubgraphRequest = {
-  amountIn: string
-  amountOut: string | null
-  asset: string
-  automatic: boolean | null
-  claimableAt: string | null
-  claimTxHash: string | null
-  failed: boolean
-  failureReason: string | null
-  kind: 'DEPOSIT' | 'REDEEM'
-  receiver: string
-  recoverTxHash: string | null
-  requestedAt: string
-  requestId: string
-  requestTxHash: string
-  status: 'PENDING' | 'FULFILLED' | 'FINALIZED' | 'CANCELLED' | 'RECOVERED'
-}
-
-// The indexer clears `failed` on `RequestRetried`, so a successful retry
-// won't be mis-labeled.
-const deriveStatus = (row: SubgraphRequest): EarnTransactionStatusType =>
-  row.failed ? 'FAILED' : row.status
-
-const toEarnTransaction = (row: SubgraphRequest): EarnTransaction =>
-  normalizeEarnTransaction({
-    amountIn: row.amountIn,
-    amountOut: row.amountOut,
-    asset: row.asset as Address,
-    automatic: row.automatic ?? true,
-    claimableAt: row.claimableAt,
-    claimTxHash: row.claimTxHash as Hash | null,
-    kind: row.kind,
-    receiver: row.receiver as Address,
-    recoverTxHash: row.recoverTxHash as Hash | null,
-    requestedAt: row.requestedAt,
-    requestId: row.requestId,
-    requestTxHash: row.requestTxHash as Hash,
-    status: deriveStatus(row),
-  })
-
-// TODO(api): swap the mock for a real fetch through the portal-backend
-// proxy. The boundary translator `toEarnTransaction` above is the contract
-// the proxy response should fulfill.
-const MOCK_DELAY_MS = 2000
-
-const buildMockRequests = function (receiver: Address): SubgraphRequest[] {
-  const now = Math.floor(Date.now() / 1000)
-  const sampleAsset = zeroAddress
-  const sampleTxHash =
-    '0x0000000000000000000000000000000000000000000000000000000000000000'
-  return [
-    {
-      amountIn: '2500000000000000000',
-      amountOut: null,
-      asset: sampleAsset,
-      automatic: true,
-      claimableAt: null,
-      claimTxHash: null,
-      failed: false,
-      failureReason: null,
-      kind: 'DEPOSIT',
-      receiver,
-      recoverTxHash: null,
-      requestedAt: String(now - 60 * 5),
-      requestId: '7',
-      requestTxHash: sampleTxHash,
-      status: 'PENDING',
-    },
-    {
-      amountIn: '1000000000000000000',
-      amountOut: '1000000000000000000',
-      asset: sampleAsset,
-      automatic: true,
-      claimableAt: String(now - 60 * 60 * 24),
-      claimTxHash: sampleTxHash,
-      failed: false,
-      failureReason: null,
-      kind: 'DEPOSIT',
-      receiver,
-      recoverTxHash: null,
-      requestedAt: String(now - 60 * 60 * 6),
-      requestId: '6',
-      requestTxHash: sampleTxHash,
-      status: 'FINALIZED',
-    },
-  ]
-}
+const getEarnRequestsUrl = (account: Address) =>
+  `${process.env.NEXT_PUBLIC_PORTAL_API_URL}/subgraphs/${hemi.id}/earn-requests/${account}`
 
 export const fetchEarnTransactions = async function ({
   account,
@@ -106,6 +15,8 @@ export const fetchEarnTransactions = async function ({
   account: Address
   networkType: string
 }): Promise<EarnTransaction[]> {
-  await new Promise(resolve => setTimeout(resolve, MOCK_DELAY_MS))
-  return buildMockRequests(account).map(toEarnTransaction)
+  const { requests } = (await fetchPlusPlus(getEarnRequestsUrl(account), {
+    method: 'GET',
+  })) as { requests: EarnTransaction[] }
+  return requests
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
@@ -33,8 +33,8 @@ export const useEarnTransactionsQuery = function () {
   )
 
   return useQuery({
-    enabled: !!address,
-    queryFn: () => fetchEarnTransactions({ account: address!, networkType }),
+    enabled: !!address && networkType === 'mainnet',
+    queryFn: () => fetchEarnTransactions({ account: address! }),
     queryKey: [...earnTransactionsKeyPrefix, networkType, address],
     refetchInterval(query) {
       const subgraphData = (query.state.data ?? []) as EarnTransaction[]


### PR DESCRIPTION
### Description

This PR wires the portal to the live `hemi-earn-requests` Envio subgraph by adding a proxy endpoint on portal-backend, replacing the mock fetcher the previous PR left behind. The portal never holds the indexer URL or Bearer token in its bundle — both stay in env vars on the backend.

  The backend gets `GET /subgraphs/:chainId/earn-requests/:address`, gated to Hemi mainnet, mirroring the architecture of the closed PR #1946 (same route shape, handler/helper layout, response envelope, and reusable paginator). What diverges is the URL builder and auth: instead of The Graph's `${gateway}/api/{key}/subgraphs/id/{id}` URL embedding, Envio uses a static endpoint plus a Bearer-token header. Both are read from `SUBGRAPH_HEMI_EARN_REQUESTS_API_URL` and `SUBGRAPH_HEMI_EARN_REQUESTS_API_KEY`, mapped via `custom-environment-variables.json`. Pagination uses plain
  `limit`/`offset` because Envio runs on Postgres and doesn't carry graph-node's 5000-skip cap, so the cursor-reset dance in the existing `paginateSubgraph` isn't needed.

  The boundary translator `toEarnRequestRow` lives on the backend and collapses the subgraph's `failed` flag into the synthetic `'FAILED'` status the portal already understands. It also passes `failed` and `failureReason` through to the response, so a future UI can surface the revert reason without another backend change.

  Portal-side, `fetchEarnTransactions` drops the mock and its boundary helpers and becomes a thin GET to the new endpoint, parsing the response as `EarnTransaction[]` directly.

  Validated locally end-to-end against the user's running Envio Hasura at `localhost:8080` + portal-backend on `3006` + portal on `3000`.

  **Heads up for the merge:** prod needs `SUBGRAPH_HEMI_EARN_REQUESTS_API_URL` and `SUBGRAPH_HEMI_EARN_REQUESTS_API_KEY` injected into the portal-backend deployment from 1Password before the
  `/hemi-earn` page works in production. Ticket with the infra team is being opened in parallel.

### Screenshots

No UI changes.

### Related issue(s)

Related to #1848 
Closes #1963 
Closes #1935 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
