### PR TITLE
Render zero APY as 0.00% instead of < 0.01%

### DIFF
--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -13,7 +13,7 @@ export const hashesMatch = (a: string | undefined, b: string | undefined) =>
   !!a && !!b && a.toLowerCase() === b.toLowerCase()
 
 export const formatApyDisplay = function (apy: number) {
-  if (apy < 0.01) {
+  if (apy > 0 && apy < 0.01) {
     return '< 0.01%'
   }
   return formatPercentage(apy)

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -13,8 +13,8 @@ export const hashesMatch = (a: string | undefined, b: string | undefined) =>
   !!a && !!b && a.toLowerCase() === b.toLowerCase()
 
 export const formatApyDisplay = function (apy: number) {
-  if (apy > 0 && apy < 0.01) {
-    return '< 0.01%'
+  if (apy !== 0 && apy > -0.01 && apy < 0.01) {
+    return apy > 0 ? '< 0.01%' : '< -0.01%'
   }
   return formatPercentage(apy)
 }

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -35,8 +35,8 @@ describe('utils', function () {
       expect(formatApyDisplay(0.005)).toBe('< 0.01%')
     })
 
-    it('should return "< 0.01%" for zero', function () {
-      expect(formatApyDisplay(0)).toBe('< 0.01%')
+    it('should return "0.00%" for zero', function () {
+      expect(formatApyDisplay(0)).toBe('0.00%')
     })
 
     it('should format percentage for value equal to 0.01', function () {

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -31,12 +31,20 @@ const recoverHash = `0x${'b'.repeat(64)}` as const
 
 describe('utils', function () {
   describe('formatApyDisplay', function () {
-    it('should return "< 0.01%" for values less than 0.01', function () {
+    it('should return "< 0.01%" for tiny positive values', function () {
       expect(formatApyDisplay(0.005)).toBe('< 0.01%')
+    })
+
+    it('should return "< -0.01%" for tiny negative values', function () {
+      expect(formatApyDisplay(-0.005)).toBe('< -0.01%')
     })
 
     it('should return "0.00%" for zero', function () {
       expect(formatApyDisplay(0)).toBe('0.00%')
+    })
+
+    it('should format percentage for negative values beyond the threshold', function () {
+      expect(formatApyDisplay(-5.25)).toBe('-5.25%')
     })
 
     it('should format percentage for value equal to 0.01', function () {


### PR DESCRIPTION
### Description

`formatApyDisplay` treated any value below `0.01` as the `< 0.01%` placeholder, including exactly `0`. A zero APY is a known, precise value rather than something too small to show, so it now falls through to `formatPercentage` and renders as `0.00%`. The `< 0.01%` placeholder remains for genuinely tiny non-zero values. Updated the corresponding unit test.

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A — N/A.
- [x] Environment variables set in CI, or N/A — N/A.