### PR TITLE
Add token logos to hemi-earn pool breadcrumbs

### DIFF
--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolNavigation.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolNavigation.tsx
@@ -4,6 +4,7 @@ import { useOnClickOutside } from '@hemilabs/react-hooks/useOnClickOutside'
 import { Button, ButtonIcon } from 'components/button'
 import { Chevron } from 'components/icons/chevron'
 import { Menu } from 'components/menu'
+import { TokenLogo } from 'components/tokenLogo'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useRouter } from 'i18n/navigation'
 import { useTranslations } from 'next-intl'
@@ -58,6 +59,7 @@ export const PoolNavigation = function ({ pool }: Props) {
           type="button"
           variant="tertiary"
         >
+          <TokenLogo size="xSmall" token={pool.shareToken} version="L1" />
           {t('navigation.pool-name', { tokenSymbol: pool.shareToken.symbol })}
           <Chevron.Bottom className="[&>path]:fill-neutral-950" />
         </Button>
@@ -67,7 +69,7 @@ export const PoolNavigation = function ({ pool }: Props) {
               items={pools.map(p => ({
                 content: (
                   <button
-                    className="-mx-2 -my-1 block whitespace-nowrap px-2 py-1 text-left text-sm"
+                    className="-mx-2 -my-1 flex items-center gap-x-2 whitespace-nowrap px-2 py-1 text-left text-sm"
                     onClick={function () {
                       setIsDropdownOpen(false)
                       router.push(
@@ -78,6 +80,11 @@ export const PoolNavigation = function ({ pool }: Props) {
                     }}
                     type="button"
                   >
+                    <TokenLogo
+                      size="xSmall"
+                      token={p.shareToken}
+                      version="L1"
+                    />
                     {t('navigation.pool-name', {
                       tokenSymbol: p.shareToken.symbol,
                     })}

--- a/portal/components/customTokenLogo.tsx
+++ b/portal/components/customTokenLogo.tsx
@@ -4,6 +4,7 @@ import { Token } from 'types/token'
 // Prefer ordering these by value rather than by key
 /* eslint-disable sort-keys */
 const sizes = {
+  xSmall: 'size-4 text-[5px]',
   small: 'size-5 text-[6px]',
   medium: 'size-6 text-[7px]',
   large: 'size-8 text-[8px]',
@@ -21,7 +22,7 @@ export const CustomTokenLogo = ({ size, token }: Props) => (
   <>
     <div
       className={`flex items-center justify-center rounded-full ${sizes[size]} overflow-hidden text-ellipsis whitespace-nowrap
-      border border-solid border-white bg-neutral-50 text-[8px] font-semibold text-neutral-700`}
+      border border-solid border-white bg-neutral-50 font-semibold text-neutral-700`}
     >
       {token.symbol}
     </div>

--- a/portal/components/hemiSubLogo.tsx
+++ b/portal/components/hemiSubLogo.tsx
@@ -7,6 +7,7 @@ import { Token } from 'types/token'
 // Prefer ordering these by value rather than by key
 /* eslint-disable sort-keys */
 const sizes = {
+  xSmall: 'size-2',
   small: 'size-2.5',
   medium: 'size-3',
   large: 'size-4',

--- a/portal/components/tokenLogo.tsx
+++ b/portal/components/tokenLogo.tsx
@@ -12,6 +12,7 @@ import { BtcLogo } from './icons/btcLogo'
 // Prefer ordering these by value rather than by key
 /* eslint-disable sort-keys */
 const sizes = {
+  xSmall: 'size-4',
   small: 'size-5',
   medium: 'size-6',
   large: 'size-8',


### PR DESCRIPTION
### Description

Show the share token logo in the hemi-earn pool navigation breadcrumb and in each item of its pool-switcher dropdown. To fit the compact breadcrumb, this adds an `xSmall` size variant across the token logo components (`TokenLogo`, `CustomTokenLogo`, `HemiSubLogo`).

While in `CustomTokenLogo`, the hardcoded `text-[8px]` on the symbol container was removed so the font size now scales with the selected size (as defined in the `sizes` map).

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->


https://github.com/user-attachments/assets/1a390e78-5c5b-400c-a258-c7a8460b3689

Note: The `sVUSD` token will be added after https://github.com/hemilabs/token-list/pull/110

### Related issue(s)

Closes #2002

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.