### PR TITLE
Update @hemilabs/token-list to 3.1.0

### DIFF
--- a/patches/@hemilabs__token-list@3.1.0.patch
+++ b/patches/@hemilabs__token-list@3.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/src/hemi.tokenlist.json b/src/hemi.tokenlist.json
-index 79a0b9e020113267aa45622aa89c000661907e9a..f5339e1dd3cfe33ea2557a883628b9a341ead386 100644
+index 9c7d37d..7bb25e9 100644
 --- a/src/hemi.tokenlist.json
 +++ b/src/hemi.tokenlist.json
 @@ -420,6 +420,11 @@
@@ -43,7 +43,7 @@ index 79a0b9e020113267aa45622aa89c000661907e9a..f5339e1dd3cfe33ea2557a883628b9a3
          "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/usdt.svg"
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/usdt.svg",
-@@ -669,11 +684,16 @@
+@@ -681,11 +696,16 @@
        "decimals": 8,
        "extensions": {
          "birthBlock": 2165818,
@@ -62,7 +62,7 @@ index 79a0b9e020113267aa45622aa89c000661907e9a..f5339e1dd3cfe33ea2557a883628b9a3
      },
      {
        "address": "0x3Adf21A6cbc9ce6D5a3ea401E7Bae9499d391298",
-@@ -740,8 +760,20 @@
+@@ -752,8 +772,20 @@
          "l1LogoURI": "https://hemilabs.github.io/token-list/l1Logos/hdai.svg"
        },
        "logoURI": "https://hemilabs.github.io/token-list/logos/hdai.svg",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ overrides:
   postcss: 8.5.14
 
 patchedDependencies:
-  '@hemilabs/token-list@3.0.0':
-    hash: 40f8f5ac870c8056be362e2259c5ccb16fc48c4e652dbd49697a62f4915bb6f1
-    path: patches/@hemilabs__token-list@3.0.0.patch
+  '@hemilabs/token-list@3.1.0':
+    hash: ba99566230e2751cb02cd9c823bd1eb799df8ea5524ea60682428190a4b89a88
+    path: patches/@hemilabs__token-list@3.1.0.patch
   '@hemilabs/wallet-watch-asset@1.0.2':
     hash: 29bbea75a794a36a5ab734b563912a6cde0b08398e00727b76066fe46a72f5ec
     path: patches/@hemilabs__wallet-watch-asset@1.0.2.patch
@@ -328,8 +328,8 @@ importers:
         specifier: 1.6.0
         version: 1.6.0(@hemilabs/wallet-watch-asset@1.0.2(patch_hash=29bbea75a794a36a5ab734b563912a6cde0b08398e00727b76066fe46a72f5ec))(@tanstack/react-query@5.100.9(react@19.1.1))(react@19.1.1)(viem-erc20@2.0.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.7(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.1.1))(@types/react@19.1.13)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@hemilabs/token-list':
-        specifier: 3.0.0
-        version: 3.0.0(patch_hash=40f8f5ac870c8056be362e2259c5ccb16fc48c4e652dbd49697a62f4915bb6f1)
+        specifier: 3.1.0
+        version: 3.1.0(patch_hash=ba99566230e2751cb02cd9c823bd1eb799df8ea5524ea60682428190a4b89a88)
       '@hemilabs/wallet-watch-asset':
         specifier: 1.0.2
         version: 1.0.2(patch_hash=29bbea75a794a36a5ab734b563912a6cde0b08398e00727b76066fe46a72f5ec)
@@ -1832,12 +1832,12 @@ packages:
       viem-erc20: ^2
       wagmi: ^2
 
-  '@hemilabs/token-list@3.0.0':
+  '@hemilabs/token-list@3.1.0':
     resolution:
       {
-        integrity: sha512-teVkh62AWC3IKLR7KB9k2HgEUo0WG8em1VauiwYmdJX4hAxz5daInTwXl8+xpkMW0dtVN8ky0rYrdmokzzaDRw==,
+        integrity: sha512-xODmuSiGozho49c6B8vcSgBKiSG4S6B+mQu92w9qvBzz+zlOzGU5FeYM1/9D0QJhdJ1JSP9Mi/5RkEpTFHDu9g==,
       }
-    engines: { node: '>=20' }
+    engines: { node: ^20.19.0 || >=22.12.0 }
 
   '@hemilabs/wallet-watch-asset@1.0.2':
     resolution:
@@ -16210,7 +16210,7 @@ snapshots:
       viem-erc20: 2.0.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       wagmi: 2.15.7(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.1.1))(@types/react@19.1.13)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
 
-  '@hemilabs/token-list@3.0.0(patch_hash=40f8f5ac870c8056be362e2259c5ccb16fc48c4e652dbd49697a62f4915bb6f1)':
+  '@hemilabs/token-list@3.1.0(patch_hash=ba99566230e2751cb02cd9c823bd1eb799df8ea5524ea60682428190a4b89a88)':
     {}
 
   '@hemilabs/wallet-watch-asset@1.0.2(patch_hash=29bbea75a794a36a5ab734b563912a6cde0b08398e00727b76066fe46a72f5ec)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ overrides:
   postcss: '8.5.14' # Needed as Next pins 8.4.31 exactly
 
 patchedDependencies:
-  '@hemilabs/token-list@3.0.0': patches/@hemilabs__token-list@3.0.0.patch
+  '@hemilabs/token-list@3.1.0': patches/@hemilabs__token-list@3.1.0.patch
   '@hemilabs/wallet-watch-asset@1.0.2': 'patches/@hemilabs__wallet-watch-asset@1.0.2.patch'
   'coinselect@3.1.13': 'patches/coinselect@3.1.13.patch'
   'viem@*': 'patches/viem.patch'

--- a/portal/package.json
+++ b/portal/package.json
@@ -17,7 +17,7 @@
     "@formatjs/intl-durationformat": "0.7.4",
     "@formo/analytics": "1.26.0",
     "@hemilabs/react-hooks": "1.6.0",
-    "@hemilabs/token-list": "3.0.0",
+    "@hemilabs/token-list": "3.1.0",
     "@hemilabs/wallet-watch-asset": "1.0.2",
     "@rainbow-me/rainbowkit": "2.2.8",
     "@sentry/nextjs": "9.9.0",


### PR DESCRIPTION
### Description

Bumps `@hemilabs/token-list` from 3.0.0 to 3.1.0 and updates the patch to keep the same changes.

### Screenshots

Now, `sVUSD` token logo becomes available

<img width="696" height="436" alt="image" src="https://github.com/user-attachments/assets/6db2771e-4bb7-4041-beb2-39f5c6d84b6e" />

<img width="610" height="296" alt="image" src="https://github.com/user-attachments/assets/56d5fc0d-ee6e-4421-9b7f-0fc9a40d7b3f" />

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.