### PR TITLE
Add withdraw drawer to Hemi Earn tx table

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
@@ -32,9 +32,6 @@ export const RowActions = function ({ transaction }: Props) {
 
   const onViewClick = function (e: MouseEvent) {
     e.stopPropagation()
-    // TODO: the REDEEM drawer doesn't exist yet — wiring it lands in the
-    // follow-up PR. Until then the click is a no-op for REDEEM rows.
-    if (transaction.kind === 'REDEEM') return
     setTxDrawerQueryString(transaction.requestTxHash)
   }
 

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -14,7 +14,10 @@ import { type ReactNode } from 'react'
 import { type EvmToken } from 'types/token'
 
 import { SparkleIcon } from '../../../_icons/sparkleIcon'
-import { getTerminalDeliveryTxHash } from '../../../_utils'
+import {
+  getTerminalDeliveryTxHash,
+  isLocalEarnTransactionRow,
+} from '../../../_utils'
 import {
   type EarnTransaction,
   type EarnTransactionStatusType,
@@ -67,14 +70,12 @@ const stepStatesByStatus: Record<EarnTransactionStatusType, StepStates> = {
   },
 }
 
-const isLocalRow = (tx: EarnTransaction) => tx.requestId.startsWith('local-')
-
 // FAILED splits by source: local rows mean the Hemi tx itself reverted (stake
 // step is FAILED), subgraph rows mean the Vetro Agent failed after a
 // successful Hemi tx (stake step completed, failure is in the cross-chain
 // step instead).
 const resolveStepStates = (tx: EarnTransaction): StepStates =>
-  tx.status === 'FAILED' && !isLocalRow(tx)
+  tx.status === 'FAILED' && !isLocalEarnTransactionRow(tx)
     ? {
         stake: ProgressStatus.COMPLETED,
         waitingForShares: ProgressStatus.FAILED,
@@ -138,7 +139,7 @@ export const HistoricalDepositReview = function ({
   // Re-approve only makes sense for local FAILED (Hemi tx reverted).
   if (
     transaction.status === 'FAILED' &&
-    isLocalRow(transaction) &&
+    isLocalEarnTransactionRow(transaction) &&
     needsApproval
   ) {
     steps.push({

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -6,6 +6,7 @@ import {
   type ProgressStatusType,
 } from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
+import { TokenLogo } from 'components/tokenLogo'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
 import { hemi } from 'hemi-viem'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
@@ -87,7 +88,7 @@ function buildStakeStep(tx: EarnTransaction, token: EvmToken, t: Translator) {
   return {
     description: (
       <div className="flex items-center gap-x-2">
-        <SparkleIcon />
+        <TokenLogo size="small" token={token} />
         <span>{t('step.stake-token', { symbol: token.symbol })}</span>
       </div>
     ),
@@ -102,7 +103,12 @@ const buildWaitingForSharesStep = (
   t: Translator,
   status: ProgressStatusType,
 ) => ({
-  description: <span>{t('step.get-share-tokens')}</span>,
+  description: (
+    <div className="flex items-center gap-x-2">
+      <SparkleIcon />
+      <span>{t('step.get-share-tokens')}</span>
+    </div>
+  ),
   status,
   txHash: getTerminalDeliveryTxHash(tx),
 })
@@ -112,7 +118,12 @@ const buildApprovalStep = (
   token: EvmToken,
   t: Translator,
 ) => ({
-  description: <span>{t('step.approve-token', { symbol: token.symbol })}</span>,
+  description: (
+    <div className="flex items-center gap-x-2">
+      <TokenLogo size="small" token={token} />
+      <span>{t('step.approve-token', { symbol: token.symbol })}</span>
+    </div>
+  ),
   explorerChainId: hemi.id,
   status: ProgressStatus.COMPLETED,
   txHash: approvalTxHash,
@@ -143,7 +154,12 @@ export const HistoricalDepositReview = function ({
     needsApproval
   ) {
     steps.push({
-      description: <span>{t('step.approval-needed')}</span>,
+      description: (
+        <div className="flex items-center gap-x-2">
+          <TokenLogo size="small" token={token} />
+          <span>{t('step.approval-needed')}</span>
+        </div>
+      ),
       status: ProgressStatus.NOT_READY,
     })
   }

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -135,12 +135,85 @@ const buildApprovalStep = (
   t: Translator,
 ) => ({
   description: (
-    <span>{t('step.approve-token', { symbol: shareToken.symbol })}</span>
+    <div className="flex items-center gap-x-2">
+      <TokenLogo size="small" token={shareToken} />
+      <span>{t('step.approve-token', { symbol: shareToken.symbol })}</span>
+    </div>
   ),
   explorerChainId: hemi.id,
   status: ProgressStatus.COMPLETED,
   txHash: approvalTxHash,
 })
+
+function deriveReceiveStatus({
+  cooldownRemainingSec,
+  isCooldownEligible,
+  receiveFromStatus,
+  unstakeMined,
+}: {
+  cooldownRemainingSec: number | undefined
+  isCooldownEligible: boolean | undefined
+  receiveFromStatus: ProgressStatusType
+  unstakeMined: boolean
+}): ProgressStatusType {
+  if (receiveFromStatus !== ProgressStatus.NOT_READY) return receiveFromStatus
+  if (!unstakeMined) return receiveFromStatus
+  const needsCooldown = isCooldownEligible !== false
+  const cooldownElapsed = cooldownRemainingSec === 0
+  return !needsCooldown || cooldownElapsed
+    ? ProgressStatus.PROGRESS
+    : receiveFromStatus
+}
+
+function buildSteps({
+  cooldownPostAction,
+  needsApproval,
+  pool,
+  receive,
+  receiveToken,
+  t,
+  transaction,
+}: {
+  cooldownPostAction: ReturnType<typeof deriveCooldownPostAction>
+  needsApproval: boolean
+  pool: EarnPool
+  receive: ProgressStatusType
+  receiveToken: EvmToken | undefined
+  t: Translator
+  transaction: EarnTransaction
+}): StepPropsWithoutPosition[] {
+  const steps: StepPropsWithoutPosition[] = []
+  if (
+    transaction.status === 'FAILED' &&
+    isLocalEarnTransactionRow(transaction) &&
+    needsApproval
+  ) {
+    steps.push({
+      description: (
+        <div className="flex items-center gap-x-2">
+          <TokenLogo size="small" token={pool.shareToken} />
+          <span>{t('step.approval-needed')}</span>
+        </div>
+      ),
+      status: ProgressStatus.NOT_READY,
+    })
+  }
+  if (transaction.approvalTxHash) {
+    steps.push(
+      buildApprovalStep(transaction.approvalTxHash, pool.shareToken, t),
+    )
+  }
+  const unstakeStep = buildUnstakeStep(transaction, pool.shareToken, t)
+  steps.push(
+    cooldownPostAction
+      ? { ...unstakeStep, postAction: cooldownPostAction }
+      : unstakeStep,
+  )
+  if (receiveToken) {
+    steps.push(buildReceiveStep(transaction, receiveToken, t, receive))
+  }
+  return steps
+}
 
 export const HistoricalWithdrawReview = function ({
   callToAction,
@@ -178,14 +251,19 @@ export const HistoricalWithdrawReview = function ({
     stakingVault: pool.stakingVault,
   })
 
+  const claimableAt = transaction.claimableAt ?? null
   const cooldownRemainingSec = useEarnCooldownRemaining(
-    transaction.claimableAt != null
-      ? BigInt(transaction.claimableAt)
-      : undefined,
+    claimableAt !== null ? BigInt(claimableAt) : undefined,
   )
 
-  const { receive, unstake } = resolveStepStates(transaction)
+  const { receive: receiveFromStatus, unstake } = resolveStepStates(transaction)
   const unstakeMined = unstake === ProgressStatus.COMPLETED
+  const receive = deriveReceiveStatus({
+    cooldownRemainingSec,
+    isCooldownEligible,
+    receiveFromStatus,
+    unstakeMined,
+  })
 
   const cooldownPostAction = deriveCooldownPostAction({
     cooldownDurationSec,
@@ -196,48 +274,25 @@ export const HistoricalWithdrawReview = function ({
     unstakeMined,
   })
 
-  // Show shareToken while we only have amountIn (share units); switch to
-  // the asset token once amountOut lands (asset units). Same rule the
-  // AmountCell applies to table rows.
   const { amount: displayAmount, token: displayToken } = pickDisplay(
     transaction,
     pool.shareToken,
     receiveToken,
   )
 
-  const steps: StepPropsWithoutPosition[] = []
-  // Re-approve only makes sense for local FAILED (Hemi tx reverted).
-  if (
-    transaction.status === 'FAILED' &&
-    isLocalEarnTransactionRow(transaction) &&
-    needsApproval
-  ) {
-    steps.push({
-      description: <span>{t('step.approval-needed')}</span>,
-      status: ProgressStatus.NOT_READY,
-    })
-  }
-  // Only locally-mirrored entries carry `approvalTxHash` — see the merge
-  // in `useEarnTransactions`. Rows opened from another browser/device won't
-  // have this step (indexer doesn't link approval to request).
-  if (transaction.approvalTxHash) {
-    steps.push(
-      buildApprovalStep(transaction.approvalTxHash, pool.shareToken, t),
-    )
-  }
-  const unstakeStep = buildUnstakeStep(transaction, pool.shareToken, t)
-  steps.push(
-    cooldownPostAction
-      ? { ...unstakeStep, postAction: cooldownPostAction }
-      : unstakeStep,
-  )
-  if (receiveToken) {
-    steps.push(buildReceiveStep(transaction, receiveToken, t, receive))
-  }
-
   if (!displayToken) {
     return null
   }
+
+  const steps = buildSteps({
+    cooldownPostAction,
+    needsApproval,
+    pool,
+    receive,
+    receiveToken,
+    t,
+    transaction,
+  })
 
   return (
     <Operation

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import { Operation } from 'components/reviewOperation/operation'
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
+import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
+import { TokenLogo } from 'components/tokenLogo'
+import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
+import { hemi } from 'hemi-viem'
+import { useNeedsApproval } from 'hooks/useNeedsApproval'
+import { useToken } from 'hooks/useToken'
+import { useTranslations } from 'next-intl'
+import { type ReactNode } from 'react'
+import { type EvmToken } from 'types/token'
+import { useAccount } from 'wagmi'
+
+import { useCooldownDuration } from '../../../_hooks/useCooldownDuration'
+import { useIsCooldownEligible } from '../../../_hooks/useIsCooldownEligible'
+import {
+  getTerminalDeliveryTxHash,
+  isLocalEarnTransactionRow,
+} from '../../../_utils'
+import { deriveCooldownPostAction } from '../../../pool/[shareAddress]/_components/poolReview/cooldownPostAction'
+import { useEarnCooldownRemaining } from '../../../pool/[shareAddress]/_hooks/useEarnCooldownRemaining'
+import {
+  type EarnPool,
+  type EarnTransaction,
+  type EarnTransactionStatusType,
+} from '../../../types'
+
+type Props = {
+  callToAction?: ReactNode
+  onClose: VoidFunction
+  pool: EarnPool
+  transaction: EarnTransaction
+}
+
+type Translator = ReturnType<
+  typeof useTranslations<'hemi-earn.transactions.drawer'>
+>
+
+type StepStates = {
+  unstake: ProgressStatusType
+  receive: ProgressStatusType
+}
+
+const stepStatesByStatus: Record<EarnTransactionStatusType, StepStates> = {
+  CANCELLED: {
+    receive: ProgressStatus.NOT_READY,
+    unstake: ProgressStatus.FAILED,
+  },
+  FAILED: {
+    receive: ProgressStatus.NOT_READY,
+    unstake: ProgressStatus.FAILED,
+  },
+  FINALIZED: {
+    receive: ProgressStatus.COMPLETED,
+    unstake: ProgressStatus.COMPLETED,
+  },
+  FULFILLED: {
+    receive: ProgressStatus.PROGRESS,
+    unstake: ProgressStatus.COMPLETED,
+  },
+  PENDING: {
+    receive: ProgressStatus.NOT_READY,
+    unstake: ProgressStatus.COMPLETED,
+  },
+  RECOVERED: {
+    receive: ProgressStatus.COMPLETED,
+    unstake: ProgressStatus.COMPLETED,
+  },
+  TX_PENDING: {
+    receive: ProgressStatus.NOT_READY,
+    unstake: ProgressStatus.PROGRESS,
+  },
+}
+
+// FAILED splits by source: local rows mean the Hemi tx itself reverted
+// (unstake step is FAILED), subgraph rows mean the Vetro Agent failed after a
+// successful Hemi tx (unstake completed, failure is in the cross-chain step).
+const resolveStepStates = (tx: EarnTransaction): StepStates =>
+  tx.status === 'FAILED' && !isLocalEarnTransactionRow(tx)
+    ? {
+        receive: ProgressStatus.FAILED,
+        unstake: ProgressStatus.COMPLETED,
+      }
+    : stepStatesByStatus[tx.status]
+
+const buildUnstakeStep = (
+  tx: EarnTransaction,
+  shareToken: EvmToken,
+  t: Translator,
+) => ({
+  description: (
+    <div className="flex items-center gap-x-2">
+      <TokenLogo size="small" token={shareToken} />
+      <span>{t('step.unstake-token', { symbol: shareToken.symbol })}</span>
+    </div>
+  ),
+  explorerChainId: hemi.id,
+  status: resolveStepStates(tx).unstake,
+  txHash: tx.requestTxHash,
+})
+
+const pickDisplay = (
+  tx: EarnTransaction,
+  shareToken: EvmToken,
+  assetToken: EvmToken | undefined,
+) =>
+  tx.amountOut != null
+    ? { amount: tx.amountOut, token: assetToken }
+    : { amount: tx.amountIn, token: shareToken }
+
+const buildReceiveStep = (
+  tx: EarnTransaction,
+  receiveToken: EvmToken,
+  t: Translator,
+  status: ProgressStatusType,
+) => ({
+  description: (
+    <div className="flex items-center gap-x-2">
+      <TokenLogo size="small" token={receiveToken} />
+      <span>{t('step.receive-token', { symbol: receiveToken.symbol })}</span>
+    </div>
+  ),
+  status,
+  txHash: getTerminalDeliveryTxHash(tx),
+})
+
+const buildApprovalStep = (
+  approvalTxHash: NonNullable<EarnTransaction['approvalTxHash']>,
+  shareToken: EvmToken,
+  t: Translator,
+) => ({
+  description: (
+    <span>{t('step.approve-token', { symbol: shareToken.symbol })}</span>
+  ),
+  explorerChainId: hemi.id,
+  status: ProgressStatus.COMPLETED,
+  txHash: approvalTxHash,
+})
+
+export const HistoricalWithdrawReview = function ({
+  callToAction,
+  onClose,
+  pool,
+  transaction,
+}: Props) {
+  const t = useTranslations('hemi-earn.transactions.drawer')
+  // The cooldown sub-step copy is shared with the live pool review; keep
+  // it under `pool.drawer` instead of duplicating the keys here.
+  const tCooldown = useTranslations('hemi-earn.pool.drawer')
+  const { address } = useAccount()
+
+  // `useToken` returns `Token | undefined` (BtcToken | EvmToken); for the
+  // Hemi-side asset address this is always an EvmToken.
+  const { data: rawReceiveToken } = useToken({
+    address: transaction.asset,
+    chainId: hemi.id,
+  })
+  const receiveToken = rawReceiveToken as EvmToken | undefined
+
+  const { needsApproval } = useNeedsApproval({
+    address: pool.shareAddress,
+    amount: BigInt(transaction.amountIn),
+    chainId: hemi.id,
+    spender: getHemiEarnRouterAddress(),
+  })
+
+  const { data: isCooldownEligible } = useIsCooldownEligible({
+    account: address,
+    stakingVault: pool.stakingVault,
+  })
+
+  const { data: cooldownDurationSec } = useCooldownDuration({
+    stakingVault: pool.stakingVault,
+  })
+
+  const cooldownRemainingSec = useEarnCooldownRemaining(
+    transaction.claimableAt != null
+      ? BigInt(transaction.claimableAt)
+      : undefined,
+  )
+
+  const { receive, unstake } = resolveStepStates(transaction)
+  const unstakeMined = unstake === ProgressStatus.COMPLETED
+
+  const cooldownPostAction = deriveCooldownPostAction({
+    cooldownDurationSec,
+    cooldownRemainingSec,
+    isCooldownEligible,
+    subgraphStatus: transaction.status,
+    t: tCooldown,
+    unstakeMined,
+  })
+
+  // Show shareToken while we only have amountIn (share units); switch to
+  // the asset token once amountOut lands (asset units). Same rule the
+  // AmountCell applies to table rows.
+  const { amount: displayAmount, token: displayToken } = pickDisplay(
+    transaction,
+    pool.shareToken,
+    receiveToken,
+  )
+
+  const steps: StepPropsWithoutPosition[] = []
+  // Re-approve only makes sense for local FAILED (Hemi tx reverted).
+  if (
+    transaction.status === 'FAILED' &&
+    isLocalEarnTransactionRow(transaction) &&
+    needsApproval
+  ) {
+    steps.push({
+      description: <span>{t('step.approval-needed')}</span>,
+      status: ProgressStatus.NOT_READY,
+    })
+  }
+  // Only locally-mirrored entries carry `approvalTxHash` — see the merge
+  // in `useEarnTransactions`. Rows opened from another browser/device won't
+  // have this step (indexer doesn't link approval to request).
+  if (transaction.approvalTxHash) {
+    steps.push(
+      buildApprovalStep(transaction.approvalTxHash, pool.shareToken, t),
+    )
+  }
+  const unstakeStep = buildUnstakeStep(transaction, pool.shareToken, t)
+  steps.push(
+    cooldownPostAction
+      ? { ...unstakeStep, postAction: cooldownPostAction }
+      : unstakeStep,
+  )
+  if (receiveToken) {
+    steps.push(buildReceiveStep(transaction, receiveToken, t, receive))
+  }
+
+  if (!displayToken) {
+    return null
+  }
+
+  return (
+    <Operation
+      amount={displayAmount}
+      callToAction={callToAction}
+      heading={t('withdraw-heading')}
+      onClose={onClose}
+      steps={steps}
+      subheading={t('withdraw-subheading')}
+      token={displayToken}
+    />
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -6,11 +6,17 @@ import { isAddressEqual } from 'viem'
 
 import { useEarnPools } from '../../../_hooks/useEarnPools'
 import { useEarnTransactions } from '../../../_hooks/useEarnTransactions'
-import { findPoolByAsset, hashesMatch } from '../../../_utils'
+import {
+  findPoolByAsset,
+  hashesMatch,
+  isLocalEarnTransactionRow,
+} from '../../../_utils'
 import { type EarnTransaction } from '../../../types'
 
 import { HistoricalDepositReview } from './historicalDepositReview'
+import { HistoricalWithdrawReview } from './historicalWithdrawReview'
 import { RetryFailedDeposit } from './retryFailedDeposit'
+import { RetryFailedWithdraw } from './retryFailedWithdraw'
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
 const findTransactionByTxId = (transactions: EarnTransaction[], txId: string) =>
@@ -49,24 +55,44 @@ const TransactionDrawerContent = function () {
   }
   const resolved = { asset, pool }
 
-  const callToAction =
-    transaction.status === 'FAILED' ? (
+  // Only local FAILED rows are retryable; subgraph FAILED (Agent rejection
+  // after a successful Hemi tx) needs the recover flow shipped in a later PR.
+  const canRetry =
+    transaction.status === 'FAILED' && isLocalEarnTransactionRow(transaction)
+  const callToAction = canRetry ? (
+    transaction.kind === 'REDEEM' ? (
+      <RetryFailedWithdraw
+        asset={resolved.asset}
+        pool={resolved.pool}
+        transaction={transaction}
+      />
+    ) : (
       <RetryFailedDeposit
         asset={resolved.asset}
         pool={resolved.pool}
         transaction={transaction}
       />
-    ) : undefined
+    )
+  ) : undefined
 
   return (
     <Drawer onClose={close}>
       <div className="drawer-content h-[80dvh] md:h-full">
-        <HistoricalDepositReview
-          callToAction={callToAction}
-          onClose={close}
-          token={resolved.asset.token}
-          transaction={transaction}
-        />
+        {transaction.kind === 'REDEEM' ? (
+          <HistoricalWithdrawReview
+            callToAction={callToAction}
+            onClose={close}
+            pool={resolved.pool}
+            transaction={transaction}
+          />
+        ) : (
+          <HistoricalDepositReview
+            callToAction={callToAction}
+            onClose={close}
+            token={resolved.asset.token}
+            transaction={transaction}
+          />
+        )}
       </div>
     </Drawer>
   )

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedWithdraw.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { Button } from 'components/button'
+import { SubmitWhenConnected } from 'components/submitWhenConnected'
+import { useTranslations } from 'next-intl'
+import { type FormEvent, useState } from 'react'
+import { useAccount } from 'wagmi'
+
+import {
+  REDEEM_SLIPPAGE_BPS,
+  applySlippage,
+} from '../../../_constants/slippage'
+import { useQuoteRedeem } from '../../../pool/[shareAddress]/_hooks/useQuoteRedeem'
+import { useSharesToAssets } from '../../../pool/[shareAddress]/_hooks/useSharesToAssets'
+import { useWithdraw } from '../../../pool/[shareAddress]/_hooks/useWithdraw'
+import { type WithdrawOperationRunning } from '../../../pool/[shareAddress]/_types/operations'
+import {
+  type EarnAsset,
+  type EarnPool,
+  type EarnTransaction,
+} from '../../../types'
+
+import { useTxDrawerQueryString } from './useTxDrawerQueryString'
+
+type Props = {
+  asset: EarnAsset
+  pool: EarnPool
+  transaction: EarnTransaction
+}
+
+// "Try again" CTA shown inside `<HistoricalWithdrawReview>` when a redeem
+// failed. Mirrors `<RetryFailedDeposit>`: reuses `useWithdraw` and on
+// `user-signed-withdraw` redirects the drawer's `earnTxId` so the FAILED
+// view transitions in place into the new in-flight view.
+export const RetryFailedWithdraw = function ({
+  asset,
+  pool,
+  transaction,
+}: Props) {
+  const [, setTxDrawerQueryString] = useTxDrawerQueryString()
+  const [operationRunning, setOperationRunning] =
+    useState<WithdrawOperationRunning>('idle')
+  const { address } = useAccount()
+  const t = useTranslations()
+
+  // `amountIn` on a REDEEM row is in share-token units — exactly what the
+  // Router burns again on retry.
+  const shares = BigInt(transaction.amountIn)
+
+  const {
+    data: { assetOut, peggedAmount } = {
+      assetOut: BigInt(0),
+      peggedAmount: BigInt(0),
+    },
+  } = useSharesToAssets({
+    assetAddress: asset.address,
+    shareAddress: pool.shareAddress,
+    shares,
+  })
+
+  const assetsOutMin =
+    assetOut > BigInt(0)
+      ? applySlippage(assetOut, REDEEM_SLIPPAGE_BPS)
+      : BigInt(0)
+
+  const { data: quote } = useQuoteRedeem({
+    account: address,
+    asset: asset.address,
+    shareAddress: pool.shareAddress,
+    shares,
+  })
+
+  const { mutate: runWithdraw } = useWithdraw({
+    assetsOutMin,
+    callbackFee: quote?.callbackFee ?? BigInt(0),
+    isInstant: quote?.isInstant ?? false,
+    on(emitter) {
+      emitter.on('approve-transaction-reverted', () =>
+        setOperationRunning('failed'),
+      )
+      emitter.on('withdraw-transaction-reverted', () =>
+        setOperationRunning('failed'),
+      )
+      emitter.on('user-signing-approval-error', () =>
+        setOperationRunning('failed'),
+      )
+      emitter.on('user-signing-withdraw-error', () =>
+        setOperationRunning('failed'),
+      )
+      emitter.on('unexpected-error', () => setOperationRunning('failed'))
+      emitter.on('user-signed-withdraw', function (newInitiateTxHash) {
+        setTxDrawerQueryString(newInitiateTxHash)
+      })
+    },
+    peggedAmount,
+    pool,
+    priorApprovalTxHash: transaction.approvalTxHash,
+    selectedAsset: asset,
+    shares,
+    // Hide the specific failed row from the table once this retry is signed.
+    supersedesInitiateTxHash: transaction.requestTxHash,
+  })
+
+  const isWithdrawing = operationRunning === 'withdrawing'
+  const canRetry = !!quote && shares > BigInt(0) && assetOut > BigInt(0)
+
+  const handleRetry = function (e: FormEvent) {
+    e.preventDefault()
+    if (!canRetry) return
+    setOperationRunning('withdrawing')
+    runWithdraw()
+  }
+
+  return (
+    <form className="flex w-full [&>button]:w-full" onSubmit={handleRetry}>
+      <SubmitWhenConnected
+        submitButton={
+          <Button disabled={isWithdrawing || !canRetry} size="small">
+            {t(isWithdrawing ? 'common.withdrawing' : 'common.try-again')}
+          </Button>
+        }
+        submitButtonSize="small"
+      />
+    </form>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
@@ -85,15 +85,14 @@ const WithdrawStatusCellResolved = function ({
     stakingVault: pool.stakingVault,
   })
 
+  const claimableAt = transaction.claimableAt ?? null
   const remainingSec = useEarnCooldownRemaining(
-    transaction.claimableAt != null
-      ? BigInt(transaction.claimableAt)
-      : undefined,
+    claimableAt !== null ? BigInt(claimableAt) : undefined,
   )
 
   const cooldownText = deriveCooldownText({
     cooldownDurationSec,
-    hasClaimableAt: transaction.claimableAt != null,
+    hasClaimableAt: claimableAt !== null,
     isCooldownEligible,
     remainingSec,
     status: transaction.status,

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -46,3 +46,8 @@ export const findPoolByShare = (
   shareAddress: Address,
 ): EarnPool | undefined =>
   pools.find(p => isAddressEqual(p.shareAddress, shareAddress))
+
+// Local rows mean the Hemi `request*` tx reverted; subgraph rows mean the
+// Agent failed after a successful Hemi tx (recover, not retry).
+export const isLocalEarnTransactionRow = (tx: EarnTransaction) =>
+  tx.requestId.startsWith('local-')

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction.ts
@@ -1,0 +1,102 @@
+import {
+  ProgressStatus,
+  type ProgressStatusType,
+} from 'components/reviewOperation/progressStatus'
+import { type useTranslations } from 'next-intl'
+import { type ReactNode } from 'react'
+import { secondsToDays, secondsToHours, secondsToWholeDays } from 'utils/time'
+
+export type CooldownPostAction = {
+  description: ReactNode
+  status: ProgressStatusType
+}
+
+export type CooldownInputs = {
+  cooldownDurationSec: number | undefined
+  cooldownRemainingSec: number | undefined
+  isCooldownEligible: boolean | undefined
+  subgraphStatus: string | undefined
+  t: ReturnType<typeof useTranslations<'hemi-earn.pool.drawer'>>
+  unstakeMined: boolean
+}
+
+// Decides what (if anything) to render under the Unstake step as a clock
+// sub-step. Pure function so the component's complexity stays low.
+//
+// Mirrors the tunnel's wait-step pattern (e.g. `reviewEvmWithdrawal`):
+// the sub-step stays mounted across its whole lifecycle (NOT_READY →
+// PROGRESS → COMPLETED) so the user keeps a visible milestone even
+// after the wait period elapses. The only case we hide it entirely is
+// when the user simply doesn't have a cooldown (whitelist / disabled).
+export function deriveCooldownPostAction({
+  cooldownDurationSec,
+  cooldownRemainingSec,
+  isCooldownEligible,
+  subgraphStatus,
+  t,
+  unstakeMined,
+}: CooldownInputs): CooldownPostAction | undefined {
+  if (isCooldownEligible === false) return undefined
+  // The cooldown is effectively over once any of:
+  //   - the local timer elapsed
+  //   - the subgraph row reached FINALIZED (auto-claim fired the moment
+  //     the cooldown matured)
+  //   - the subgraph row reached RECOVERED (cancel/recovery ended the
+  //     cooldown early)
+  // Keep the sub-step visible as a COMPLETED milestone — without this,
+  // an auto-claim landing seconds after the timer hits zero would make
+  // the sub-step disappear right when the user expects to see it tick
+  // over to "done".
+  const cooldownOver =
+    cooldownRemainingSec === 0 ||
+    subgraphStatus === 'FINALIZED' ||
+    subgraphStatus === 'RECOVERED'
+  if (cooldownOver) {
+    return {
+      description: t('cooldown-ended'),
+      status: ProgressStatus.COMPLETED,
+    }
+  }
+  // Duration still loading — render nothing for now; the postAction
+  // shows up once the on-chain read settles.
+  if (cooldownDurationSec === undefined) return undefined
+
+  const days = secondsToWholeDays(cooldownDurationSec)
+
+  if (!unstakeMined) {
+    return {
+      description: t('wait-cooldown-pending', { days }),
+      status: ProgressStatus.NOT_READY,
+    }
+  }
+
+  if (cooldownRemainingSec === undefined) {
+    return {
+      description: t('wait-cooldown-pending', { days }),
+      status: ProgressStatus.PROGRESS,
+    }
+  }
+
+  // Sub-hour remaining: avoid the misleading "0h" by collapsing to a
+  // generic "less than an hour" copy. Tick interval is at minute
+  // resolution, so showing a precise minute countdown would lie about
+  // freshness; the shorter copy is honest about where we are.
+  if (cooldownRemainingSec < 3600) {
+    return {
+      description: t('wait-cooldown-countdown-soon'),
+      status: ProgressStatus.PROGRESS,
+    }
+  }
+
+  const remainingDays = Math.floor(secondsToDays(cooldownRemainingSec))
+  const remainingHours = Math.floor(
+    secondsToHours(cooldownRemainingSec - remainingDays * 86400),
+  )
+  return {
+    description: t('wait-cooldown-countdown', {
+      days: remainingDays,
+      hours: remainingHours,
+    }),
+    status: ProgressStatus.PROGRESS,
+  }
+}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { AddTokenToWallet } from 'components/addTokenToWallet'
-import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import { Operation } from 'components/reviewOperation/operation'
 import {
   ProgressStatus,
   type ProgressStatusType,
 } from 'components/reviewOperation/progressStatus'
 import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
+import { TokenLogo } from 'components/tokenLogo'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
 import { encodeRequestDeposit } from 'hemi-earn-actions/actions'
 import { useChain } from 'hooks/useChain'
@@ -147,11 +147,18 @@ export const ReviewDeposit = function ({ onClose }: Props) {
 
     return {
       description: (
-        <ChainLabel
-          active={depositStatus === DepositStatus.APPROVAL_TX_PENDING}
-          chainId={chainId}
-          label={t('approving', { symbol: selectedAsset.token.symbol })}
-        />
+        <div className="flex items-center gap-x-2">
+          <TokenLogo size="small" token={selectedAsset.token} />
+          <span
+            className={`text-sm font-normal ${
+              depositStatus === DepositStatus.APPROVAL_TX_PENDING
+                ? 'text-orange-600'
+                : 'text-neutral-500'
+            }`}
+          >
+            {t('approving', { symbol: selectedAsset.token.symbol })}
+          </span>
+        </div>
       ),
       explorerChainId: chainId,
       fees: getStepFees({
@@ -190,7 +197,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
     return {
       description: (
         <div className="flex items-center gap-x-2">
-          <SparkleIcon />
+          <TokenLogo size="small" token={selectedAsset.token} />
           <span>
             {t('stake-token', { symbol: selectedAsset.token.symbol })}
           </span>
@@ -219,7 +226,12 @@ export const ReviewDeposit = function ({ onClose }: Props) {
     }
 
     return {
-      description: <span>{t('get-share-tokens')}</span>,
+      description: (
+        <div className="flex items-center gap-x-2">
+          <SparkleIcon />
+          <span>{t('get-share-tokens')}</span>
+        </div>
+      ),
       status: getStatus(),
       txHash: terminalHash,
     }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -15,10 +15,8 @@ import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useEstimateFees } from 'hooks/useEstimateFees'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import { useTranslations } from 'next-intl'
-import { type ReactNode } from 'react'
 import { type EvmToken } from 'types/token'
 import { getNativeToken } from 'utils/nativeToken'
-import { secondsToDays, secondsToHours, secondsToWholeDays } from 'utils/time'
 import { parseTokenUnits } from 'utils/token'
 import { type Address, type Hash, formatUnits } from 'viem'
 import { useAccount, useEstimateGas } from 'wagmi'
@@ -40,24 +38,11 @@ import {
   type WithdrawStatusType,
 } from '../../_types/operations'
 
+import { deriveCooldownPostAction } from './cooldownPostAction'
 import { RetryWithdraw } from './retryWithdraw'
 
 type Props = {
   onClose: VoidFunction
-}
-
-type CooldownPostAction = {
-  description: ReactNode
-  status: ProgressStatusType
-}
-
-type CooldownInputs = {
-  cooldownDurationSec: number | undefined
-  cooldownRemainingSec: number | undefined
-  isCooldownEligible: boolean | undefined
-  subgraphStatus: string | undefined
-  t: ReturnType<typeof useTranslations<'hemi-earn.pool.drawer'>>
-  unstakeMined: boolean
 }
 
 // Maps the local withdraw status, subgraph row, and cooldown state to the
@@ -161,87 +146,6 @@ function encodeRedeemForGasEstimate({
     receiver: account,
     shares,
   })
-}
-
-// Decides what (if anything) to render under the Unstake step as a clock
-// sub-step. Pure function so the component's complexity stays low.
-//
-// Mirrors the tunnel's wait-step pattern (e.g. `reviewEvmWithdrawal`):
-// the sub-step stays mounted across its whole lifecycle (NOT_READY →
-// PROGRESS → COMPLETED) so the user keeps a visible milestone even
-// after the wait period elapses. The only case we hide it entirely is
-// when the user simply doesn't have a cooldown (whitelist / disabled).
-function deriveCooldownPostAction({
-  cooldownDurationSec,
-  cooldownRemainingSec,
-  isCooldownEligible,
-  subgraphStatus,
-  t,
-  unstakeMined,
-}: CooldownInputs): CooldownPostAction | undefined {
-  if (isCooldownEligible === false) return undefined
-  // The cooldown is effectively over once any of:
-  //   - the local timer elapsed
-  //   - the subgraph row reached CLAIMED (auto-claim fired the moment
-  //     the cooldown matured)
-  //   - the subgraph row reached RECOVERED (cancel/recovery ended the
-  //     cooldown early)
-  // Keep the sub-step visible as a COMPLETED milestone — without this,
-  // an auto-claim landing seconds after the timer hits zero would make
-  // the sub-step disappear right when the user expects to see it tick
-  // over to "done".
-  const cooldownOver =
-    cooldownRemainingSec === 0 ||
-    subgraphStatus === 'FINALIZED' ||
-    subgraphStatus === 'RECOVERED'
-  if (cooldownOver) {
-    return {
-      description: t('cooldown-ended'),
-      status: ProgressStatus.COMPLETED,
-    }
-  }
-  // Duration still loading — render nothing for now; the postAction
-  // shows up once the on-chain read settles.
-  if (cooldownDurationSec === undefined) return undefined
-
-  const days = secondsToWholeDays(cooldownDurationSec)
-
-  if (!unstakeMined) {
-    return {
-      description: t('wait-cooldown-pending', { days }),
-      status: ProgressStatus.NOT_READY,
-    }
-  }
-
-  if (cooldownRemainingSec === undefined) {
-    return {
-      description: t('wait-cooldown-pending', { days }),
-      status: ProgressStatus.PROGRESS,
-    }
-  }
-
-  // Sub-hour remaining: avoid the misleading "0h" by collapsing to a
-  // generic "less than an hour" copy. Tick interval is at minute
-  // resolution, so showing a precise minute countdown would lie about
-  // freshness; the shorter copy is honest about where we are.
-  if (cooldownRemainingSec < 3600) {
-    return {
-      description: t('wait-cooldown-countdown-soon'),
-      status: ProgressStatus.PROGRESS,
-    }
-  }
-
-  const remainingDays = Math.floor(secondsToDays(cooldownRemainingSec))
-  const remainingHours = Math.floor(
-    secondsToHours(cooldownRemainingSec - remainingDays * 86400),
-  )
-  return {
-    description: t('wait-cooldown-countdown', {
-      days: remainingDays,
-      hours: remainingHours,
-    }),
-    status: ProgressStatus.PROGRESS,
-  }
 }
 
 // Drawer opens after the user signs the first wallet prompt (approval if

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import { Operation } from 'components/reviewOperation/operation'
 import {
   ProgressStatus,
@@ -176,8 +175,6 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
   const { data: cooldownDurationSec } = useCooldownDuration({
     stakingVault: pool.stakingVault,
   })
-  // `claimableAt` is `string | null` — use `!= null` so a legitimate `'0'`
-  // isn't conflated with "unset" the way a truthy-check would.
   const cooldownRemainingSec = useEarnCooldownRemaining(
     subgraphRow?.claimableAt != null
       ? BigInt(subgraphRow.claimableAt)
@@ -282,11 +279,18 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
 
     return {
       description: (
-        <ChainLabel
-          active={withdrawStatus === WithdrawStatus.APPROVAL_TX_PENDING}
-          chainId={chainId}
-          label={t('approving', { symbol: pool.shareToken.symbol })}
-        />
+        <div className="flex items-center gap-x-2">
+          <TokenLogo size="small" token={pool.shareToken} />
+          <span
+            className={`text-sm font-normal ${
+              withdrawStatus === WithdrawStatus.APPROVAL_TX_PENDING
+                ? 'text-orange-600'
+                : 'text-neutral-500'
+            }`}
+          >
+            {t('approving', { symbol: pool.shareToken.symbol })}
+          </span>
+        </div>
       ),
       explorerChainId: chainId,
       fees: getStepFees({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdraw.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdraw.ts
@@ -58,7 +58,7 @@ type UseWithdraw = {
   // flagged `settled` so the table doesn't show the old failure alongside
   // the new attempt.
   supersedesInitiateTxHash?: Hash
-  updateWithdrawOperation: (payload?: WithdrawOperation) => void
+  updateWithdrawOperation?: (payload?: WithdrawOperation) => void
 }
 
 export const useWithdraw = function ({
@@ -179,7 +179,7 @@ export const useWithdraw = function ({
 
       emitter.on('user-signed-approval', function (approvalTxHash) {
         observedApprovalTxHash = approvalTxHash
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           amountIn: shares.toString(),
           approvalTxHash,
           status: WithdrawStatus.APPROVAL_TX_PENDING,
@@ -199,14 +199,14 @@ export const useWithdraw = function ({
       })
 
       emitter.on('approve-transaction-reverted', function (receipt) {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.APPROVAL_TX_FAILED,
         })
         updateNativeBalanceAfterFees(receipt)
       })
 
       emitter.on('approve-transaction-succeeded', function (receipt) {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.APPROVAL_TX_COMPLETED,
         })
         updateNativeBalanceAfterFees(receipt)
@@ -214,13 +214,13 @@ export const useWithdraw = function ({
       })
 
       emitter.on('user-signing-approval-error', function () {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.APPROVAL_TX_FAILED,
         })
       })
 
       emitter.on('user-signed-withdraw', function (transactionHash) {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           amountIn: shares.toString(),
           status: WithdrawStatus.WITHDRAW_TX_PENDING,
           transactionHash,
@@ -244,7 +244,7 @@ export const useWithdraw = function ({
       })
 
       emitter.on('user-signing-withdraw-error', function () {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.WITHDRAW_TX_FAILED,
         })
       })
@@ -252,7 +252,7 @@ export const useWithdraw = function ({
       emitter.on('withdraw-transaction-succeeded', function (receipt) {
         // TODO(phase-3): parse the `RedeemRequested` log to capture the
         // requestId so the UI can track cross-chain fulfillment.
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.WITHDRAW_TX_CONFIRMED,
         })
         upsertLocalOperation({
@@ -289,7 +289,7 @@ export const useWithdraw = function ({
       })
 
       emitter.on('withdraw-transaction-reverted', function (receipt) {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.WITHDRAW_TX_FAILED,
         })
         upsertLocalOperation({
@@ -302,25 +302,25 @@ export const useWithdraw = function ({
       })
 
       emitter.on('withdraw-failed-validation', function () {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.WITHDRAW_TX_FAILED,
         })
       })
 
       emitter.on('quote-failed', function () {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.WITHDRAW_TX_FAILED,
         })
       })
 
       emitter.on('withdraw-failed', function () {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.WITHDRAW_TX_FAILED,
         })
       })
 
       emitter.on('unexpected-error', function () {
-        updateWithdrawOperation({
+        updateWithdrawOperation?.({
           status: WithdrawStatus.WITHDRAW_TX_FAILED,
         })
       })

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -97,8 +97,12 @@
           "approval-needed": "Approval needed",
           "approve-token": "Approve {symbol}",
           "stake-token": "Stake {symbol}",
-          "get-share-tokens": "Get share tokens"
-        }
+          "get-share-tokens": "Get share tokens",
+          "unstake-token": "Unstake {symbol}",
+          "receive-token": "Receive {symbol}"
+        },
+        "withdraw-heading": "Stake withdrawal details",
+        "withdraw-subheading": "Review your stake withdrawal transaction."
       },
       "nothing-here": "Nothing here yet",
       "nothing-here-subtitle": "Your transactions will appear once you get started.",
@@ -240,6 +244,7 @@
     "waiting-completed": "Waiting completed",
     "wallets-connected": "{count} Connected {count, plural, =1 {Wallet} other {Wallets}} ",
     "withdraw": "Withdraw",
+    "withdrawing": "Withdrawing...",
     "wrong-network": "Wrong Network",
     "wrong-type-network": "Wrong {type} Network",
     "your-wallet-not-connected": "Your wallet is not connected"

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -97,8 +97,12 @@
           "approval-needed": "Aprobación necesaria",
           "approve-token": "Aprobar {symbol}",
           "stake-token": "Hacer stake de {symbol}",
-          "get-share-tokens": "Recibir share tokens"
-        }
+          "get-share-tokens": "Recibir share tokens",
+          "unstake-token": "Retirar {symbol}",
+          "receive-token": "Recibir {symbol}"
+        },
+        "withdraw-heading": "Detalles del retiro de stake",
+        "withdraw-subheading": "Revise su transacción de retiro de stake."
       },
       "nothing-here": "Aún no hay nada aquí",
       "nothing-here-subtitle": "Sus transacciones aparecerán una vez que comience.",
@@ -240,6 +244,7 @@
     "waiting-completed": "Espera completada",
     "wallets-connected": "{count} {count, plural, =1 {Billetera Conectada} other {Billeteras Conectadas}} ",
     "withdraw": "Retirar",
+    "withdrawing": "Retirando...",
     "wrong-network": "Red Incorrecta",
     "wrong-type-network": "Red {type} Incorrecta",
     "your-wallet-not-connected": "Tu billetera no está conectada"

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -97,8 +97,12 @@
           "approval-needed": "Aprovação necessária",
           "approve-token": "Aprovar {symbol}",
           "stake-token": "Fazer stake de {symbol}",
-          "get-share-tokens": "Receber share tokens"
-        }
+          "get-share-tokens": "Receber share tokens",
+          "unstake-token": "Sacar {symbol}",
+          "receive-token": "Receber {symbol}"
+        },
+        "withdraw-heading": "Detalhes do saque de stake",
+        "withdraw-subheading": "Revise sua transação de saque de stake."
       },
       "nothing-here": "Nada por aqui ainda",
       "nothing-here-subtitle": "Suas transações aparecerão assim que você começar.",
@@ -240,6 +244,7 @@
     "waiting-completed": "Espera concluída",
     "wallets-connected": "{count} {count, plural, =1 {Carteira Conectada} other {Carteiras Conectadas}}",
     "withdraw": "Retirar",
+    "withdrawing": "A retirar...",
     "wrong-network": "Rede Errada",
     "wrong-type-network": "Rede {type} Errada",
     "your-wallet-not-connected": "A sua carteira não está conectada"

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -1,12 +1,16 @@
-import { zeroAddress } from 'viem'
+import { type Address, zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
 
 import {
+  findPoolByAsset,
+  findPoolByShare,
   formatApyDisplay,
   getTerminalDeliveryTxHash,
   hashesMatch,
+  isLocalEarnTransactionRow,
 } from '../../../../../app/[locale]/hemi-earn/_utils'
 import {
+  type EarnPool,
   type EarnTransaction,
   type EarnTransactionStatusType,
 } from '../../../../../app/[locale]/hemi-earn/types'
@@ -116,6 +120,57 @@ describe('utils', function () {
 
     it('returns undefined when tx is undefined', function () {
       expect(getTerminalDeliveryTxHash(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('findPoolByAsset / findPoolByShare', function () {
+    const shareA = '0x000000000000000000000000000000000000aaaa' as Address
+    const shareB = '0x000000000000000000000000000000000000bbbb' as Address
+    const assetA1 = '0x0000000000000000000000000000000000001111' as Address
+    const assetA2 = '0x0000000000000000000000000000000000002222' as Address
+    const assetB1 = '0x0000000000000000000000000000000000003333' as Address
+    const unknown = '0x0000000000000000000000000000000000009999' as Address
+
+    const makePool = (shareAddress: Address, assets: Address[]) =>
+      ({
+        assets: assets.map(address => ({ address })),
+        shareAddress,
+      }) as unknown as EarnPool
+
+    const pools: EarnPool[] = [
+      makePool(shareA, [assetA1, assetA2]),
+      makePool(shareB, [assetB1]),
+    ]
+
+    it('findPoolByAsset finds the pool whose `assets` includes the address', function () {
+      expect(findPoolByAsset(pools, assetA2)?.shareAddress).toBe(shareA)
+      expect(findPoolByAsset(pools, assetB1)?.shareAddress).toBe(shareB)
+    })
+
+    it('findPoolByAsset returns undefined for an unknown asset', function () {
+      expect(findPoolByAsset(pools, unknown)).toBeUndefined()
+    })
+
+    it('findPoolByShare finds the pool by share address', function () {
+      expect(findPoolByShare(pools, shareB)?.shareAddress).toBe(shareB)
+    })
+
+    it('findPoolByShare returns undefined for an unknown share', function () {
+      expect(findPoolByShare(pools, unknown)).toBeUndefined()
+    })
+  })
+
+  describe('isLocalEarnTransactionRow', function () {
+    it('returns true for a row whose `requestId` is locally-prefixed', function () {
+      expect(
+        isLocalEarnTransactionRow({ ...baseTx, requestId: 'local-1700000000' }),
+      ).toBe(true)
+    })
+
+    it('returns false for a row whose `requestId` is a subgraph numeric id', function () {
+      expect(isLocalEarnTransactionRow({ ...baseTx, requestId: '42' })).toBe(
+        false,
+      )
     })
   })
 


### PR DESCRIPTION
### Description

This PR adds the withdraw drawer to the Hemi Earn transactions table — clicking View on a REDEEM row now opens a read-only timeline that mirrors the deposit drawer, with an Approval step (when local-store carries the hash), an Unstake step with the cooldown post-action sub-step, and a Receive step that lights up on FINALIZED. FAILED rows get a Try again CTA via the new `RetryFailedWithdraw` wrapper around `useWithdraw`, redirecting the drawer's `earnTxId` on `user-signed-withdraw` so the FAILED view transitions in place to the new in-flight view.

  The retry CTA is gated on `isLocalEarnTransactionRow` so only Hemi-side reverts (request deposit/redeem) retry — Agent-side failures (subgraph `failed=true` after a successful Hemi tx) wait for the recovery flow that ships in a follow-up PR. The predicate is extracted into `_utils` and reused in both historical reviews. The retry wrapper also mirrors `retryWithdraw.tsx`'s safeguards: the button stays disabled until `useSharesToAssets` resolves (so `assetsOutMin` can never collapse to zero), and `isInstant` is read straight from the redeem quote so the request body, gas reservation, and Agent check always agree.

  While in there, `deriveCooldownPostAction` was pulled out of `reviewWithdraw` into a shared helper consumed by both drawers, the historical `unstakeMined` was aligned to the resolved step state so a failed local row no longer shows a misleading cooldown spinner under a FAILED Unstake step, and `useWithdraw`'s `updateWithdrawOperation` became optional (matching `useDeposit`) so the historical retry doesn't need a no-op callback. Three new i18n keys land for the withdraw drawer copy plus a `common.withdrawing` filler the button label was missing.

  ## Note
  - Out of scope: manual claim/recover CTAs and the dedicated "something went wrong" state for Agent failures land in a follow-up that also revisits CANCELLED step states.

### Screenshots

Flow:

https://github.com/user-attachments/assets/3816020e-defd-4b13-829c-3d02a64afde0


### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
