### PR TITLE
Price Hemi Earn pegged tokens via oracles

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/earnFiatBalance.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnFiatBalance.tsx
@@ -1,0 +1,14 @@
+import { RenderFiatBalance } from 'components/fiatBalance'
+import { type ComponentProps } from 'react'
+
+import { useEarnTokenPrices } from '../_hooks/useEarnTokenPrices'
+
+// Hemi Earn's counterpart to `components/fiatBalance`'s `RenderFiatBalance`: the
+// same component priced through `useEarnTokenPrices` (portal feed + gateway
+// oracle prices) instead of the plain portal feed, so pegged tokens (vetBTC,
+// VUSD) resolve via their whitelisted-proxy `priceSymbol`. A thin wrapper so the
+// shared `RenderFiatBalance` (and its ErrorBoundary) stays the single source of
+// the rendering, defaulting the rest of the app to the portal feed.
+export const RenderEarnFiatBalance = (
+  props: Omit<ComponentProps<typeof RenderFiatBalance>, 'usePrices'>,
+) => <RenderFiatBalance {...props} usePrices={useEarnTokenPrices} />

--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
@@ -2,7 +2,6 @@
 
 import { ButtonLink } from 'components/button'
 import { ExternalLink } from 'components/externalLink'
-import { RenderFiatBalance } from 'components/fiatBalance'
 import { TokenLogo } from 'components/tokenLogo'
 import { useChain } from 'hooks/useChain'
 import { mainnet } from 'networks/mainnet'
@@ -12,6 +11,7 @@ import { formatCompactFiat, formatEvmAddress } from 'utils/format'
 import { useEarnRewards } from '../../_hooks/useEarnRewards'
 import { formatApyDisplay } from '../../_utils'
 import { type EarnPool } from '../../types'
+import { RenderEarnFiatBalance } from '../earnFiatBalance'
 
 import { PoolInfoItem } from './poolInfoItem'
 import { TokenIconStack } from './tokenIconStack'
@@ -69,10 +69,10 @@ export const PoolInfoBar = function ({ pool }: Props) {
         </PoolInfoItem>
         <PoolInfoItem label={t('total-deposits')}>
           <span className="body-text-medium text-neutral-950">
-            <RenderFiatBalance
+            <RenderEarnFiatBalance
               balance={pool.totalDeposits}
               customFormatter={usd => formatCompactFiat(Number(usd), locale)}
-              queryStatus="success"
+              queryStatus={pool.totalDepositsStatus}
               token={pool.peggedToken}
             />
           </span>

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTokenPrices.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTokenPrices.ts
@@ -1,0 +1,72 @@
+import {
+  type QueryClient,
+  type UseQueryOptions,
+  queryOptions,
+} from '@tanstack/react-query'
+import { gateways } from '@vetro-protocol/gateway'
+import { tokenPricesQueryOptions } from 'hooks/useTokenPrices'
+
+import { oraclePricesQueryOptions } from './fetchOraclePrices'
+
+type Prices = Record<string, string>
+
+// "USD" pegs are the identity; any other peg unit (BTC, ETH) is converted to
+// USD with its portal price. A missing peg price degrades that gateway's
+// tokens to $0 rather than crashing.
+const pegToUsdRate = (pegBaseSymbol: string, portal: Prices) =>
+  pegBaseSymbol === 'USD' ? 1 : Number(portal[pegBaseSymbol] ?? 0)
+
+// The Hemi Earn price feed: the app-wide portal `/prices` feed (`useTokenPrices`)
+// extended with each gateway's on-chain oracle prices. Oracle entries are
+// denominated in the gateway's peg unit, converted to USD (× the peg's USD
+// price) and override the portal entry on symbol collision, since the oracle is
+// the source the protocol itself uses. A pegged token (vetBTC, VUSD) has no
+// oracle of its own; it is priced by aliasing to a whitelisted proxy in its
+// gateway via `extensions.priceSymbol` (vetBTC→WBTC, VUSD→USDT), resolved
+// downstream by `getTokenPrice`. Kept earn-scoped so the rest of the app keeps
+// using the plain portal feed.
+export const fetchEarnTokenPrices = async function (
+  queryClient: QueryClient,
+): Promise<Prices> {
+  const [portal, gatewaysWithOracle] = await Promise.all([
+    queryClient.ensureQueryData(tokenPricesQueryOptions()),
+    Promise.all(
+      gateways.map(async gateway => ({
+        gateway,
+        oracle: await queryClient.ensureQueryData(
+          oraclePricesQueryOptions(gateway.address),
+        ),
+      })),
+    ),
+  ])
+
+  return {
+    ...portal,
+    ...Object.fromEntries(
+      gatewaysWithOracle.flatMap(({ gateway, oracle }) =>
+        Object.entries(oracle).map(
+          ([symbol, peggedPrice]) =>
+            [
+              symbol,
+              String(
+                Number(peggedPrice) *
+                  pegToUsdRate(gateway.pegBaseSymbol, portal),
+              ),
+            ] as const,
+        ),
+      ),
+    ),
+  }
+}
+
+export const earnTokenPricesQueryOptions = (
+  options: Omit<UseQueryOptions<Prices, Error>, 'queryKey' | 'queryFn'> = {},
+) =>
+  queryOptions({
+    queryFn: ({ client }) => fetchEarnTokenPrices(client),
+    queryKey: ['hemi-earn', 'token-prices'],
+    // refetch every 5 min
+    refetchInterval: 5 * 60 * 1000,
+    staleTime: 30 * 1000,
+    ...options,
+  })

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.ts
@@ -1,4 +1,5 @@
 import { type QueryClient, queryOptions } from '@tanstack/react-query'
+import { gateways } from '@vetro-protocol/gateway'
 import { hemi } from 'hemi-viem'
 import { tokenQueryOptions } from 'hooks/useToken'
 import { mainnet } from 'networks/mainnet'
@@ -6,6 +7,7 @@ import { type RemoteChain } from 'types/chain'
 import { type EvmToken } from 'types/token'
 import { type Address, isAddressEqual } from 'viem'
 
+import { gatewayForRemoteShareQueryOptions } from '../_hooks/gatewayForRemoteShare'
 import { vaultAssetQueryOptions } from '../_hooks/vaultAsset'
 import { type EarnAsset, type EarnPool } from '../types'
 
@@ -18,6 +20,17 @@ export type ShareSkeleton = Pick<
   EarnPool,
   'assets' | 'peggedToken' | 'shareAddress' | 'shareToken' | 'stakingVault'
 >
+
+// Pegged tokens (vetBTC, VUSD) aren't in the curated token list, so they
+// resolve via the erc20 fallback with no `priceSymbol`. They have no oracle of
+// their own either, so — like vetro-4 — price them by aliasing to a
+// whitelisted proxy token in their gateway. `useEarnTokenPrices` exposes those
+// proxies' oracle-adjusted USD prices, and `getTokenPrice` reads the alias
+// from `extensions.priceSymbol`.
+const pegBaseToPriceSymbol: Record<string, string> = {
+  BTC: 'WBTC',
+  USD: 'USDT',
+}
 
 export const fetchHemiEarnShares = async function (
   queryClient: QueryClient,
@@ -60,7 +73,30 @@ export const fetchHemiEarnShares = async function (
         resolveToken(shareAddress, hemi.id),
         resolveToken(peggedAddress, mainnet.id),
       ])
-      if (!shareToken || !peggedToken) return null
+      if (!shareToken || !peggedToken) {
+        return null
+      }
+      // The pegged token's USD price comes from its gateway's peg base (e.g.
+      // BTC for the vetBTC gateway, USD for VUSD). Resolve the gateway from the
+      // staking vault (same path `fetchComposition` uses; the `asset()` leg is
+      // already cached) and tag the pegged token with the matching feed symbol.
+      const gatewayAddress = await queryClient.ensureQueryData(
+        gatewayForRemoteShareQueryOptions(remoteShare),
+      )
+      const pegBaseSymbol = gateways.find(gateway =>
+        isAddressEqual(gateway.address, gatewayAddress),
+      )?.pegBaseSymbol
+      const priceSymbol = pegBaseSymbol
+        ? pegBaseToPriceSymbol[pegBaseSymbol]
+        : undefined
+      // Build a new token rather than mutate — the resolved token is a shared
+      // cached reference. Fall back to the unpriced token for unmapped pegs.
+      const pricedPeggedToken = priceSymbol
+        ? {
+            ...peggedToken,
+            extensions: { ...peggedToken.extensions, priceSymbol },
+          }
+        : peggedToken
       const tokens = await Promise.all(
         configs
           .filter(entry => isAddressEqual(entry.share, shareAddress))
@@ -69,10 +105,12 @@ export const fetchHemiEarnShares = async function (
       const assets: EarnAsset[] = tokens
         .filter((token): token is EvmToken => token !== undefined)
         .map(token => ({ address: token.address as Address, token }))
-      if (assets.length === 0) return null
+      if (assets.length === 0) {
+        return null
+      }
       return {
         assets,
-        peggedToken,
+        peggedToken: pricedPeggedToken,
         shareAddress,
         shareToken,
         stakingVault: remoteShare,

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.ts
@@ -1,0 +1,86 @@
+import { type QueryClient, queryOptions } from '@tanstack/react-query'
+import { getTreasury } from '@vetro-protocol/gateway/actions'
+import {
+  getTokenConfig,
+  getWhitelistedTokens,
+} from '@vetro-protocol/treasury/actions'
+import { tokenQueryOptions } from 'hooks/useToken'
+import { mainnet } from 'networks/mainnet'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { type Address, formatUnits } from 'viem'
+import { readContract } from 'viem/actions'
+
+// Minimal Chainlink aggregator interface. A whitelisted token's oracle reports
+// the token's price denominated in the gateway's peg unit (e.g. WBTC/BTC for
+// the vetBTC gateway), not USD.
+const aggregatorV3Abi = [
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'latestAnswer',
+    outputs: [{ internalType: 'int256', name: '', type: 'int256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
+// Reads every whitelisted-token oracle for a gateway and returns a
+// `{ SYMBOL: price }` dict where each price is denominated in the gateway's peg
+// unit (BTC for the vetBTC gateway, USD for VUSD). `fetchEarnTokenPrices`
+// converts these to USD. The dict is keyed by the token's uppercased symbol so
+// each entry is unique within the gateway — `priceSymbol` is only a downstream
+// lookup alias and would collide here when several tokens share one alias.
+export const fetchOraclePrices = async function (
+  queryClient: QueryClient,
+  gatewayAddress: Address,
+): Promise<Record<string, string>> {
+  const client = getEvmL1PublicClient(mainnet.id)
+  const treasuryAddress = await getTreasury(client, { address: gatewayAddress })
+  const tokenAddresses = await getWhitelistedTokens(client, {
+    address: treasuryAddress,
+  })
+
+  const entries = await Promise.all(
+    tokenAddresses.map(async function (address) {
+      const [token, [, oracle]] = await Promise.all([
+        queryClient.ensureQueryData(
+          tokenQueryOptions({ address, chainId: mainnet.id }),
+        ),
+        getTokenConfig(client, { address: treasuryAddress, token: address }),
+      ])
+      const [latestAnswer, decimals] = await Promise.all([
+        readContract(client, {
+          abi: aggregatorV3Abi,
+          address: oracle,
+          functionName: 'latestAnswer',
+        }),
+        readContract(client, {
+          abi: aggregatorV3Abi,
+          address: oracle,
+          functionName: 'decimals',
+        }),
+      ])
+      return [
+        token.symbol.toUpperCase(),
+        formatUnits(latestAnswer, decimals),
+      ] as const
+    }),
+  )
+
+  return Object.fromEntries(entries)
+}
+
+export const oraclePricesQueryOptions = (gatewayAddress: Address) =>
+  queryOptions({
+    queryFn: ({ client }) => fetchOraclePrices(client, gatewayAddress),
+    queryKey: ['hemi-earn', 'oracle-prices', gatewayAddress],
+    // refetch every 5 min
+    refetchInterval: 5 * 60 * 1000,
+    staleTime: 30 * 1000,
+  })

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.ts
@@ -23,8 +23,14 @@ const aggregatorV3Abi = [
   },
   {
     inputs: [],
-    name: 'latestAnswer',
-    outputs: [{ internalType: 'int256', name: '', type: 'int256' }],
+    name: 'latestRoundData',
+    outputs: [
+      { internalType: 'uint80', name: 'roundId', type: 'uint80' },
+      { internalType: 'int256', name: 'answer', type: 'int256' },
+      { internalType: 'uint256', name: 'startedAt', type: 'uint256' },
+      { internalType: 'uint256', name: 'updatedAt', type: 'uint256' },
+      { internalType: 'uint80', name: 'answeredInRound', type: 'uint80' },
+    ],
     stateMutability: 'view',
     type: 'function',
   },
@@ -54,11 +60,11 @@ export const fetchOraclePrices = async function (
         ),
         getTokenConfig(client, { address: treasuryAddress, token: address }),
       ])
-      const [latestAnswer, decimals] = await Promise.all([
+      const [[, answer], decimals] = await Promise.all([
         readContract(client, {
           abi: aggregatorV3Abi,
           address: oracle,
-          functionName: 'latestAnswer',
+          functionName: 'latestRoundData',
         }),
         readContract(client, {
           abi: aggregatorV3Abi,
@@ -68,7 +74,7 @@ export const fetchOraclePrices = async function (
       ])
       return [
         token.symbol.toUpperCase(),
-        formatUnits(latestAnswer, decimals),
+        formatUnits(answer, decimals),
       ] as const
     }),
   )

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -27,8 +27,10 @@ export const useEarnPools = function () {
     isPending: isSharesPending,
   } = useHemiEarnShares()
 
-  // TVL queries are intentionally NOT part of `isPending`: the page should
-  // render with a `0n` placeholder while the cross-chain read is in flight.
+  // TVL queries are intentionally NOT part of `isPending`: the page renders
+  // immediately while the cross-chain read is in flight, and each pool's
+  // total-deposits cell shows its own skeleton (driven by `totalDepositsStatus`
+  // below) rather than blocking the whole page.
   const tvlQueries = useQueries({
     queries: shares.map(share => ({
       ...earnTvlQueryOptions({
@@ -55,7 +57,8 @@ export const useEarnPools = function () {
     shareAddress: share.shareAddress,
     shareToken: share.shareToken,
     stakingVault: share.stakingVault,
-    totalDeposits: tvlQueries[index]?.data ?? BigInt(0),
+    totalDeposits: tvlQueries[index]?.data,
+    totalDepositsStatus: tvlQueries[index]?.status ?? 'pending',
   }))
 
   return { data, isError: isSharesError, isPending: isSharesPending }

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTokenPrices.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTokenPrices.ts
@@ -1,0 +1,14 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+
+import { earnTokenPricesQueryOptions } from '../_fetchers/fetchEarnTokenPrices'
+
+type Prices = Record<string, string>
+
+// USD prices for Hemi Earn: `useTokenPrices` (the portal `/prices` feed)
+// extended with each gateway's on-chain oracle prices (see
+// `fetchEarnTokenPrices`). Use this — rather than `useTokenPrices` — anywhere
+// Hemi Earn prices a pegged token (vetBTC, VUSD), which resolves through its
+// `extensions.priceSymbol` whitelisted-proxy alias.
+export const useEarnTokenPrices = (
+  options: Omit<UseQueryOptions<Prices, Error>, 'queryKey' | 'queryFn'> = {},
+) => useQuery(earnTokenPricesQueryOptions(options))

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
@@ -2,13 +2,13 @@
 
 import { useQueries } from '@tanstack/react-query'
 import Big from 'big.js'
-import { useTokenPrices } from 'hooks/useTokenPrices'
 import { getTokenPrice } from 'utils/token'
 import { formatUnits } from 'viem'
 
 import { sharesToPeggedOptions } from '../_fetchers/fetchSharesToPegged'
 
 import { useEarnPositions } from './useEarnPositions'
+import { useEarnTokenPrices } from './useEarnTokenPrices'
 
 type TotalDepositsData = { totalUsd: string }
 
@@ -20,7 +20,7 @@ const positionUsd = (
 
 // Sums the USD value of every share position the user holds. Each entry is
 // `convertToAssets(stakingVault, shares)` (shares → pegged token) priced via
-// `getTokenPrice(peggedToken)` against the portal price feed.
+// `getTokenPrice(peggedToken)` against the oracle-merged earn price feed.
 export const useTotalDeposits = function () {
   const {
     data: positions = [],
@@ -31,7 +31,7 @@ export const useTotalDeposits = function () {
     data: prices,
     isError: isPricesError,
     isPending: isPricesPending,
-  } = useTokenPrices({ retryOnMount: false })
+  } = useEarnTokenPrices({ retryOnMount: false })
 
   const peggedAmountQueries = useQueries({
     queries: positions.map(position =>

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolFormContent.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolFormContent.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
 import { type EvmToken, type Token } from 'types/token'
 
+import { RenderEarnFiatBalance } from '../../../_components/earnFiatBalance'
 import { usePoolForm } from '../_context/poolFormContext'
 
 import { AssetSelector } from './assetSelector'
@@ -61,6 +62,7 @@ export const PoolFormContent = function ({
         disabled={isRunningOperation}
         errorKey={errorKey}
         fiatBalance={fiatBalance}
+        fiatBalanceComponent={RenderEarnFiatBalance}
         label={inputLabel}
         maxBalanceButton={setMaxBalanceButton}
         onChange={updateInput}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolInfoCards.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolInfoCards.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { RenderFiatBalance } from 'components/fiatBalance'
 import { useTranslations } from 'next-intl'
 import { formatFiatNumber } from 'utils/format'
 
+import { RenderEarnFiatBalance } from '../../../_components/earnFiatBalance'
 import { AvgApyIcon } from '../../../_icons/avgApyIcon'
 import { TotalDepositsIcon } from '../../../_icons/totalDepositsIcon'
 import { formatApyDisplay } from '../../../_utils'
@@ -27,10 +27,10 @@ export const PoolInfoCards = function ({ pool }: Props) {
           isLoading={false}
           label={t('pool.total-deposits')}
           value={
-            <RenderFiatBalance
+            <RenderEarnFiatBalance
               balance={pool.totalDeposits}
               customFormatter={usd => `$${formatFiatNumber(usd)}`}
-              queryStatus="success"
+              queryStatus={pool.totalDepositsStatus}
               token={pool.peggedToken}
             />
           }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/userPoolBalance.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/userPoolBalance.tsx
@@ -1,9 +1,9 @@
 import { RenderCryptoBalance } from 'components/cryptoBalance'
-import { RenderFiatBalance } from 'components/fiatBalance'
 import { TokenLogo } from 'components/tokenLogo'
 import { useTranslations } from 'next-intl'
 import { useAccount } from 'wagmi'
 
+import { RenderEarnFiatBalance } from '../../../_components/earnFiatBalance'
 import { usePoolForm } from '../_context/poolFormContext'
 import { useUserShareValue } from '../_hooks/useUserShareValue'
 
@@ -38,7 +38,7 @@ export const UserPoolBalance = function () {
         <span className="flex items-center text-sm font-normal text-neutral-500">
           <span className="mr-0.5">$</span>
           {isConnected ? (
-            <RenderFiatBalance
+            <RenderEarnFiatBalance
               balance={data?.peggedAmount}
               queryStatus={status}
               token={pool.peggedToken}

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -1,3 +1,4 @@
+import { type QueryStatus } from '@tanstack/react-query'
 import { type EvmToken } from 'types/token'
 import { type Address, type Chain, type Hash } from 'viem'
 
@@ -64,7 +65,9 @@ export type EarnAsset = {
 // `totalDeposits` is `StakingVault.totalAssets()`, expressed in the pegged
 // token's units (vBTC, vUSD — that's what the vault's `asset()` returns).
 // Pair it with `peggedToken` for formatting and pricing; never with
-// `shareToken`, since the share OFT has no public price feed.
+// `shareToken`, since the share OFT has no public price feed. It is
+// `undefined` while the TVL read is in flight — pair with `totalDepositsStatus`
+// so consumers can show a skeleton (pending) or '-' (error) instead of `$0`.
 // `apy` is tri-state:
 //   `undefined` — APY query still pending (show skeleton)
 //   `null`      — APY query settled but no value for this share (error or
@@ -79,7 +82,8 @@ export type EarnPool = {
   shareToken: EvmToken
   // Ethereum-side ERC-4626 staking vault (`Router.assetsData(asset).remoteShare`)
   stakingVault: Address
-  totalDeposits: bigint
+  totalDeposits: bigint | undefined
+  totalDepositsStatus: QueryStatus
 }
 
 // `yourDeposit` is the raw share OFT balance (denominated in

--- a/portal/components/fiatBalance.tsx
+++ b/portal/components/fiatBalance.tsx
@@ -23,12 +23,17 @@ const RenderFiatBalanceUnsafe = function ({
   customFormatter = formatFiatNumber,
   queryStatus,
   token,
+  usePrices = useTokenPrices,
 }: Props & {
   balance: bigint | undefined
   customFormatter?: (amount: string) => string
   queryStatus: QueryStatus
+  // The price feed to read from. Defaults to the app-wide portal feed;
+  // callers that price against a different feed (e.g. Hemi Earn's
+  // oracle-merged `useEarnTokenPrices`) inject their own hook.
+  usePrices?: typeof useTokenPrices
 }) {
-  const { data: pricesData, status: pricesStatus } = useTokenPrices({
+  const { data: pricesData, status: pricesStatus } = usePrices({
     retryOnMount: false,
   })
 

--- a/portal/components/tokenInput/index.tsx
+++ b/portal/components/tokenInput/index.tsx
@@ -1,7 +1,7 @@
 import { RenderFiatBalance } from 'components/fiatBalance'
 import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { ComponentType, ReactNode } from 'react'
+import { ComponentProps, ComponentType, ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { Token } from 'types/token'
 import { parseTokenUnits } from 'utils/token'
@@ -33,6 +33,10 @@ type Props<T extends Token> = {
     balance: bigint | undefined
     token: Token
   }
+  // Renders the fiat preview. Defaults to the app-wide portal-priced
+  // `RenderFiatBalance`; callers pricing against a different feed (e.g. Hemi
+  // Earn's oracle-merged `RenderEarnFiatBalance`) pass their own.
+  fiatBalanceComponent?: ComponentType<ComponentProps<typeof RenderFiatBalance>>
   label: string
   maxBalanceButton?: ReactNode
   onChange: (value: string) => void
@@ -57,6 +61,7 @@ export const TokenInput = function <T extends Token>({
   disabled,
   errorKey,
   fiatBalance,
+  fiatBalanceComponent,
   label,
   maxBalanceButton,
   onChange,
@@ -67,6 +72,7 @@ export const TokenInput = function <T extends Token>({
 }: Props<T>) {
   const t = useTranslations('tunnel-page')
   const BalanceComponent = balanceComponent ?? Balance
+  const FiatBalanceComponent = fiatBalanceComponent ?? RenderFiatBalance
   return (
     <div
       className="hover:shadow-bs h-[124px] rounded-lg border border-solid border-transparent bg-neutral-50
@@ -91,13 +97,13 @@ export const TokenInput = function <T extends Token>({
             <div className="flex items-center text-sm  text-neutral-500">
               <span className="mr-1">$</span>
               {fiatBalance ? (
-                <RenderFiatBalance
+                <FiatBalanceComponent
                   balance={fiatBalance.balance}
                   queryStatus="success"
                   token={fiatBalance.token}
                 />
               ) : !Number.isNaN(value) ? (
-                <RenderFiatBalance
+                <FiatBalanceComponent
                   balance={parseTokenUnits(value, token)}
                   queryStatus="success"
                   token={token}

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchEarnTokenPrices.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchEarnTokenPrices.test.ts
@@ -1,0 +1,144 @@
+import { gateways } from '@vetro-protocol/gateway'
+import { fetchEarnTokenPrices } from 'app/[locale]/hemi-earn/_fetchers/fetchEarnTokenPrices'
+import { oraclePricesQueryOptions } from 'app/[locale]/hemi-earn/_fetchers/fetchOraclePrices'
+import { tokenPricesQueryOptions } from 'hooks/useTokenPrices'
+import { mainnet } from 'networks/mainnet'
+import { type EvmToken } from 'types/token'
+import { getTokenPrice } from 'utils/token'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createTestQueryClient } from '../../../../createTestQueryClient'
+
+// Avoid pulling `eth-rpc-cache` (broken ESM resolution under vitest) through
+// the `fetchOraclePrices` → chainClients import chain. The oracle dicts are
+// seeded into the cache, so the on-chain reader is never invoked here.
+vi.mock('utils/chainClients', () => ({
+  getEvmL1PublicClient: vi.fn(),
+  getPublicClient: vi.fn(),
+}))
+
+const usdGateway = gateways.find(gateway => gateway.pegBaseSymbol === 'USD')!
+const btcGateway = gateways.find(gateway => gateway.pegBaseSymbol === 'BTC')!
+
+// `fetchEarnTokenPrices` reads every gateway's oracle dict from the cache, so
+// seed both even when a test only exercises one (an unseeded entry would hit
+// the network). Defaults are empty so each test only declares what it needs.
+const seed = function (
+  queryClient: ReturnType<typeof createTestQueryClient>,
+  {
+    btcOracle = {},
+    portal,
+    usdOracle = {},
+  }: {
+    btcOracle?: Record<string, string>
+    portal: Record<string, string>
+    usdOracle?: Record<string, string>
+  },
+) {
+  queryClient.setQueryData(tokenPricesQueryOptions().queryKey, portal)
+  queryClient.setQueryData(
+    oraclePricesQueryOptions(usdGateway.address).queryKey,
+    usdOracle,
+  )
+  queryClient.setQueryData(
+    oraclePricesQueryOptions(btcGateway.address).queryKey,
+    btcOracle,
+  )
+}
+
+describe('app/[locale]/hemi-earn/_fetchers/fetchEarnTokenPrices', function () {
+  it('passes USD-pegged oracle entries through unchanged', async function () {
+    const queryClient = createTestQueryClient()
+    seed(queryClient, {
+      portal: { USDC: '1', USDT: '1' },
+      usdOracle: { USDC: '0.999', USDT: '1.001' },
+    })
+
+    const result = await fetchEarnTokenPrices(queryClient)
+
+    expect(result.USDC).toBe('0.999')
+    expect(result.USDT).toBe('1.001')
+  })
+
+  it("multiplies BTC-pegged oracle entries by portal['BTC']", async function () {
+    const queryClient = createTestQueryClient()
+    seed(queryClient, {
+      // 1 WBTC = 0.998 BTC, 1 cbBTC = 1.0001 BTC
+      btcOracle: { CBBTC: '1.0001', WBTC: '0.998' },
+      portal: { BTC: '76800', USDT: '1' },
+    })
+
+    const result = await fetchEarnTokenPrices(queryClient)
+
+    // WBTC: 0.998 × 76800 = 76646.4
+    expect(Number(result.WBTC)).toBeCloseTo(76646.4, 4)
+    // cbBTC: 1.0001 × 76800 = 76807.68
+    expect(Number(result.CBBTC)).toBeCloseTo(76807.68, 4)
+    // Portal BTC entry survives untouched.
+    expect(result.BTC).toBe('76800')
+  })
+
+  it('prices a BTC-pegged token through its WBTC oracle proxy', async function () {
+    const queryClient = createTestQueryClient()
+    seed(queryClient, {
+      // The vetBTC gateway's WBTC oracle reports 0.998 BTC per WBTC.
+      btcOracle: { WBTC: '0.998' },
+      portal: { BTC: '76800' },
+    })
+
+    const prices = await fetchEarnTokenPrices(queryClient)
+
+    // vetBTC has no oracle of its own; it aliases to its gateway's whitelisted
+    // WBTC proxy via `priceSymbol`. So its USD price is the WBTC oracle rate
+    // (0.998 BTC) converted to USD through the portal BTC price:
+    // 0.998 × 76800 = 76646.4.
+    const vetBtc = {
+      address: '0xf196C68233464A16CFDa319a47c21f4cECa62001',
+      chainId: mainnet.id,
+      decimals: 18,
+      extensions: { priceSymbol: 'WBTC' },
+      name: 'Vetro BTC',
+      symbol: 'vetBTC',
+    } satisfies EvmToken
+
+    expect(Number(getTokenPrice(vetBtc, prices))).toBeCloseTo(76646.4, 4)
+  })
+
+  it('lets oracle entries override portal entries on collision', async function () {
+    const queryClient = createTestQueryClient()
+    seed(queryClient, {
+      btcOracle: { WBTC: '0.998' },
+      // Portal disagrees on the WBTC USD price.
+      portal: { BTC: '76800', WBTC: '99999' },
+    })
+
+    const result = await fetchEarnTokenPrices(queryClient)
+
+    // Oracle wins: 0.998 × 76800 = 76646.4
+    expect(Number(result.WBTC)).toBeCloseTo(76646.4, 4)
+  })
+
+  it("zeros a gateway's tokens when its peg base is missing from portal", async function () {
+    const queryClient = createTestQueryClient()
+    seed(queryClient, {
+      btcOracle: { WBTC: '0.998' },
+      // Degraded portal feed without a BTC entry.
+      portal: { USDT: '1' },
+    })
+
+    const result = await fetchEarnTokenPrices(queryClient)
+
+    expect(result.WBTC).toBe('0')
+    // Other portal entries are unaffected.
+    expect(result.USDT).toBe('1')
+  })
+
+  it('passes portal-only entries through when oracles are empty', async function () {
+    const queryClient = createTestQueryClient()
+    seed(queryClient, { portal: { BTC: '76800', HEMI: '0.0086' } })
+
+    const result = await fetchEarnTokenPrices(queryClient)
+
+    expect(result).toEqual({ BTC: '76800', HEMI: '0.0086' })
+  })
+})

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.test.ts
@@ -3,6 +3,7 @@ import {
   hemiEarnAssetConfigsQueryOptions,
 } from 'app/[locale]/hemi-earn/_fetchers/fetchHemiEarnAssetConfigs'
 import { fetchHemiEarnShares } from 'app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares'
+import { gatewayForRemoteShareQueryOptions } from 'app/[locale]/hemi-earn/_hooks/gatewayForRemoteShare'
 import { vaultAssetQueryOptions } from 'app/[locale]/hemi-earn/_hooks/vaultAsset'
 import { hemi } from 'hemi-viem'
 import { getUseTokenQueryKey } from 'hooks/useToken'
@@ -28,6 +29,10 @@ const SVETBTC = '0xD8D63De3b64bd06d99F8F5AD8B78Ed2fE7525eC0' as Address
 const REMOTE_SHARE = '0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e' as Address
 // The pegged token is the staking vault's `asset()` — an Ethereum-mainnet token.
 const VETBTC = '0xf196C68233464A16CFDa319a47c21f4cECa62001' as Address
+// Real `@vetro-protocol/gateway` entries — the BTC peg aliases the pegged
+// token to the 'WBTC' proxy, the USD peg to 'USDT'.
+const BTC_GATEWAY = '0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB' as Address
+const USD_GATEWAY = '0xDaD503f8B9d42bb7af3AfC588358D30163e4416F' as Address
 const ASSET = '0x1111111111111111111111111111111111111111' as Address
 const ASSET_2 = '0x2222222222222222222222222222222222222222' as Address
 const REMOTE_ASSET = '0x3333333333333333333333333333333333333333' as Address
@@ -62,10 +67,12 @@ const seed = function (
   queryClient: ReturnType<typeof createTestQueryClient>,
   {
     configs,
+    gateway = BTC_GATEWAY,
     peggedAddress,
     tokens = [svetBtcToken, vetBtcToken, assetToken, asset2Token],
   }: {
     configs: HemiEarnAssetConfig[]
+    gateway?: Address
     peggedAddress: Address
     tokens?: EvmToken[]
   },
@@ -74,6 +81,10 @@ const seed = function (
   queryClient.setQueryData(
     vaultAssetQueryOptions(REMOTE_SHARE).queryKey,
     peggedAddress,
+  )
+  queryClient.setQueryData(
+    gatewayForRemoteShareQueryOptions(REMOTE_SHARE).queryKey,
+    gateway,
   )
   for (const token of tokens) {
     queryClient.setQueryData(
@@ -100,6 +111,32 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares', function () {
     expect(result[0].shareToken.symbol).toBe('svetBTC')
     expect(result[0].assets).toHaveLength(1)
     expect(result[0].assets[0].token.symbol).toBe('hemiBTC')
+  })
+
+  it('aliases the BTC-pegged token to its whitelisted WBTC proxy', async function () {
+    const queryClient = createTestQueryClient()
+    seed(queryClient, {
+      configs: [makeConfig({ asset: ASSET, share: SVETBTC })],
+      gateway: BTC_GATEWAY,
+      peggedAddress: VETBTC,
+    })
+
+    const result = await fetchHemiEarnShares(queryClient)
+
+    expect(result[0].peggedToken.extensions?.priceSymbol).toBe('WBTC')
+  })
+
+  it('aliases the USD-pegged token to its whitelisted USDT proxy', async function () {
+    const queryClient = createTestQueryClient()
+    seed(queryClient, {
+      configs: [makeConfig({ asset: ASSET, share: SVETBTC })],
+      gateway: USD_GATEWAY,
+      peggedAddress: VETBTC,
+    })
+
+    const result = await fetchHemiEarnShares(queryClient)
+
+    expect(result[0].peggedToken.extensions?.priceSymbol).toBe('USDT')
   })
 
   it('collapses a multi-asset share into a single skeleton carrying every asset', async function () {

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.test.ts
@@ -31,12 +31,17 @@ const ORACLE = '0x2222222222222222222222222222222222222222' as Address
 const WBTC = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599' as Address
 
 // Each whitelisted token's oracle reports its price in the gateway's peg unit.
-// `latestAnswer` (8 decimals) of 0.998 → "0.998".
-const mockOracleRead = (latestAnswer: bigint, decimals: number) =>
+// `latestRoundData` returns the price as the `answer` field of the round tuple;
+// an 8-decimal answer of 0.998 → "0.998".
+const mockOracleRead = (answer: bigint, decimals: number) =>
   vi
     .mocked(readContract)
     .mockImplementation((_client, { functionName }: { functionName: string }) =>
-      Promise.resolve(functionName === 'decimals' ? decimals : latestAnswer),
+      Promise.resolve(
+        functionName === 'decimals'
+          ? decimals
+          : [BigInt(0), answer, BigInt(0), BigInt(0), BigInt(0)],
+      ),
     )
 
 const seedToken = (

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.test.ts
@@ -1,0 +1,100 @@
+import { getTreasury } from '@vetro-protocol/gateway/actions'
+import {
+  getTokenConfig,
+  getWhitelistedTokens,
+} from '@vetro-protocol/treasury/actions'
+import { fetchOraclePrices } from 'app/[locale]/hemi-earn/_fetchers/fetchOraclePrices'
+import { getUseTokenQueryKey } from 'hooks/useToken'
+import { mainnet } from 'networks/mainnet'
+import { type EvmToken } from 'types/token'
+import { type Address, zeroAddress } from 'viem'
+import { readContract } from 'viem/actions'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTestQueryClient } from '../../../../createTestQueryClient'
+
+// The reader only needs a client handle to pass to the mocked actions; the
+// reads themselves are mocked, so a stub client is enough.
+vi.mock('utils/chainClients', () => ({
+  getEvmL1PublicClient: vi.fn(() => ({})),
+}))
+vi.mock('@vetro-protocol/gateway/actions', () => ({ getTreasury: vi.fn() }))
+vi.mock('@vetro-protocol/treasury/actions', () => ({
+  getTokenConfig: vi.fn(),
+  getWhitelistedTokens: vi.fn(),
+}))
+vi.mock('viem/actions', () => ({ readContract: vi.fn() }))
+
+const GATEWAY = '0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB' as Address
+const TREASURY = '0x1111111111111111111111111111111111111111' as Address
+const ORACLE = '0x2222222222222222222222222222222222222222' as Address
+const WBTC = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599' as Address
+
+// Each whitelisted token's oracle reports its price in the gateway's peg unit.
+// `latestAnswer` (8 decimals) of 0.998 → "0.998".
+const mockOracleRead = (latestAnswer: bigint, decimals: number) =>
+  vi
+    .mocked(readContract)
+    .mockImplementation((_client, { functionName }: { functionName: string }) =>
+      Promise.resolve(functionName === 'decimals' ? decimals : latestAnswer),
+    )
+
+const seedToken = (
+  queryClient: ReturnType<typeof createTestQueryClient>,
+  address: Address,
+  symbol: string,
+) =>
+  queryClient.setQueryData(getUseTokenQueryKey(address, mainnet.id), {
+    address,
+    chainId: mainnet.id,
+    decimals: 8,
+    name: symbol,
+    symbol,
+  } satisfies EvmToken)
+
+describe('app/[locale]/hemi-earn/_fetchers/fetchOraclePrices', function () {
+  beforeEach(function () {
+    vi.clearAllMocks()
+    vi.mocked(getTreasury).mockResolvedValue(TREASURY)
+    vi.mocked(getTokenConfig).mockResolvedValue([
+      zeroAddress,
+      ORACLE,
+      BigInt(0),
+      true,
+      true,
+      8,
+    ])
+  })
+
+  it("keys each whitelisted token's oracle price by its uppercased symbol", async function () {
+    const queryClient = createTestQueryClient()
+    seedToken(queryClient, WBTC, 'WBTC')
+    vi.mocked(getWhitelistedTokens).mockResolvedValue([WBTC])
+    // 0.998 WBTC/BTC at 8 decimals.
+    mockOracleRead(BigInt(99800000), 8)
+
+    const result = await fetchOraclePrices(queryClient, GATEWAY)
+
+    expect(result).toEqual({ WBTC: '0.998' })
+  })
+
+  it('uppercases mixed-case token symbols so the alias lookup matches', async function () {
+    const queryClient = createTestQueryClient()
+    seedToken(queryClient, WBTC, 'wBTC')
+    vi.mocked(getWhitelistedTokens).mockResolvedValue([WBTC])
+    mockOracleRead(BigInt(100000000), 8)
+
+    const result = await fetchOraclePrices(queryClient, GATEWAY)
+
+    expect(result).toEqual({ WBTC: '1' })
+  })
+
+  it('returns an empty dict when the gateway has no whitelisted tokens', async function () {
+    const queryClient = createTestQueryClient()
+    vi.mocked(getWhitelistedTokens).mockResolvedValue([])
+
+    const result = await fetchOraclePrices(queryClient, GATEWAY)
+
+    expect(result).toEqual({})
+  })
+})


### PR DESCRIPTION
### Description

Pegged tokens (vetBTC, VUSD) aren't in the curated token list and have no price feed of their own, so Hemi Earn rendered them — and any value derived from them (Total Deposits, your balance, pool TVL) — at $0.

This adds an earn-scoped price feed (`useEarnTokenPrices`) that merges the portal `/prices` feed with each Vetro gateway's on-chain oracle prices, converting each to USD via the gateway's peg base. Pegged tokens resolve through their whitelisted-proxy `priceSymbol` (vetBTC→WBTC, VUSD→USDT). The oracle-merged feed is kept earn-scoped so the rest of the app stays on the plain portal feed.

Supporting changes:
- Made `RenderFiatBalance` composable via an injectable prices hook, so `RenderEarnFiatBalance` is a thin wrapper rather than a duplicate component.
- Let `TokenInput` accept a `fiatBalanceComponent`, so the pool deposit/withdraw forms price the pegged token through the earn feed instead of the portal feed.
- A pool's Total Deposits now shows a skeleton while the TVL read is in flight (instead of a placeholder `$0`), and `-` on error.

### Screenshots

<img width="1360" height="416" alt="image" src="https://github.com/user-attachments/assets/1ad3d551-11f0-4689-9613-51ef7cc0fc4e" />

<img width="2188" height="924" alt="image" src="https://github.com/user-attachments/assets/d7cce056-2b14-4e6a-b371-51b8a378f286" />

<img width="2194" height="1098" alt="image" src="https://github.com/user-attachments/assets/81e9644b-9eb8-4ab4-86b0-9bd32c3ff1fa" />

### Related issue(s)

Closes #2000

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.