### PR TITLE
Improve table width on desktop viewports

### DIFF
--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
@@ -49,7 +49,7 @@ const stakingColumns = ({
     ),
     header: () => <Header text={t('table.locked-amount')} />,
     id: 'locked-amount',
-    meta: { width: 170 },
+    meta: { width: 144 },
   },
   {
     cell({ row }) {
@@ -64,7 +64,7 @@ const stakingColumns = ({
     },
     header: () => <Header text={t('table.lockup')} />,
     id: 'lockup',
-    meta: { width: 120 },
+    meta: { width: 88 },
   },
   {
     cell({ row }) {
@@ -77,7 +77,7 @@ const stakingColumns = ({
     },
     header: () => <Header text={t('voting-power')} />,
     id: 'voting-power',
-    meta: { width: 150 },
+    meta: { width: 116 },
   },
   {
     cell({ row }) {
@@ -90,20 +90,20 @@ const stakingColumns = ({
     },
     header: () => <Header text={t('table.claimable-rewards')} />,
     id: 'rewards',
-    meta: { width: 170 },
+    meta: { width: 134 },
   },
   {
     cell: ({ row }) => <TimeRemaining operation={row.original} />,
     header: () => <Header text={t('table.time-remaining')} />,
     id: 'time-remaining',
-    meta: { className: 'justify-end', width: 140 },
+    meta: { className: 'justify-end', width: 108 },
   },
   {
     cell: ({ row }) => (
       <ActionCell openRowId={openRowId} row={row} setOpenRowId={setOpenRowId} />
     ),
     id: 'action',
-    meta: { width: 60 },
+    meta: { width: 52 },
   },
 ]
 

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/linearProgress.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/linearProgress.tsx
@@ -9,7 +9,7 @@ export function LinearProgress({ percentage, unlockTime }: Props) {
   const width = `${Math.min(100, Math.max(0, percentage))}%`
 
   return (
-    <div className="relative flex h-7 min-w-28 items-center justify-center overflow-hidden rounded-md bg-neutral-100 px-2 py-1.5">
+    <div className="relative flex h-7 min-w-20 items-center justify-center overflow-hidden rounded-md bg-neutral-100 px-2 py-1.5">
       <div
         className="bg-linear-progress-bar absolute inset-y-0 left-0 transition-all duration-300 ease-out"
         style={{


### PR DESCRIPTION
Closes #1998

## What

Adjust the Governance Staking table column widths so all columns fit on desktop without horizontal scrolling.

## Changes

Reduced column widths (table min-width **810px → 642px**) in `stakeTable/index.tsx`:

| Column | Before | After |
|---|---|---|
| locked-amount | 170 | 144 |
| lockup | 120 | 88 |
| voting-power | 150 | 116 |
| rewards | 170 | 134 |
| time-remaining | 140 | 108 |
| action | 60 | 52 |

Plus the time-remaining progress pill `min-w-28` → `min-w-20` (80px) in `linearProgress.tsx`, per the issue's suggestion.

Widths were chosen to stay above each header's text width (`Claimable rewards`, `Time remaining`) so nothing overlaps or truncates.

## Screenshot
<img alt="Captura de pantalla 2026-06-17 a la(s) 11 47 06 a  m" src="https://github.com/user-attachments/assets/d70d7022-4d70-4052-9d88-55b1588eb78b" />

## Testing

Verified visually on desktop: all six columns render with no horizontal scrollbar and no header/content overflow.
