### PR TITLE
Encapsulate account and client in useQuoteRedeem

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedWithdraw.tsx
@@ -4,7 +4,6 @@ import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { useTranslations } from 'next-intl'
 import { type FormEvent, useState } from 'react'
-import { useAccount } from 'wagmi'
 
 import {
   REDEEM_SLIPPAGE_BPS,
@@ -40,7 +39,6 @@ export const RetryFailedWithdraw = function ({
   const [, setTxDrawerQueryString] = useTxDrawerQueryString()
   const [operationRunning, setOperationRunning] =
     useState<WithdrawOperationRunning>('idle')
-  const { address } = useAccount()
   const t = useTranslations()
 
   // `amountIn` on a REDEEM row is in share-token units — exactly what the
@@ -64,7 +62,6 @@ export const RetryFailedWithdraw = function ({
       : BigInt(0)
 
   const { data: quote } = useQuoteRedeem({
-    account: address,
     asset: asset.address,
     shareAddress: pool.shareAddress,
     shares,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/retryWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/retryWithdraw.tsx
@@ -3,7 +3,6 @@ import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { useTranslations } from 'next-intl'
 import { type FormEvent, useState } from 'react'
 import { parseTokenUnits } from 'utils/token'
-import { useAccount } from 'wagmi'
 
 import {
   REDEEM_SLIPPAGE_BPS,
@@ -29,7 +28,6 @@ export const RetryWithdraw = function () {
   } = usePoolForm()
 
   const t = useTranslations()
-  const { address } = useAccount()
   // Input is in share-token units (svetBTC); the Router burns shares
   // directly. `assetsOutMin` is derived from the asset preview below.
   const shares = parseTokenUnits(input, pool.shareToken)
@@ -51,7 +49,6 @@ export const RetryWithdraw = function () {
       : BigInt(0)
 
   const { data: quote } = useQuoteRedeem({
-    account: address,
     asset: selectedAsset.address,
     shareAddress: pool.shareAddress,
     shares,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -219,7 +219,6 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
     })
 
   const { data: quote } = useQuoteRedeem({
-    account: address,
     asset: selectedAsset.address,
     shareAddress: pool.shareAddress,
     shares,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.ts
@@ -72,7 +72,10 @@ export async function fetchQuoteRedeem({
   return { callbackFee, isInstant, nativeFee }
 }
 
-export type QuoteRedeemHookParams = Omit<QuoteRedeemParams, 'account'> & {
+export type QuoteRedeemHookParams = Omit<
+  QuoteRedeemParams,
+  'account' | 'queryClient'
+> & {
   account: Address | undefined
 }
 
@@ -81,7 +84,7 @@ const getQuoteRedeemQueryKey = ({
   asset,
   shareAddress,
   shares,
-}: Omit<QuoteRedeemHookParams, 'queryClient'>) =>
+}: QuoteRedeemHookParams) =>
   [
     'hemi-earn',
     'quote-redeem',
@@ -94,13 +97,12 @@ const getQuoteRedeemQueryKey = ({
 export const quoteRedeemOptions = ({
   account,
   asset,
-  queryClient,
   shareAddress,
   shares,
 }: QuoteRedeemHookParams): UseQueryOptions<QuoteRedeem> => ({
   enabled: shares > BigInt(0) && !!account,
   // The `enabled` flag above guarantees `account` is defined when this runs.
-  queryFn: () =>
+  queryFn: ({ client: queryClient }) =>
     fetchQuoteRedeem({
       account: account!,
       asset,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchWithdrawPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchWithdrawPreview.ts
@@ -65,7 +65,6 @@ export const withdrawPreviewOptions = ({
           quoteRedeemOptions({
             account,
             asset,
-            queryClient,
             shareAddress,
             shares,
           }),

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteRedeem.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useQuoteRedeem.ts
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { useAccount } from 'wagmi'
 
 import {
   type QuoteRedeemHookParams,
@@ -6,5 +7,11 @@ import {
 } from '../_fetchers/fetchQuoteRedeem'
 
 export const useQuoteRedeem = (
-  params: Omit<QuoteRedeemHookParams, 'queryClient'>,
-) => useQuery(quoteRedeemOptions({ ...params, queryClient: useQueryClient() }))
+  params: Omit<QuoteRedeemHookParams, 'account'>,
+) =>
+  useQuery(
+    quoteRedeemOptions({
+      ...params,
+      account: useAccount().address,
+    }),
+  )


### PR DESCRIPTION
### Description

Refactors `useQuoteRedeem` so it owns the data it needs instead of having every call site thread it in. `account` is now read from `useAccount()` inside the hook, and the `QueryClient` is read from the react-query query function context (`{ client }`) rather than `useQueryClient()`. As a result, callers no longer pass `account`, and `quoteRedeemOptions` no longer takes an explicit `queryClient` param.

#2011 lists both quote hooks, but only the redeem side still threaded `account` through. `useQuoteDeposit` has since become account-free on its own — the deposit quote doesn't depend on the connected account, so its params and its three call sites pass no `account` to drop. This PR completes the remaining (redeem) half of the issue's scope.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Closes #2011

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.