### PR TITLE
Add "from pools" badge to staked balance

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/earnCard.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnCard.tsx
@@ -5,6 +5,7 @@ import { type ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 type Props = {
+  badge?: ReactNode
   icon: ReactNode
   isError: boolean
   isLoading: boolean
@@ -12,7 +13,14 @@ type Props = {
   value: ReactNode
 }
 
-export const EarnCard = ({ icon, isError, isLoading, label, value }: Props) => (
+export const EarnCard = ({
+  badge,
+  icon,
+  isError,
+  isLoading,
+  label,
+  value,
+}: Props) => (
   <Card shadow="sm">
     <div className="w-full p-4">
       <div className="flex flex-col gap-y-2">
@@ -29,6 +37,9 @@ export const EarnCard = ({ icon, isError, isLoading, label, value }: Props) => (
             <Skeleton className="h-7 w-20" />
           )}
         </p>
+        {!isLoading && !isError && badge && (
+          <div className="self-start empty:hidden">{badge}</div>
+        )}
       </div>
     </div>
   </Card>

--- a/portal/app/[locale]/hemi-earn/_components/fromPoolsBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/fromPoolsBadge.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useQueries } from '@tanstack/react-query'
+import { TokenLogo } from 'components/tokenLogo'
+import { Tooltip } from 'components/tooltip'
+import { useTranslations } from 'next-intl'
+import { type EvmToken } from 'types/token'
+import { formatNumber } from 'utils/format'
+import { formatUnits } from 'viem'
+
+import { sharesToPeggedOptions } from '../_fetchers/fetchSharesToPegged'
+import { useEarnPositions } from '../_hooks/useEarnPositions'
+
+import { RenderEarnFiatBalance } from './earnFiatBalance'
+
+type PoolRowProps = {
+  peggedAmount: bigint | undefined
+  peggedAmountStatus: 'error' | 'pending' | 'success'
+  peggedToken: EvmToken
+  shareAmount: bigint
+  shareToken: EvmToken
+}
+
+const PoolRow = ({
+  peggedAmount,
+  peggedAmountStatus,
+  peggedToken,
+  shareAmount,
+  shareToken,
+}: PoolRowProps) => (
+  <div className="flex items-center gap-x-1 sm:min-w-52">
+    <TokenLogo size="small" token={shareToken} />
+    <span className="mr-auto text-sm font-medium text-white">
+      {shareToken.symbol}
+    </span>
+    <span className="text-sm font-medium text-white">
+      $
+      <RenderEarnFiatBalance
+        balance={peggedAmount}
+        queryStatus={peggedAmountStatus}
+        token={peggedToken}
+      />
+    </span>
+    <span className="text-sm font-medium text-neutral-400">
+      ({formatNumber(formatUnits(shareAmount, shareToken.decimals))}{' '}
+      {shareToken.symbol})
+    </span>
+  </div>
+)
+
+export const FromPoolsBadge = function () {
+  const t = useTranslations('hemi-earn.info')
+  const { data: positions = [], isError, isPending } = useEarnPositions()
+
+  const peggedAmountQueries = useQueries({
+    queries: positions.map(position =>
+      sharesToPeggedOptions({
+        shareAddress: position.shareAddress,
+        shares: position.yourDeposit,
+      }),
+    ),
+  })
+
+  const count = positions.length
+
+  if (isError || isPending || count === 0) {
+    return null
+  }
+
+  return (
+    <Tooltip
+      text={
+        <div className="flex flex-col gap-y-1">
+          {positions.map((position, index) => (
+            <PoolRow
+              key={position.shareAddress}
+              peggedAmount={peggedAmountQueries[index]?.data?.peggedAmount}
+              peggedAmountStatus={
+                peggedAmountQueries[index]?.status ?? 'pending'
+              }
+              peggedToken={position.peggedToken}
+              shareAmount={position.yourDeposit}
+              shareToken={position.shareToken}
+            />
+          ))}
+        </div>
+      }
+      variant="simple"
+    >
+      <span className="text-xxs flex h-4 w-fit items-center justify-center rounded-md border border-solid border-neutral-200 bg-neutral-100 px-1.5 font-medium text-neutral-600">
+        {t('from-pools', { count })}
+      </span>
+    </Tooltip>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/stakedBalance.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/stakedBalance.tsx
@@ -9,6 +9,7 @@ import { useTotalDeposits } from '../_hooks/useTotalDeposits'
 import { TotalDepositsIcon } from '../_icons/totalDepositsIcon'
 
 import { EarnCard } from './earnCard'
+import { FromPoolsBadge } from './fromPoolsBadge'
 
 export const StakedBalance = function () {
   const { data, isError, isPending } = useTotalDeposits()
@@ -18,6 +19,7 @@ export const StakedBalance = function () {
 
   return (
     <EarnCard
+      badge={<FromPoolsBadge />}
       icon={<TotalDepositsIcon />}
       isError={isError || isDisconnected}
       isLoading={isPending}

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -3,6 +3,7 @@
     "heading": "Earn yield with Hemi Earn",
     "info": {
       "earned-amount": "Your earned amount",
+      "from-pools": "{count, plural, one {From # pool} other {From # pools}}",
       "staked-balance": "Your staked balance"
     },
     "navigation": {

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -3,6 +3,7 @@
     "heading": "Obtenga rendimiento con Hemi Earn",
     "info": {
       "earned-amount": "Cantidad ganada",
+      "from-pools": "{count, plural, one {De # fondo} other {De # fondos}}",
       "staked-balance": "Su saldo invertido"
     },
     "navigation": {

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -3,6 +3,7 @@
     "heading": "Obtenha rendimento com Hemi Earn",
     "info": {
       "earned-amount": "Valor ganho",
+      "from-pools": "{count, plural, one {De # fundo} other {De # fundos}}",
       "staked-balance": "Seu saldo aplicado"
     },
     "navigation": {


### PR DESCRIPTION
### Description

Adds a "From N pools" badge beneath the staked balance value on the Hemi Earn card. The badge surfaces how many pool positions the user holds, and on hover its tooltip breaks each position down by share symbol, USD value, and share amount. It hides itself when the user has no positions.

To support this, `EarnCard` gains an optional `badge` slot (rendered only when the card is showing its value, not while loading or in error), and a new `from-pools` pluralized string is added in en/es/pt.

### Screenshots

https://github.com/user-attachments/assets/dc2ab107-3fb7-47ec-8c39-3dce2c530528

### Related issue(s)

Closes #1959

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.