### PR TITLE
Add manual claim/recover to Hemi Earn deposits

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
@@ -13,7 +13,12 @@ import Skeleton from 'react-loading-skeleton'
 import { formatUnits } from 'viem'
 
 import { useEarnPools } from '../../_hooks/useEarnPools'
-import { findPoolByAsset } from '../../_utils'
+import {
+  findPoolByAsset,
+  hasFailedSettlement,
+  needsManualClaim,
+  needsRecover,
+} from '../../_utils'
 import { type EarnTransaction } from '../../types'
 
 import { RowActions } from './rowActions'
@@ -104,18 +109,27 @@ export const buildColumns = ({
       row.original.kind === 'REDEEM' ? (
         <WithdrawStatusCell transaction={row.original} />
       ) : (
-        <StatusBadge kind={row.original.kind} status={row.original.status} />
+        <StatusBadge
+          kind={row.original.kind}
+          manualClaimNeeded={needsManualClaim(row.original)}
+          manualRecoverNeeded={needsRecover(row.original)}
+          settlementFailed={hasFailedSettlement(row.original)}
+          status={row.original.status}
+        />
       ),
     header: () => <Header text={t('column.status')} />,
     id: 'status',
-    meta: { className: 'justify-start flex-grow-0', width: 190 },
+    // Wide enough to keep the longest status ("Something went wrong - Recover
+    // funds" / the manual-claim copy) on a single line across locales.
+    meta: { className: 'justify-start flex-grow-0', width: 340 },
   },
   {
     cell: ({ row }) => <RowActions transaction={row.original} />,
     id: 'actions',
     // On mobile this column is reordered to the front, so it hugs the left
     // edge (the table's first-cell pl-4 gives the 16px lead). From 'md' up it
-    // returns to the trailing edge and right-aligns.
-    meta: { className: 'justify-start md:justify-end', width: 90 },
+    // returns to the trailing edge and right-aligns. Wide enough to fit the
+    // "Claim share tokens" / "Recover funds" CTA without overflowing the cell.
+    meta: { className: 'justify-start md:justify-end', width: 180 },
   },
 ]

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
@@ -13,12 +13,7 @@ import Skeleton from 'react-loading-skeleton'
 import { formatUnits } from 'viem'
 
 import { useEarnPools } from '../../_hooks/useEarnPools'
-import {
-  findPoolByAsset,
-  hasFailedSettlement,
-  needsManualClaim,
-  needsRecover,
-} from '../../_utils'
+import { findPoolByAsset } from '../../_utils'
 import { type EarnTransaction } from '../../types'
 
 import { RowActions } from './rowActions'
@@ -109,13 +104,7 @@ export const buildColumns = ({
       row.original.kind === 'REDEEM' ? (
         <WithdrawStatusCell transaction={row.original} />
       ) : (
-        <StatusBadge
-          kind={row.original.kind}
-          manualClaimNeeded={needsManualClaim(row.original)}
-          manualRecoverNeeded={needsRecover(row.original)}
-          settlementFailed={hasFailedSettlement(row.original)}
-          status={row.original.status}
-        />
+        <StatusBadge transaction={row.original} />
       ),
     header: () => <Header text={t('column.status')} />,
     id: 'status',

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
@@ -4,41 +4,28 @@ import { Button, ButtonIcon } from 'components/button'
 import { useTranslations } from 'next-intl'
 import { type MouseEvent } from 'react'
 
-import { needsManualClaim, needsRecover } from '../../_utils'
-import {
-  type EarnTransaction,
-  type EarnTransactionStatusType,
-} from '../../types'
+import { isEarnRowInFlight, needsManualClaim, needsRecover } from '../../_utils'
+import { type EarnTransaction } from '../../types'
 import { LoaderIcon } from '../icons/loaderIcon'
 import { TrashIcon } from '../icons/trashIcon'
 
 import { DepositRowCta } from './transactionDrawer/settleDeposit'
 import { useTxDrawerQueryString } from './transactionDrawer/useTxDrawerQueryString'
 
-const TERMINAL_STATUSES: EarnTransactionStatusType[] = [
-  'CANCELLED',
-  'FAILED',
-  'FINALIZED',
-  'RECOVERED',
-]
-
 type Props = {
   transaction: EarnTransaction
 }
 
-// Spinner while the row is in flight: a mining claim/recover settlement (even on
-// a CANCELLED row, which the status set treats as terminal) or a non-terminal
-// status. A reverted settlement shows no spinner — it's "Tx Failed" with a
-// Retry. The inline Claim/Recover CTA is only for the untouched manual state;
-// once a settlement exists (mining or reverted) the row hands back to View and
-// the drawer carries the spinner/Retry.
+// Spinner while the row is in flight (auto-progressing, including an auto-recover
+// CANCELLED deposit, or a claim/recover settlement tx mining), but never on a
+// reverted settlement — that's "Tx Failed" with a Retry. The inline
+// Claim/Recover CTA is only for the untouched manual state; once a settlement
+// exists (mining or reverted) the row hands back to View and the drawer carries
+// the spinner/Retry.
 function resolveActionState(transaction: EarnTransaction) {
   const { settlement } = transaction
-  const settlementPending = !!settlement && !settlement.failed
   return {
-    showLoaderIcon:
-      settlementPending ||
-      (!TERMINAL_STATUSES.includes(transaction.status) && !settlement?.failed),
+    showLoaderIcon: isEarnRowInFlight(transaction) && !settlement?.failed,
     showManualCta:
       !settlement &&
       (needsManualClaim(transaction) || needsRecover(transaction)),

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
@@ -4,28 +4,53 @@ import { Button, ButtonIcon } from 'components/button'
 import { useTranslations } from 'next-intl'
 import { type MouseEvent } from 'react'
 
-import { type EarnTransaction } from '../../types'
+import { needsManualClaim, needsRecover } from '../../_utils'
+import {
+  type EarnTransaction,
+  type EarnTransactionStatusType,
+} from '../../types'
 import { LoaderIcon } from '../icons/loaderIcon'
 import { TrashIcon } from '../icons/trashIcon'
 
+import { DepositRowCta } from './transactionDrawer/settleDeposit'
 import { useTxDrawerQueryString } from './transactionDrawer/useTxDrawerQueryString'
+
+const TERMINAL_STATUSES: EarnTransactionStatusType[] = [
+  'CANCELLED',
+  'FAILED',
+  'FINALIZED',
+  'RECOVERED',
+]
 
 type Props = {
   transaction: EarnTransaction
 }
 
+// Spinner while the row is in flight: a mining claim/recover settlement (even on
+// a CANCELLED row, which the status set treats as terminal) or a non-terminal
+// status. A reverted settlement shows no spinner — it's "Tx Failed" with a
+// Retry. The inline Claim/Recover CTA is only for the untouched manual state;
+// once a settlement exists (mining or reverted) the row hands back to View and
+// the drawer carries the spinner/Retry.
+function resolveActionState(transaction: EarnTransaction) {
+  const { settlement } = transaction
+  const settlementPending = !!settlement && !settlement.failed
+  return {
+    showLoaderIcon:
+      settlementPending ||
+      (!TERMINAL_STATUSES.includes(transaction.status) && !settlement?.failed),
+    showManualCta:
+      !settlement &&
+      (needsManualClaim(transaction) || needsRecover(transaction)),
+  }
+}
+
 export const RowActions = function ({ transaction }: Props) {
   const t = useTranslations('hemi-earn.transactions')
   const [, setTxDrawerQueryString] = useTxDrawerQueryString()
-  const showLoaderIcon =
-    transaction.status !== 'FINALIZED' &&
-    transaction.status !== 'CANCELLED' &&
-    transaction.status !== 'RECOVERED' &&
-    transaction.status !== 'FAILED'
 
-  // The Router stays PENDING for the whole cooldown window; FULFILLED is
-  // the brief post-claimUnstake window before the return OFT lands. Both
-  // are user-cancelable.
+  const { showLoaderIcon, showManualCta } = resolveActionState(transaction)
+
   const showCancelButton =
     transaction.kind === 'REDEEM' &&
     (transaction.status === 'PENDING' || transaction.status === 'FULFILLED')
@@ -41,17 +66,25 @@ export const RowActions = function ({ transaction }: Props) {
     // write hook land in a follow-up PR.
   }
 
+  const viewButton = (
+    <Button
+      onClick={onViewClick}
+      size="xSmall"
+      type="button"
+      variant="secondary"
+    >
+      {showLoaderIcon ? <LoaderIcon /> : null}
+      {t('view')}
+    </Button>
+  )
+
   return (
     <div className="flex items-center gap-x-2 pr-4">
-      <Button
-        onClick={onViewClick}
-        size="xSmall"
-        type="button"
-        variant="secondary"
-      >
-        {showLoaderIcon ? <LoaderIcon /> : null}
-        {t('view')}
-      </Button>
+      {showManualCta ? (
+        <DepositRowCta fallback={viewButton} transaction={transaction} />
+      ) : (
+        viewButton
+      )}
       {showCancelButton ? (
         <ButtonIcon
           aria-label={t('cancel-withdraw')}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
@@ -1,5 +1,6 @@
 import { CheckCircleIcon } from 'components/icons/checkCircleIcon'
 import { ErrorIcon } from 'components/icons/errorIcon'
+import { WarningIcon } from 'components/icons/warningIcon'
 import { useTranslations } from 'next-intl'
 
 import {
@@ -8,55 +9,107 @@ import {
 } from '../../types'
 import { InProgressIcon } from '../icons/inProgressIcon'
 
+type Translator = ReturnType<typeof useTranslations<'hemi-earn.transactions'>>
+
 type Props = {
   cooldownText?: string
   kind: EarnTransactionKindType
+  manualClaimNeeded?: boolean
+  manualRecoverNeeded?: boolean
+  // The user-signed claim/recover tx reverted; surfaces as "Tx Failed" even
+  // though the on-chain status is still FULFILLED/CANCELLED.
+  settlementFailed?: boolean
   status: EarnTransactionStatusType
 }
 
-export const StatusBadge = function ({ cooldownText, kind, status }: Props) {
-  const t = useTranslations('hemi-earn.transactions')
+const inProgress = (text: string) => ({
+  icon: <InProgressIcon />,
+  text,
+  textClassName: 'text-neutral-900',
+})
+
+const failedBadge = (t: Translator) => ({
+  icon: <ErrorIcon className="text-rose-500" />,
+  text: t('status.tx-failed'),
+  textClassName: 'text-neutral-900',
+})
+
+function resolveStatusBadge(
+  kind: EarnTransactionKindType,
+  status: EarnTransactionStatusType,
+  t: Translator,
+) {
   if (status === 'FINALIZED') {
-    return (
-      <div className="flex items-center gap-x-2">
-        <CheckCircleIcon className="text-neutral-400" />
-        <span className="text-neutral-500">
-          {kind === 'REDEEM' ? t('status.withdrawn') : t('status.deposited')}
-        </span>
-      </div>
-    )
+    return {
+      icon: <CheckCircleIcon className="text-neutral-400" />,
+      text: kind === 'REDEEM' ? t('status.withdrawn') : t('status.deposited'),
+      textClassName: 'text-neutral-500',
+    }
   }
   if (status === 'FAILED') {
-    return (
-      <div className="flex items-center gap-x-2">
-        <ErrorIcon className="text-rose-500" />
-        <span className="text-neutral-900">{t('status.tx-failed')}</span>
-      </div>
-    )
+    return failedBadge(t)
   }
-  if (status === 'CANCELLED' && kind === 'REDEEM') {
-    return (
-      <div className="flex items-center gap-x-2">
-        <ErrorIcon className="text-neutral-400" />
-        <span className="text-neutral-500">
-          {t('status.withdrawal-canceled')}
-        </span>
-      </div>
-    )
+  // A cancelled deposit returned the original asset (the Recover CTA pulls it
+  // out); a cancelled redeem is terminal.
+  if (status === 'CANCELLED') {
+    return kind === 'REDEEM'
+      ? {
+          icon: <ErrorIcon className="text-neutral-400" />,
+          text: t('status.withdrawal-canceled'),
+          textClassName: 'text-neutral-500',
+        }
+      : inProgress(t('status.returned'))
   }
-  if (cooldownText !== undefined) {
-    return (
-      <div className="flex items-center gap-x-2">
-        <InProgressIcon />
-        <span className="text-neutral-900">{cooldownText}</span>
-      </div>
-    )
+  // Recovered deposits are surfaced (recovered redeems stay filtered upstream).
+  if (status === 'RECOVERED') {
+    return {
+      icon: <CheckCircleIcon className="text-neutral-400" />,
+      text: t('status.funds-returned'),
+      textClassName: 'text-neutral-500',
+    }
   }
-  // RECOVERED is filtered upstream so it never reaches the badge.
+  return undefined
+}
+
+function resolveBadge(
+  {
+    cooldownText,
+    kind,
+    manualClaimNeeded,
+    manualRecoverNeeded,
+    settlementFailed,
+    status,
+  }: Props,
+  t: Translator,
+) {
+  // A reverted claim/recover wins over the (now stale) manual-needed state.
+  if (settlementFailed) return failedBadge(t)
+  if (manualRecoverNeeded) {
+    return {
+      icon: <WarningIcon className="text-amber-500" />,
+      text: t('status.recover-funds-needed'),
+      textClassName: 'text-neutral-900',
+    }
+  }
+  const byStatus = resolveStatusBadge(kind, status, t)
+  if (byStatus) return byStatus
+  if (cooldownText !== undefined) return inProgress(cooldownText)
+  return inProgress(
+    t(manualClaimNeeded ? 'status.manual-claim-needed' : 'status.in-progress'),
+  )
+}
+
+export const StatusBadge = function (props: Props) {
+  const t = useTranslations('hemi-earn.transactions')
+  const { icon, text, textClassName } = resolveBadge(props, t)
   return (
-    <div className="flex items-center gap-x-2">
-      <InProgressIcon />
-      <span className="text-neutral-900">{t('status.in-progress')}</span>
+    <div className="flex min-w-0 items-center gap-x-2">
+      <span className="flex shrink-0">{icon}</span>
+      <span
+        className={`min-w-0 whitespace-normal leading-tight ${textClassName}`}
+      >
+        {text}
+      </span>
     </div>
   )
 }

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
@@ -4,6 +4,12 @@ import { WarningIcon } from 'components/icons/warningIcon'
 import { useTranslations } from 'next-intl'
 
 import {
+  hasFailedSettlement,
+  needsManualClaim,
+  needsRecover,
+} from '../../_utils'
+import {
+  type EarnTransaction,
   type EarnTransactionKindType,
   type EarnTransactionStatusType,
 } from '../../types'
@@ -13,13 +19,7 @@ type Translator = ReturnType<typeof useTranslations<'hemi-earn.transactions'>>
 
 type Props = {
   cooldownText?: string
-  kind: EarnTransactionKindType
-  manualClaimNeeded?: boolean
-  manualRecoverNeeded?: boolean
-  // The user-signed claim/recover tx reverted; surfaces as "Tx Failed" even
-  // though the on-chain status is still FULFILLED/CANCELLED.
-  settlementFailed?: boolean
-  status: EarnTransactionStatusType
+  transaction: EarnTransaction
 }
 
 const inProgress = (text: string) => ({
@@ -72,19 +72,14 @@ function resolveStatusBadge(
 }
 
 function resolveBadge(
-  {
-    cooldownText,
-    kind,
-    manualClaimNeeded,
-    manualRecoverNeeded,
-    settlementFailed,
-    status,
-  }: Props,
+  transaction: EarnTransaction,
+  cooldownText: string | undefined,
   t: Translator,
 ) {
+  const { kind, status } = transaction
   // A reverted claim/recover wins over the (now stale) manual-needed state.
-  if (settlementFailed) return failedBadge(t)
-  if (manualRecoverNeeded) {
+  if (hasFailedSettlement(transaction)) return failedBadge(t)
+  if (needsRecover(transaction)) {
     return {
       icon: <WarningIcon className="text-amber-500" />,
       text: t('status.recover-funds-needed'),
@@ -95,13 +90,21 @@ function resolveBadge(
   if (byStatus) return byStatus
   if (cooldownText !== undefined) return inProgress(cooldownText)
   return inProgress(
-    t(manualClaimNeeded ? 'status.manual-claim-needed' : 'status.in-progress'),
+    t(
+      needsManualClaim(transaction)
+        ? 'status.manual-claim-needed'
+        : 'status.in-progress',
+    ),
   )
 }
 
-export const StatusBadge = function (props: Props) {
+export const StatusBadge = function ({ cooldownText, transaction }: Props) {
   const t = useTranslations('hemi-earn.transactions')
-  const { icon, text, textClassName } = resolveBadge(props, t)
+  const { icon, text, textClassName } = resolveBadge(
+    transaction,
+    cooldownText,
+    t,
+  )
   return (
     <div className="flex min-w-0 items-center gap-x-2">
       <span className="flex shrink-0">{icon}</span>

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -13,11 +13,15 @@ import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import { useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
 import { type EvmToken } from 'types/token'
+import { type Hash } from 'viem'
 
 import { SparkleIcon } from '../../../_icons/sparkleIcon'
 import {
   getTerminalDeliveryTxHash,
   isLocalEarnTransactionRow,
+  isRecoverPath,
+  needsManualClaim,
+  needsRecover,
 } from '../../../_utils'
 import {
   type EarnTransaction,
@@ -42,7 +46,9 @@ type StepStates = {
 
 const stepStatesByStatus: Record<EarnTransactionStatusType, StepStates> = {
   CANCELLED: {
-    stake: ProgressStatus.FAILED,
+    // The request tx landed (stake done); the cancel/return shows in the
+    // recover-path terminal step, not a failed stake.
+    stake: ProgressStatus.COMPLETED,
     waitingForShares: ProgressStatus.NOT_READY,
   },
   FAILED: {
@@ -98,20 +104,75 @@ function buildStakeStep(tx: EarnTransaction, token: EvmToken, t: Translator) {
   }
 }
 
-const buildWaitingForSharesStep = (
+// COMPLETED wins over everything; a reverted settlement → FAILED; a mining tx →
+// PROGRESS; a pending manual action → READY (active, not a spinner); else the
+// natural status.
+function resolveTerminalStatus(
   tx: EarnTransaction,
-  t: Translator,
-  status: ProgressStatusType,
-) => ({
-  description: (
-    <div className="flex items-center gap-x-2">
-      <SparkleIcon />
-      <span>{t('step.get-share-tokens')}</span>
-    </div>
-  ),
-  status,
-  txHash: getTerminalDeliveryTxHash(tx),
-})
+  baseStatus: ProgressStatusType,
+  settlementTxHash: Hash | undefined,
+): ProgressStatusType {
+  const natural = isRecoverPath(tx)
+    ? tx.status === 'RECOVERED'
+      ? ProgressStatus.COMPLETED
+      : ProgressStatus.PROGRESS
+    : baseStatus
+  if (natural === ProgressStatus.COMPLETED) return ProgressStatus.COMPLETED
+  if (tx.settlement?.failed) return ProgressStatus.FAILED
+  if (settlementTxHash) return ProgressStatus.PROGRESS
+  if (needsManualClaim(tx) || needsRecover(tx)) return ProgressStatus.READY
+  return natural
+}
+
+// Happy path → "Get share tokens"; recover path → "Funds returned" (the asset
+// comes back, so it's labeled with the asset token).
+function buildTerminalStep({
+  baseStatus,
+  settlementTxHash,
+  t,
+  token,
+  tx,
+}: {
+  baseStatus: ProgressStatusType
+  settlementTxHash: Hash | undefined
+  t: Translator
+  token: EvmToken
+  tx: EarnTransaction
+}): StepPropsWithoutPosition {
+  const status = resolveTerminalStatus(tx, baseStatus, settlementTxHash)
+  const txHash = settlementTxHash ?? getTerminalDeliveryTxHash(tx)
+  // Only a manual claim/recover has a user-signed tx worth linking.
+  const explorerChainId = tx.automatic === false ? hemi.id : undefined
+  if (isRecoverPath(tx)) {
+    // "Funds returned" only once RECOVERED; CANCELLED still awaits the recover.
+    const recoverLabel =
+      tx.status === 'RECOVERED'
+        ? 'step.funds-returned'
+        : 'step.funds-to-recover'
+    return {
+      description: (
+        <div className="flex items-center gap-x-2">
+          <TokenLogo size="small" token={token} />
+          <span>{t(recoverLabel)}</span>
+        </div>
+      ),
+      explorerChainId,
+      status,
+      txHash,
+    }
+  }
+  return {
+    description: (
+      <div className="flex items-center gap-x-2">
+        <SparkleIcon />
+        <span>{t('step.get-share-tokens')}</span>
+      </div>
+    ),
+    explorerChainId,
+    status,
+    txHash,
+  }
+}
 
 const buildApprovalStep = (
   approvalTxHash: NonNullable<EarnTransaction['approvalTxHash']>,
@@ -145,6 +206,11 @@ export const HistoricalDepositReview = function ({
   })
 
   const { waitingForShares } = resolveStepStates(transaction)
+  // Only a still-mining settlement drives the step to PROGRESS; a failed one
+  // leaves the natural (FAILED) status and surfaces a Retry CTA instead.
+  const { settlement } = transaction
+  const settlementTxHash =
+    settlement && !settlement.failed ? settlement.txHash : undefined
 
   const steps: StepPropsWithoutPosition[] = []
   // Re-approve only makes sense for local FAILED (Hemi tx reverted).
@@ -170,7 +236,15 @@ export const HistoricalDepositReview = function ({
     steps.push(buildApprovalStep(transaction.approvalTxHash, token, t))
   }
   steps.push(buildStakeStep(transaction, token, t))
-  steps.push(buildWaitingForSharesStep(transaction, t, waitingForShares))
+  steps.push(
+    buildTerminalStep({
+      baseStatus: waitingForShares,
+      settlementTxHash,
+      t,
+      token,
+      tx: transaction,
+    }),
+  )
 
   return (
     <Operation

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -141,8 +141,9 @@ function buildTerminalStep({
 }): StepPropsWithoutPosition {
   const status = resolveTerminalStatus(tx, baseStatus, settlementTxHash)
   const txHash = settlementTxHash ?? getTerminalDeliveryTxHash(tx)
-  // Only a manual claim/recover has a user-signed tx worth linking.
-  const explorerChainId = tx.automatic === false ? hemi.id : undefined
+  // Link whenever a delivery hash is available — an auto-finalized claim/recover
+  // has one too, even though the user didn't sign it.
+  const explorerChainId = txHash ? hemi.id : undefined
   if (isRecoverPath(tx)) {
     // "Funds returned" only once RECOVERED; CANCELLED still awaits the recover.
     const recoverLabel =

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -23,18 +23,27 @@ import { HistoricalDepositReview } from './historicalDepositReview'
 import { HistoricalWithdrawReview } from './historicalWithdrawReview'
 import { RetryFailedDeposit } from './retryFailedDeposit'
 import { RetryFailedWithdraw } from './retryFailedWithdraw'
-import { ClaimDeposit, RecoverDeposit } from './settleDeposit'
+import {
+  AddShareTokenToWallet,
+  ClaimDeposit,
+  RecoverDeposit,
+} from './settleDeposit'
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
 // The drawer is already open, so the deposit CTAs don't redirect on sign. A
 // `failedKind` (the user's claim/recover Hemi tx reverted) surfaces the CTA as
 // a Retry even though the subgraph status no longer matches.
-function depositCallToAction(
-  asset: EarnAsset,
-  pool: EarnPool,
-  transaction: EarnTransaction,
-  failedKind: 'CLAIM' | 'RECOVER' | undefined,
-) {
+function depositCallToAction({
+  asset,
+  failedKind,
+  pool,
+  transaction,
+}: {
+  asset: EarnAsset
+  failedKind: 'CLAIM' | 'RECOVER' | undefined
+  pool: EarnPool
+  transaction: EarnTransaction
+}) {
   if (canRetryRow(transaction)) {
     return (
       <RetryFailedDeposit asset={asset} pool={pool} transaction={transaction} />
@@ -48,7 +57,12 @@ function depositCallToAction(
       <RecoverDeposit asset={asset} pool={pool} transaction={transaction} />
     )
   }
-  return undefined
+  // Shares have landed (claim done) — offer to add the share token to the
+  // wallet, matching the live drawer and the tunnel history.
+  if (transaction.status === 'FINALIZED') {
+    return <AddShareTokenToWallet token={pool.shareToken} />
+  }
+  return null
 }
 
 const findTransactionByTxId = (transactions: EarnTransaction[], txId: string) =>
@@ -100,12 +114,12 @@ const TransactionDrawerContent = function () {
             transaction={transaction}
           />
         )
-      : depositCallToAction(
-          resolved.asset,
-          resolved.pool,
-          transaction,
+      : depositCallToAction({
+          asset: resolved.asset,
           failedKind,
-        )
+          pool: resolved.pool,
+          transaction,
+        })
 
   return (
     <Drawer onClose={close}>

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -7,17 +7,49 @@ import { isAddressEqual } from 'viem'
 import { useEarnPools } from '../../../_hooks/useEarnPools'
 import { useEarnTransactions } from '../../../_hooks/useEarnTransactions'
 import {
+  canRetryRow,
   findPoolByAsset,
   hashesMatch,
-  isLocalEarnTransactionRow,
+  needsManualClaim,
+  needsRecover,
 } from '../../../_utils'
-import { type EarnTransaction } from '../../../types'
+import {
+  type EarnAsset,
+  type EarnPool,
+  type EarnTransaction,
+} from '../../../types'
 
 import { HistoricalDepositReview } from './historicalDepositReview'
 import { HistoricalWithdrawReview } from './historicalWithdrawReview'
 import { RetryFailedDeposit } from './retryFailedDeposit'
 import { RetryFailedWithdraw } from './retryFailedWithdraw'
+import { ClaimDeposit, RecoverDeposit } from './settleDeposit'
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
+
+// The drawer is already open, so the deposit CTAs don't redirect on sign. A
+// `failedKind` (the user's claim/recover Hemi tx reverted) surfaces the CTA as
+// a Retry even though the subgraph status no longer matches.
+function depositCallToAction(
+  asset: EarnAsset,
+  pool: EarnPool,
+  transaction: EarnTransaction,
+  failedKind: 'CLAIM' | 'RECOVER' | undefined,
+) {
+  if (canRetryRow(transaction)) {
+    return (
+      <RetryFailedDeposit asset={asset} pool={pool} transaction={transaction} />
+    )
+  }
+  if (needsManualClaim(transaction) || failedKind === 'CLAIM') {
+    return <ClaimDeposit asset={asset} pool={pool} transaction={transaction} />
+  }
+  if (needsRecover(transaction) || failedKind === 'RECOVER') {
+    return (
+      <RecoverDeposit asset={asset} pool={pool} transaction={transaction} />
+    )
+  }
+  return undefined
+}
 
 const findTransactionByTxId = (transactions: EarnTransaction[], txId: string) =>
   transactions.find(t => hashesMatch(t.requestTxHash, txId))
@@ -54,26 +86,26 @@ const TransactionDrawerContent = function () {
     )
   }
   const resolved = { asset, pool }
+  const { settlement } = transaction
+  const failedKind = settlement?.failed ? settlement.kind : undefined
 
-  // Only local FAILED rows are retryable; subgraph FAILED (Agent rejection
-  // after a successful Hemi tx) needs the recover flow shipped in a later PR.
-  const canRetry =
-    transaction.status === 'FAILED' && isLocalEarnTransactionRow(transaction)
-  const callToAction = canRetry ? (
-    transaction.kind === 'REDEEM' ? (
-      <RetryFailedWithdraw
-        asset={resolved.asset}
-        pool={resolved.pool}
-        transaction={transaction}
-      />
-    ) : (
-      <RetryFailedDeposit
-        asset={resolved.asset}
-        pool={resolved.pool}
-        transaction={transaction}
-      />
-    )
-  ) : undefined
+  // REDEEM only surfaces the retry CTA (its claim/recover/cancel flows land in a
+  // later PR); DEPOSIT additionally surfaces manual Claim / Recover.
+  const callToAction =
+    transaction.kind === 'REDEEM'
+      ? canRetryRow(transaction) && (
+          <RetryFailedWithdraw
+            asset={resolved.asset}
+            pool={resolved.pool}
+            transaction={transaction}
+          />
+        )
+      : depositCallToAction(
+          resolved.asset,
+          resolved.pool,
+          transaction,
+          failedKind,
+        )
 
   return (
     <Drawer onClose={close}>

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleDeposit.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import { Button } from 'components/button'
+import { SubmitWhenConnected } from 'components/submitWhenConnected'
+import { useTranslations } from 'next-intl'
+import { type FormEvent, type ReactNode } from 'react'
+import { isAddressEqual } from 'viem'
+
+import { useClaimDeposit } from '../../../_hooks/useClaimDeposit'
+import { useEarnPools } from '../../../_hooks/useEarnPools'
+import { useRecoverDeposit } from '../../../_hooks/useRecoverDeposit'
+import {
+  findPoolByAsset,
+  needsManualClaim,
+  needsRecover,
+} from '../../../_utils'
+import {
+  type EarnAsset,
+  type EarnPool,
+  type EarnTransaction,
+} from '../../../types'
+
+import { useTxDrawerQueryString } from './useTxDrawerQueryString'
+
+type Props = {
+  asset: EarnAsset
+  // Drawer CTAs stretch full-width; the table cell renders a compact button.
+  fullWidth?: boolean
+  pool: EarnPool
+  // When rendered in the table the drawer isn't open yet, so opening it on
+  // signing lets the user watch the settlement mine. In the drawer it's already
+  // open, so the redirect is skipped.
+  redirectOnSign?: boolean
+  transaction: EarnTransaction
+}
+
+const SettleDepositForm = ({
+  disabled,
+  fullWidth,
+  label,
+  onSubmit,
+}: {
+  disabled: boolean
+  fullWidth: boolean
+  label: ReactNode
+  onSubmit: (e: FormEvent) => void
+}) => (
+  <form
+    className={fullWidth ? 'flex w-full [&>button]:w-full' : 'flex'}
+    onSubmit={onSubmit}
+  >
+    <SubmitWhenConnected
+      submitButton={
+        <Button disabled={disabled} size="small">
+          {label}
+        </Button>
+      }
+      submitButtonSize="small"
+    />
+  </form>
+)
+
+export const ClaimDeposit = function ({
+  asset,
+  fullWidth = true,
+  pool,
+  redirectOnSign,
+  transaction,
+}: Props) {
+  const t = useTranslations('hemi-earn.transactions')
+  const tCommon = useTranslations('common')
+  const [, setTxDrawerQueryString] = useTxDrawerQueryString()
+
+  const { isPending, mutate } = useClaimDeposit({
+    asset,
+    on: redirectOnSign
+      ? emitter =>
+          emitter.on('user-signed-tx', () =>
+            setTxDrawerQueryString(transaction.requestTxHash),
+          )
+      : undefined,
+    pool,
+    transaction,
+  })
+
+  const { settlement } = transaction
+  const own = settlement?.kind === 'CLAIM' ? settlement : undefined
+  const pending = isPending || (!!own && !own.failed)
+  const failed = own?.failed ?? false
+
+  const onSubmit = function (e: FormEvent) {
+    e.preventDefault()
+    if (pending) return
+    mutate()
+  }
+
+  return (
+    <SettleDepositForm
+      disabled={pending}
+      fullWidth={fullWidth}
+      label={
+        pending
+          ? t('claiming')
+          : failed
+            ? tCommon('try-again')
+            : t('claim-share-tokens')
+      }
+      onSubmit={onSubmit}
+    />
+  )
+}
+
+export const RecoverDeposit = function ({
+  asset,
+  fullWidth = true,
+  pool,
+  redirectOnSign,
+  transaction,
+}: Props) {
+  const t = useTranslations('hemi-earn.transactions')
+  const tCommon = useTranslations('common')
+  const [, setTxDrawerQueryString] = useTxDrawerQueryString()
+
+  const { isPending, mutate } = useRecoverDeposit({
+    asset,
+    on: redirectOnSign
+      ? emitter =>
+          emitter.on('user-signed-tx', () =>
+            setTxDrawerQueryString(transaction.requestTxHash),
+          )
+      : undefined,
+    pool,
+    transaction,
+  })
+
+  const { settlement } = transaction
+  const own = settlement?.kind === 'RECOVER' ? settlement : undefined
+  const pending = isPending || (!!own && !own.failed)
+  const failed = own?.failed ?? false
+
+  const onSubmit = function (e: FormEvent) {
+    e.preventDefault()
+    if (pending) return
+    mutate()
+  }
+
+  return (
+    <SettleDepositForm
+      disabled={pending}
+      fullWidth={fullWidth}
+      label={
+        pending
+          ? t('recovering')
+          : failed
+            ? tCommon('try-again')
+            : t('recover-funds')
+      }
+      onSubmit={onSubmit}
+    />
+  )
+}
+
+// The table-row variant: resolves the pool/asset and renders the compact
+// Claim/Recover CTA (or nothing) for a deposit row. Retry stays a View→drawer
+// flow, so it isn't handled here.
+export const DepositRowCta = function ({
+  fallback,
+  transaction,
+}: {
+  // Rendered when the pool/asset can't be resolved yet (pools still loading) or
+  // for a delisted asset — keeps the row's View affordance instead of an empty
+  // cell.
+  fallback?: ReactNode
+  transaction: EarnTransaction
+}) {
+  const { data: pools = [] } = useEarnPools()
+  const pool = findPoolByAsset(pools, transaction.asset)
+  const asset = pool?.assets.find(a =>
+    isAddressEqual(a.address, transaction.asset),
+  )
+
+  if (!pool || !asset) {
+    return fallback ?? null
+  }
+  if (needsManualClaim(transaction)) {
+    return (
+      <ClaimDeposit
+        asset={asset}
+        fullWidth={false}
+        pool={pool}
+        redirectOnSign
+        transaction={transaction}
+      />
+    )
+  }
+  if (needsRecover(transaction)) {
+    return (
+      <RecoverDeposit
+        asset={asset}
+        fullWidth={false}
+        pool={pool}
+        redirectOnSign
+        transaction={transaction}
+      />
+    )
+  }
+  return null
+}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleDeposit.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { AddTokenToWallet } from 'components/addTokenToWallet'
 import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { useTranslations } from 'next-intl'
 import { type FormEvent, type ReactNode } from 'react'
+import { type EvmToken } from 'types/token'
 import { isAddressEqual } from 'viem'
 
 import { useClaimDeposit } from '../../../_hooks/useClaimDeposit'
@@ -205,4 +207,22 @@ export const DepositRowCta = function ({
     )
   }
   return null
+}
+
+// "Add {share token} to wallet" CTA, surfaced once a deposit is FINALIZED (the
+// share OFT has landed). Shared by the live and historical deposit drawers so
+// both match the tunnel-history affordance.
+export const AddShareTokenToWallet = function ({ token }: { token: EvmToken }) {
+  const tCommon = useTranslations('common')
+  return (
+    <AddTokenToWallet
+      labels={{
+        error: tCommon('add-token-to-wallet-error'),
+        idle: tCommon('add-token-to-wallet-idle'),
+        pending: tCommon('add-token-to-wallet-pending'),
+        success: tCommon('add-token-to-wallet-success'),
+      }}
+      token={token}
+    />
+  )
 }

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
@@ -99,20 +99,14 @@ const WithdrawStatusCellResolved = function ({
     t,
   })
 
-  return (
-    <StatusBadge
-      cooldownText={cooldownText}
-      kind="REDEEM"
-      status={transaction.status}
-    />
-  )
+  return <StatusBadge cooldownText={cooldownText} transaction={transaction} />
 }
 
 export const WithdrawStatusCell = function ({ transaction }: Props) {
   const { data: pools = [] } = useEarnPools()
   const pool = findPoolByAsset(pools, transaction.asset)
   if (!pool) {
-    return <StatusBadge kind="REDEEM" status={transaction.status} />
+    return <StatusBadge transaction={transaction} />
   }
   return <WithdrawStatusCellResolved pool={pool} transaction={transaction} />
 }

--- a/portal/app/[locale]/hemi-earn/_context/localEarnOperationsContext.tsx
+++ b/portal/app/[locale]/hemi-earn/_context/localEarnOperationsContext.tsx
@@ -12,7 +12,7 @@ import { type Address, type Hash } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { hashesMatch } from '../_utils'
-import { type LocalEarnOperation } from '../types'
+import { type EarnSettlement, type LocalEarnOperation } from '../types'
 
 const STORAGE_KEY = 'hemi-earn:local-operations'
 const TTL_SECONDS = 90 * 24 * 60 * 60
@@ -37,6 +37,13 @@ type LocalEarnOperationsContextValue = {
   // hides from the merge but the entry stays around so the drawer can
   // still read locally-captured metadata like `approvalTxHash`).
   markSettledByInitiateTxHash: (initiateTxHash: Hash) => void
+  // Records (or clears, with `undefined`) the manual claim/recover state on the
+  // local entry whose `initiateTxHash` matches the request tx. No-op when the
+  // request has no local entry (e.g. the deposit was made in another browser).
+  setSettlement: (
+    initiateTxHash: Hash,
+    settlement: EarnSettlement | undefined,
+  ) => void
   upsertLocalOperation: (payload: UpsertPayload) => void
 }
 
@@ -164,6 +171,27 @@ export const LocalEarnOperationsProvider = function ({
     [address, setStore],
   )
 
+  const setSettlement = useCallback(
+    function (initiateTxHash: Hash, settlement: EarnSettlement | undefined) {
+      if (!address) return
+      const targetAccount = normalizeAccount(address)
+      setStore(function (prev) {
+        const accountEntries = prev[targetAccount]
+        if (!accountEntries) return prev
+        const needle = initiateTxHash.toLowerCase()
+        let mutated = false
+        const updated = accountEntries.map(function (e) {
+          if (e.initiateTxHash?.toLowerCase() !== needle) return e
+          mutated = true
+          return { ...e, settlement }
+        })
+        if (!mutated) return prev
+        return { ...prev, [targetAccount]: updated }
+      })
+    },
+    [address, setStore],
+  )
+
   const localOperations = useMemo(
     function () {
       if (!address) return []
@@ -177,12 +205,14 @@ export const LocalEarnOperationsProvider = function ({
       clearForAccount,
       localOperations,
       markSettledByInitiateTxHash,
+      setSettlement,
       upsertLocalOperation,
     }),
     [
       clearForAccount,
       localOperations,
       markSettledByInitiateTxHash,
+      setSettlement,
       upsertLocalOperation,
     ],
   )

--- a/portal/app/[locale]/hemi-earn/_hooks/useClaimDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useClaimDeposit.ts
@@ -1,0 +1,19 @@
+import { type EventEmitter } from 'events'
+import { type ClaimDepositEvents } from 'hemi-earn-actions'
+import { claimDeposit } from 'hemi-earn-actions/actions'
+
+import { type EarnAsset, type EarnPool, type EarnTransaction } from '../types'
+
+import { useSettleDeposit } from './useSettleDeposit'
+
+type UseClaimDeposit = {
+  asset: EarnAsset
+  on?: (emitter: EventEmitter<ClaimDepositEvents>) => void
+  pool: EarnPool
+  transaction: EarnTransaction
+}
+
+// Signs `Router.claimDeposit(requestId)` for a FULFILLED + manual deposit so the
+// shares land in the user's wallet (→ FINALIZED).
+export const useClaimDeposit = (params: UseClaimDeposit) =>
+  useSettleDeposit({ ...params, action: claimDeposit, kind: 'CLAIM' })

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { hemi } from 'hemi-viem'
 import { getTokenBalanceQueryKey } from 'hooks/useBalance'
 import { useEffect, useRef } from 'react'
-import { type Address, isAddressEqual } from 'viem'
+import { type Address, getAddress, isAddressEqual } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { earnPositionsKeyPrefix } from '../_fetchers/fetchEarnPositions'
@@ -52,11 +52,8 @@ function reconcileLocals({
   }
 }
 
-const isInFlightStatus = (status: EarnTransactionStatusType) =>
-  status !== 'FINALIZED' &&
-  status !== 'CANCELLED' &&
-  status !== 'RECOVERED' &&
-  status !== 'FAILED'
+const isPreDeliveryStatus = (status: EarnTransactionStatusType) =>
+  status !== 'FINALIZED' && status !== 'RECOVERED'
 
 type DeliveredStatus = 'FINALIZED' | 'RECOVERED'
 
@@ -84,7 +81,7 @@ function detectCrossChainDeliveries(
   for (const row of rows) {
     if (row.status !== 'FINALIZED' && row.status !== 'RECOVERED') continue
     const prev = previous.get(row.requestTxHash.toLowerCase())
-    if (prev === undefined || !isInFlightStatus(prev)) continue
+    if (prev === undefined || !isPreDeliveryStatus(prev)) continue
     events.push({
       asset: row.asset,
       kind: row.kind,
@@ -136,7 +133,7 @@ function invalidateOnDelivery(
       queryKey: getTokenBalanceQueryKey({
         account: event.receiver,
         chainId: hemi.id,
-        tokenAddress,
+        tokenAddress: getAddress(tokenAddress),
       }),
     })
   }

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactions.ts
@@ -131,11 +131,27 @@ export const useEarnTransactions = function () {
           .map(op => [op.initiateTxHash!.toLowerCase(), op]),
       )
       const subgraph = (data ?? [])
-        .filter(t => t.status !== 'RECOVERED')
+        // Recovered deposits surface as a "Funds returned" terminal row;
+        // recovered redeems stay hidden (their UX lands in a later PR).
+        .filter(t => !(t.status === 'RECOVERED' && t.kind === 'REDEEM'))
         .map(function (t) {
           const local = localByRequestHash.get(t.requestTxHash.toLowerCase())
-          if (!local?.approvalTxHash) return t
-          return { ...t, approvalTxHash: local.approvalTxHash }
+          if (!local) return t
+          // The authoritative terminal Router status wins over a lingering
+          // local settlement — a pending marker mid-indexing-lag or a stale
+          // reverted one. A FINALIZED/RECOVERED row must never re-expose the
+          // claim/recover CTA or a "Tx Failed" overlay.
+          const isTerminal =
+            t.status === 'FINALIZED' || t.status === 'RECOVERED'
+          return {
+            ...t,
+            ...(local.approvalTxHash
+              ? { approvalTxHash: local.approvalTxHash }
+              : {}),
+            ...(local.settlement && !isTerminal
+              ? { settlement: local.settlement }
+              : {}),
+          }
         })
       const subgraphHashes = new Set(
         subgraph.map(t => t.requestTxHash.toLowerCase()),

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
@@ -19,10 +19,12 @@ import { useLocalEarnOperations } from './useLocalEarnOperations'
 // consumers — a single network call per interval drives every subscriber.
 //
 // Polling: every 10s while at least one row is non-terminal (cross-chain
-// in flight, auto-claim pending, cooldown maturing) or a local entry hasn't
-// shown up in the subgraph yet. Stops on FINALIZED / CANCELLED / RECOVERED
-// / FAILED — FAILED is portal-terminal because the user needs to retry, not
-// wait for the eventual Router cancel.
+// in flight, auto-claim pending, cooldown maturing, or a deposit awaiting
+// recovery) or a local entry hasn't shown up in the subgraph yet. Stops on
+// FINALIZED / RECOVERED / FAILED and on a REDEEM CANCELLED (withdrawal
+// canceled). A DEPOSIT CANCELLED keeps polling because it still walks to
+// RECOVERED (auto, or via the user's recover) — mirroring how FULFILLED walks
+// to FINALIZED. FAILED is portal-terminal: the user retries, not waits.
 export const useEarnTransactionsQuery = function () {
   const [networkType] = useNetworkType()
   const { address } = useAccount()
@@ -41,9 +43,11 @@ export const useEarnTransactionsQuery = function () {
       const hasSubgraphInFlight = subgraphData.some(
         t =>
           t.status !== 'FINALIZED' &&
-          t.status !== 'CANCELLED' &&
           t.status !== 'RECOVERED' &&
-          t.status !== 'FAILED',
+          t.status !== 'FAILED' &&
+          // A DEPOSIT CANCELLED still walks to RECOVERED; only a REDEEM
+          // CANCELLED is terminal (withdrawal canceled).
+          !(t.status === 'CANCELLED' && t.kind === 'REDEEM'),
       )
       return hasSubgraphInFlight || inFlightLocalsExist ? 10_000 : false
     },

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
@@ -38,7 +38,7 @@ export const useEarnTransactionsQuery = function () {
     queryKey: [...earnTransactionsKeyPrefix, networkType, address],
     refetchInterval(query) {
       const subgraphData = (query.state.data ?? []) as EarnTransaction[]
-      return subgraphData.some(isEarnRowInFlight) || inFlightLocalsExist
+      return inFlightLocalsExist || subgraphData.some(isEarnRowInFlight)
         ? 10_000
         : false
     },

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
@@ -8,6 +8,7 @@ import {
   earnTransactionsKeyPrefix,
   fetchEarnTransactions,
 } from '../_fetchers/fetchEarnTransactions'
+import { isEarnRowInFlight } from '../_utils'
 import { type EarnTransaction } from '../types'
 
 import { useLocalEarnOperations } from './useLocalEarnOperations'
@@ -18,13 +19,10 @@ import { useLocalEarnOperations } from './useLocalEarnOperations'
 // subgraph view). React Query dedupes the underlying fetch across both
 // consumers — a single network call per interval drives every subscriber.
 //
-// Polling: every 10s while at least one row is non-terminal (cross-chain
-// in flight, auto-claim pending, cooldown maturing, or a deposit awaiting
-// recovery) or a local entry hasn't shown up in the subgraph yet. Stops on
-// FINALIZED / RECOVERED / FAILED and on a REDEEM CANCELLED (withdrawal
-// canceled). A DEPOSIT CANCELLED keeps polling because it still walks to
-// RECOVERED (auto, or via the user's recover) — mirroring how FULFILLED walks
-// to FINALIZED. FAILED is portal-terminal: the user retries, not waits.
+// Polling: every 10s while a row is in flight (`isEarnRowInFlight`: cross-chain
+// pending, auto-claim/auto-recover progressing, a deposit awaiting recovery,
+// cooldown maturing) or a local entry hasn't shown up in the subgraph yet.
+// Stops on the terminals (FINALIZED/RECOVERED/FAILED and a REDEEM CANCELLED).
 export const useEarnTransactionsQuery = function () {
   const [networkType] = useNetworkType()
   const { address } = useAccount()
@@ -40,16 +38,9 @@ export const useEarnTransactionsQuery = function () {
     queryKey: [...earnTransactionsKeyPrefix, networkType, address],
     refetchInterval(query) {
       const subgraphData = (query.state.data ?? []) as EarnTransaction[]
-      const hasSubgraphInFlight = subgraphData.some(
-        t =>
-          t.status !== 'FINALIZED' &&
-          t.status !== 'RECOVERED' &&
-          t.status !== 'FAILED' &&
-          // A DEPOSIT CANCELLED still walks to RECOVERED; only a REDEEM
-          // CANCELLED is terminal (withdrawal canceled).
-          !(t.status === 'CANCELLED' && t.kind === 'REDEEM'),
-      )
-      return hasSubgraphInFlight || inFlightLocalsExist ? 10_000 : false
+      return subgraphData.some(isEarnRowInFlight) || inFlightLocalsExist
+        ? 10_000
+        : false
     },
   })
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useRecoverDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRecoverDeposit.ts
@@ -1,0 +1,19 @@
+import { type EventEmitter } from 'events'
+import { type RecoverDepositEvents } from 'hemi-earn-actions'
+import { recoverDeposit } from 'hemi-earn-actions/actions'
+
+import { type EarnAsset, type EarnPool, type EarnTransaction } from '../types'
+
+import { useSettleDeposit } from './useSettleDeposit'
+
+type UseRecoverDeposit = {
+  asset: EarnAsset
+  on?: (emitter: EventEmitter<RecoverDepositEvents>) => void
+  pool: EarnPool
+  transaction: EarnTransaction
+}
+
+// Signs `Router.recoverDeposit(requestId)` for a CANCELLED + manual deposit so
+// the original asset returns to the user's wallet (→ RECOVERED).
+export const useRecoverDeposit = (params: UseRecoverDeposit) =>
+  useSettleDeposit({ ...params, action: recoverDeposit, kind: 'RECOVER' })

--- a/portal/app/[locale]/hemi-earn/_hooks/useSettleDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useSettleDeposit.ts
@@ -6,8 +6,8 @@ import { type EventEmitter } from 'events'
 import { type ClaimDepositEvents } from 'hemi-earn-actions'
 import { hemi } from 'hemi-viem'
 import { getTokenBalanceQueryKey } from 'hooks/useBalance'
-import { useAccount, useConfig } from 'wagmi'
-import { getWalletClient } from 'wagmi/actions'
+import { useHemiWalletClient } from 'hooks/useHemiClient'
+import { useAccount } from 'wagmi'
 
 import { earnPositionsKeyPrefix } from '../_fetchers/fetchEarnPositions'
 import { earnTransactionsKeyPrefix } from '../_fetchers/fetchEarnTransactions'
@@ -47,7 +47,7 @@ export const useSettleDeposit = function ({
   transaction,
 }: UseSettleDeposit) {
   const { address } = useAccount()
-  const config = useConfig()
+  const { hemiWalletClient } = useHemiWalletClient()
   const ensureConnectedTo = useEnsureConnectedTo()
   const queryClient = useQueryClient()
   const { setSettlement } = useLocalEarnOperations()
@@ -74,12 +74,10 @@ export const useSettleDeposit = function ({
 
       await ensureConnectedTo(hemi.id)
 
-      const walletClient = await getWalletClient(config, { chainId: hemi.id })
-
       const { emitter, promise } = action({
         account: address,
         requestId: BigInt(requestId),
-        walletClient,
+        walletClient: hemiWalletClient!,
       })
 
       // Any failure flags the settlement so the drawer offers a Retry. On
@@ -118,7 +116,12 @@ export const useSettleDeposit = function ({
     },
     onSettled() {
       queryClient.invalidateQueries({ queryKey: earnTransactionsKeyPrefix })
-      queryClient.invalidateQueries({ queryKey: deliveredBalanceQueryKey })
+      // `resetQueries` (not `invalidate`) so the manage page shows a fresh value
+      // instead of flashing the stale balance: the deposit form usually mounts
+      // *after* the mutation (the user clicks "manage" post-recover), and an
+      // invalidated-but-cached entry would render the old number until the
+      // background refetch lands.
+      queryClient.resetQueries({ queryKey: deliveredBalanceQueryKey })
       queryClient.invalidateQueries({ queryKey: nativeTokenBalanceQueryKey })
       // `resetQueries` (not `removeQueries`) so the `useEarnPositions` observer
       // refetches and the staked-balance card updates — same rationale as

--- a/portal/app/[locale]/hemi-earn/_hooks/useSettleDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useSettleDeposit.ts
@@ -1,0 +1,129 @@
+import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo'
+import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
+import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { type EventEmitter } from 'events'
+import { type ClaimDepositEvents } from 'hemi-earn-actions'
+import { hemi } from 'hemi-viem'
+import { getTokenBalanceQueryKey } from 'hooks/useBalance'
+import { useAccount, useConfig } from 'wagmi'
+import { getWalletClient } from 'wagmi/actions'
+
+import { earnPositionsKeyPrefix } from '../_fetchers/fetchEarnPositions'
+import { earnTransactionsKeyPrefix } from '../_fetchers/fetchEarnTransactions'
+import { type EarnAsset, type EarnPool, type EarnTransaction } from '../types'
+
+import { useLocalEarnOperations } from './useLocalEarnOperations'
+
+// Both `claimDeposit` and `recoverDeposit` share this exact signature.
+type SettleAction = (typeof import('hemi-earn-actions/actions'))['claimDeposit']
+
+type UseSettleDeposit = {
+  // The `hemi-earn-actions` wallet action to run (`claimDeposit` /
+  // `recoverDeposit`). Both finalize a single Hemi Router tx with no approval
+  // or quote leg.
+  action: SettleAction
+  asset: EarnAsset
+  // Drives which delivered-token balance to refresh and the settlement kind:
+  // claim delivers shares, recover returns the original asset.
+  kind: 'CLAIM' | 'RECOVER'
+  on?: (emitter: EventEmitter<ClaimDepositEvents>) => void
+  pool: EarnPool
+  transaction: EarnTransaction
+}
+
+// Shared mutation core for the two single-tx deposit settlements. Mirrors the
+// `useWithdraw` scaffolding (wallet client + invalidations) but without the
+// approval/quote machinery. The settlement state is persisted on the local
+// entry (`setSettlement`): flagged failed on revert so the CTA returns as a
+// Retry, left pending on success and dropped by the merge once the row is
+// terminal (so the CTA doesn't flicker back during the indexing lag).
+export const useSettleDeposit = function ({
+  action,
+  asset,
+  kind,
+  on,
+  pool,
+  transaction,
+}: UseSettleDeposit) {
+  const { address } = useAccount()
+  const config = useConfig()
+  const ensureConnectedTo = useEnsureConnectedTo()
+  const queryClient = useQueryClient()
+  const { setSettlement } = useLocalEarnOperations()
+  const updateNativeBalanceAfterFees = useUpdateNativeBalanceAfterReceipt(
+    hemi.id,
+  )
+  const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(hemi.id)
+
+  const { requestId } = transaction
+
+  // Claim drops shares into the user's wallet; recover returns the original
+  // asset. Refresh whichever lands.
+  const deliveredBalanceQueryKey = getTokenBalanceQueryKey({
+    account: address,
+    chainId: hemi.id,
+    tokenAddress: kind === 'CLAIM' ? pool.shareAddress : asset.address,
+  })
+
+  return useMutation({
+    async mutationFn() {
+      if (!address) {
+        throw new Error('No account connected')
+      }
+
+      await ensureConnectedTo(hemi.id)
+
+      const walletClient = await getWalletClient(config, { chainId: hemi.id })
+
+      const { emitter, promise } = action({
+        account: address,
+        requestId: BigInt(requestId),
+        walletClient,
+      })
+
+      // Any failure flags the settlement so the drawer offers a Retry. On
+      // success the marker is left pending — the merge drops it once the row is
+      // FINALIZED/RECOVERED, so the CTA stays suppressed through the indexing
+      // lag instead of re-appearing while the status is still FULFILLED/
+      // CANCELLED. Keyed by the request tx (`requestTxHash` = the local entry's
+      // `initiateTxHash`).
+      const fail = () =>
+        setSettlement(transaction.requestTxHash, { failed: true, kind })
+
+      emitter.on('user-signed-tx', function (txHash) {
+        setSettlement(transaction.requestTxHash, {
+          failed: false,
+          kind,
+          txHash,
+        })
+      })
+      emitter.on('tx-transaction-succeeded', function (receipt) {
+        updateNativeBalanceAfterFees(receipt)
+      })
+      emitter.on('tx-transaction-reverted', function (receipt) {
+        fail()
+        updateNativeBalanceAfterFees(receipt)
+      })
+      emitter.on('tx-failed', fail)
+      emitter.on('tx-failed-validation', fail)
+      emitter.on('user-signing-tx-error', fail)
+      emitter.on('unexpected-error', fail)
+
+      // Caller hook (e.g. the table CTA) listens for `user-signed-tx` to
+      // redirect the drawer.
+      on?.(emitter)
+
+      return promise
+    },
+    onSettled() {
+      queryClient.invalidateQueries({ queryKey: earnTransactionsKeyPrefix })
+      queryClient.invalidateQueries({ queryKey: deliveredBalanceQueryKey })
+      queryClient.invalidateQueries({ queryKey: nativeTokenBalanceQueryKey })
+      // `resetQueries` (not `removeQueries`) so the `useEarnPositions` observer
+      // refetches and the staked-balance card updates — same rationale as
+      // `useWithdraw`.
+      queryClient.resetQueries({ queryKey: earnPositionsKeyPrefix })
+    },
+  })
+}

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -84,3 +84,15 @@ export const canRetryRow = (tx: EarnTransaction) =>
 // misleading "needed" state.
 export const hasFailedSettlement = (tx: EarnTransaction) =>
   tx.settlement?.failed === true
+
+// A row the table is still actively tracking — drives both the polling loop and
+// the row spinner. Terminal: FINALIZED/RECOVERED/FAILED for any kind, plus a
+// CANCELLED REDEEM (withdrawal canceled). A CANCELLED DEPOSIT stays in flight:
+// it still walks to RECOVERED, whether auto-recover or via the user's recover,
+// so the table keeps polling and reflects it (even across devices/sessions),
+// mirroring how a FULFILLED deposit walks to FINALIZED.
+export const isEarnRowInFlight = (tx: EarnTransaction) =>
+  tx.status !== 'FINALIZED' &&
+  tx.status !== 'RECOVERED' &&
+  tx.status !== 'FAILED' &&
+  !(tx.status === 'CANCELLED' && tx.kind === 'REDEEM')

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -51,3 +51,36 @@ export const findPoolByShare = (
 // Agent failed after a successful Hemi tx (recover, not retry).
 export const isLocalEarnTransactionRow = (tx: EarnTransaction) =>
   tx.requestId.startsWith('local-')
+
+// A FULFILLED deposit with auto-claim off: the shares are back on the Router
+// but the user must sign `claimDeposit(id)` to receive them.
+export const needsManualClaim = (tx: EarnTransaction) =>
+  tx.kind === 'DEPOSIT' && tx.status === 'FULFILLED' && tx.automatic === false
+
+// A CANCELLED deposit with auto-recover off: the original asset is back on the
+// Router and the user must sign `recoverDeposit(id)` to pull it to their wallet.
+// `recoverDeposit` reverts unless the request is CANCELLED, so this is the only
+// state where the Recover CTA is valid.
+export const needsRecover = (tx: EarnTransaction) =>
+  tx.kind === 'DEPOSIT' && tx.status === 'CANCELLED' && tx.automatic === false
+
+// Broader than `needsRecover`: any deposit on the recover branch (awaiting or
+// past recovery), regardless of `automatic`. Drives the display — the terminal
+// step shows the returned asset, not shares — even when auto-recover means no
+// CTA is shown.
+export const isRecoverPath = (tx: EarnTransaction) =>
+  tx.kind === 'DEPOSIT' &&
+  (tx.status === 'CANCELLED' || tx.status === 'RECOVERED')
+
+// The Hemi `request*` tx reverted before it ever landed on-chain, so the user
+// can re-run the original request. Subgraph FAILED rows are a different beast
+// (handled elsewhere), hence the local-only gate.
+export const canRetryRow = (tx: EarnTransaction) =>
+  tx.status === 'FAILED' && isLocalEarnTransactionRow(tx)
+
+// A manual claim/recover the user signed reverted on Hemi. The on-chain status
+// is unchanged (still FULFILLED/CANCELLED), so we surface the revert as a
+// failure in the badge/step and offer a retry, rather than trusting the now
+// misleading "needed" state.
+export const hasFailedSettlement = (tx: EarnTransaction) =>
+  tx.settlement?.failed === true

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { AddTokenToWallet } from 'components/addTokenToWallet'
 import { Operation } from 'components/reviewOperation/operation'
 import {
   ProgressStatus,
@@ -20,6 +19,7 @@ import { type Hash, formatUnits } from 'viem'
 import { useAccount, useEstimateGas } from 'wagmi'
 
 import {
+  AddShareTokenToWallet,
   ClaimDeposit,
   RecoverDeposit,
 } from '../../../../_components/transactionsSection/transactionDrawer/settleDeposit'
@@ -143,7 +143,6 @@ export const ReviewDeposit = function ({ onClose }: Props) {
   const { depositOperation, input, pool, selectedAsset } = usePoolForm()
   const { localOperations } = useLocalEarnOperations()
   const t = useTranslations('hemi-earn.pool.drawer')
-  const tCommon = useTranslations('common')
   const chainId = selectedAsset.token.chainId
   const chain = useChain(chainId)
   const { address } = useAccount()
@@ -331,6 +330,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       settlementFailed,
       settlementTxHash,
     } = getSharesStepMeta(subgraphRow, settlement)
+    const deliveryHash = settlementTxHash ?? terminalHash
 
     return {
       // Recover path → the asset comes back, labeled with the asset token.
@@ -347,7 +347,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
           <span>{t('get-share-tokens')}</span>
         </div>
       ),
-      explorerChainId: subgraphRow?.automatic === false ? chainId : undefined,
+      explorerChainId: deliveryHash ? chainId : undefined,
       status: resolveGetSharesStatus({
         awaitingUserAction,
         hasSettlementTx: !!settlementTxHash,
@@ -358,7 +358,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
         isRecover,
         settlementFailed,
       }),
-      txHash: settlementTxHash ?? terminalHash,
+      txHash: deliveryHash,
     }
   }
 
@@ -398,17 +398,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
     // that points the wallet at a token with no balance and confuses
     // wallets that gate metadata reads on a non-zero balance.
     if (subgraphRow?.status === 'FINALIZED') {
-      return (
-        <AddTokenToWallet
-          labels={{
-            error: tCommon('add-token-to-wallet-error'),
-            idle: tCommon('add-token-to-wallet-idle'),
-            pending: tCommon('add-token-to-wallet-pending'),
-            success: tCommon('add-token-to-wallet-success'),
-          }}
-          token={pool.shareToken}
-        />
-      )
+      return <AddShareTokenToWallet token={pool.shareToken} />
     }
     return null
   }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -16,16 +16,32 @@ import { useEstimateFees } from 'hooks/useEstimateFees'
 import { useTranslations } from 'next-intl'
 import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
-import { formatUnits } from 'viem'
+import { type Hash, formatUnits } from 'viem'
 import { useAccount, useEstimateGas } from 'wagmi'
 
+import {
+  ClaimDeposit,
+  RecoverDeposit,
+} from '../../../../_components/transactionsSection/transactionDrawer/settleDeposit'
 import {
   DEPOSIT_SLIPPAGE_BPS,
   applySlippage,
 } from '../../../../_constants/slippage'
 import { useEarnTransactionsQuery } from '../../../../_hooks/useEarnTransactionsQuery'
+import { useLocalEarnOperations } from '../../../../_hooks/useLocalEarnOperations'
 import { SparkleIcon } from '../../../../_icons/sparkleIcon'
-import { getTerminalDeliveryTxHash, hashesMatch } from '../../../../_utils'
+import {
+  getTerminalDeliveryTxHash,
+  hashesMatch,
+  isRecoverPath,
+  needsManualClaim,
+  needsRecover,
+} from '../../../../_utils'
+import {
+  type EarnSettlement,
+  type EarnTransaction,
+  type LocalEarnOperation,
+} from '../../../../types'
 import { usePoolForm } from '../../_context/poolFormContext'
 import { useDepositShares } from '../../_hooks/useDepositShares'
 import { useQuoteDeposit } from '../../_hooks/useQuoteDeposit'
@@ -37,10 +53,95 @@ type Props = {
   onClose: VoidFunction
 }
 
+// COMPLETED wins; a remote failure or reverted settlement → FAILED; a mining tx
+// → PROGRESS; a pending manual action → READY; else PROGRESS (recover/auto or
+// confirmed) or NOT_READY.
+function resolveGetSharesStatus({
+  awaitingUserAction,
+  hasSettlementTx,
+  isComplete,
+  isDepositConfirmed,
+  isFailed,
+  isRecover,
+  settlementFailed,
+}: {
+  awaitingUserAction: boolean
+  hasSettlementTx: boolean
+  isComplete: boolean
+  isDepositConfirmed: boolean
+  isFailed: boolean
+  isRecover: boolean
+  settlementFailed: boolean
+}): ProgressStatusType {
+  if (isComplete) return ProgressStatus.COMPLETED
+  if (isFailed || settlementFailed) return ProgressStatus.FAILED
+  if (hasSettlementTx) return ProgressStatus.PROGRESS
+  if (awaitingUserAction) return ProgressStatus.READY
+  if (isRecover || isDepositConfirmed) return ProgressStatus.PROGRESS
+  return ProgressStatus.NOT_READY
+}
+
+// `subgraphRow` is raw (not merge-enriched), so the manual claim/recover
+// settlement is read straight from the local store keyed by the request tx.
+const findLocalSettlement = (
+  localOperations: LocalEarnOperation[],
+  requestTxHash: Hash | undefined,
+) =>
+  requestTxHash
+    ? localOperations.find(
+        op =>
+          op.initiateTxHash && hashesMatch(op.initiateTxHash, requestTxHash),
+      )?.settlement
+    : undefined
+
+// `subgraphRow` is raw (not merge-enriched), so fold the local settlement in
+// before handing it to the CTA — otherwise the button can't reflect the
+// pending/reverted claim (it'd stay "Claim share tokens" after a revert).
+const enrichWithSettlement = (
+  row: EarnTransaction | undefined,
+  settlement: EarnSettlement | undefined,
+): EarnTransaction | undefined =>
+  row && settlement ? { ...row, settlement } : row
+
+function getSharesStepMeta(
+  subgraphRow: EarnTransaction | undefined,
+  marker: { failed: boolean; txHash?: Hash } | undefined,
+) {
+  // A failed marker leaves the natural status (so a Retry shows); only a
+  // still-mining one drives PROGRESS.
+  const settlementTxHash = marker && !marker.failed ? marker.txHash : undefined
+  const settlementFailed = marker?.failed ?? false
+  if (!subgraphRow) {
+    return {
+      awaitingUserAction: false,
+      isComplete: false,
+      isFailed: false,
+      isRecover: false,
+      settlementFailed,
+      settlementTxHash,
+    }
+  }
+  const isRecover = isRecoverPath(subgraphRow)
+  return {
+    awaitingUserAction:
+      needsManualClaim(subgraphRow) || needsRecover(subgraphRow),
+    isComplete: isRecover
+      ? subgraphRow.status === 'RECOVERED'
+      : subgraphRow.status === 'FINALIZED',
+    // Remote (Gateway/Agent) failure: the subgraph derives `failed → FAILED`
+    // while the Router stays PENDING. Reflect it instead of spinning forever.
+    isFailed: subgraphRow.status === 'FAILED',
+    isRecover,
+    settlementFailed,
+    settlementTxHash,
+  }
+}
+
 // Drawer opens after the user signs the first wallet prompt (approval if
 // needed, otherwise the deposit).
 export const ReviewDeposit = function ({ onClose }: Props) {
   const { depositOperation, input, pool, selectedAsset } = usePoolForm()
+  const { localOperations } = useLocalEarnOperations()
   const t = useTranslations('hemi-earn.pool.drawer')
   const tCommon = useTranslations('common')
   const chainId = selectedAsset.token.chainId
@@ -55,6 +156,12 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       r.kind === 'DEPOSIT' &&
       hashesMatch(r.requestTxHash, depositOperation?.transactionHash),
   )
+
+  const settlement = findLocalSettlement(
+    localOperations,
+    subgraphRow?.requestTxHash,
+  )
+  const settledRow = enrichWithSettlement(subgraphRow, settlement)
 
   const depositStatus =
     depositOperation?.status ?? DepositStatus.APPROVAL_TX_COMPLETED
@@ -216,24 +323,42 @@ export const ReviewDeposit = function ({ onClose }: Props) {
 
   const addGetShareTokensStep = function () {
     const terminalHash = getTerminalDeliveryTxHash(subgraphRow)
-
-    const getStatus = function (): ProgressStatusType {
-      if (terminalHash) return ProgressStatus.COMPLETED
-      if (depositStatus === DepositStatus.DEPOSIT_TX_CONFIRMED) {
-        return ProgressStatus.PROGRESS
-      }
-      return ProgressStatus.NOT_READY
-    }
+    const {
+      awaitingUserAction,
+      isComplete,
+      isFailed,
+      isRecover,
+      settlementFailed,
+      settlementTxHash,
+    } = getSharesStepMeta(subgraphRow, settlement)
 
     return {
-      description: (
+      // Recover path → the asset comes back, labeled with the asset token.
+      // "Funds returned" only once RECOVERED; while still awaiting it reads as
+      // the pending "Funds to recover".
+      description: isRecover ? (
+        <div className="flex items-center gap-x-2">
+          <TokenLogo size="small" token={selectedAsset.token} />
+          <span>{t(isComplete ? 'funds-returned' : 'funds-to-recover')}</span>
+        </div>
+      ) : (
         <div className="flex items-center gap-x-2">
           <SparkleIcon />
           <span>{t('get-share-tokens')}</span>
         </div>
       ),
-      status: getStatus(),
-      txHash: terminalHash,
+      explorerChainId: subgraphRow?.automatic === false ? chainId : undefined,
+      status: resolveGetSharesStatus({
+        awaitingUserAction,
+        hasSettlementTx: !!settlementTxHash,
+        isComplete,
+        isDepositConfirmed:
+          depositStatus === DepositStatus.DEPOSIT_TX_CONFIRMED,
+        isFailed,
+        isRecover,
+        settlementFailed,
+      }),
+      txHash: settlementTxHash ?? terminalHash,
     }
   }
 
@@ -245,6 +370,28 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       ].includes(depositStatus)
     ) {
       return <RetryDeposit />
+    }
+    // Auto-claim off: the user signs the claim here once the Agent has
+    // delivered the shares back to the Router (FULFILLED).
+    if (settledRow && needsManualClaim(settledRow)) {
+      return (
+        <ClaimDeposit
+          asset={selectedAsset}
+          pool={pool}
+          transaction={settledRow}
+        />
+      )
+    }
+    // The request was cancelled and the original asset is back on the Router;
+    // the user signs the recover to pull it to their wallet.
+    if (settledRow && needsRecover(settledRow)) {
+      return (
+        <RecoverDeposit
+          asset={selectedAsset}
+          pool={pool}
+          transaction={settledRow}
+        />
+      )
     }
     // Shares only land in the user's wallet once cross-chain delivery
     // completes (subgraph FINALIZED). Showing the "Add token" CTA before

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -28,6 +28,15 @@ export type EarnTransactionKindType = 'DEPOSIT' | 'REDEEM'
 // (`InRelativeTime`). `'TX_PENDING'` and `'FAILED'` are portal-synthetic
 // statuses (derived in `useEarnTransactions` and at the fetcher boundary
 // respectively) — they don't exist in the subgraph schema.
+// A manual claim/recover the user signed on Hemi, tracked locally (the
+// reverted tx isn't a subgraph event). `failed` lets the drawer offer a Retry
+// to re-call the same step — same idea as the request-deposit retry.
+export type EarnSettlement = {
+  failed: boolean
+  kind: 'CLAIM' | 'RECOVER'
+  txHash?: Hash
+}
+
 export type EarnTransaction = {
   amountIn: string
   amountOut: string | null
@@ -48,6 +57,9 @@ export type EarnTransaction = {
   requestedAt: string
   requestId: string
   requestTxHash: Hash
+  // Locally-tracked manual claim/recover attempt for this request (enriched
+  // from the local store by `useEarnTransactions`, like `approvalTxHash`).
+  settlement?: EarnSettlement
   status: EarnTransactionStatusType
 }
 
@@ -116,6 +128,10 @@ type LocalEarnOperationBase = {
   chainId: Chain['id']
   initiateTxHash?: Hash
   operator?: Address
+  // Manual claim/recover the user signed on this request (keyed by the same
+  // `initiateTxHash` = the request tx). Survives the soft-settle so the drawer
+  // keeps offering the Retry after the subgraph indexes the request.
+  settlement?: EarnSettlement
   settled?: boolean
   shareAddress: Address
   // Unix seconds. Matches the unit of `TTL_SECONDS` in

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -34,6 +34,8 @@
         "cooldown-ended": "Cooldown period complete",
         "stake-token": "Stake {symbol}",
         "get-share-tokens": "Get share tokens",
+        "funds-returned": "Funds returned",
+        "funds-to-recover": "Funds to recover",
         "receive-token": "Receive {symbol}",
         "unstake-token": "Unstake {symbol}",
         "wait-cooldown-countdown": "{days, plural, =0 {Cooldown ends in {hours}h} other {Cooldown ends in #d {hours}h}}",
@@ -78,6 +80,8 @@
       "total-deposits": "Total deposits"
     },
     "transactions": {
+      "claim-share-tokens": "Claim share tokens",
+      "claiming": "Claiming...",
       "column": {
         "amount": "Amount",
         "date": "Date",
@@ -96,6 +100,8 @@
           "approve-token": "Approve {symbol}",
           "stake-token": "Stake {symbol}",
           "get-share-tokens": "Get share tokens",
+          "funds-returned": "Funds returned",
+          "funds-to-recover": "Funds to recover",
           "unstake-token": "Unstake {symbol}",
           "receive-token": "Receive {symbol}"
         },
@@ -104,14 +110,20 @@
       },
       "nothing-here": "Nothing here yet",
       "nothing-here-subtitle": "Your transactions will appear once you get started.",
+      "recover-funds": "Recover funds",
+      "recovering": "Recovering...",
       "status": {
         "cooldown-ready-in-days": "Cooldown · ready in {value}d",
         "cooldown-ready-in-hours": "Cooldown · ready in {value}h",
         "cooldown-ready-in-minutes": "Cooldown · ready in {value}m",
         "cooldown-ready-soon": "Cooldown · ready in < 1m",
         "deposited": "Deposited",
+        "funds-returned": "Funds returned",
         "in-progress": "In progress",
+        "manual-claim-needed": "In progress - Manual claim needed",
         "ready-to-claim": "Ready to claim",
+        "recover-funds-needed": "Something went wrong - Recover funds",
+        "returned": "Returned",
         "tx-failed": "Tx Failed",
         "withdrawal-canceled": "Withdrawal canceled",
         "withdrawn": "Withdrawn"

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -34,6 +34,8 @@
         "cooldown-ended": "Período de espera completado",
         "stake-token": "Hacer stake de {symbol}",
         "get-share-tokens": "Recibir share tokens",
+        "funds-returned": "Fondos devueltos",
+        "funds-to-recover": "Fondos por recuperar",
         "receive-token": "Recibir {symbol}",
         "unstake-token": "Hacer unstake de {symbol}",
         "wait-cooldown-countdown": "{days, plural, =0 {El período de espera termina en {hours}h} other {El período de espera termina en #d {hours}h}}",
@@ -78,6 +80,8 @@
       "total-deposits": "Depósitos totales"
     },
     "transactions": {
+      "claim-share-tokens": "Recibir share tokens",
+      "claiming": "Recibiendo...",
       "column": {
         "amount": "Cantidad",
         "date": "Fecha",
@@ -96,6 +100,8 @@
           "approve-token": "Aprobar {symbol}",
           "stake-token": "Hacer stake de {symbol}",
           "get-share-tokens": "Recibir share tokens",
+          "funds-returned": "Fondos devueltos",
+          "funds-to-recover": "Fondos por recuperar",
           "unstake-token": "Retirar {symbol}",
           "receive-token": "Recibir {symbol}"
         },
@@ -104,14 +110,20 @@
       },
       "nothing-here": "Aún no hay nada aquí",
       "nothing-here-subtitle": "Sus transacciones aparecerán una vez que comience.",
+      "recover-funds": "Recuperar fondos",
+      "recovering": "Recuperando...",
       "status": {
         "cooldown-ready-in-days": "Cooldown · listo en {value}d",
         "cooldown-ready-in-hours": "Cooldown · listo en {value}h",
         "cooldown-ready-in-minutes": "Cooldown · listo en {value}m",
         "cooldown-ready-soon": "Cooldown · listo en < 1m",
         "deposited": "Depositado",
+        "funds-returned": "Fondos devueltos",
         "in-progress": "En progreso",
+        "manual-claim-needed": "En progreso - Reclamo manual necesario",
         "ready-to-claim": "Listo para recibir",
+        "recover-funds-needed": "Algo salió mal - Recuperar fondos",
+        "returned": "Devuelto",
         "tx-failed": "Tx fallida",
         "withdrawal-canceled": "Retiro cancelado",
         "withdrawn": "Retirado"

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -34,6 +34,8 @@
         "cooldown-ended": "Período de espera concluído",
         "stake-token": "Fazer stake de {symbol}",
         "get-share-tokens": "Receber share tokens",
+        "funds-returned": "Fundos devolvidos",
+        "funds-to-recover": "Fundos a recuperar",
         "receive-token": "Receber {symbol}",
         "unstake-token": "Fazer unstake de {symbol}",
         "wait-cooldown-countdown": "{days, plural, =0 {O período de espera termina em {hours}h} other {O período de espera termina em #d {hours}h}}",
@@ -78,6 +80,8 @@
       "total-deposits": "Depósitos totais"
     },
     "transactions": {
+      "claim-share-tokens": "Receber share tokens",
+      "claiming": "Recebendo...",
       "column": {
         "amount": "Quantia",
         "date": "Data",
@@ -96,6 +100,8 @@
           "approve-token": "Aprovar {symbol}",
           "stake-token": "Fazer stake de {symbol}",
           "get-share-tokens": "Receber share tokens",
+          "funds-returned": "Fundos devolvidos",
+          "funds-to-recover": "Fundos a recuperar",
           "unstake-token": "Sacar {symbol}",
           "receive-token": "Receber {symbol}"
         },
@@ -104,14 +110,20 @@
       },
       "nothing-here": "Nada por aqui ainda",
       "nothing-here-subtitle": "Suas transações aparecerão assim que você começar.",
+      "recover-funds": "Recuperar fundos",
+      "recovering": "Recuperando...",
       "status": {
         "cooldown-ready-in-days": "Cooldown · pronto em {value}d",
         "cooldown-ready-in-hours": "Cooldown · pronto em {value}h",
         "cooldown-ready-in-minutes": "Cooldown · pronto em {value}m",
         "cooldown-ready-soon": "Cooldown · pronto em < 1m",
         "deposited": "Depositado",
+        "funds-returned": "Fundos devolvidos",
         "in-progress": "Em andamento",
+        "manual-claim-needed": "Em andamento - Resgate manual necessário",
         "ready-to-claim": "Pronto para receber",
+        "recover-funds-needed": "Algo deu errado - Recuperar fundos",
+        "returned": "Devolvido",
         "tx-failed": "Tx falhou",
         "withdrawal-canceled": "Saque cancelado",
         "withdrawn": "Sacado"

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -2,12 +2,17 @@ import { type Address, zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
 
 import {
+  canRetryRow,
   findPoolByAsset,
   findPoolByShare,
   formatApyDisplay,
   getTerminalDeliveryTxHash,
+  hasFailedSettlement,
   hashesMatch,
   isLocalEarnTransactionRow,
+  isRecoverPath,
+  needsManualClaim,
+  needsRecover,
 } from '../../../../../app/[locale]/hemi-earn/_utils'
 import {
   type EarnPool,
@@ -171,6 +176,158 @@ describe('utils', function () {
       expect(isLocalEarnTransactionRow({ ...baseTx, requestId: '42' })).toBe(
         false,
       )
+    })
+  })
+
+  describe('needsManualClaim', function () {
+    it('is true for a FULFILLED deposit with auto-claim off', function () {
+      expect(
+        needsManualClaim({
+          ...baseTx,
+          automatic: false,
+          kind: 'DEPOSIT',
+          status: 'FULFILLED',
+        }),
+      ).toBe(true)
+    })
+
+    it('is false when auto-claim is on', function () {
+      expect(
+        needsManualClaim({ ...baseTx, automatic: true, status: 'FULFILLED' }),
+      ).toBe(false)
+    })
+
+    it.each<EarnTransactionStatusType>(['PENDING', 'CANCELLED', 'FINALIZED'])(
+      'is false for non-FULFILLED status %s',
+      function (status) {
+        expect(needsManualClaim({ ...baseTx, automatic: false, status })).toBe(
+          false,
+        )
+      },
+    )
+
+    it('is false for a REDEEM row', function () {
+      expect(
+        needsManualClaim({
+          ...baseTx,
+          automatic: false,
+          kind: 'REDEEM',
+          status: 'FULFILLED',
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('needsRecover', function () {
+    it('is true for a CANCELLED deposit with auto-recover off', function () {
+      expect(
+        needsRecover({
+          ...baseTx,
+          automatic: false,
+          kind: 'DEPOSIT',
+          status: 'CANCELLED',
+        }),
+      ).toBe(true)
+    })
+
+    it('is false when auto-recover is on', function () {
+      expect(
+        needsRecover({ ...baseTx, automatic: true, status: 'CANCELLED' }),
+      ).toBe(false)
+    })
+
+    it('is false for RECOVERED (already recovered, not actionable)', function () {
+      expect(
+        needsRecover({ ...baseTx, automatic: false, status: 'RECOVERED' }),
+      ).toBe(false)
+    })
+
+    it('is false for a REDEEM row', function () {
+      expect(
+        needsRecover({
+          ...baseTx,
+          automatic: false,
+          kind: 'REDEEM',
+          status: 'CANCELLED',
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('isRecoverPath', function () {
+    it.each<EarnTransactionStatusType>(['CANCELLED', 'RECOVERED'])(
+      'is true for a deposit in status %s regardless of automatic',
+      function (status) {
+        expect(isRecoverPath({ ...baseTx, automatic: true, status })).toBe(true)
+        expect(isRecoverPath({ ...baseTx, automatic: false, status })).toBe(
+          true,
+        )
+      },
+    )
+
+    it.each<EarnTransactionStatusType>(['PENDING', 'FULFILLED', 'FINALIZED'])(
+      'is false for the happy-path status %s',
+      function (status) {
+        expect(isRecoverPath({ ...baseTx, status })).toBe(false)
+      },
+    )
+
+    it('is false for a REDEEM row', function () {
+      expect(
+        isRecoverPath({ ...baseTx, kind: 'REDEEM', status: 'CANCELLED' }),
+      ).toBe(false)
+    })
+  })
+
+  describe('canRetryRow', function () {
+    it('is true for a local FAILED row', function () {
+      expect(
+        canRetryRow({
+          ...baseTx,
+          requestId: 'local-1700000000',
+          status: 'FAILED',
+        }),
+      ).toBe(true)
+    })
+
+    it('is false for a subgraph FAILED row (numeric requestId)', function () {
+      expect(
+        canRetryRow({ ...baseTx, requestId: '42', status: 'FAILED' }),
+      ).toBe(false)
+    })
+
+    it('is false for a non-FAILED local row', function () {
+      expect(
+        canRetryRow({
+          ...baseTx,
+          requestId: 'local-1700000000',
+          status: 'PENDING',
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('hasFailedSettlement', function () {
+    it('is true when the settlement is flagged failed', function () {
+      expect(
+        hasFailedSettlement({
+          ...baseTx,
+          settlement: { failed: true, kind: 'CLAIM' },
+        }),
+      ).toBe(true)
+    })
+
+    it('is false for a pending (not-yet-failed) settlement', function () {
+      expect(
+        hasFailedSettlement({
+          ...baseTx,
+          settlement: { failed: false, kind: 'RECOVER', txHash: recoverHash },
+        }),
+      ).toBe(false)
+    })
+
+    it('is false when there is no settlement', function () {
+      expect(hasFailedSettlement(baseTx)).toBe(false)
     })
   })
 

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -9,6 +9,7 @@ import {
   getTerminalDeliveryTxHash,
   hasFailedSettlement,
   hashesMatch,
+  isEarnRowInFlight,
   isLocalEarnTransactionRow,
   isRecoverPath,
   needsManualClaim,
@@ -328,6 +329,37 @@ describe('utils', function () {
 
     it('is false when there is no settlement', function () {
       expect(hasFailedSettlement(baseTx)).toBe(false)
+    })
+  })
+
+  describe('isEarnRowInFlight', function () {
+    it.each<EarnTransactionStatusType>(['PENDING', 'FULFILLED', 'TX_PENDING'])(
+      'is true for the non-terminal status %s',
+      function (status) {
+        expect(isEarnRowInFlight({ ...baseTx, status })).toBe(true)
+      },
+    )
+
+    it.each<EarnTransactionStatusType>(['FINALIZED', 'RECOVERED', 'FAILED'])(
+      'is false for the terminal status %s',
+      function (status) {
+        expect(isEarnRowInFlight({ ...baseTx, status })).toBe(false)
+      },
+    )
+
+    it.each([true, false])(
+      'is true for a CANCELLED deposit (automatic=%s — both walk to RECOVERED)',
+      function (automatic) {
+        expect(
+          isEarnRowInFlight({ ...baseTx, automatic, status: 'CANCELLED' }),
+        ).toBe(true)
+      },
+    )
+
+    it('is false for a CANCELLED redeem (withdrawal canceled, terminal)', function () {
+      expect(
+        isEarnRowInFlight({ ...baseTx, kind: 'REDEEM', status: 'CANCELLED' }),
+      ).toBe(false)
     })
   })
 

--- a/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
@@ -44,10 +44,13 @@ const baseRequest = (id: string, requestId: bigint): Request => ({
   status: 'PENDING',
 })
 
-// Status ranking. Terminal states share rank 2 and are sticky: once a request
-// is terminal it never changes, and status never regresses to a lower rank.
+// Status ranking. Terminal states share rank 2 and are sticky; intermediate
+// states (FULFILLED, CANCELLED) sit at rank 1 so they can transition forward
+// to their respective terminals (FINALIZED via RequestClaimed, RECOVERED via
+// RequestRecovered). Once a request is terminal it never changes, and status
+// never regresses to a lower rank.
 const STATUS_RANK: Record<Request['status'], number> = {
-  CANCELLED: 2,
+  CANCELLED: 1,
   FINALIZED: 2,
   FULFILLED: 1,
   PENDING: 0,

--- a/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
@@ -381,6 +381,37 @@ describe('terminal lifecycle', () => {
     expect(req.finalizedAt).toBe(1_700_000_000n)
   })
 
+  it('RequestCancelled then RequestRecovered transitions through to RECOVERED', async () => {
+    // Production on-chain path for the manual-recover flow:
+    //   PENDING → (Agent.cancel) → CANCELLED → (user signs recoverDeposit) → RECOVERED
+    // Both events fire in sequence at the Router; the indexer must let
+    // CANCELLED transition forward to RECOVERED. Mirrors the existing
+    // FULFILLED → FINALIZED progression for the happy path.
+    await onChain(HEMI, [
+      {
+        block: { number: HEMI_START, timestamp: 1_700_000_000 },
+        contract: 'Router',
+        event: 'RequestCancelled',
+        params: { amount: 1000n, requestId: 62n },
+      },
+      {
+        block: { number: HEMI_START + 1, timestamp: 1_700_000_100 },
+        contract: 'Router',
+        event: 'RequestRecovered',
+        params: { requestId: 62n },
+        transaction: { from: SENDER, hash: '0xrecover62' },
+      },
+    ])
+
+    const req = await ti.Request.getOrThrow('62')
+    expect(req.status).toBe('RECOVERED')
+    expect(req.recoverTxHash).toBe('0xrecover62')
+    expect(req.finalizedAt).toBe(1_700_000_100n)
+    // Cancellation companion stays populated from the intermediate step —
+    // historical record of why the recovery was needed.
+    expect(req.cancelledAmount).toBe(1000n)
+  })
+
   it('a later terminal event does not clobber the finalized request', async () => {
     await onChain(HEMI, [
       {


### PR DESCRIPTION
### Description

This PR implements the manual claim and recover flows for Hemi Earn deposits. When a deposit has auto-finalize off, it stops at FULFILLED (the user signs the claim to receive shares) or CANCELLED (the user signs the recover to pull the original asset back) — both need a Router tx on Hemi that the UI wasn't offering yet. Now the table row and both the live and historical drawers surface a Claim / Recover CTA, and the user signs it right there.

  If that signed tx reverts on Hemi, the attempt is tracked on the existing `hemi-earn:local-operations` entry so the drawer offers a "Try again" instead of silently dropping back to the idle state. That marker is reconciled against the authoritative subgraph status in the merge and dropped once the row reaches FINALIZED/RECOVERED, so a finished deposit never flickers its CTA back during the indexing lag or shows a stale "Tx Failed".

  There's also a status fix: a reverted Agent step leaves a `failed` flag the indexer never clears on cancel, which was masking a recoverable (CANCELLED) deposit as FAILED and hiding the recover CTA. `deriveStatus` now lets a terminal Router status win over a still-PENDING failure. This is a temporary portal-side bridge — once the Envio endpoint PR lands, this translation moves to portal-backend.

  On the subgraph, CANCELLED is demoted from terminal rank so it can transition to RECOVERED, and the transactions query keeps polling a cancelled deposit until it recovers (otherwise it could get stuck on CANCELLED after the user's recover).

  Tested locally end-to-end against the anvil + Envio sandbox (claim, recover, retry-on-revert, and the full CANCELLED → RECOVERED cycle).

### Screenshots

Claim

https://github.com/user-attachments/assets/2eeab88b-d1ba-42e2-8fd6-23fec232cd0a



Recover

https://github.com/user-attachments/assets/523dcf3b-2527-4673-bd0a-ff5cf6254c82


### Related issue(s)

Related to #1848 
Related to #1977 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
