### PR TITLE
Update APY parsing for new Vetro response shape

### DIFF
--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
@@ -8,7 +8,7 @@ import { type Address } from 'viem'
 const apiUrl = process.env.NEXT_PUBLIC_VETRO_API_URL
 export const isApyApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
 
-type ApyByVault = Record<Address, { '7d': number }>
+type ApyByVault = Record<Address, { apy: number }>
 
 // Shared queryOptions: a single network call serves every share via the
 // per-vault map returned by the API. Pair with `selectApyValue` below to
@@ -26,9 +26,9 @@ export const earnApyQueryOptions = () =>
 // The API keys its per-vault map by the share's Ethereum-side staking vault,
 // so callers pass that (`pool.stakingVault`). Returns `undefined` while the
 // query is pending, `null` once settled but missing for that vault (errored
-// response or vault not in the payload), and the 7-day number otherwise.
+// response or vault not in the payload), and the apy number otherwise.
 export const selectApyValue = (
   data: ApyByVault | undefined,
   isPending: boolean,
   stakingVault: Address,
-) => (isPending ? undefined : data?.[stakingVault]?.['7d'] ?? null)
+) => (isPending ? undefined : data?.[stakingVault]?.apy ?? null)

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
@@ -8,7 +8,7 @@ import { type Address } from 'viem'
 const apiUrl = process.env.NEXT_PUBLIC_VETRO_API_URL
 export const isApyApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
 
-type ApyByVault = Record<Address, { apy: number }>
+type ApyByVault = Partial<Record<Address, { apy: number }>>
 
 // Shared queryOptions: a single network call serves every share via the
 // per-vault map returned by the API. Pair with `selectApyValue` below to

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -72,7 +72,7 @@ export type EarnAsset = {
 //   `undefined` — APY query still pending (show skeleton)
 //   `null`      — APY query settled but no value for this share (error or
 //                 missing in response → show '-')
-//   `number`    — 7-day APY available
+//   `number`    — APY available
 export type EarnPool = {
   apy: number | null | undefined
   assets: EarnAsset[]


### PR DESCRIPTION
### Description

The Hemi Earn page consumes Vetro's `/variable-stake/apy` endpoint to display each pool's APY. [vetro-protocol/vetro-monorepo#493](https://github.com/vetro-protocol/vetro-monorepo/pull/493) changes that endpoint's response: instead of a trailing 7-day share-value regression keyed under `7d`, it now returns a forward-looking APY computed from each vault's on-chain `rewardRate`, keyed under `apy` — i.e. `{ [address]: { "apy": <number> } }` instead of `{ [address]: { "7d": <number> } }`.

This PR updates the portal to consume the new shape: the `ApyByVault` type and the `selectApyValue` selector now read the `apy` field. The existing tri-state behavior is preserved (`undefined` while pending, `null` when settled-but-missing → renders "-", and the number otherwise, including a genuine `0`).

### Screenshots

APY now correctly updated from Vetro side

<img width="1490" height="292" alt="image" src="https://github.com/user-attachments/assets/1c07c6ba-66ab-4364-90f6-46b9e1fdaae2" />

<img width="1092" height="318" alt="image" src="https://github.com/user-attachments/assets/a78c25bd-c304-45b9-a50c-7e29e900c9e0" />


### Related issue(s)

Related to vetro-protocol/vetro-monorepo#493

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.