### PR TITLE
Replace bloq Slack action with hemilabs one

### DIFF
--- a/.github/actions/deploy-subgraph/action.yml
+++ b/.github/actions/deploy-subgraph/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: bloq/actions/notify-deploy-to-slack@ffeb51ecfe42bb78533630b64c1082b09ef3bd2f # v1.6.1
+    - uses: hemilabs/actions/notify-deploy-to-slack@7b7b652a4a4a7512207fb9ce319d8661cf79ad10
       with:
         app-name: Hemi Portal Subgraph ${{ inputs.subgraph }}
         environment: staging
@@ -42,7 +42,7 @@ runs:
       shell: bash
       working-directory: subgraphs/${{ inputs.subgraph }}
     - if: always()
-      uses: bloq/actions/notify-deploy-to-slack@ffeb51ecfe42bb78533630b64c1082b09ef3bd2f # v1.6.1
+      uses: hemilabs/actions/notify-deploy-to-slack@7b7b652a4a4a7512207fb9ce319d8661cf79ad10
       with:
         app-name: Hemi Portal Subgraph ${{ inputs.subgraph }}
         environment: staging

--- a/.github/workflows/hostinger-deployment.yml
+++ b/.github/workflows/hostinger-deployment.yml
@@ -20,7 +20,7 @@ jobs:
     environment: ${{ github.event_name == 'release' && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: bloq/actions/notify-deploy-to-slack@ffeb51ecfe42bb78533630b64c1082b09ef3bd2f # v1.6.1
+      - uses: hemilabs/actions/notify-deploy-to-slack@7b7b652a4a4a7512207fb9ce319d8661cf79ad10
         with:
           app-name: Hemi Portal
           environment: ${{ vars.ENVIRONMENT_NAME }}
@@ -72,7 +72,7 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       - if: ${{ !cancelled() }}
-        uses: bloq/actions/notify-deploy-to-slack@ffeb51ecfe42bb78533630b64c1082b09ef3bd2f # v1.6.1
+        uses: hemilabs/actions/notify-deploy-to-slack@7b7b652a4a4a7512207fb9ce319d8661cf79ad10
         with:
           app-name: Hemi Portal
           environment: ${{ vars.ENVIRONMENT_NAME }}


### PR DESCRIPTION
### Description

The `bloq/actions/notify-deploy-to-slack` action bundles `slack-github-action` v1.x, which runs on Node 20 and triggers GitHub's Node 20 deprecation warning during deploys. This swaps it for the hemilabs port of the same action, which pins `slack-github-action` v3.0.3 (Node 24). The action inputs are identical, so this is a drop-in replacement with no `with:` changes.

Updated in all 4 usages across `.github/actions/deploy-subgraph/action.yml` and `.github/workflows/hostinger-deployment.yml`.

### Screenshots

N/A

### Related issue(s)

Closes #1999

### Checklist

- [ ] Manual testing passed, or N/A — will be verified on next deploy run.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.