### PR TITLE
Simplify Hemi Earn APY label

### DIFF
--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -71,7 +71,7 @@
     },
     "subheading": "One click earn for your assets",
     "pool-info": {
-      "apy": "Current 7-Day APY",
+      "apy": "APY",
       "manage": "Manage",
       "pool-contract": "Pool Contract",
       "share-token": "Share token",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -71,7 +71,7 @@
     },
     "subheading": "Gane rendimiento con sus activos en un solo clic",
     "pool-info": {
-      "apy": "TEA actual de 7 días",
+      "apy": "TEA",
       "manage": "Gestionar",
       "pool-contract": "Contrato del fondo",
       "share-token": "Token de participación",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -71,7 +71,7 @@
     },
     "subheading": "Ganhe rendimento com seus ativos em um clique",
     "pool-info": {
-      "apy": "TEA atual de 7 dias",
+      "apy": "TEA",
       "manage": "Gerenciar",
       "pool-contract": "Contrato do fundo",
       "share-token": "Token de participação",


### PR DESCRIPTION
### Description

Following Vetro's APY update, the value shown in Hemi Earn now reflects the current APY rather than a trailing 7-day average. The "Current 7-Day APY" label was therefore inaccurate — this shortens it to "APY" across all languages (en/es/pt).

### Screenshots

Before

<img width="1408" height="218" alt="image" src="https://github.com/user-attachments/assets/d59bebfb-3e90-4e97-a4d8-f7357b30c5f3" />

Now

<img width="1448" height="250" alt="image" src="https://github.com/user-attachments/assets/7815c4a9-d203-4a9c-a4cb-b1a2af66dcfb" />


### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.