### PR TITLE
Fix network selector row not being clickable

### DIFF
--- a/portal/app/[locale]/_components/navbar/_components/networkSwitch.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/networkSwitch.tsx
@@ -141,7 +141,7 @@ const NetworkSwitchImpl = function ({
                 return {
                   content: (
                     <button
-                      className={`flex w-full items-center gap-x-2 ${
+                      className={`-mx-2 -my-1 flex w-full items-center gap-x-2 px-2 py-1 ${
                         selected ? 'text-neutral-950' : ''
                       }`}
                       disabled={selected}

--- a/portal/app/[locale]/_components/navbar/_components/networkSwitch.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/networkSwitch.tsx
@@ -141,7 +141,7 @@ const NetworkSwitchImpl = function ({
                 return {
                   content: (
                     <button
-                      className={`-mx-2 -my-1 flex w-full items-center gap-x-2 px-2 py-1 ${
+                      className={`flex w-full items-center gap-x-2 ${
                         selected ? 'text-neutral-950' : ''
                       }`}
                       disabled={selected}

--- a/portal/app/[locale]/_components/navbar/_components/networkSwitch.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/networkSwitch.tsx
@@ -141,7 +141,7 @@ const NetworkSwitchImpl = function ({
                 return {
                   content: (
                     <button
-                      className={`flex items-center gap-x-2 ${
+                      className={`flex w-full items-center gap-x-2 ${
                         selected ? 'text-neutral-950' : ''
                       }`}
                       disabled={selected}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->
  Fixes the Mainnet/Testnet network selector so the entire row is clickable,
  not just the network name.

  The dropdown rows show the hover background on the full-width `<li>`, but the
  `onClick` lived on the inner `<button>`, which is sized to its content. So
  clicking the hovered row anywhere except on the "Mainnet"/"Testnet" label did
  nothing. Added `w-full` to the button so its click target spans the full row
  width, matching the visible hover area.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/26435d80-2637-4c32-a442-eb9c81c84037



### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1957 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
