### PR TITLE
Fix wrong deposit amount in Hemi Earn table

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
@@ -13,20 +13,13 @@ import Skeleton from 'react-loading-skeleton'
 import { formatUnits } from 'viem'
 
 import { useEarnPools } from '../../_hooks/useEarnPools'
-import { findPoolByAsset } from '../../_utils'
+import { findPoolByAsset, pickEarnRowAmount } from '../../_utils'
 import { type EarnTransaction } from '../../types'
 
 import { RowActions } from './rowActions'
 import { StatusBadge } from './statusBadge'
 import { WithdrawStatusCell } from './withdrawStatusCell'
 
-// For REDEEM, the amount unit depends on which Vetro phase the row is in:
-// post-FULFILLED we have `amountOut` in asset units (hemiBTC), pre-FULFILLED
-// only `amountIn` is available and it's in share-token units (svetBTC).
-// The displayed token has to match: shareToken from the pool while we're
-// showing shares, the Hemi-side asset token afterwards. For DEPOSIT,
-// `amountIn` is already in asset units, so the generic `useToken(asset)`
-// lookup is enough.
 function AmountCell({ transaction }: { transaction: EarnTransaction }) {
   const { data: assetToken, isLoading } = useToken({
     address: transaction.asset,
@@ -38,12 +31,10 @@ function AmountCell({ transaction }: { transaction: EarnTransaction }) {
       ? findPoolByAsset(pools, transaction.asset)
       : undefined
 
-  const showingShares =
-    transaction.kind === 'REDEEM' && transaction.amountOut == null
-  const token = showingShares ? pool?.shareToken : assetToken
-  const rawAmount = showingShares
-    ? transaction.amountIn
-    : (transaction.amountOut ?? transaction.amountIn)
+  const { rawAmount, token } = pickEarnRowAmount(transaction, {
+    assetToken,
+    shareToken: pool?.shareToken,
+  })
 
   if (!token) {
     if (isLoading) return <Skeleton className="w-16" />

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -1,3 +1,4 @@
+import { type Token } from 'types/token'
 import { formatPercentage } from 'utils/format'
 import { type Address, isAddressEqual } from 'viem'
 
@@ -84,6 +85,22 @@ export const canRetryRow = (tx: EarnTransaction) =>
 // misleading "needed" state.
 export const hasFailedSettlement = (tx: EarnTransaction) =>
   tx.settlement?.failed === true
+
+// Picks the amount + token to render for an earn transaction row. A DEPOSIT
+// always shows the deposited asset (`amountIn`, asset units) — its `amountOut`
+// is the minted share amount (sVetToken, 18 decimals) and must never be rendered
+// against the 8-decimal asset token. A REDEEM shows shares (`amountIn` +
+// shareToken) until FULFILLED, then the returned asset (`amountOut` + assetToken).
+export const pickEarnRowAmount = (
+  transaction: EarnTransaction,
+  { assetToken, shareToken }: { assetToken?: Token; shareToken?: Token },
+): { rawAmount: string; token: Token | undefined } =>
+  transaction.kind === 'REDEEM'
+    ? {
+        rawAmount: transaction.amountOut ?? transaction.amountIn,
+        token: transaction.amountOut == null ? shareToken : assetToken,
+      }
+    : { rawAmount: transaction.amountIn, token: assetToken }
 
 // A row the table is still actively tracking — drives both the polling loop and
 // the row spinner. Terminal: FINALIZED/RECOVERED/FAILED for any kind, plus a

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -99,7 +99,7 @@ export const pickEarnRowAmount = (
   transaction.kind === 'REDEEM'
     ? {
         rawAmount: transaction.amountOut ?? transaction.amountIn,
-        token: transaction.amountOut == null ? shareToken : assetToken,
+        token: transaction.amountOut === null ? shareToken : assetToken,
       }
     : { rawAmount: transaction.amountIn, token: assetToken }
 

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -90,7 +90,8 @@ export const hasFailedSettlement = (tx: EarnTransaction) =>
 // always shows the deposited asset (`amountIn`, asset units) — its `amountOut`
 // is the minted share amount (sVetToken, 18 decimals) and must never be rendered
 // against the 8-decimal asset token. A REDEEM shows shares (`amountIn` +
-// shareToken) until FULFILLED, then the returned asset (`amountOut` + assetToken).
+// shareToken) while `amountOut` is unset, then the returned asset (`amountOut` +
+// assetToken) once it's populated at fulfillment.
 export const pickEarnRowAmount = (
   transaction: EarnTransaction,
   { assetToken, shareToken }: { assetToken?: Token; shareToken?: Token },

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -1,3 +1,4 @@
+import { type EvmToken } from 'types/token'
 import { type Address, zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
 
@@ -14,6 +15,7 @@ import {
   isRecoverPath,
   needsManualClaim,
   needsRecover,
+  pickEarnRowAmount,
 } from '../../../../../app/[locale]/hemi-earn/_utils'
 import {
   type EarnPool,
@@ -360,6 +362,60 @@ describe('utils', function () {
       expect(
         isEarnRowInFlight({ ...baseTx, kind: 'REDEEM', status: 'CANCELLED' }),
       ).toBe(false)
+    })
+  })
+
+  describe('pickEarnRowAmount', function () {
+    const assetToken = { decimals: 8, symbol: 'hemiBTC' } as unknown as EvmToken
+    const shareToken = {
+      decimals: 18,
+      symbol: 'svetBTC',
+    } as unknown as EvmToken
+    const tokens = { assetToken, shareToken }
+
+    it('uses amountIn + assetToken for a DEPOSIT even once amountOut (shares) is set', function () {
+      // Regression: a finalized deposit carries `amountOut` = minted shares
+      // (18-dec). Rendering it against the 8-dec asset token showed 1,000,000
+      // instead of the deposited 0.0001.
+      expect(
+        pickEarnRowAmount(
+          {
+            ...baseTx,
+            amountIn: '10000',
+            amountOut: '100000000000000',
+            kind: 'DEPOSIT',
+            status: 'FINALIZED',
+          },
+          tokens,
+        ),
+      ).toEqual({ rawAmount: '10000', token: assetToken })
+    })
+
+    it('uses amountIn + assetToken for a DEPOSIT with no amountOut yet', function () {
+      expect(
+        pickEarnRowAmount(
+          { ...baseTx, amountIn: '10000', amountOut: null, kind: 'DEPOSIT' },
+          tokens,
+        ),
+      ).toEqual({ rawAmount: '10000', token: assetToken })
+    })
+
+    it('uses amountIn + shareToken for a REDEEM before it is fulfilled', function () {
+      expect(
+        pickEarnRowAmount(
+          { ...baseTx, amountIn: '5000', amountOut: null, kind: 'REDEEM' },
+          tokens,
+        ),
+      ).toEqual({ rawAmount: '5000', token: shareToken })
+    })
+
+    it('uses amountOut + assetToken for a REDEEM once fulfilled', function () {
+      expect(
+        pickEarnRowAmount(
+          { ...baseTx, amountIn: '5000', amountOut: '7777', kind: 'REDEEM' },
+          tokens,
+        ),
+      ).toEqual({ rawAmount: '7777', token: assetToken })
     })
   })
 


### PR DESCRIPTION
### Description

This PR fixes the Hemi Earn transactions table showing a wrong amount for finalized deposits.. it rendered values about 10^10x too large (e.g. 1,000,000 hemiBTC instead of the deposited 0.0001), even though the Stake deposit details drawer showed the correct value all along.

  The root cause was in the table's amount cell: it picked the raw amount with `amountOut ?? amountIn`. For a finalized deposit, `amountOut` is the minted share tokens (sVetToken, 18 decimals), not the deposited asset, so the cell took the 18-decimal share amount and formatted it against the 8-decimal asset token. That fallback only makes sense for redeems, where the post-fulfilled `amountOut` really is the asset received. The drawer was fine because it always reads `amountIn`. Confirmed against the reported tx (production API returns `amountIn=10000`, `amountOut=100000000000000`; on-chain the transfer and the Router event are `10000` = 0.0001 hemiBTC).

  The fix moves the amount/token selection into a small pure helper `pickEarnRowAmount` so a deposit always shows `amountIn` with the asset token, while the redeem behavior (shares + share token until fulfilled, then the returned asset) stays exactly as before. The withdraw path was already correct and is left untouched. Added unit tests for the deposit regression and both redeem phases.

### Screenshots

No UI changes.

### Related issue(s)

Closes #2024 
Fixes #2024 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
