### PR TITLE
Bump prettier and reformat codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "husky": "9.1.7",
     "knip": "6.13.1",
     "lint-staged": "17.0.5",
-    "prettier": "3.1.1",
-    "prettier-plugin-tailwindcss": "0.5.9"
+    "prettier": "3.8.4",
+    "prettier-plugin-tailwindcss": "0.8.0"
   },
   "private": true,
   "packageManager": "pnpm@10.33.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,11 +49,11 @@ importers:
         specifier: 17.0.5
         version: 17.0.5
       prettier:
-        specifier: 3.1.1
-        version: 3.1.1
+        specifier: 3.8.4
+        version: 3.8.4
       prettier-plugin-tailwindcss:
-        specifier: 0.5.9
-        version: 0.5.9(prettier@3.1.1)
+        specifier: 0.8.0
+        version: 0.8.0(prettier@3.8.4)
 
   packages/btc-wallet:
     dependencies:
@@ -12165,30 +12165,36 @@ packages:
       }
     engines: { node: '>= 0.8.0' }
 
-  prettier-plugin-tailwindcss@0.5.9:
+  prettier-plugin-tailwindcss@0.8.0:
     resolution:
       {
-        integrity: sha512-9x3t1s2Cjbut2QiP+O0mDqV3gLXTe2CgRlQDgucopVkUdw26sQi53p/q4qvGxMLBDfk/dcTV57Aa/zYwz9l8Ew==,
+        integrity: sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==,
       }
-    engines: { node: '>=14.21.3' }
+    engines: { node: '>=20.19' }
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
       '@prettier/plugin-pug': '*'
       '@shopify/prettier-plugin-liquid': '*'
       '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
       prettier: ^3.0
       prettier-plugin-astro: '*'
       prettier-plugin-css-order: '*'
-      prettier-plugin-import-sort: '*'
       prettier-plugin-jsdoc: '*'
       prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
       prettier-plugin-organize-attributes: '*'
       prettier-plugin-organize-imports: '*'
-      prettier-plugin-style-order: '*'
+      prettier-plugin-sort-imports: '*'
       prettier-plugin-svelte: '*'
-      prettier-plugin-twig-melody: '*'
     peerDependenciesMeta:
       '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
         optional: true
       '@prettier/plugin-pug':
         optional: true
@@ -12196,39 +12202,39 @@ packages:
         optional: true
       '@trivago/prettier-plugin-sort-imports':
         optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
       prettier-plugin-astro:
         optional: true
       prettier-plugin-css-order:
-        optional: true
-      prettier-plugin-import-sort:
         optional: true
       prettier-plugin-jsdoc:
         optional: true
       prettier-plugin-marko:
         optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
       prettier-plugin-organize-attributes:
         optional: true
       prettier-plugin-organize-imports:
         optional: true
-      prettier-plugin-style-order:
+      prettier-plugin-sort-imports:
         optional: true
       prettier-plugin-svelte:
         optional: true
-      prettier-plugin-twig-melody:
-        optional: true
-
-  prettier@3.1.1:
-    resolution:
-      {
-        integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==,
-      }
-    engines: { node: '>=14' }
-    hasBin: true
 
   prettier@3.5.3:
     resolution:
       {
         integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==,
+      }
+    engines: { node: '>=14' }
+    hasBin: true
+
+  prettier@3.8.4:
+    resolution:
+      {
+        integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==,
       }
     engines: { node: '>=14' }
     hasBin: true
@@ -23535,13 +23541,13 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.5.9(prettier@3.1.1):
+  prettier-plugin-tailwindcss@0.8.0(prettier@3.8.4):
     dependencies:
-      prettier: 3.1.1
-
-  prettier@3.1.1: {}
+      prettier: 3.8.4
 
   prettier@3.5.3: {}
+
+  prettier@3.8.4: {}
 
   process-nextick-args@2.0.1: {}
 

--- a/portal/app/[locale]/_components/appLayoutContainer.tsx
+++ b/portal/app/[locale]/_components/appLayoutContainer.tsx
@@ -10,15 +10,11 @@ const UI = ({
   networkType,
 }: Props & { networkType: NetworkType }) => (
   <div
-    className={`
-      backdrop-blur-20 relative flex h-full w-3/4 flex-1 flex-col self-stretch overflow-y-hidden
-    bg-neutral-50/55 md:w-[calc(75%-8px)] xl:rounded-l-xl
-      ${
-        networkType === 'testnet'
-          ? 'md:border-2 md:border-orange-600'
-          : 'border-neutral-300/55 xl:border'
-      }
-      `}
+    className={`relative flex h-full w-3/4 flex-1 flex-col self-stretch overflow-y-hidden bg-neutral-50/55 backdrop-blur-20 md:w-[calc(75%-8px)] xl:rounded-l-xl ${
+      networkType === 'testnet'
+        ? 'md:border-2 md:border-orange-600'
+        : 'border-neutral-300/55 xl:border'
+    } `}
     id="app-layout-container"
   >
     {children}

--- a/portal/app/[locale]/_components/badge.tsx
+++ b/portal/app/[locale]/_components/badge.tsx
@@ -4,10 +4,7 @@ import { Suspense } from 'react'
 const BadgeImpl = function () {
   const [networkType] = useNetworkType()
   return (
-    <span
-      className="text-xxs h-4.5 flex items-center justify-center rounded-md bg-neutral-900
-    px-1.5 text-center font-medium capitalize text-white"
-    >
+    <span className="flex h-4.5 items-center justify-center rounded-md bg-neutral-900 px-1.5 text-center text-xxs font-medium capitalize text-white">
       {networkType}
     </span>
   )

--- a/portal/app/[locale]/_components/earnCard/earnRewards.tsx
+++ b/portal/app/[locale]/_components/earnCard/earnRewards.tsx
@@ -14,8 +14,7 @@ const CloseButton = ({
   onClick: MouseEventHandler<HTMLButtonElement>
 }) => (
   <button
-    className="group/close-button pointer-events-auto absolute right-3.5 top-3 z-10 flex h-5 w-5 items-center justify-center md:opacity-0
-    md:transition-opacity md:duration-300 md:group-hover/card-image:visible md:group-hover/card-image:opacity-100"
+    className="group/close-button pointer-events-auto absolute right-3.5 top-3 z-10 flex h-5 w-5 items-center justify-center md:opacity-0 md:transition-opacity md:duration-300 md:group-hover/card-image:visible md:group-hover/card-image:opacity-100"
     onClick={onClick}
     type="button"
   >

--- a/portal/app/[locale]/_components/earnCard/index.tsx
+++ b/portal/app/[locale]/_components/earnCard/index.tsx
@@ -45,7 +45,7 @@ export const EarnCard = function () {
 
   return (
     <ErrorBoundary>
-      <div className="group/card-image h-22 fixed bottom-24 right-6 z-20 max-w-64 cursor-pointer sm:bottom-10">
+      <div className="group/card-image fixed bottom-24 right-6 z-20 h-22 max-w-64 cursor-pointer sm:bottom-10">
         <ExternalLink href={MerkleUrl} onClick={navigate}>
           <EarnRewards onClose={close} />
         </ExternalLink>

--- a/portal/app/[locale]/_components/header/index.tsx
+++ b/portal/app/[locale]/_components/header/index.tsx
@@ -25,15 +25,12 @@ type Props = {
 }
 
 export const Header = ({ isMenuOpen, openNavbar, toggleMenu }: Props) => (
-  <header
-    className="md:h-13 md:py-4.5 flex h-14 items-center border-b border-solid
-     border-neutral-300/55 bg-white px-3 py-3 md:bg-transparent md:px-0"
-  >
+  <header className="flex h-14 items-center border-b border-solid border-neutral-300/55 bg-white px-3 py-3 md:h-13 md:bg-transparent md:px-0 md:py-4.5">
     <div className="flex items-center gap-x-2 md:hidden">
       <HomeLink />
       <Badge />
     </div>
-    <div className="size-13 hidden items-center justify-center border-r border-neutral-300/55 md:flex xl:hidden">
+    <div className="hidden size-13 items-center justify-center border-r border-neutral-300/55 md:flex xl:hidden">
       <ButtonIcon onClick={openNavbar} size="xSmall" variant="secondary">
         <HamburgerIcon />
       </ButtonIcon>

--- a/portal/app/[locale]/_components/mainContainer.tsx
+++ b/portal/app/[locale]/_components/mainContainer.tsx
@@ -10,13 +10,11 @@ const UI = ({
   networkType,
 }: Props & { networkType: NetworkType }) => (
   <div
-    className={`box-border h-[calc(100dvh-7rem)] grow-0
-          sm:h-[calc(100dvh-3.5rem)] sm:flex-grow md:h-[calc(100dvh-4.25rem-1rem)]
-          ${
-            networkType === 'testnet'
-              ? 'max-md:border-3 max-md:border-solid max-md:border-orange-600'
-              : ''
-          }`}
+    className={`box-border h-[calc(100dvh-7rem)] grow-0 sm:h-[calc(100dvh-3.5rem)] sm:flex-grow md:h-[calc(100dvh-4.25rem-1rem)] ${
+      networkType === 'testnet'
+        ? 'max-md:border-3 max-md:border-solid max-md:border-orange-600'
+        : ''
+    }`}
   >
     {children}
   </div>

--- a/portal/app/[locale]/_components/mobileBottomBar.tsx
+++ b/portal/app/[locale]/_components/mobileBottomBar.tsx
@@ -17,10 +17,7 @@ type Props = {
 }
 
 export const MobileBottomBar = ({ closeMenu, isMenuOpen, openMenu }: Props) => (
-  <div
-    className="fixed inset-x-0 bottom-0 z-50 flex h-14 items-center
-      border-t border-neutral-300/55 bg-white px-3 sm:hidden"
-  >
+  <div className="fixed inset-x-0 bottom-0 z-50 flex h-14 items-center border-t border-neutral-300/55 bg-white px-3 sm:hidden">
     <WalletConnection placement="bottom-bar" />
     <div className="ml-auto">
       {/* When opening (hamburger): stopImmediatePropagation blocks

--- a/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
@@ -116,10 +116,7 @@ const Backdrop = ({
   onClick: MouseEventHandler<HTMLDivElement>
 }) => (
   <div
-    className="absolute left-0 top-0 z-20
-    h-screen w-screen bg-gradient-to-b
-    from-neutral-950/0 to-neutral-950/25
-    md:hidden"
+    className="absolute left-0 top-0 z-20 h-screen w-screen bg-gradient-to-b from-neutral-950/0 to-neutral-950/25 md:hidden"
     onClick={onClick}
   />
 )
@@ -173,19 +170,13 @@ const DexImpl = function () {
         dropdownPortalContainer &&
         ReactDOM.createPortal(
           <div
-            className="md:translate-y-30 absolute bottom-0 left-0 top-24
-              z-30 flex w-full flex-col items-start overflow-y-auto rounded-t-2xl
-              bg-white p-4 shadow-lg md:top-0 md:h-fit md:w-64 md:translate-x-56
-              md:rounded-lg md:p-1 xl:translate-x-2"
+            className="absolute bottom-0 left-0 top-24 z-30 flex w-full flex-col items-start overflow-y-auto rounded-t-2xl bg-white p-4 shadow-lg md:top-0 md:h-fit md:w-64 md:translate-x-56 md:translate-y-30 md:rounded-lg md:p-1 xl:translate-x-2"
             onMouseDown={e => e.stopPropagation()}
             onTouchStart={e => e.stopPropagation()}
             ref={ref}
           >
             <ItemTitle text={t('aggregators')} />
-            <div
-              className="w-full *:w-full *:bg-white *:px-3 *:py-2 *:max-md:h-14 *:max-md:bg-transparent 
-                [&_a>div]:flex-row [&_a]:w-full [&_span]:max-md:text-base"
-            >
+            <div className="w-full *:w-full *:bg-white *:px-3 *:py-2 *:max-md:h-14 *:max-md:bg-transparent [&_a>div]:flex-row [&_a]:w-full [&_span]:max-md:text-base">
               <ExternalLink
                 event="nav - rubic"
                 href="https://app.rubic.exchange"

--- a/portal/app/[locale]/_components/navbar/_components/help/helpButton.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/helpButton.tsx
@@ -17,8 +17,7 @@ export const HelpButton = ({ isOpen, setIsOpen }: Props) => (
       <QuestionMark
         className={`size-5 md:size-4 ${
           isOpen ? '[&>path]:fill-neutral-950' : '[&>path]:fill-neutral-500'
-        } 
-     [&>path]:transition-colors [&>path]:duration-200 group-hover/icon:[&>path]:fill-neutral-950`}
+        } [&>path]:transition-colors [&>path]:duration-200 group-hover/icon:[&>path]:fill-neutral-950`}
       />
     </ButtonIcon>
   </div>

--- a/portal/app/[locale]/_components/navbar/_components/help/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/index.tsx
@@ -40,14 +40,11 @@ const IconContainer = ({
   selected,
 }: Selectable & { children: ReactNode }) => (
   <div
-    className={`flex h-10 w-10
-      items-center justify-center rounded-lg bg-neutral-50
-      md:h-4 md:w-4 group-hover/row:[&>svg>path]:fill-neutral-950
-      ${
-        selected
-          ? '[&>svg>path]:fill-neutral-950'
-          : '[&>svg>path]:fill-neutral-500'
-      }`}
+    className={`flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-50 md:h-4 md:w-4 group-hover/row:[&>svg>path]:fill-neutral-950 ${
+      selected
+        ? '[&>svg>path]:fill-neutral-950'
+        : '[&>svg>path]:fill-neutral-500'
+    }`}
   >
     {children}
   </div>
@@ -55,8 +52,7 @@ const IconContainer = ({
 
 const Row = (props: { children: ReactNode } & ComponentProps<'div'>) => (
   <div
-    className="group/row flex h-14 items-center justify-between px-4
-    md:h-8 md:px-3 md:py-2"
+    className="group/row flex h-14 items-center justify-between px-4 md:h-8 md:px-3 md:py-2"
     {...props}
   />
 )
@@ -71,8 +67,7 @@ const MenuContainer = ({
 }) => (
   <div
     {...props}
-    className={`w-full cursor-pointer rounded-lg transition-colors duration-300
-       ${isOpen ? 'rounded-lg bg-neutral-50' : 'hover:bg-neutral-50'}`}
+    className={`w-full cursor-pointer rounded-lg transition-colors duration-300 ${isOpen ? 'rounded-lg bg-neutral-50' : 'hover:bg-neutral-50'}`}
     ref={ref}
   >
     {children}
@@ -84,10 +79,9 @@ const ItemText = ({
   text,
 }: Pick<Props, 'text'> & Selectable) => (
   <span
-    className={`text-base font-medium transition-colors duration-300
-      group-hover/row:text-neutral-950 md:text-sm ${
-        selected ? 'text-neutral-950' : 'text-neutral-700'
-      }`}
+    className={`text-base font-medium transition-colors duration-300 group-hover/row:text-neutral-950 md:text-sm ${
+      selected ? 'text-neutral-950' : 'text-neutral-700'
+    }`}
   >
     {text}
   </span>
@@ -157,18 +151,10 @@ const LanguageMenu = function ({ active }: LanguageProps) {
   }
 
   return (
-    <div
-      className="absolute bottom-0 right-0 z-40 flex
-    h-fit w-52 -translate-x-8 -translate-y-32
-    flex-col items-start
-    justify-center rounded-lg bg-white p-2 shadow-lg
-    md:top-0 md:translate-x-48 md:translate-y-1 md:p-1"
-    >
+    <div className="absolute bottom-0 right-0 z-40 flex h-fit w-52 -translate-x-8 -translate-y-32 flex-col items-start justify-center rounded-lg bg-white p-2 shadow-lg md:top-0 md:translate-x-48 md:translate-y-1 md:p-1">
       {locales.map(locale => (
         <div
-          className="group/row flex w-full items-center
-          justify-between rounded-md px-3
-          py-2 capitalize hover:bg-neutral-50"
+          className="group/row flex w-full items-center justify-between rounded-md px-3 py-2 capitalize hover:bg-neutral-50"
           key={locale}
           onClick={() => onClick(locale)}
         >
@@ -186,13 +172,7 @@ const LanguageMenu = function ({ active }: LanguageProps) {
 }
 
 const LegalAndPrivacy = () => (
-  <div
-    className="-translate-y-18 absolute bottom-0 right-0 z-20
-        flex w-64 -translate-x-8 flex-col
-        items-start gap-x-2
-        rounded-lg bg-white p-4 shadow-lg
-        md:translate-x-60 md:translate-y-7"
-  >
+  <div className="absolute bottom-0 right-0 z-20 flex w-64 -translate-x-8 -translate-y-18 flex-col items-start gap-x-2 rounded-lg bg-white p-4 shadow-lg md:translate-x-60 md:translate-y-7">
     <TermsAndConditions />
     <CmcAttribution />
   </div>
@@ -204,10 +184,7 @@ const Backdrop = ({
   onClick: MouseEventHandler<HTMLDivElement>
 }) => (
   <div
-    className="absolute left-0 top-0 z-20
-    h-screen w-screen bg-gradient-to-b
-    from-neutral-950/0 to-neutral-950/25
-    md:hidden"
+    className="absolute left-0 top-0 z-20 h-screen w-screen bg-gradient-to-b from-neutral-950/0 to-neutral-950/25 md:hidden"
     onClick={onClick}
   />
 )
@@ -229,11 +206,7 @@ export const Help = function () {
         helpPortalContainer &&
         ReactDOM.createPortal(
           <div
-            className="absolute bottom-0 left-0 z-30
-            flex h-36 w-full flex-col
-            items-start rounded-t-2xl bg-white p-4 shadow-lg
-            md:top-0 md:h-fit md:w-64 md:translate-x-52 md:translate-y-12
-            md:rounded-lg md:p-1 lg:translate-x-2 lg:translate-y-2"
+            className="absolute bottom-0 left-0 z-30 flex h-36 w-full flex-col items-start rounded-t-2xl bg-white p-4 shadow-lg md:top-0 md:h-fit md:w-64 md:translate-x-52 md:translate-y-12 md:rounded-lg md:p-1 lg:translate-x-2 lg:translate-y-2"
             onMouseDown={e => e.stopPropagation()}
             onTouchStart={e => e.stopPropagation()}
           >

--- a/portal/app/[locale]/_components/navbar/_components/itemAccordion.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/itemAccordion.tsx
@@ -103,7 +103,7 @@ function ItemAccordionUI({
       <div
         className="mt-1 overflow-hidden transition-[height] duration-300 ease-in-out"
         style={{
-          height: isOpen ? contentRef.current?.scrollHeight ?? 'auto' : 0,
+          height: isOpen ? (contentRef.current?.scrollHeight ?? 'auto') : 0,
         }}
       >
         <div ref={contentRef}>
@@ -126,14 +126,11 @@ function ItemAccordionUI({
                 }
               >
                 <div
-                  className={`group/item relative ml-4 flex flex-col gap-1 px-5 py-1.5 text-sm
-                  before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-neutral-200
-                  ${
+                  className={`group/item relative ml-4 flex flex-col gap-1 px-5 py-1.5 text-sm before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-neutral-200 ${
                     isSelected
                       ? 'after:absolute after:left-0 after:top-1/2 after:h-4/6 after:w-0.5 after:-translate-y-1/2 after:bg-orange-600'
                       : ''
-                  }
-                `}
+                  } `}
                 >
                   <ItemText selected={isSelected} text={itemText} />
                 </div>

--- a/portal/app/[locale]/_components/navbar/_components/navItem.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/navItem.tsx
@@ -99,13 +99,11 @@ export const AccordionIconContainer = ({
   selected = false,
 }: Selectable & { children: ReactNode }) => (
   <div
-    className={`flex size-6 items-center justify-center rounded-md
-      transition-colors duration-300 md:size-5
-      group-hover/nav:[&>svg>path]:fill-neutral-950 ${
-        selected
-          ? '[&>svg>path]:fill-neutral-950'
-          : '[&>svg>path]:fill-neutral-400'
-      }`}
+    className={`flex size-6 items-center justify-center rounded-md transition-colors duration-300 md:size-5 group-hover/nav:[&>svg>path]:fill-neutral-950 ${
+      selected
+        ? '[&>svg>path]:fill-neutral-950'
+        : '[&>svg>path]:fill-neutral-400'
+    }`}
   >
     {children}
   </div>
@@ -116,12 +114,11 @@ export const AccordionItemText = ({
   text,
 }: Pick<NavItemProps, 'text'> & Selectable) => (
   <span
-    className={`text-base font-medium transition-colors duration-300
-       group-hover/nav:text-neutral-950 md:text-sm ${
-         selected
-           ? 'text-neutral-950'
-           : 'text-neutral-600 group-hover/item:text-neutral-950'
-       }`}
+    className={`text-base font-medium transition-colors duration-300 group-hover/nav:text-neutral-950 md:text-sm ${
+      selected
+        ? 'text-neutral-950'
+        : 'text-neutral-600 group-hover/item:text-neutral-950'
+    }`}
   >
     {text}
   </span>

--- a/portal/app/[locale]/_components/navbar/_components/networkSwitch.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/networkSwitch.tsx
@@ -129,7 +129,7 @@ const NetworkSwitchImpl = function ({
         document.body &&
         ReactDOM.createPortal(
           <div
-            className="md:w-50 absolute z-40 lg:fixed"
+            className="absolute z-40 md:w-50 lg:fixed"
             onMouseDown={e => e.stopPropagation()}
             onTouchStart={e => e.stopPropagation()}
             ref={ref}

--- a/portal/app/[locale]/_components/navbar/_components/tvl/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/tvl/index.tsx
@@ -40,10 +40,7 @@ const TvlImpl = function () {
 
   return (
     isNotTestnet && (
-      <section
-        className="h-22 relative mb-4 flex flex-col gap-y-3 rounded-lg bg-neutral-800 
-        p-4 md:mb-0 md:mt-3"
-      >
+      <section className="relative mb-4 flex h-22 flex-col gap-y-3 rounded-lg bg-neutral-800 p-4 md:mb-0 md:mt-3">
         <div className="flex w-full items-center justify-between">
           <span className="text-sm font-medium text-white">{t('tvl')}:</span>
           <DollarSign />
@@ -59,7 +56,7 @@ export const Tvl = () => (
     fallback={
       // Statically render a skeleton as TVL is only shown and mainnet, but in addition to this,
       // the position changes on the navbar.
-      <Skeleton className="h-22 mb-4 w-full rounded-lg md:mb-0 md:mt-4" />
+      <Skeleton className="mb-4 h-22 w-full rounded-lg md:mb-0 md:mt-4" />
     }
   >
     <TvlImpl />

--- a/portal/app/[locale]/_components/navbar/_components/videoAsset.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/videoAsset.tsx
@@ -14,7 +14,7 @@ const VideoAssetImpl = function () {
 
   return (
     <div
-      className={`w-54 h-30 absolute scale-150 overflow-x-hidden ${
+      className={`absolute h-30 w-54 scale-150 overflow-x-hidden ${
         isNotTestnet ? '-translate-y-22' : '-translate-y-30'
       }`}
     >

--- a/portal/app/[locale]/_components/navbar/navbarDesktop.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarDesktop.tsx
@@ -42,7 +42,7 @@ const PaddedListItem = ({
 }) => <li className={`[&>div]:px-2 ${className}`}>{children}</li>
 
 export const NavbarDesktop = () => (
-  <div className="w-54 relative flex h-full flex-col justify-between overflow-x-hidden bg-white pt-3">
+  <div className="relative flex h-full w-54 flex-col justify-between overflow-x-hidden bg-white pt-3">
     <div className="mb-6 flex items-center justify-between px-3">
       <div className="ml-2 flex items-center justify-start gap-x-2">
         <HomeLink />

--- a/portal/app/[locale]/_components/navbar/navbarMobile.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarMobile.tsx
@@ -58,7 +58,7 @@ const CustomContainer = (props: ComponentProps<typeof ItemContainer>) => (
 export const NavbarMobile = function () {
   const t = useTranslations('navbar')
   return (
-    <div className="h-90dvh flex flex-col bg-white pb-14 sm:pb-0">
+    <div className="flex h-90dvh flex-col bg-white pb-14 sm:pb-0">
       <div className="flex-1 overflow-y-auto px-5 py-6">
         <ul className="flex h-fit flex-wrap justify-start gap-2">
           {featureFlags.enableHemiEarnPage && (

--- a/portal/app/[locale]/_components/testnetIndicator.tsx
+++ b/portal/app/[locale]/_components/testnetIndicator.tsx
@@ -8,10 +8,7 @@ const UI = function () {
   }
 
   return (
-    <span
-      className="absolute left-1/2 z-10 -translate-x-1/2 rounded-b bg-orange-600
-    px-2 text-sm font-medium text-white"
-    >
+    <span className="absolute left-1/2 z-10 -translate-x-1/2 rounded-b bg-orange-600 px-2 text-sm font-medium text-white">
       Testnet
     </span>
   )

--- a/portal/app/[locale]/btc-yield/_components/acknowledge.tsx
+++ b/portal/app/[locale]/btc-yield/_components/acknowledge.tsx
@@ -17,8 +17,7 @@ export const Acknowledge = function ({ acknowledged, setAcknowledged }: Props) {
     >
       <input
         checked={acknowledged}
-        className="checkbox mt-0.5 h-4 w-4 shrink-0 cursor-pointer appearance-none rounded
-            bg-white shadow-sm transition-all checked:bg-orange-600 focus:ring-2 focus:ring-orange-600"
+        className="checkbox mt-0.5 h-4 w-4 shrink-0 cursor-pointer appearance-none rounded bg-white shadow-sm transition-all checked:bg-orange-600 focus:ring-2 focus:ring-orange-600"
         id="acknowledge-beta-site"
         onChange={e => setAcknowledged(e.target.checked)}
         type="checkbox"

--- a/portal/app/[locale]/btc-yield/_components/getStarted.tsx
+++ b/portal/app/[locale]/btc-yield/_components/getStarted.tsx
@@ -39,10 +39,7 @@ export const GetStarted = function ({ onClose }: Props) {
 
   return (
     <article className="group/get-started relative mb-8 gap-x-5 gap-y-10 border-y border-solid border-neutral-300/55 py-6">
-      <div
-        className="transition-filter flex flex-col items-center justify-between gap-x-3 gap-y-6
-        duration-300 group-hover/get-started:opacity-65 group-hover/get-started:blur-sm sm:flex-row"
-      >
+      <div className="flex flex-col items-center justify-between gap-x-3 gap-y-6 transition-filter duration-300 group-hover/get-started:opacity-65 group-hover/get-started:blur-sm sm:flex-row">
         <Step
           heading={t('common.connect-wallet')}
           image={step1}
@@ -59,10 +56,7 @@ export const GetStarted = function ({ onClose }: Props) {
           subheading={t('bitcoin-yield.put-to-work', { symbol })}
         />
       </div>
-      <div
-        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 scale-95 opacity-0 transition-all
-        delay-75 duration-300 group-hover/get-started:scale-100 group-hover/get-started:opacity-100"
-      >
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 scale-95 opacity-0 transition-all delay-75 duration-300 group-hover/get-started:scale-100 group-hover/get-started:opacity-100">
         <Button
           onClick={onClose}
           size="xSmall"

--- a/portal/app/[locale]/btc-yield/_components/info.tsx
+++ b/portal/app/[locale]/btc-yield/_components/info.tsx
@@ -4,10 +4,7 @@ import { PoolDeposits } from './poolDeposits'
 import { PoolTokenValue } from './poolTokenValue'
 
 export const Info = () => (
-  <div
-    className="xs:flex-row flex w-full flex-col flex-wrap items-center justify-between gap-4 md:flex-nowrap md:gap-5
-      [&>.card-container]:w-full [&>.card-container]:max-md:basis-[calc(50%-theme(spacing.2))]"
-  >
+  <div className="flex w-full flex-col flex-wrap items-center justify-between gap-4 xs:flex-row md:flex-nowrap md:gap-5 [&>.card-container]:w-full [&>.card-container]:max-md:basis-[calc(50%-theme(spacing.2))]">
     <PoolDeposits />
     <Holders />
     <EarningRate />

--- a/portal/app/[locale]/btc-yield/_components/integrations.tsx
+++ b/portal/app/[locale]/btc-yield/_components/integrations.tsx
@@ -27,7 +27,7 @@ const Integration = ({
     <Card>
       <ExternalLink href={href}>
         <span className="flex w-full flex-col gap-y-1 p-6">
-          <span className="relative size-12 rounded-md bg-neutral-900 ">
+          <span className="relative size-12 rounded-md bg-neutral-900">
             <Image
               alt={`${name} logo`}
               className="px-2.5"
@@ -53,7 +53,7 @@ export const Integrations = function () {
   return (
     <section className="mt-12 flex flex-col gap-y-5 md:mt-14 md:gap-y-6">
       <h3>{t('heading', { symbol: poolAsset.symbol })}</h3>
-      <div className="xs:flex-row flex w-full flex-col flex-wrap gap-4 md:flex-nowrap md:gap-5 [&>.card-container]:w-full [&>.card-container]:max-md:basis-[calc(50%-theme(spacing.2))]">
+      <div className="flex w-full flex-col flex-wrap gap-4 xs:flex-row md:flex-nowrap md:gap-5 [&>.card-container]:w-full [&>.card-container]:max-md:basis-[calc(50%-theme(spacing.2))]">
         <Integration
           category={t('categories.defi')}
           description={t('spectra-description')}

--- a/portal/app/[locale]/btc-yield/_components/operation.tsx
+++ b/portal/app/[locale]/btc-yield/_components/operation.tsx
@@ -43,7 +43,7 @@ export const Operation = function ({
         onSubmit?.()
       }}
     >
-      <div className="min-h-21 mb-3 flex flex-col gap-y-3">
+      <div className="mb-3 flex min-h-21 flex-col gap-y-3">
         <DrawerTopSection heading={heading} onClose={onClose} />
         <DrawerParagraph>{subheading}</DrawerParagraph>
       </div>

--- a/portal/app/[locale]/btc-yield/_components/preview.tsx
+++ b/portal/app/[locale]/btc-yield/_components/preview.tsx
@@ -55,7 +55,7 @@ export const Preview = function ({
             {t('withdraw')}
           </Tab>
         </Tabs>
-        <div className="[&>*]:shadow-bs mb-2 [&>*]:hover:shadow-sm">
+        <div className="mb-2 [&>*]:shadow-bs [&>*]:hover:shadow-sm">
           <TokenInput
             balanceComponent={balanceComponent}
             disabled={isOperating}

--- a/portal/app/[locale]/btc-yield/page.tsx
+++ b/portal/app/[locale]/btc-yield/page.tsx
@@ -14,7 +14,7 @@ import { useOperationDrawer } from './_hooks/useOperationDrawer'
 const PoolTable = dynamic(
   () => import('./_components/poolTable').then(mod => mod.PoolTable),
   {
-    loading: () => <Skeleton className="h-17 mt-8 w-full rounded-xl" />,
+    loading: () => <Skeleton className="mt-8 h-17 w-full rounded-xl" />,
     ssr: false,
   },
 )

--- a/portal/app/[locale]/ecosystem/_components/demoCard.tsx
+++ b/portal/app/[locale]/ecosystem/_components/demoCard.tsx
@@ -41,17 +41,13 @@ export const DemoCard = function ({
   const addTracking = () => (enabled ? () => track(event) : undefined)
 
   return (
-    <div
-      className="solid group/demo-card relative h-[270px] flex-shrink
-    flex-grow rounded-[17px] border border-neutral-300/55
-    hover:cursor-pointer md:h-56 md:w-[295px] md:flex-shrink-0 md:flex-grow-0"
-    >
+    <div className="solid group/demo-card relative h-[270px] flex-shrink flex-grow rounded-[17px] border border-neutral-300/55 hover:cursor-pointer md:h-56 md:w-[295px] md:flex-shrink-0 md:flex-grow-0">
       <div className="absolute left-6 top-5 -z-10 h-12 w-12">
         <Image alt={altText} fill priority={true} src={icon} />
       </div>
       <Image
         alt={altText}
-        className="group-hover/demo-card:opacity-88 -z-20 rounded-2xl duration-150"
+        className="-z-20 rounded-2xl duration-150 group-hover/demo-card:opacity-88"
         fill
         priority={true}
         src={bgImage}

--- a/portal/app/[locale]/genesis-drop/_components/blur.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/blur.tsx
@@ -1,5 +1,5 @@
 // It's mandatory to listen to https://www.youtube.com/watch?v=SSbBvKaM6sk
 // when updating this component ( ͡° ͜ʖ ͡°)
 export const Blur = () => (
-  <div className="blur-1.5xl bg-sky-450 absolute inset-x-0 bottom-0 -z-10 h-24 rounded-[135px] opacity-35" />
+  <div className="absolute inset-x-0 bottom-0 -z-10 h-24 rounded-[135px] bg-sky-450 opacity-35 blur-1.5xl" />
 )

--- a/portal/app/[locale]/genesis-drop/_components/claimDetails.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/claimDetails.tsx
@@ -57,7 +57,7 @@ function usePageVisitTracker(claimGroupId: number) {
 }
 
 const Row = ({ children }: { children: ReactNode }) => (
-  <div className="text-mid flex items-center justify-between border-b border-solid border-neutral-300/55 py-3 font-medium last:border-b-0">
+  <div className="flex items-center justify-between border-b border-solid border-neutral-300/55 py-3 text-mid font-medium last:border-b-0">
     {children}
   </div>
 )
@@ -100,7 +100,7 @@ export const ClaimDetails = function ({ eligibility }: Props) {
   const t = useTranslations('genesis-drop')
 
   const loadingSkeleton = (
-    <Skeleton className="w-21 h-4" containerClassName="flex-1" />
+    <Skeleton className="h-4 w-21" containerClassName="flex-1" />
   )
 
   const isStandardLock = () => transaction?.lockupMonths === 6
@@ -219,7 +219,7 @@ export const ClaimDetails = function ({ eligibility }: Props) {
         </>
       )}
       <div
-        className="md:w-120 relative w-full rounded-xl bg-neutral-50"
+        className="relative w-full rounded-xl bg-neutral-50 md:w-120"
         style={{
           boxShadow:
             '0 0 0 1px rgba(10, 10, 10, 0.08), 0 1px 2px 0 rgba(10, 10, 10, 0.10)',

--- a/portal/app/[locale]/genesis-drop/_components/claimOptions.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/claimOptions.tsx
@@ -150,7 +150,7 @@ export const ClaimOptions = function ({ eligibility }: Props) {
           }
         />
         <div className="relative">
-          <div className="border-1.5 border-sky-450 absolute -inset-2 rounded-2xl border-solid" />
+          <div className="absolute -inset-2 rounded-2xl border-1.5 border-solid border-sky-450" />
           <Strategy
             amount={eligibility.amount}
             bgColor="bg-recommended-claim"

--- a/portal/app/[locale]/genesis-drop/_components/eligible.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/eligible.tsx
@@ -71,7 +71,7 @@ export const Eligible = function ({ eligibility }: Props) {
   // if we reached this point, the user is eligible and can claim
   return (
     <>
-      <div className="md:max-w-105 max-h-24 w-full max-w-96">
+      <div className="max-h-24 w-full max-w-96 md:max-w-105">
         <EligibilityStatus amount={amount} status="eligible" />
       </div>
       <div className="flex items-center gap-x-1">

--- a/portal/app/[locale]/genesis-drop/_components/recommendedBadge.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/recommendedBadge.tsx
@@ -4,7 +4,7 @@ export const RecommendedBadge = function () {
   const t = useTranslations('genesis-drop.claim-options')
 
   return (
-    <div className="bg-sky-550/5 border-sky-550/15 flex h-6 items-center justify-center rounded-xl border border-solid px-2">
+    <div className="flex h-6 items-center justify-center rounded-xl border border-solid border-sky-550/15 bg-sky-550/5 px-2">
       <span className="text-xs font-medium text-sky-500">
         {t('recommended')}
       </span>

--- a/portal/app/[locale]/genesis-drop/_components/strategy.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/strategy.tsx
@@ -125,7 +125,7 @@ export const Strategy = function ({
 
   return (
     <form
-      className={`sm:w-86 max-sm:max-w-90 relative w-full max-w-full rounded-lg bg-neutral-100 ${boxShadows[recommendationLevel]} flex flex-col`}
+      className={`relative w-full max-w-full rounded-lg bg-neutral-100 max-sm:max-w-90 sm:w-86 ${boxShadows[recommendationLevel]} flex flex-col`}
       onSubmit={handleSubmit}
     >
       <div
@@ -151,11 +151,11 @@ export const Strategy = function ({
             symbol: () => hemiToken.symbol,
           })}
         </p>
-        <div className="h-15 flex items-center justify-center border-y border-solid border-t-neutral-300/55 px-6 [&>button]:w-full">
+        <div className="flex h-15 items-center justify-center border-y border-solid border-t-neutral-300/55 px-6 [&>button]:w-full">
           {submitButton}
         </div>
       </div>
-      <div className="md:min-h-47 flex-1 rounded-b-lg max-md:h-fit">
+      <div className="flex-1 rounded-b-lg max-md:h-fit md:min-h-47">
         {recommendationLevel === 'low' ? (
           <SimpleBonus
             amount={renderStakedAmount(<Skeleton className="h-3 w-10" />)}

--- a/portal/app/[locale]/genesis-drop/_components/termsAndConditions.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/termsAndConditions.tsx
@@ -85,16 +85,16 @@ export const TermsAndConditions = function ({ onAccept, onClose }: Props) {
 
   return (
     <Modal onClose={onClose}>
-      <div className="max-w-120 relative w-full bg-neutral-50">
+      <div className="relative w-full max-w-120 bg-neutral-50">
         <div className="relative z-10 rounded-lg bg-white shadow-sm">
-          <h3 className="text-mid-md px-6 py-4 font-semibold  text-neutral-950">
+          <h3 className="px-6 py-4 text-mid-md font-semibold text-neutral-950">
             {t('genesis-drop.terms-and-conditions.title')}
           </h3>
           <div className="h-px w-full border-b border-solid border-b-neutral-300/55" />
           <LegalText />
         </div>
         <form
-          className="h-15 relative flex w-full items-center justify-between gap-x-4 rounded-b-xl bg-neutral-50 px-4 [&>button]:w-full"
+          className="relative flex h-15 w-full items-center justify-between gap-x-4 rounded-b-xl bg-neutral-50 px-4 [&>button]:w-full"
           onSubmit={handleSubmit}
           style={{
             boxShadow:

--- a/portal/app/[locale]/genesis-drop/_hooks/useClaimTokens.ts
+++ b/portal/app/[locale]/genesis-drop/_hooks/useClaimTokens.ts
@@ -67,9 +67,8 @@ export const useClaimTokens = function ({
         walletClient: hemiWalletClient!,
       })
 
-      emitter.on(
-        'claim-failed-validation',
-        () => track?.('genesis-drop - failed validation', { lockupMonths }),
+      emitter.on('claim-failed-validation', () =>
+        track?.('genesis-drop - failed validation', { lockupMonths }),
       )
 
       emitter.on('claim-transaction-succeeded', function (receipt) {

--- a/portal/app/[locale]/genesis-drop/page.tsx
+++ b/portal/app/[locale]/genesis-drop/page.tsx
@@ -58,7 +58,7 @@ export default function Page() {
       return (
         <>
           <DisconnectedState />
-          <p className="max-w-50 mt-1 text-center text-xs font-medium text-neutral-500">
+          <p className="mt-1 max-w-50 text-center text-xs font-medium text-neutral-500">
             {t('connect-demos-wallet')}
           </p>
         </>

--- a/portal/app/[locale]/get-started/_components/addChain/networkConfigCard.tsx
+++ b/portal/app/[locale]/get-started/_components/addChain/networkConfigCard.tsx
@@ -5,7 +5,7 @@ export const NetworkConfigCard = ({
   ...props
 }: ComponentProps<'div'>) => (
   <div
-    className={`shadow-bs rounded-lg bg-white p-4 ${className ?? ''}`}
+    className={`rounded-lg bg-white p-4 shadow-bs ${className ?? ''}`}
     {...props}
   />
 )

--- a/portal/app/[locale]/get-started/_components/learnMore.tsx
+++ b/portal/app/[locale]/get-started/_components/learnMore.tsx
@@ -35,7 +35,7 @@ const TutorialCard = function ({
 
   return (
     <ExternalLink
-      className="shadow-bs flex h-28 overflow-hidden rounded-lg bg-white transition-colors hover:bg-neutral-50"
+      className="flex h-28 overflow-hidden rounded-lg bg-white shadow-bs transition-colors hover:bg-neutral-50"
       href={href}
       onClick={addTracking()}
     >

--- a/portal/app/[locale]/get-started/_components/step.tsx
+++ b/portal/app/[locale]/get-started/_components/step.tsx
@@ -6,13 +6,13 @@ type Props = {
 }
 
 const StepNumber = ({ position }: { position: number }) => (
-  <div className="text-xxs flex size-full items-center justify-center font-semibold lining-nums tabular-nums text-white">
+  <div className="flex size-full items-center justify-center text-xxs font-semibold lining-nums tabular-nums text-white">
     {position}
   </div>
 )
 
 export const Step = ({ description, position }: Props) => (
-  <div className="h-17 relative w-5 shrink-0">
+  <div className="relative h-17 w-5 shrink-0">
     <div className="absolute left-1/2 top-0 -translate-x-1/2">
       <LongVerticalLine dashed={false} stroke="stroke-neutral-300" />
     </div>

--- a/portal/app/[locale]/hemi-earn/_components/fromPoolsBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/fromPoolsBadge.tsx
@@ -87,7 +87,7 @@ export const FromPoolsBadge = function () {
       }
       variant="simple"
     >
-      <span className="text-xxs flex h-4 w-fit items-center justify-center rounded-md border border-solid border-neutral-200 bg-neutral-100 px-1.5 font-medium text-neutral-600">
+      <span className="flex h-4 w-fit items-center justify-center rounded-md border border-solid border-neutral-200 bg-neutral-100 px-1.5 text-xxs font-medium text-neutral-600">
         {t('from-pools', { count })}
       </span>
     </Tooltip>

--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
@@ -27,8 +27,8 @@ export const PoolInfoBar = function ({ pool }: Props) {
   const explorerUrl = chain?.blockExplorers?.default.url
 
   return (
-    <div className="md:min-h-19.5 flex w-full flex-col gap-4 rounded-xl bg-white p-4 shadow-sm md:flex-row md:items-center md:gap-6">
-      <div className="md:w-19 flex h-10 w-full shrink-0 items-center justify-center rounded-lg bg-neutral-100">
+    <div className="flex w-full flex-col gap-4 rounded-xl bg-white p-4 shadow-sm md:min-h-19.5 md:flex-row md:items-center md:gap-6">
+      <div className="flex h-10 w-full shrink-0 items-center justify-center rounded-lg bg-neutral-100 md:w-19">
         <TokenIconStack tokens={pool.exposureTokens} />
       </div>
       <div className="grid grid-cols-2 gap-4 md:flex md:flex-1 md:items-center md:gap-6">

--- a/portal/app/[locale]/hemi-earn/_components/poolsList.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsList.tsx
@@ -7,7 +7,7 @@ import { useEarnPools } from '../_hooks/useEarnPools'
 import { PoolInfoBar } from './poolInfoBar'
 
 const PoolInfoBarSkeleton = () => (
-  <Skeleton className="md:h-19.5 h-58 w-full rounded-xl" />
+  <Skeleton className="h-58 w-full rounded-xl md:h-19.5" />
 )
 
 export const PoolsList = function () {

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
@@ -43,7 +43,7 @@ function AmountCell({ transaction }: { transaction: EarnTransaction }) {
   const token = showingShares ? pool?.shareToken : assetToken
   const rawAmount = showingShares
     ? transaction.amountIn
-    : transaction.amountOut ?? transaction.amountIn
+    : (transaction.amountOut ?? transaction.amountIn)
 
   if (!token) {
     if (isLoading) return <Skeleton className="w-16" />

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
@@ -61,7 +61,7 @@ function deriveCooldownText({
   if (hasClaimableAt && remainingSec === 0) {
     return t('status.ready-to-claim')
   }
-  const displaySec = hasClaimableAt ? remainingSec ?? 0 : cooldownDurationSec
+  const displaySec = hasClaimableAt ? (remainingSec ?? 0) : cooldownDurationSec
   if (displaySec === undefined || displaySec <= 0) return undefined
   return formatCooldownText(displaySec, t)
 }

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
@@ -31,4 +31,4 @@ export const selectApyValue = (
   data: ApyByVault | undefined,
   isPending: boolean,
   stakingVault: Address,
-) => (isPending ? undefined : data?.[stakingVault]?.apy ?? null)
+) => (isPending ? undefined : (data?.[stakingVault]?.apy ?? null))

--- a/portal/app/[locale]/hemi-earn/page.tsx
+++ b/portal/app/[locale]/hemi-earn/page.tsx
@@ -12,7 +12,7 @@ import { useHemiEarnShares } from './_hooks/useHemiEarnShares'
 
 const PoolsListSkeleton = () => (
   <div className="mt-6 flex w-full flex-col gap-4">
-    <Skeleton className="md:h-19.5 h-58 w-full rounded-xl" />
+    <Skeleton className="h-58 w-full rounded-xl md:h-19.5" />
   </div>
 )
 

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionChart.tsx
@@ -31,7 +31,7 @@ export const CompositionChart = function ({
     const hoveredItem = hoveredIndex !== null ? data[hoveredIndex] : null
 
     return (
-      <div className="shadow-bs relative flex h-full items-center justify-center rounded-lg bg-neutral-50">
+      <div className="relative flex h-full items-center justify-center rounded-lg bg-neutral-50 shadow-bs">
         <svg
           height={chartSize}
           viewBox={`0 0 ${chartSize} ${chartSize}`}
@@ -61,7 +61,7 @@ export const CompositionChart = function ({
           />
         </svg>
         {hoveredItem !== null && (
-          <span className="text-mid-md pointer-events-none absolute font-semibold text-orange-500">
+          <span className="pointer-events-none absolute text-mid-md font-semibold text-orange-500">
             {formatPercentage(hoveredItem.share)}
           </span>
         )}
@@ -74,7 +74,7 @@ export const CompositionChart = function ({
   }
 
   return (
-    <div className="shadow-bs flex h-full items-center justify-center rounded-lg bg-neutral-50 p-6">
+    <div className="flex h-full items-center justify-center rounded-lg bg-neutral-50 p-6 shadow-bs">
       <Skeleton circle height={chartSize - 75} width={chartSize - 75} />
     </div>
   )

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationSummary.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationSummary.tsx
@@ -61,7 +61,7 @@ const TopRow = function ({ amount, label, token }: TopRowProps) {
             showTokenLogo={false}
             token={token}
           />
-          <div className="shadow-bs rounded-full">
+          <div className="rounded-full shadow-bs">
             <TokenLogo size="small" token={token} />
           </div>
         </div>

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -80,7 +80,7 @@ function buildReceiveStep({
   // outside this drawer (tracked in its own follow-up).
   const claimTxHash =
     subgraphRow?.status === 'FINALIZED'
-      ? subgraphRow.claimTxHash ?? undefined
+      ? (subgraphRow.claimTxHash ?? undefined)
       : undefined
   const unstakeMined = withdrawStatus === WithdrawStatus.WITHDRAW_TX_CONFIRMED
   // Two distinct questions, kept as separate predicates so each reads

--- a/portal/app/[locale]/stake/_components/manageStake/disclaimerEth.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/disclaimerEth.tsx
@@ -17,7 +17,7 @@ export const DisclaimerEth = function () {
         subheading={t('unstake-eth-as-weth-subheading')}
       >
         <ExternalLink
-          className="group/disclaimer flex cursor-pointer items-center gap-x-1 text-sm "
+          className="group/disclaimer flex cursor-pointer items-center gap-x-1 text-sm"
           href="https://pure.finance/en/wrap-eth/"
         >
           <span className="text-orange-600 group-hover/disclaimer:text-orange-700">

--- a/portal/app/[locale]/stake/_components/manageStake/preview.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/preview.tsx
@@ -66,7 +66,7 @@ export const Preview = function ({
             </Tab>
           </Tabs>
         )}
-        <div className="[&>*]:shadow-bs mb-2 [&>*]:hover:shadow-sm">
+        <div className="mb-2 [&>*]:shadow-bs [&>*]:hover:shadow-sm">
           <TokenInput
             balanceComponent={balanceComponent}
             disabled={isOperating}

--- a/portal/app/[locale]/stake/_components/stakeDisabledTestnet.tsx
+++ b/portal/app/[locale]/stake/_components/stakeDisabledTestnet.tsx
@@ -6,15 +6,14 @@ import { StakeAndEarn } from './stakeAndEarn'
 
 export const StakeDisabledTestnet = () => (
   <div
-    className="flex flex-col items-center rounded-xl px-5 pt-12
-    shadow-md md:mt-12 lg:h-[60dvh] lg:flex-row lg:justify-evenly lg:gap-x-12 lg:py-12 2xl:gap-x-24"
+    className="flex flex-col items-center rounded-xl px-5 pt-12 shadow-md md:mt-12 lg:h-[60dvh] lg:flex-row lg:justify-evenly lg:gap-x-12 lg:py-12 2xl:gap-x-24"
     style={{
       background:
         'radial-gradient(100% 100% at 50% 0%, rgba(253, 239, 232, 0.16) 14.12%, rgba(255, 108, 21, 0.16) 32.29%, rgba(255, 24, 20, 0.03) 98.87%), #FFF',
     }}
   >
     <div className="flex flex-col items-center gap-y-7">
-      <div className="[&>div>svg]:lg:-translate-x-34 [&>div>svg]:-translate-x-1/2 [&>div>svg]:max-lg:left-1/2">
+      <div className="[&>div>svg]:-translate-x-1/2 [&>div>svg]:max-lg:left-1/2 [&>div>svg]:lg:-translate-x-34">
         <StakeAndEarn />
       </div>
       <ChangeToMainnet />

--- a/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -102,7 +102,7 @@ export const StakeStrategyTable = function ({ data, loading }: Props) {
 
   return (
     <div className="w-full rounded-xl text-sm font-medium">
-      <div className="md:min-h-136 h-[56dvh] overflow-hidden">
+      <div className="h-[56dvh] overflow-hidden md:min-h-136">
         <Table
           columns={cols}
           data={data}

--- a/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -157,7 +157,7 @@ export const StakeAssetsTable = function () {
 
   return (
     <div className="w-full rounded-xl text-sm font-medium">
-      <div className="md:min-h-136 h-[56dvh] overflow-hidden">
+      <div className="h-[56dvh] overflow-hidden md:min-h-136">
         <Table
           columns={cols}
           data={sortedTokens}

--- a/portal/app/[locale]/staking-dashboard/_components/lockup/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/lockup/index.tsx
@@ -279,7 +279,7 @@ export function Lockup({
 
   return (
     <>
-      <div className="hover:shadow-bs w-full space-y-4 rounded-lg border border-solid border-transparent bg-neutral-50 p-4 ring-1 ring-transparent">
+      <div className="w-full space-y-4 rounded-lg border border-solid border-transparent bg-neutral-50 p-4 ring-1 ring-transparent hover:shadow-bs">
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-neutral-500">
             {t('lockup-period')}

--- a/portal/app/[locale]/staking-dashboard/_components/operation.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/operation.tsx
@@ -30,7 +30,7 @@ export const Operation = ({
   token,
 }: Props) => (
   <>
-    <div className="min-h-21 mb-3 flex flex-col gap-y-3">
+    <div className="mb-3 flex min-h-21 flex-col gap-y-3">
       <DrawerTopSection heading={heading} onClose={onClose} />
       <DrawerParagraph>{subheading}</DrawerParagraph>
     </div>

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseUnlockTime/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseUnlockTime/index.tsx
@@ -200,7 +200,7 @@ export const ReviewIncreaseUnlockTime = function ({ onClose }: Props) {
 
   return (
     <>
-      <div className="min-h-21 mb-3 flex flex-col gap-y-3">
+      <div className="mb-3 flex min-h-21 flex-col gap-y-3">
         <DrawerTopSection
           heading={tDrawer('increase-unlock-time.heading', {
             symbol: token.symbol,

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
@@ -183,7 +183,7 @@ export function StakeTable({ data, filter = 'active', loading }: Props) {
 
   return (
     <div className="w-full rounded-xl bg-neutral-100 text-sm font-medium">
-      <div className="md:min-h-136 h-[56dvh] overflow-hidden">
+      <div className="h-[56dvh] overflow-hidden md:min-h-136">
         {getContent()}
       </div>
     </div>

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/linearProgress.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/linearProgress.tsx
@@ -11,7 +11,7 @@ export function LinearProgress({ percentage, unlockTime }: Props) {
   return (
     <div className="relative flex h-7 min-w-28 items-center justify-center overflow-hidden rounded-md bg-neutral-100 px-2 py-1.5">
       <div
-        className="bg-linear-progress-bar absolute inset-y-0 left-0 transition-all duration-300 ease-out"
+        className="absolute inset-y-0 left-0 bg-linear-progress-bar transition-all duration-300 ease-out"
         style={{
           width,
         }}

--- a/portal/app/[locale]/staking-dashboard/_components/votingPowerSummary.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/votingPowerSummary.tsx
@@ -32,10 +32,7 @@ export const VotingPowerSummary = function () {
     ) : null
 
   return (
-    <div
-      className="xs:flex-row flex w-full flex-col flex-wrap items-center justify-between gap-6 md:flex-nowrap
-        [&>.card-container]:w-full [&>.card-container]:max-md:min-w-0 [&>.card-container]:max-md:basis-full"
-    >
+    <div className="flex w-full flex-col flex-wrap items-center justify-between gap-6 xs:flex-row md:flex-nowrap [&>.card-container]:w-full [&>.card-container]:max-md:min-w-0 [&>.card-container]:max-md:basis-full">
       <CardInfo<bigint>
         data={isWalletReady ? positionsSum : undefined}
         formatValue={formatVeHemi}

--- a/portal/app/[locale]/staking-dashboard/page.tsx
+++ b/portal/app/[locale]/staking-dashboard/page.tsx
@@ -39,7 +39,7 @@ function StakingContent() {
         <VotingPowerSummary />
       </div>
       <div className="mt-6 flex flex-col-reverse gap-6 lg:flex-row">
-        <div className="xl:grow-2 w-full lg:w-1/2 xl:shrink xl:basis-0">
+        <div className="w-full lg:w-1/2 xl:shrink xl:grow-2 xl:basis-0">
           <div className="mb-4 ml-1 flex flex-row md:w-fit">
             <StakeTableFilter filter={filter} onFilter={handleFilter} />
           </div>

--- a/portal/app/[locale]/tunnel/_components/receivingAddress.tsx
+++ b/portal/app/[locale]/tunnel/_components/receivingAddress.tsx
@@ -12,10 +12,7 @@ export const ReceivingAddress = ({
   receivingText,
   tooltipText,
 }: Props) => (
-  <div
-    className="px-auto flex h-24 flex-col items-center rounded-b-2xl border
-    border-solid border-neutral-300/55 bg-neutral-100 pb-3 pt-11 text-sm font-medium"
-  >
+  <div className="px-auto flex h-24 flex-col items-center rounded-b-2xl border border-solid border-neutral-300/55 bg-neutral-100 pb-3 pt-11 text-sm font-medium">
     <div className="flex items-center gap-x-2">
       <span className="text-neutral-600">{receivingText}</span>
       <Tooltip

--- a/portal/app/[locale]/tunnel/_components/walletsConnected.tsx
+++ b/portal/app/[locale]/tunnel/_components/walletsConnected.tsx
@@ -29,10 +29,7 @@ export const WalletsConnected = function () {
   const { btcWalletStatus, evmWalletStatus } = useAccounts()
   const t = useTranslations('connect-wallets')
   return (
-    <div
-      className="flex flex-nowrap items-center justify-between
-      gap-x-7 md:justify-center"
-    >
+    <div className="flex flex-nowrap items-center justify-between gap-x-7 md:justify-center">
       <Wallet status={evmWalletStatus} title={t('evm-wallet')} />
       <Wallet status={btcWalletStatus} title={t('btc-wallet')} />
     </div>

--- a/portal/app/[locale]/tunnel/_hooks/useTunnelState.ts
+++ b/portal/app/[locale]/tunnel/_hooks/useTunnelState.ts
@@ -396,7 +396,7 @@ export const useTunnelState = function (): TunnelState & TunnelFunctionEvents {
         const targetAddress =
           nativeToken.extensions?.bridgeInfo?.[hemi.id]?.tokenAddress
         const fromToken = targetAddress
-          ? getTokenByAddress(targetAddress, hemi.id) ?? tunneledEthHemi
+          ? (getTokenByAddress(targetAddress, hemi.id) ?? tunneledEthHemi)
           : tunneledEthHemi
 
         const toToken = getTunnelToken(fromToken, toNetworkId)

--- a/portal/app/[locale]/tunnel/transaction-history/_components/depositStatus.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/depositStatus.tsx
@@ -32,7 +32,7 @@ export const DepositStatus = function ({ deposit }: Props) {
       [EvmDepositStatus.DEPOSIT_RELAYED]: <TxStatus.Success />,
     }
 
-    const skeleton = <Skeleton className="w-15 h-8" />
+    const skeleton = <Skeleton className="h-8 w-15" />
 
     if (deposit.status === undefined) {
       return skeleton

--- a/portal/app/[locale]/tunnel/transaction-history/_components/table.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/table.tsx
@@ -38,9 +38,7 @@ import { WithdrawStatus } from './withdrawStatus'
 
 const ColumnHeader = ({ children, className = '' }: ComponentProps<'th'>) => (
   <th
-    className={`border-color-neutral/55 transaction-history-cell ${className} h-8 border-b
-    border-t border-solid bg-neutral-50 font-medium first:rounded-l-lg first:border-l last:rounded-r-lg
-    last:border-r first:[&>span]:pl-4 last:[&>span]:pl-5`}
+    className={`border-color-neutral/55 transaction-history-cell ${className} h-8 border-b border-t border-solid bg-neutral-50 font-medium first:rounded-l-lg first:border-l last:rounded-r-lg last:border-r first:[&>span]:pl-4 last:[&>span]:pl-5`}
   >
     {children}
   </th>
@@ -48,8 +46,7 @@ const ColumnHeader = ({ children, className = '' }: ComponentProps<'th'>) => (
 
 const Column = (props: ComponentProps<'td'>) => (
   <td
-    className={`h-13 transaction-history-cell cursor-pointer border-b border-solid border-neutral-300/55
-    py-2.5 last:pr-2.5 group-hover/history-row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pl-5`}
+    className={`transaction-history-cell h-13 cursor-pointer border-b border-solid border-neutral-300/55 py-2.5 last:pr-2.5 group-hover/history-row:bg-neutral-50 first:[&>*]:pl-4 last:[&>*]:pl-5`}
     {...props}
   />
 )

--- a/portal/app/[locale]/tunnel/transaction-history/_components/transactionHistory.css
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/transactionHistory.css
@@ -42,9 +42,7 @@
       - spacing.17 is the header's height
       - spacing.12 is the bottom padding of the body
      */
-    @apply h-[calc(100dvh-6px-theme(spacing.2)-theme(spacing.3)-theme(spacing.4)-theme(spacing.6)-theme(spacing.14)-theme(spacing.14)-theme(spacing.14)-theme(spacing.16)-theme(spacing.24))]
-      md:h-[calc(100dvh-theme(spacing.2)*2-theme(spacing.2)-theme(spacing.3)-theme(spacing.8)-theme(spacing.12)-theme(spacing.12)-theme(spacing.14)-theme(spacing.17))]
-      xl:h-[calc(100dvh-theme(spacing.2)*2-theme(spacing.2)-theme(spacing.8)-theme(spacing.12)-theme(spacing.12)-theme(spacing.14)-theme(spacing.17)-theme(spacing.12))];
+    @apply h-[calc(100dvh-6px-theme(spacing.2)-theme(spacing.3)-theme(spacing.4)-theme(spacing.6)-theme(spacing.14)-theme(spacing.14)-theme(spacing.14)-theme(spacing.16)-theme(spacing.24))] md:h-[calc(100dvh-theme(spacing.2)*2-theme(spacing.2)-theme(spacing.3)-theme(spacing.8)-theme(spacing.12)-theme(spacing.12)-theme(spacing.14)-theme(spacing.17))] xl:h-[calc(100dvh-theme(spacing.2)*2-theme(spacing.2)-theme(spacing.8)-theme(spacing.12)-theme(spacing.12)-theme(spacing.14)-theme(spacing.17)-theme(spacing.12))];
 
     scrollbar-color: #d4d4d4 transparent;
     scrollbar-width: thin;

--- a/portal/app/[locale]/tunnel/transaction-history/_components/txTime.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/txTime.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const TxTime = function ({ timestamp }: Props) {
   // Unconfirmed TXs won't have a timestamp
   if (timestamp === undefined) {
-    return <Skeleton className="w-15 h-8" />
+    return <Skeleton className="h-8 w-15" />
   }
 
   return (

--- a/portal/app/[locale]/tunnel/transaction-history/_components/withdrawAction.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/withdrawAction.tsx
@@ -103,7 +103,7 @@ function BitcoinWithdrawAction({ withdraw }: Props) {
 // different content depending on the withdrawal parameters.
 export const WithdrawAction = ({ withdraw }: Props) =>
   withdraw.status === undefined ? (
-    <Skeleton className="w-15 h-8" />
+    <Skeleton className="h-8 w-15" />
   ) : isToEvmWithdraw(withdraw) ? (
     <EvmWithdrawAction withdraw={withdraw} />
   ) : (

--- a/portal/app/[locale]/tunnel/transaction-history/_components/withdrawStatus.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/withdrawStatus.tsx
@@ -47,7 +47,7 @@ const EvmWithdrawStatus = function ({
     [MessageStatus.RELAYED]: <TxStatus.Success />,
   }
 
-  return statuses[withdrawal.status] ?? <Skeleton className="w-15 h-8" />
+  return statuses[withdrawal.status] ?? <Skeleton className="h-8 w-15" />
 }
 
 // After the withdrawal is initiated, the operation is in a wait state for up to

--- a/portal/app/[locale]/tunnel/transaction-history/page.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/page.tsx
@@ -38,7 +38,7 @@ const Page = function () {
         subtitle={t('transaction-history.subtitle')}
         title={t('transaction-history.title')}
       />
-      <div className="rounded-2.5xl mt-6 bg-neutral-100 p-1 text-sm font-medium md:mt-8">
+      <div className="mt-6 rounded-2.5xl bg-neutral-100 p-1 text-sm font-medium md:mt-8">
         <TopBar
           filterOption={filterOption}
           onFilterOptionChange={setFilterOption}

--- a/portal/components/button/button.css
+++ b/portal/components/button/button.css
@@ -6,8 +6,7 @@ crashes, so Adapters for Nuqs are not available. We don't need them, but the but
 Because of that, we can add all the styles here, and then use plain buttons in those error pages.
 */
 .button--base {
-  @apply relative z-0 box-border flex items-center
-  justify-center overflow-hidden font-medium focus:outline-none disabled:opacity-55;
+  @apply relative z-0 box-border flex items-center justify-center overflow-hidden font-medium focus:outline-none disabled:opacity-55;
   /*
   Adds a smooth hover background effect using a before pseudo-element.
   This ensures consistent transitions across button variants by:
@@ -15,25 +14,20 @@ Because of that, we can add all the styles here, and then use plain buttons in t
   - Starting fully transparent (`before:opacity-0`) and transitioning to visible on hover (`hover:before:opacity-100`)
   - Applying a transition effect on opacity (`before:transition-opacity before:duration-200`)
   */
-  @apply before:absolute before:inset-0 before:-z-10 before:opacity-0
-  before:transition-opacity before:duration-200 before:content-['']
-  hover:before:opacity-100 disabled:hover:before:opacity-0;
+  @apply before:absolute before:inset-0 before:-z-10 before:opacity-0 before:transition-opacity before:duration-200 before:content-[''] hover:before:opacity-100 disabled:hover:before:opacity-0;
 }
 
 /* Button Variants */
 .button-primary {
-  @apply focus-visible:shadow-button-primary-focused before:bg-button-primary-hovered
-    bg-orange-600 text-white disabled:opacity-55;
+  @apply bg-orange-600 text-white before:bg-button-primary-hovered focus-visible:shadow-button-primary-focused disabled:opacity-55;
 }
 
 .button-secondary {
-  @apply focus-visible:shadow-button-secondary-focused bg-white text-neutral-950 shadow-sm
-  before:bg-neutral-50 disabled:bg-neutral-50 disabled:opacity-55;
+  @apply bg-white text-neutral-950 shadow-sm before:bg-neutral-50 focus-visible:shadow-button-secondary-focused disabled:bg-neutral-50 disabled:opacity-55;
 }
 
 .button-tertiary {
-  @apply focus-visible:shadow-button-tertiary-focused bg-transparent
-    text-neutral-950 before:bg-neutral-100 focus:bg-neutral-100;
+  @apply bg-transparent text-neutral-950 before:bg-neutral-100 focus:bg-neutral-100 focus-visible:shadow-button-tertiary-focused;
 }
 
 /* Button Sizes */
@@ -62,7 +56,7 @@ Because of that, we can add all the styles here, and then use plain buttons in t
 }
 
 .button-x-large {
-  @apply text-mid h-11 rounded-lg;
+  @apply h-11 rounded-lg text-mid;
 }
 
 .button-x-large.button-icon {

--- a/portal/components/cardInfo.tsx
+++ b/portal/components/cardInfo.tsx
@@ -30,7 +30,7 @@ export const CardInfo = function <T>({
   }
   return (
     <Card shadow="sm">
-      <div className="h-20.5 relative w-full p-4">
+      <div className="relative h-20.5 w-full p-4">
         <div className="flex flex-shrink-0 flex-col gap-y-2">
           <span className="body-text-medium text-neutral-500">{label}</span>
           <h3>{getValue()}</h3>

--- a/portal/components/connectWallets/connectWalletAccordion.tsx
+++ b/portal/components/connectWallets/connectWalletAccordion.tsx
@@ -90,7 +90,7 @@ export function ConnectWalletAccordion<T extends WalletItem>({
   return (
     <div className="rounded-lg bg-white shadow-sm">
       <button
-        className="hover:bg-connect-wallet-hovered group flex w-full cursor-pointer items-center gap-x-2 p-4"
+        className="group flex w-full cursor-pointer items-center gap-x-2 p-4 hover:bg-connect-wallet-hovered"
         onClick={handleClick}
       >
         {icon}
@@ -127,7 +127,7 @@ export function ConnectWalletAccordion<T extends WalletItem>({
 
                 return (
                   <button
-                    className="size-30 group relative mb-2 flex shrink-0 flex-col items-center justify-center gap-2 rounded-lg bg-neutral-50/80 p-2 transition-shadow duration-300 hover:shadow-sm md:mb-0"
+                    className="group relative mb-2 flex size-30 shrink-0 flex-col items-center justify-center gap-2 rounded-lg bg-neutral-50/80 p-2 transition-shadow duration-300 hover:shadow-sm md:mb-0"
                     key={wallet.id}
                     onClick={() => handleWalletClick(wallet)}
                   >
@@ -148,7 +148,7 @@ export function ConnectWalletAccordion<T extends WalletItem>({
                       {wallet.name}
                     </span>
                     {showInstall && (
-                      <div className="group-hover:backdrop-blur-2 absolute inset-0 flex items-center justify-center rounded-lg bg-white/80 opacity-0 transition-all duration-300 group-hover:opacity-100">
+                      <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-white/80 opacity-0 transition-all duration-300 group-hover:opacity-100 group-hover:backdrop-blur-2">
                         <div className="flex items-center gap-1 text-orange-500 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
                           <DownloadIcon />
                           <span className="text-sm font-semibold">

--- a/portal/components/connectWallets/walletQRCodeView.tsx
+++ b/portal/components/connectWallets/walletQRCodeView.tsx
@@ -119,7 +119,7 @@ export function WalletQRCodeView({ onBack, wallet }: Props) {
         </div>
       </div>
       <div className="flex h-full flex-col items-center justify-center gap-3 py-3.5">
-        <div className="shadow-bs hidden size-full items-center justify-center rounded-md bg-neutral-50/80 md:flex">
+        <div className="hidden size-full items-center justify-center rounded-md bg-neutral-50/80 shadow-bs md:flex">
           {uri ? (
             <QRCodeSVG size={240} value={uri} />
           ) : (

--- a/portal/components/connectedWallet/connectedAccount.tsx
+++ b/portal/components/connectedWallet/connectedAccount.tsx
@@ -107,10 +107,7 @@ const ConnectedWallet = function ({
   }
 
   return (
-    <div
-      className="group/connected-wallet relative flex h-8 items-center rounded-lg
-        py-2 text-sm font-medium text-neutral-950"
-    >
+    <div className="group/connected-wallet relative flex h-8 items-center rounded-lg py-2 text-sm font-medium text-neutral-950">
       <div className="flex items-center gap-3">
         <div className="relative size-8">
           <ProfileIcon />

--- a/portal/components/connectedWallet/wrongNetwork.tsx
+++ b/portal/components/connectedWallet/wrongNetwork.tsx
@@ -26,8 +26,7 @@ export const WrongNetwork = function ({
 
   return (
     <button
-      className="group/wrong-network flex items-center gap-x-2 bg-transparent p-2 text-sm font-medium
-        text-rose-600 duration-150 hover:scale-105 hover:text-rose-700"
+      className="group/wrong-network flex items-center gap-x-2 bg-transparent p-2 text-sm font-medium text-rose-600 duration-150 hover:scale-105 hover:text-rose-700"
       onClick={onClick}
     >
       <span>{t('wrong-type-network', { type })}</span>

--- a/portal/components/customTokenDrawer/acknowledge.tsx
+++ b/portal/components/customTokenDrawer/acknowledge.tsx
@@ -16,8 +16,7 @@ export const Acknowledge = function ({ acknowledged, onChange }: Props) {
     >
       <input
         checked={acknowledged}
-        className="checkbox h-4 w-4 cursor-pointer appearance-none rounded bg-white shadow-sm
-              transition-all checked:bg-orange-600 focus:ring-2 focus:ring-orange-600"
+        className="checkbox h-4 w-4 cursor-pointer appearance-none rounded bg-white shadow-sm transition-all checked:bg-orange-600 focus:ring-2 focus:ring-orange-600"
         id="custom-token-acknowledged"
         onChange={e => onChange(e.target.checked)}
         type="checkbox"

--- a/portal/components/customTokenDrawer/positionStatus.tsx
+++ b/portal/components/customTokenDrawer/positionStatus.tsx
@@ -3,10 +3,7 @@ type Props = {
 }
 
 export const PositionStatus = ({ position }: Props) => (
-  <div
-    className="flex aspect-square h-5 items-center justify-center rounded-full 
-    bg-neutral-300/55 text-neutral-500"
-  >
+  <div className="flex aspect-square h-5 items-center justify-center rounded-full bg-neutral-300/55 text-neutral-500">
     <span className="flex-shrink-0 flex-grow-0 text-center text-sm lining-nums tabular-nums">
       {position}
     </span>

--- a/portal/components/customTokenDrawer/tokenSection.tsx
+++ b/portal/components/customTokenDrawer/tokenSection.tsx
@@ -87,7 +87,7 @@ export const TokenSection = function ({
             {t('layer-token-address', { layer })}
           </DrawerParagraph>
         </div>
-        <div className="left-2.25 relative top-0.5">
+        <div className="relative left-2.25 top-0.5">
           <ShortVerticalLine stroke="stroke-neutral-300/55" />
         </div>
         <div className="mt-1 flex gap-x-3">

--- a/portal/components/customTokenLogo.tsx
+++ b/portal/components/customTokenLogo.tsx
@@ -21,8 +21,7 @@ type Props = {
 export const CustomTokenLogo = ({ size, token }: Props) => (
   <>
     <div
-      className={`flex items-center justify-center rounded-full ${sizes[size]} overflow-hidden text-ellipsis whitespace-nowrap
-      border border-solid border-white bg-neutral-50 font-semibold text-neutral-700`}
+      className={`flex items-center justify-center rounded-full ${sizes[size]} overflow-hidden text-ellipsis whitespace-nowrap border border-solid border-white bg-neutral-50 font-semibold text-neutral-700`}
     >
       {token.symbol}
     </div>

--- a/portal/components/customTunnelsThroughPartners/partnerLink.tsx
+++ b/portal/components/customTunnelsThroughPartners/partnerLink.tsx
@@ -18,8 +18,7 @@ export const PartnerLink = function ({
   const { enabled, track } = useUmami()
   return (
     <ExternalLink
-      className="group/link flex w-full items-center gap-x-1 rounded-xl bg-white p-3
-        text-base font-medium text-neutral-950 shadow-sm transition-all duration-200 hover:bg-neutral-50 hover:shadow-md"
+      className="group/link flex w-full items-center gap-x-1 rounded-xl bg-white p-3 text-base font-medium text-neutral-950 shadow-sm transition-all duration-200 hover:bg-neutral-50 hover:shadow-md"
       href={url}
       onClick={enabled ? () => track('partner bridge', { partner }) : undefined}
     >

--- a/portal/components/drawer/drawer.css
+++ b/portal/components/drawer/drawer.css
@@ -43,7 +43,7 @@
   }
 
   .drawer-content {
-    @apply md:w-drawer flex min-h-0 w-full flex-col bg-white pb-14 pt-6 sm:pb-0;
+    @apply flex min-h-0 w-full flex-col bg-white pb-14 pt-6 sm:pb-0 md:w-drawer;
   }
 
   /* Use the .skip-parent-padding-x for elements that should not have the px-* applied. For example, components

--- a/portal/components/error500/index.tsx
+++ b/portal/components/error500/index.tsx
@@ -36,7 +36,7 @@ export const Error500 = function ({
     <div className="flex h-full">
       <Image
         alt="hemi 500 error background"
-        className="-top-15 absolute inset-0 -z-10 m-auto w-4/5"
+        className="absolute inset-0 -top-15 -z-10 m-auto w-4/5"
         src={svg500Error}
       />
       <div className="m-auto flex flex-col items-center gap-4">

--- a/portal/components/modal.tsx
+++ b/portal/components/modal.tsx
@@ -44,7 +44,7 @@ export const Modal = function ({
       <OverlayComponent />
       <dialog
         className={`pointer-event-auto fixed inset-0 z-50 flex min-h-screen justify-center overflow-y-auto overflow-x-hidden rounded-2xl bg-transparent shadow-xl outline-none focus:outline-none md:min-h-0 ${
-          verticalAlign === 'top' ? 'pt-13 m-0 items-start' : 'items-center'
+          verticalAlign === 'top' ? 'm-0 items-start pt-13' : 'items-center'
         }`}
         onTouchStart={e => e.stopPropagation()}
       >

--- a/portal/components/reviewOperation/box.tsx
+++ b/portal/components/reviewOperation/box.tsx
@@ -22,10 +22,7 @@ export const TwoRowBox = ({
   <div className={`relative z-0 flex w-full flex-col ${bottom ? '-mb-3' : ''}`}>
     <div className={`${commonCss} z-10 justify-between bg-white`}>{top}</div>
     {bottom && (
-      <div
-        className="pt-4.5 relative flex h-[50px] w-full -translate-y-2 items-center gap-x-1
-  rounded-b-lg border border-solid border-neutral-300/55 bg-neutral-100 px-4 pb-2.5"
-      >
+      <div className="relative flex h-[50px] w-full -translate-y-2 items-center gap-x-1 rounded-b-lg border border-solid border-neutral-300/55 bg-neutral-100 px-4 pb-2.5 pt-4.5">
         {bottom}
       </div>
     )}

--- a/portal/components/reviewOperation/callToActionContainer.tsx
+++ b/portal/components/reviewOperation/callToActionContainer.tsx
@@ -5,10 +5,7 @@ export const CallToActionContainer = ({
 }: {
   children: ReactNode
 }) => (
-  <div
-    className="mt-auto flex w-full flex-col items-end
-      border-t border-solid border-neutral-300/55 bg-neutral-50 p-6"
-  >
+  <div className="mt-auto flex w-full flex-col items-end border-t border-solid border-neutral-300/55 bg-neutral-50 p-6">
     {children}
   </div>
 )

--- a/portal/components/reviewOperation/operation.tsx
+++ b/portal/components/reviewOperation/operation.tsx
@@ -26,7 +26,7 @@ export const Operation = ({
   token,
 }: Props) => (
   <>
-    <div className="min-h-21 mb-3 flex flex-col gap-y-3">
+    <div className="mb-3 flex min-h-21 flex-col gap-y-3">
       <DrawerTopSection heading={heading} onClose={onClose} />
       <DrawerParagraph>{subheading}</DrawerParagraph>
     </div>

--- a/portal/components/reviewOperation/step.tsx
+++ b/portal/components/reviewOperation/step.tsx
@@ -59,7 +59,7 @@ const Completed = function ({
   const t = useTranslations('common.transaction-status')
   return (
     <>
-      <div className="left-2.25 absolute top-0.5">
+      <div className="absolute left-2.25 top-0.5">
         <ShortVerticalLine dashed={false} stroke="stroke-orange-600" />
       </div>
       <div className="mt-4">
@@ -79,7 +79,7 @@ const Completed = function ({
         top={<span className="mr-auto text-neutral-600">{description}</span>}
       />
       {!!postAction && (
-        <div className="left-2.25 absolute bottom-6">
+        <div className="absolute bottom-6 left-2.25">
           <LongVerticalLine dashed={false} stroke="stroke-orange-600" />
         </div>
       )}
@@ -89,7 +89,7 @@ const Completed = function ({
 
 const NotReady = ({ description, position, postAction }: Props) => (
   <>
-    <div className="left-2.25 absolute top-0.5">
+    <div className="absolute left-2.25 top-0.5">
       <ShortVerticalLine stroke="stroke-neutral-300/55" />
     </div>
     <div className="mt-4">
@@ -99,7 +99,7 @@ const NotReady = ({ description, position, postAction }: Props) => (
       <span className="text-neutral-600">{description}</span>
     </OneRowBox>
     {!!postAction && (
-      <div className="left-2.25 absolute bottom-6">
+      <div className="absolute bottom-6 left-2.25">
         <ShortVerticalLine stroke="stroke-neutral-300/55" />
       </div>
     )}
@@ -117,7 +117,7 @@ const Progress = function ({
   const t = useTranslations('common.transaction-status')
   return (
     <>
-      <div className="left-2.25 absolute top-0.5">
+      <div className="absolute left-2.25 top-0.5">
         <ShortVerticalLine dashed={false} stroke="stroke-orange-600" />
       </div>
       <div className="mt-4">
@@ -140,7 +140,7 @@ const Progress = function ({
         }
       />
       {!!postAction && (
-        <div className="left-2.25 absolute bottom-6">
+        <div className="absolute bottom-6 left-2.25">
           <LongVerticalLine stroke="stroke-neutral-300/55" />
         </div>
       )}
@@ -150,7 +150,7 @@ const Progress = function ({
 
 const Ready = ({ description, fees, position, postAction }: Props) => (
   <>
-    <div className="left-2.25 absolute top-0.5">
+    <div className="absolute left-2.25 top-0.5">
       <ShortVerticalLine dashed={false} stroke="stroke-orange-600" />
     </div>
     <div className="mt-4">
@@ -161,7 +161,7 @@ const Ready = ({ description, fees, position, postAction }: Props) => (
       {fees && <Fees {...fees} />}
     </OneRowBox>
     {!!postAction && (
-      <div className="left-2.25 absolute bottom-6">
+      <div className="absolute bottom-6 left-2.25">
         <ShortVerticalLine stroke="stroke-neutral-300/55" />
       </div>
     )}
@@ -179,7 +179,7 @@ const Failed = function ({
   const t = useTranslations('common.transaction-status')
   return (
     <>
-      <div className="left-2.25 absolute top-0.5">
+      <div className="absolute left-2.25 top-0.5">
         <ShortVerticalLine dashed={false} stroke="stroke-rose-500" />
       </div>
       <div className="mt-4">
@@ -204,7 +204,7 @@ const Failed = function ({
         }
       />
       {!!postAction && (
-        <div className="left-2.25 absolute bottom-6">
+        <div className="absolute bottom-6 left-2.25">
           <ShortVerticalLine stroke="stroke-neutral-300/55" />
         </div>
       )}
@@ -216,7 +216,7 @@ const Rejected = function ({ description, fees, position, postAction }: Props) {
   const t = useTranslations('common.transaction-status')
   return (
     <>
-      <div className="left-2.25 absolute top-0.5">
+      <div className="absolute left-2.25 top-0.5">
         <ShortVerticalLine dashed={false} stroke="stroke-orange-600" />
       </div>
       <div className="mt-4">
@@ -232,7 +232,7 @@ const Rejected = function ({ description, fees, position, postAction }: Props) {
         }
       />
       {!!postAction && (
-        <div className="left-2.25 absolute bottom-6">
+        <div className="absolute bottom-6 left-2.25">
           <ShortVerticalLine stroke="stroke-neutral-300/55" />
         </div>
       )}

--- a/portal/components/subLogoTooltip.tsx
+++ b/portal/components/subLogoTooltip.tsx
@@ -39,8 +39,7 @@ export function SubLogoTooltip({
       {tooltipText ? (
         <span
           aria-hidden
-          className="absolute bottom-0 right-0 z-10 inline-flex translate-x-1/2 translate-y-1/2 items-center justify-center
-            rounded-full border-[1.6px] border-solid border-white bg-white"
+          className="absolute bottom-0 right-0 z-10 inline-flex translate-x-1/2 translate-y-1/2 items-center justify-center rounded-full border-[1.6px] border-solid border-white bg-white"
         >
           {icon ?? (
             <SubLogoInfoIcon className="size-3 text-neutral-500 transition-colors duration-200 group-hover/sub-logo:text-neutral-900 group-focus-visible/sub-logo:text-neutral-900" />

--- a/portal/components/tabs.tsx
+++ b/portal/components/tabs.tsx
@@ -31,14 +31,11 @@ export const Tab = function ({
   const isLink = tabIsLink(props)
   return (
     <li
-      className={`
-        flex flex-1 items-center *:w-full md:flex-auto
-      ${
+      className={`flex flex-1 items-center *:w-full md:flex-auto ${
         selected
           ? '*:duration-600 before:*:duration-600 *:cursor-default *:bg-white *:transition-colors before:*:bg-white before:*:transition-colors hover:before:*:bg-white'
           : '*:duration-600 before:*:duration-600 *:bg-neutral-100 *:text-neutral-700 *:shadow-none *:transition-colors before:*:bg-neutral-100 before:*:transition-colors hover:*:text-neutral-950'
-      }
-    `}
+      } `}
     >
       {(!isLink || disabled) && (
         <Button

--- a/portal/components/toast/index.tsx
+++ b/portal/components/toast/index.tsx
@@ -70,11 +70,7 @@ export const Toast = function ({
   // ancestor in the app layout would create a subordinate stacking context
   // and trap the toast behind any open drawer regardless of z-index.
   return ReactDOM.createPortal(
-    <div
-      className="border-black/88 shadow-soft fixed inset-x-4 bottom-20 z-40 flex items-center gap-3 rounded-xl
-      border bg-neutral-800 p-3.5 pb-4 text-white
-      md:bottom-auto md:left-auto md:right-8 md:top-20"
-    >
+    <div className="fixed inset-x-4 bottom-20 z-40 flex items-center gap-3 rounded-xl border border-black/88 bg-neutral-800 p-3.5 pb-4 text-white shadow-soft md:bottom-auto md:left-auto md:right-8 md:top-20">
       <div className="shrink-0">
         {variant !== undefined ? (
           <ToastIcon variant={variant} />

--- a/portal/components/tokenInput/index.tsx
+++ b/portal/components/tokenInput/index.tsx
@@ -74,27 +74,22 @@ export const TokenInput = function <T extends Token>({
   const BalanceComponent = balanceComponent ?? Balance
   const FiatBalanceComponent = fiatBalanceComponent ?? RenderFiatBalance
   return (
-    <div
-      className="hover:shadow-bs h-[124px] rounded-lg border border-solid border-transparent bg-neutral-50
-      p-4 font-medium text-neutral-500"
-    >
+    <div className="h-[124px] rounded-lg border border-solid border-transparent bg-neutral-50 p-4 font-medium text-neutral-500 hover:shadow-bs">
       <div className="flex h-full items-center justify-between">
         <div className="flex h-full flex-shrink flex-grow flex-col items-start">
           <span className="text-sm">{label}</span>
           <input
-            className={`
-            max-w-1/2 my-2 w-full bg-transparent text-4xl ${getTextColor(
+            className={`max-w-1/2 my-2 w-full bg-transparent text-4xl ${getTextColor(
               value,
               errorKey,
-            )}
-            outline-none`}
+            )} outline-none`}
             disabled={disabled}
             onChange={e => onChange(e.target.value)}
             type="text"
             value={value}
           />
           {showFiatBalance && (
-            <div className="flex items-center text-sm  text-neutral-500">
+            <div className="flex items-center text-sm text-neutral-500">
               <span className="mr-1">$</span>
               {fiatBalance ? (
                 <FiatBalanceComponent

--- a/portal/components/tokenSelector/index.tsx
+++ b/portal/components/tokenSelector/index.tsx
@@ -68,8 +68,7 @@ export const TokenSelector = function ({
   return (
     <>
       <button
-        className="shadow-soft group/token-selector flex h-8 w-40 items-center gap-x-1.5 rounded-lg border
-        border-solid border-neutral-300/55 bg-white px-3 py-1.5 text-sm font-medium transition-colors duration-200 hover:bg-neutral-50"
+        className="group/token-selector flex h-8 w-40 items-center gap-x-1.5 rounded-lg border border-solid border-neutral-300/55 bg-white px-3 py-1.5 text-sm font-medium shadow-soft transition-colors duration-200 hover:bg-neutral-50"
         disabled={disabled || tokens.length < 2}
         onClick={openModal}
         type="button"

--- a/portal/components/tokenSelector/token.tsx
+++ b/portal/components/tokenSelector/token.tsx
@@ -20,7 +20,7 @@ export const CustomToken = ({ token }: { token: TokenType | undefined }) => (
     </div>
     <div className="flex w-full flex-col">
       <div className="flex items-center justify-between">
-        {token ? <span>{token.name}</span> : <Skeleton className="w-26 h-4" />}
+        {token ? <span>{token.name}</span> : <Skeleton className="h-4 w-26" />}
       </div>
       <div className="flex items-center justify-between">
         {token ? (

--- a/portal/utils/sync-history/bitcoin.ts
+++ b/portal/utils/sync-history/bitcoin.ts
@@ -330,14 +330,15 @@ export const createBitcoinSync = function ({
           ...localDepositSyncInfo,
           fromKnownTx: hasVaultSyncToMinTx
             ? undefined
-            : localDepositSyncInfo.fromKnownTx ??
-              unprocessedTransactions[0].txId,
+            : (localDepositSyncInfo.fromKnownTx ??
+              unprocessedTransactions[0].txId),
           hasSyncToMinTx,
           // Track which vault we're currently processing - store the vault index (ID), not array position
           iterationVault: hasSyncToMinTx ? undefined : vaultIndex,
           // Once we sync up to the oldest transaction, next time we will only sync up to this point
           toKnownTx: hasVaultSyncToMinTx
-            ? localDepositSyncInfo.fromKnownTx ?? localDepositSyncInfo.toKnownTx
+            ? (localDepositSyncInfo.fromKnownTx ??
+              localDepositSyncInfo.toKnownTx)
             : localDepositSyncInfo.toKnownTx,
           // store it in case we need to restart the sync from a specific point, otherwise undefined
           txPivot: hasVaultSyncToMinTx ? undefined : batchPivotTx,
@@ -358,7 +359,7 @@ export const createBitcoinSync = function ({
         // Reset pivotTxId for each new vault - only use saved pivot if we're continuing the same vault
         pivotTxId:
           localDepositSyncInfo.iterationVault === vaultIndex
-            ? depositsSyncInfo.txPivot ?? depositsSyncInfo.fromKnownTx
+            ? (depositsSyncInfo.txPivot ?? depositsSyncInfo.fromKnownTx)
             : undefined,
         processTransactions,
         // caller of this function checks transactions is .length > 0, so there will always be a last option


### PR DESCRIPTION
### Description

Upgrade `prettier` 3.1.1 → 3.8.4 and `prettier-plugin-tailwindcss` 0.5.9 → 0.8.0, then run the formatter across the `portal` package. All other file changes are purely mechanical: Tailwind class reordering, multi-line `@apply`/`className` collapsing, and explicit parens around `??` chains used inside ternaries. No runtime behavior changes.

### Screenshots

N/A — no UI or behavior changes.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.