### PR TITLE
Add explainer banners above earn settle CTAs

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -251,8 +251,8 @@ export const HistoricalDepositReview = function ({
 
   return (
     <Operation
+      aboveCallToAction={<SettleBanner transaction={transaction} />}
       amount={transaction.amountIn}
-      bottomSection={<SettleBanner transaction={transaction} />}
       callToAction={callToAction}
       heading={t('deposit-heading')}
       onClose={onClose}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -28,6 +28,8 @@ import {
   type EarnTransactionStatusType,
 } from '../../../types'
 
+import { SettleBanner } from './settleShared'
+
 type Props = {
   callToAction?: ReactNode
   onClose: VoidFunction
@@ -250,6 +252,7 @@ export const HistoricalDepositReview = function ({
   return (
     <Operation
       amount={transaction.amountIn}
+      bottomSection={<SettleBanner transaction={transaction} />}
       callToAction={callToAction}
       heading={t('deposit-heading')}
       onClose={onClose}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -35,6 +35,8 @@ import {
   type EarnTransactionStatusType,
 } from '../../../types'
 
+import { SettleBanner } from './settleShared'
+
 type Props = {
   callToAction?: ReactNode
   onClose: VoidFunction
@@ -384,6 +386,7 @@ export const HistoricalWithdrawReview = function ({
   return (
     <Operation
       amount={displayAmount}
+      bottomSection={<SettleBanner transaction={transaction} />}
       callToAction={callToAction}
       heading={t('withdraw-heading')}
       onClose={onClose}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -385,8 +385,8 @@ export const HistoricalWithdrawReview = function ({
 
   return (
     <Operation
+      aboveCallToAction={<SettleBanner transaction={transaction} />}
       amount={displayAmount}
-      bottomSection={<SettleBanner transaction={transaction} />}
       callToAction={callToAction}
       heading={t('withdraw-heading')}
       onClose={onClose}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
@@ -3,6 +3,7 @@
 import { AddTokenToWallet } from 'components/addTokenToWallet'
 import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
+import { WarningBox } from 'components/warningBox'
 import {
   claimDeposit,
   claimRedeem,
@@ -20,6 +21,7 @@ import {
   findPoolByAsset,
   needsManualClaim,
   needsRecover,
+  pickSettleBannerKey,
 } from '../../../_utils'
 import {
   type EarnAsset,
@@ -192,6 +194,31 @@ export const SettleRowCta = function ({
     )
   }
   return null
+}
+
+// Explains the manual Claim/Recover CTA — shown above the CTA inside the drawers.
+// Self-gates via `pickSettleBannerKey`, so nothing renders for the retry-original
+// / add-to-wallet / in-flight states. Uses its own translation namespace so it's
+// reusable across drawers that translate under different roots (`pool.drawer` vs
+// `transactions.drawer`).
+export const SettleBanner = function ({
+  transaction,
+}: {
+  transaction: EarnTransaction | undefined
+}) {
+  const t = useTranslations('hemi-earn.transactions.banner')
+  const key = pickSettleBannerKey(transaction)
+  if (!key) return null
+  // `mt-auto` pins the banner to the bottom of the scrollable body, just above
+  // the CTA footer; the padding matches the drawer's 24px gutter (16px mobile).
+  return (
+    <div className="mt-auto px-4 py-6 md:px-6">
+      <WarningBox
+        heading={t(`${key}.heading`)}
+        subheading={t(`${key}.subheading`)}
+      />
+    </div>
+  )
 }
 
 // "Add {token} to wallet" CTA surfaced once a request is FINALIZED (the delivered

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
@@ -209,10 +209,11 @@ export const SettleBanner = function ({
   const t = useTranslations('hemi-earn.transactions.banner')
   const key = pickSettleBannerKey(transaction)
   if (!key) return null
-  // `mt-auto` pins the banner to the bottom of the scrollable body, just above
-  // the CTA footer; the padding matches the drawer's 24px gutter (16px mobile).
+  // Rendered in the drawer's `aboveCallToAction` slot (outside the scroll area)
+  // so it stays pinned above the CTA regardless of step count. The padding
+  // matches the drawer's 24px gutter (16px on mobile).
   return (
-    <div className="mt-auto px-4 py-6 md:px-6">
+    <div className="px-4 py-6 md:px-6">
       <WarningBox
         heading={t(`${key}.heading`)}
         subheading={t(`${key}.subheading`)}

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -101,10 +101,10 @@ export const hasFailedSettlement = (tx: EarnTransaction) =>
   tx.settlement?.failed === true
 
 // Which explanatory banner (if any) a drawer should show above the settle CTA —
-// undefined unless the row is awaiting a manual claim (FULFILLED) or recover
-// (CANCELLED). The shares/funds split follows the same delivered-token inversion
-// as `SettleCta`: a deposit claim / redeem recover act on shares; a deposit
-// recover / redeem claim act on the underlying asset (funds).
+// undefined unless the row is awaiting an *untouched* manual claim (FULFILLED) or
+// recover (CANCELLED). The shares/funds split follows the same delivered-token
+// inversion as `SettleCta`: a deposit claim / redeem recover act on shares; a
+// deposit recover / redeem claim act on the underlying asset (funds).
 export const pickSettleBannerKey = function (
   tx: EarnTransaction | undefined,
 ):
@@ -114,6 +114,10 @@ export const pickSettleBannerKey = function (
   | 'recover-shares'
   | undefined {
   if (!tx) return undefined
+  // A settlement marker means the user already signed (the CTA now reads
+  // "Claiming…") or it reverted ("Try again"); the banner's "Click on 'Claim …'"
+  // copy would contradict the button, so drop it once they've engaged.
+  if (tx.settlement) return undefined
   const operation = needsManualClaim(tx)
     ? 'CLAIM'
     : needsRecover(tx)

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -100,6 +100,33 @@ export const canRetryRow = (tx: EarnTransaction) =>
 export const hasFailedSettlement = (tx: EarnTransaction) =>
   tx.settlement?.failed === true
 
+// Which explanatory banner (if any) a drawer should show above the settle CTA —
+// undefined unless the row is awaiting a manual claim (FULFILLED) or recover
+// (CANCELLED). The shares/funds split follows the same delivered-token inversion
+// as `SettleCta`: a deposit claim / redeem recover act on shares; a deposit
+// recover / redeem claim act on the underlying asset (funds).
+export const pickSettleBannerKey = function (
+  tx: EarnTransaction | undefined,
+):
+  | 'claim-funds'
+  | 'claim-shares'
+  | 'recover-funds'
+  | 'recover-shares'
+  | undefined {
+  if (!tx) return undefined
+  const operation = needsManualClaim(tx)
+    ? 'CLAIM'
+    : needsRecover(tx)
+      ? 'RECOVER'
+      : undefined
+  if (!operation) return undefined
+  const deliversShares = (tx.kind === 'DEPOSIT') === (operation === 'CLAIM')
+  if (operation === 'CLAIM') {
+    return deliversShares ? 'claim-shares' : 'claim-funds'
+  }
+  return deliversShares ? 'recover-shares' : 'recover-funds'
+}
+
 // Picks the amount + token to render for an earn transaction row. A DEPOSIT
 // always shows the deposited asset (`amountIn`, asset units) — its `amountOut`
 // is the minted share amount (sVetToken, 18 decimals) and must never be rendered

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -20,6 +20,7 @@ import { useAccount, useEstimateGas } from 'wagmi'
 
 import {
   AddTokenToWalletCta,
+  SettleBanner,
   SettleCta,
 } from '../../../../_components/transactionsSection/transactionDrawer/settleShared'
 import {
@@ -393,6 +394,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
   return (
     <Operation
       amount={depositOperation?.amountIn ?? amount.toString()}
+      bottomSection={<SettleBanner transaction={settledRow} />}
       callToAction={getCallToAction()}
       heading={t('deposit.heading')}
       onClose={onClose}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -393,8 +393,8 @@ export const ReviewDeposit = function ({ onClose }: Props) {
 
   return (
     <Operation
+      aboveCallToAction={<SettleBanner transaction={settledRow} />}
       amount={depositOperation?.amountIn ?? amount.toString()}
-      bottomSection={<SettleBanner transaction={settledRow} />}
       callToAction={getCallToAction()}
       heading={t('deposit.heading')}
       onClose={onClose}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -22,6 +22,7 @@ import { useAccount, useEstimateGas } from 'wagmi'
 
 import {
   AddTokenToWalletCta,
+  SettleBanner,
   SettleCta,
 } from '../../../../_components/transactionsSection/transactionDrawer/settleShared'
 import {
@@ -485,6 +486,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
   return (
     <Operation
       amount={withdrawOperation?.amountIn ?? shares.toString()}
+      bottomSection={<SettleBanner transaction={settledRow} />}
       callToAction={getCallToAction()}
       heading={t('withdraw.heading')}
       onClose={onClose}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -485,8 +485,8 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
 
   return (
     <Operation
+      aboveCallToAction={<SettleBanner transaction={settledRow} />}
       amount={withdrawOperation?.amountIn ?? shares.toString()}
-      bottomSection={<SettleBanner transaction={settledRow} />}
       callToAction={getCallToAction()}
       heading={t('withdraw.heading')}
       onClose={onClose}

--- a/portal/components/reviewOperation/index.tsx
+++ b/portal/components/reviewOperation/index.tsx
@@ -5,6 +5,7 @@ import { CallToActionContainer } from './callToActionContainer'
 import { Step, type StepPropsWithoutPosition } from './step'
 
 type Props = {
+  aboveCallToAction?: ReactNode
   amount: ReactNode
   bottomSection?: ReactNode
   callToAction?: ReactNode
@@ -12,6 +13,7 @@ type Props = {
 }
 
 export const ReviewOperation = ({
+  aboveCallToAction,
   amount,
   bottomSection,
   callToAction,
@@ -35,6 +37,7 @@ export const ReviewOperation = ({
       </DrawerSection>
       {bottomSection}
     </div>
+    {aboveCallToAction}
     {!!callToAction && (
       <CallToActionContainer>{callToAction}</CallToActionContainer>
     )}

--- a/portal/components/reviewOperation/operation.tsx
+++ b/portal/components/reviewOperation/operation.tsx
@@ -5,6 +5,7 @@ import { type StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { ComponentProps, ReactNode } from 'react'
 
 type Props = {
+  aboveCallToAction?: ReactNode
   callToAction?: ReactNode
   bottomSection?: ReactNode
   steps: StepPropsWithoutPosition[]
@@ -16,6 +17,7 @@ type Props = {
   }
 
 export const Operation = ({
+  aboveCallToAction,
   amount,
   bottomSection,
   callToAction,
@@ -31,6 +33,7 @@ export const Operation = ({
       <DrawerParagraph>{subheading}</DrawerParagraph>
     </div>
     <ReviewOperation
+      aboveCallToAction={aboveCallToAction}
       amount={<Amount token={token} value={amount} />}
       bottomSection={bottomSection}
       callToAction={callToAction}

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -82,6 +82,24 @@
       "total-deposits": "Total deposits"
     },
     "transactions": {
+      "banner": {
+        "claim-funds": {
+          "heading": "We couldn't claim your funds automatically",
+          "subheading": "Click on 'Claim Funds' to get your funds."
+        },
+        "claim-shares": {
+          "heading": "We couldn't claim your share tokens automatically",
+          "subheading": "Click on 'Claim Share Tokens' to get your tokens."
+        },
+        "recover-funds": {
+          "heading": "Transaction failed",
+          "subheading": "Something went wrong. Use the button below to return your funds to your wallet."
+        },
+        "recover-shares": {
+          "heading": "Transaction failed",
+          "subheading": "Something went wrong. Use the button below to return your shares to your wallet."
+        }
+      },
       "claim-funds": "Claim funds",
       "claim-share-tokens": "Claim share tokens",
       "claiming": "Claiming...",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -85,11 +85,11 @@
       "banner": {
         "claim-funds": {
           "heading": "We couldn't claim your funds automatically",
-          "subheading": "Click on 'Claim Funds' to get your funds."
+          "subheading": "Click on 'Claim funds' to get your funds."
         },
         "claim-shares": {
           "heading": "We couldn't claim your share tokens automatically",
-          "subheading": "Click on 'Claim Share Tokens' to get your tokens."
+          "subheading": "Click on 'Claim share tokens' to get your tokens."
         },
         "recover-funds": {
           "heading": "Transaction failed",
@@ -97,7 +97,7 @@
         },
         "recover-shares": {
           "heading": "Transaction failed",
-          "subheading": "Something went wrong. Use the button below to return your shares to your wallet."
+          "subheading": "Something went wrong. Use the button below to return your share tokens to your wallet."
         }
       },
       "claim-funds": "Claim funds",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -84,20 +84,20 @@
     "transactions": {
       "banner": {
         "claim-funds": {
-          "heading": "No pudimos recibir tus fondos automáticamente",
-          "subheading": "Haz clic en 'Recibir fondos' para recibir tus fondos."
+          "heading": "No pudimos recibir sus fondos automáticamente",
+          "subheading": "Haga clic en 'Recibir fondos' para recibir sus fondos."
         },
         "claim-shares": {
-          "heading": "No pudimos recibir tus share tokens automáticamente",
-          "subheading": "Haz clic en 'Recibir share tokens' para recibir tus tokens."
+          "heading": "No pudimos recibir sus share tokens automáticamente",
+          "subheading": "Haga clic en 'Recibir share tokens' para recibir sus tokens."
         },
         "recover-funds": {
           "heading": "La transacción falló",
-          "subheading": "Algo salió mal. Usa el botón de abajo para devolver tus fondos a tu billetera."
+          "subheading": "Algo salió mal. Use el botón de abajo para devolver sus fondos a su billetera."
         },
         "recover-shares": {
           "heading": "La transacción falló",
-          "subheading": "Algo salió mal. Usa el botón de abajo para devolver tus shares a tu billetera."
+          "subheading": "Algo salió mal. Use el botón de abajo para devolver sus share tokens a su billetera."
         }
       },
       "claim-funds": "Recibir fondos",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -82,6 +82,24 @@
       "total-deposits": "Depósitos totales"
     },
     "transactions": {
+      "banner": {
+        "claim-funds": {
+          "heading": "No pudimos recibir tus fondos automáticamente",
+          "subheading": "Haz clic en 'Recibir fondos' para recibir tus fondos."
+        },
+        "claim-shares": {
+          "heading": "No pudimos recibir tus share tokens automáticamente",
+          "subheading": "Haz clic en 'Recibir share tokens' para recibir tus tokens."
+        },
+        "recover-funds": {
+          "heading": "La transacción falló",
+          "subheading": "Algo salió mal. Usa el botón de abajo para devolver tus fondos a tu billetera."
+        },
+        "recover-shares": {
+          "heading": "La transacción falló",
+          "subheading": "Algo salió mal. Usa el botón de abajo para devolver tus shares a tu billetera."
+        }
+      },
       "claim-funds": "Recibir fondos",
       "claim-share-tokens": "Recibir share tokens",
       "claiming": "Recibiendo...",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -97,7 +97,7 @@
         },
         "recover-shares": {
           "heading": "Transação falhou",
-          "subheading": "Algo deu errado. Use o botão abaixo para devolver suas shares à sua carteira."
+          "subheading": "Algo deu errado. Use o botão abaixo para devolver seus share tokens à sua carteira."
         }
       },
       "claim-funds": "Receber fundos",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -82,6 +82,24 @@
       "total-deposits": "Depósitos totais"
     },
     "transactions": {
+      "banner": {
+        "claim-funds": {
+          "heading": "Não foi possível receber seus fundos automaticamente",
+          "subheading": "Clique em 'Receber fundos' para receber seus fundos."
+        },
+        "claim-shares": {
+          "heading": "Não foi possível receber seus share tokens automaticamente",
+          "subheading": "Clique em 'Receber share tokens' para receber seus tokens."
+        },
+        "recover-funds": {
+          "heading": "Transação falhou",
+          "subheading": "Algo deu errado. Use o botão abaixo para devolver seus fundos à sua carteira."
+        },
+        "recover-shares": {
+          "heading": "Transação falhou",
+          "subheading": "Algo deu errado. Use o botão abaixo para devolver suas shares à sua carteira."
+        }
+      },
       "claim-funds": "Receber fundos",
       "claim-share-tokens": "Receber share tokens",
       "claiming": "Recebendo...",

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -19,6 +19,7 @@ import {
   needsManualClaim,
   needsRecover,
   pickEarnRowAmount,
+  pickSettleBannerKey,
   resolveSettleStepStatus,
 } from '../../../../../app/[locale]/hemi-earn/_utils'
 import {
@@ -610,6 +611,31 @@ describe('utils', function () {
         resolveSettleStepStatus({ ...base, fallback: ProgressStatus.PROGRESS }),
       ).toBe(ProgressStatus.PROGRESS)
       expect(resolveSettleStepStatus(base)).toBe(ProgressStatus.NOT_READY)
+    })
+  })
+
+  describe('pickSettleBannerKey', function () {
+    it.each<[EarnTransaction['kind'], EarnTransactionStatusType, string]>([
+      ['DEPOSIT', 'FULFILLED', 'claim-shares'],
+      ['REDEEM', 'FULFILLED', 'claim-funds'],
+      ['DEPOSIT', 'CANCELLED', 'recover-funds'],
+      ['REDEEM', 'CANCELLED', 'recover-shares'],
+    ])('%s %s → %s', function (kind, status, expected) {
+      expect(pickSettleBannerKey({ ...baseTx, kind, status })).toBe(expected)
+    })
+
+    it.each<EarnTransactionStatusType>([
+      'PENDING',
+      'TX_PENDING',
+      'FINALIZED',
+      'RECOVERED',
+      'FAILED',
+    ])('returns undefined for the non-actionable status %s', function (status) {
+      expect(pickSettleBannerKey({ ...baseTx, status })).toBeUndefined()
+    })
+
+    it('returns undefined for an undefined row', function () {
+      expect(pickSettleBannerKey(undefined)).toBeUndefined()
     })
   })
 })

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -637,5 +637,25 @@ describe('utils', function () {
     it('returns undefined for an undefined row', function () {
       expect(pickSettleBannerKey(undefined)).toBeUndefined()
     })
+
+    it('returns undefined while a claim/recover is pending (settlement marker)', function () {
+      expect(
+        pickSettleBannerKey({
+          ...baseTx,
+          settlement: { failed: false, kind: 'CLAIM' },
+          status: 'FULFILLED',
+        }),
+      ).toBeUndefined()
+    })
+
+    it('returns undefined after a reverted settlement (try-again state)', function () {
+      expect(
+        pickSettleBannerKey({
+          ...baseTx,
+          settlement: { failed: true, kind: 'RECOVER' },
+          status: 'CANCELLED',
+        }),
+      ).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
### Description

This PR adds an explanatory banner above the manual Claim/Recover CTAs in the Hemi Earn drawers, so the user understands why they suddenly have to click a button — auto-settlement either failed or was opted out.

  Whenever a row is awaiting a manual claim (FULFILLED) or recover (CANCELLED), a WarningBox shows above the CTA: "We couldn't claim your … automatically" for claim, "Transaction failed … return your …" for recover. The wording follows the same delivered-token inversion as the CTA itself (a deposit claim / redeem recover act on shares; a deposit recover / redeem claim act on the underlying asset), so it reads right in every flow.

  The variant selection is a pure `pickSettleBannerKey` helper, unit-tested across the 2x2 matrix plus the no-banner states. The banner reuses the existing `WarningBox` and self-gates on the row status, so it only renders when a Claim/Recover CTA is actually present. It's wired into all four drawers (live + historical, deposit + withdraw) through the `Operation` `bottomSection` slot, pinned just above the CTA.

### Screenshots

#### Claim
<img width="503" height="400" alt="Captura de Tela 2026-06-24 às 17 54 09" src="https://github.com/user-attachments/assets/6160c81a-65e1-4f8c-98f8-0e166288bf14" />
<img width="487" height="309" alt="Captura de Tela 2026-06-24 às 18 04 18" src="https://github.com/user-attachments/assets/40075912-51cd-457d-bb23-9a1a24bed469" />



#### Recover

<img width="487" height="325" alt="Captura de Tela 2026-06-24 às 17 59 33" src="https://github.com/user-attachments/assets/ce4c324d-356e-4fa9-9dbe-262e665731fe" />

<img width="485" height="328" alt="Captura de Tela 2026-06-24 às 18 01 07" src="https://github.com/user-attachments/assets/bae00d34-9332-41b9-9a51-17414fd4dd92" />

### Related issue(s)

Related to #1848 
Related to #1977 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
