### PR TITLE
Add formal-tone rule for es/pt translations

### DIFF
--- a/.github/instructions/portal.md
+++ b/.github/instructions/portal.md
@@ -20,3 +20,13 @@ Furthermore, consider the [code structure](../../portal//README.md#structure), w
   - Ensure all three language files have the same keys with appropriate translations
   - Keys should be alphabetically sorted
 - The current supported languages are English (`en` - it is the default locale), Spanish (`es`) and Portuguese (`pt`).
+- **Translations must address the user with a formal, respectful register** (the same "you" the rest of the UI uses). Machine translation defaults to the informal register, so always review the tone of any string you add or edit:
+  - **Spanish (`es`)** — use the formal _usted_ form, never the informal _tú_:
+    - Possessives: `su` / `sus`, not `tu` / `tus` (e.g. "sus fondos", not "tus fondos").
+    - Verbs and imperatives: conjugate for _usted_ — "Haga clic", "Use", "Conecte", "Intente de nuevo" — not "Haz clic", "Usa", "Conecta", "Intenta de nuevo".
+    - Pronouns: prefer "le" / "lo" / "la"; avoid "te" / "ti".
+  - **Portuguese (`pt`)** — use the _você_ form, never the _tu_ form:
+    - Possessives: `seu` / `sua` / `seus` / `suas`, not `teu` / `tua` / `teus` / `tuas` (e.g. "seus fundos", not "teus fundos").
+    - Verbs: conjugate for _você_ (third person) — "Clique", "Use" — not "Clica", "Usa".
+    - Pronouns: prefer "você" / "lhe"; avoid "te" / "ti" / "contigo".
+  - Keep established product terms untranslated, as the rest of the UI does (e.g. "share tokens", "Testnet").


### PR DESCRIPTION
### Description

Add a tone/register rule to the portal Copilot instructions so AI-assisted and machine translations address users formally. Spanish must use the *usted* form ("su/sus", "Haga clic") and Portuguese the *você* form ("seu/sua", "Clique") instead of the informal *tú*/*tu* register these tools default to. Also reminds contributors to keep established product terms ("share tokens", "Testnet") untranslated.

This came out of review feedback on #2034, where machine-translated strings landed in the informal register.

### Screenshots

N/A — documentation-only change.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
