### PR TITLE
Add Button states and icons to Storybook

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,9 @@ importers:
       storybook:
         specifier: 10.4.4
         version: 10.4.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.1.13)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(utf-8-validate@5.0.10)
+      storybook-addon-pseudo-states:
+        specifier: 10.4.4
+        version: 10.4.4(storybook@10.4.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.1.13)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(utf-8-validate@5.0.10))
       tailwindcss:
         specifier: 3.4.14
         version: 3.4.14
@@ -15900,6 +15903,14 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  storybook-addon-pseudo-states@10.4.4:
+    resolution:
+      {
+        integrity: sha512-AoZy3g3Lxzr0qfCT+xB6GgCHBcvReVyFOHbyU8B3apW8YoB7cxkj32y3+P63LbPSqAe61gK9B/FQFQ/2UAxw0Q==,
+      }
+    peerDependencies:
+      storybook: ^10.4.4
+
   storybook@10.4.4:
     resolution:
       {
@@ -28928,6 +28939,10 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  storybook-addon-pseudo-states@10.4.4(storybook@10.4.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.1.13)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(utf-8-validate@5.0.10)):
+    dependencies:
+      storybook: 10.4.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.1.13)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(utf-8-validate@5.0.10)
 
   storybook@10.4.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.1.13)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(utf-8-validate@5.0.10):
     dependencies:

--- a/portal/.storybook/main.ts
+++ b/portal/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/nextjs'
 
 const config: StorybookConfig = {
-  addons: [],
+  addons: ['storybook-addon-pseudo-states'],
   framework: {
     name: '@storybook/nextjs',
     options: {},

--- a/portal/package.json
+++ b/portal/package.json
@@ -92,6 +92,7 @@
     "qrcode-terminal": "0.12.0",
     "serve": "14.2.4",
     "storybook": "10.4.4",
+    "storybook-addon-pseudo-states": "10.4.4",
     "tailwindcss": "3.4.14",
     "typescript": "5.8.3",
     "vite-tsconfig-paths": "6.1.1",

--- a/portal/stories/button.stories.tsx
+++ b/portal/stories/button.stories.tsx
@@ -1,13 +1,38 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { Button } from 'components/button'
+import { Chevron } from 'components/icons/chevron'
+import { ComponentProps } from 'react'
+
+type StoryProps = ComponentProps<typeof Button> & {
+  iconPosition: 'none' | 'left' | 'right'
+}
+
+// Match the Figma icon colors: white on primary, dark on secondary/tertiary.
+// The Chevron path ships a fixed gray fill, so override it like the app does.
+// `variant` defaults to primary in the component, so anything but an explicit
+// secondary/tertiary keeps the white icon (matches the rendered button).
+const iconColor = (variant: StoryProps['variant']) =>
+  variant === 'secondary' || variant === 'tertiary'
+    ? '[&>path]:fill-neutral-950'
+    : '[&>path]:fill-white'
 
 const meta = {
+  args: {
+    children: 'Connect Wallet',
+    iconPosition: 'none',
+    size: 'small',
+    variant: 'primary',
+  },
   argTypes: {
     children: {
       control: 'text',
     },
     disabled: {
       control: 'boolean',
+    },
+    iconPosition: {
+      control: 'inline-radio',
+      options: ['none', 'left', 'right'],
     },
     size: {
       control: 'select',
@@ -19,42 +44,60 @@ const meta = {
     },
   },
   component: Button,
+  render: ({ children, iconPosition, variant, ...args }) => (
+    <Button variant={variant} {...args}>
+      {iconPosition === 'left' && (
+        <Chevron.Left className={iconColor(variant)} />
+      )}
+      {children}
+      {iconPosition === 'right' && (
+        <Chevron.Right className={iconColor(variant)} />
+      )}
+    </Button>
+  ),
   title: 'Components/Button',
-} satisfies Meta<typeof Button>
+} satisfies Meta<StoryProps>
 
 export default meta
 
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<StoryProps>
 
 export const Primary: Story = {
   args: {
-    children: 'Connect Wallet',
-    size: 'small',
     variant: 'primary',
   },
 }
 
 export const Secondary: Story = {
   args: {
-    children: 'Connect Wallet',
-    size: 'small',
     variant: 'secondary',
   },
 }
 
 export const Tertiary: Story = {
   args: {
-    children: 'Connect Wallet',
-    size: 'small',
     variant: 'tertiary',
   },
 }
 
 export const Disabled: Story = {
   args: {
-    children: 'Connect Wallet',
     disabled: true,
-    size: 'small',
-    variant: 'primary',
+  },
+}
+
+export const Hover: Story = {
+  parameters: {
+    pseudo: {
+      hover: true,
+    },
+  },
+}
+
+export const Focus: Story = {
+  parameters: {
+    pseudo: {
+      focusVisible: true,
+    },
   },
 }


### PR DESCRIPTION
## Refine the Button story to match the Figma design

https://github.com/user-attachments/assets/98c946dd-a857-4b1e-87fd-8824da7bd3f2

Follow-up to the Storybook base setup. Expands the `Button` story so the full
Figma matrix (variants × sizes × states × icons) is reachable from Storybook.

### Changes
- **`storybook-addon-pseudo-states@10.4.4`** (matches the pinned `storybook` 10.4.4)
  registered in `.storybook/main.ts` — adds a toolbar to force `:hover` / `:focus`.
- **`iconPosition` control** (none / left / right) that composes the portal's
  `Chevron` as `children`, with Figma-accurate colors per variant
  (white on primary, neutral-950 on secondary/tertiary — overridden via
  `[&>path]:fill-*`, the same pattern the app uses).
- New **`Hover`** and **`Focus`** stories pinned to those pseudo-states.

### Notes
- The Button component itself is unchanged — it already implements this exact
  Figma design (sizes 28/32/44px, paddings 10/12/16px, gaps 4/8px, focus ring
  `#FFEBD4`, disabled 55%). Verified against the Figma node.
- Icon colors are set at the story level (the shared `Chevron` ships a fixed
  gray fill), mirroring real app usage — the component is not touched.

### Verification
- ✅ `pnpm install --frozen-lockfile` in sync
- ✅ `storybook:build` succeeds (EXIT 0)
- ✅ ESLint (max-warnings 0) and Prettier pass
- ✅ Lockfile change is additive: 0 removed, 1 added (the addon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
