### PR TITLE
Expose cancellationRequested in earn-requests

### DIFF
--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "scripts": {
     "build": "tsc",
     "start": "node --import=./src/instrument.ts server.ts"

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -814,6 +814,7 @@ export const getEarnRequests = async function ({
             amountOut
             asset
             automatic
+            cancellationRequested
             claimableAt
             claimTxHash
             failed

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -19,6 +19,10 @@ export type EarnRequestStatus = SubgraphRequestStatus | 'FAILED'
 type EarnRequestCommonFields = {
   amountIn: string
   amountOut: string | null
+  // True once the user signed `Router.cancel` (vs `failed` = an Agent-side
+  // failure) — lets the portal brand a deliberate cancel apart from a real
+  // failure on a CANCELLED redeem.
+  cancellationRequested: boolean
   claimableAt: string | null
   failed: boolean
   failureReason: string | null

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -19,9 +19,10 @@ export type EarnRequestStatus = SubgraphRequestStatus | 'FAILED'
 type EarnRequestCommonFields = {
   amountIn: string
   amountOut: string | null
-  // True once the user signed `Router.cancel` (vs `failed` = an Agent-side
-  // failure) — lets the portal brand a deliberate cancel apart from a real
-  // failure on a CANCELLED redeem.
+  // True once a cancellation has been requested — either the user signing
+  // `Router.cancel` or an Agent-side cancellation-intent event. Distinct
+  // from `failed` (an Agent-side failure), so the portal can brand a
+  // deliberate cancel apart from a real failure on a CANCELLED redeem.
   cancellationRequested: boolean
   claimableAt: string | null
   failed: boolean


### PR DESCRIPTION
### Description

This PR exposes `cancellationRequested` from the earn-requests backend endpoint so the portal can tell a deliberate user cancel apart from an Agent-side failure on a CANCELLED redeem — they share the recover flow, but only a real failure should read as "something went wrong".

The `hemi-earn-requests` subgraph already indexes the field (it's set when the user signs `Router.cancel`), but `getEarnRequests` wasn't selecting it, so the portal only saw `status: CANCELLED` for both cases. The change adds `cancellationRequested` to the GraphQL query and to the shared `EarnRequestCommonFields` type — `toEarnRequestRow` already spreads `...row`, so it flows through untouched. No logic changes.

  This is part 1 of 2: the portal-side consumption and the cancel UI (button, modal, hook, copy branching) land in a follow-up. Verified against the local API — the field now comes back per request, and combined with `failed` it pins down the user cancels (`cancellationRequested && !failed`) vs real failures.

### Screenshots

N/A. No UI changes.

### Related issue(s)

Related to #2031 
Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
