### PR TITLE
Add Button Loader to Storybook

### DIFF
--- a/portal/.storybook/preview.ts
+++ b/portal/.storybook/preview.ts
@@ -1,8 +1,21 @@
 import type { Preview } from '@storybook/nextjs'
+import { createElement } from 'react'
+import { SkeletonTheme } from 'react-loading-skeleton'
 
+import 'react-loading-skeleton/dist/skeleton.css'
 import 'styles/globals.css'
 
 const preview: Preview = {
+  // Mirror the SkeletonTheme set on the app root layout so skeleton-based
+  // components (e.g. ButtonLoader) render with the same colors in Storybook.
+  decorators: [
+    Story =>
+      createElement(
+        SkeletonTheme,
+        { baseColor: '#E5E5E5', highlightColor: '#FAFAFA' },
+        createElement(Story),
+      ),
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/portal/.storybook/preview.ts
+++ b/portal/.storybook/preview.ts
@@ -2,8 +2,8 @@ import type { Preview } from '@storybook/nextjs'
 import { createElement } from 'react'
 import { SkeletonTheme } from 'react-loading-skeleton'
 
-import 'react-loading-skeleton/dist/skeleton.css'
 import 'styles/globals.css'
+import 'react-loading-skeleton/dist/skeleton.css'
 
 const preview: Preview = {
   // Mirror the SkeletonTheme set on the app root layout so skeleton-based

--- a/portal/stories/buttonLoader.stories.tsx
+++ b/portal/stories/buttonLoader.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Button } from 'components/button'
+import { ComponentProps } from 'react'
+import Skeleton from 'react-loading-skeleton'
+
+import buttonMeta from './button.stories'
+
+// Reuse the Button story's controls (size, variant, children, icon, disabled) and
+// add a `loading` toggle. The loader has no size of its own: it overlays the button
+// and fills it, so changing `size` resizes the button and the skeleton follows.
+type StoryProps = ComponentProps<typeof Button> & {
+  iconPosition: 'none' | 'left' | 'right'
+  loading: boolean
+}
+
+const meta = {
+  ...buttonMeta,
+  args: {
+    ...buttonMeta.args,
+    loading: true,
+  },
+  argTypes: {
+    ...buttonMeta.argTypes,
+    loading: {
+      control: 'boolean',
+    },
+  },
+  render: ({ loading, ...args }) => (
+    <div className="relative inline-block">
+      {buttonMeta.render?.(args)}
+      {loading && (
+        <span className="absolute inset-0">
+          <Skeleton
+            className={`block h-full ${
+              args.size === 'xSmall' ? 'rounded-md' : 'rounded-lg'
+            }`}
+            containerClassName="block h-full leading-none"
+          />
+        </span>
+      )}
+    </div>
+  ),
+  title: 'Components/Button Loader',
+} satisfies Meta<StoryProps>
+
+export default meta
+
+type Story = StoryObj<StoryProps>
+
+export const Default: Story = {}

--- a/portal/stories/buttonLoader.stories.tsx
+++ b/portal/stories/buttonLoader.stories.tsx
@@ -1,50 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
-import { Button } from 'components/button'
-import { ComponentProps } from 'react'
-import Skeleton from 'react-loading-skeleton'
+import { ButtonLoader } from 'components/buttonLoader'
 
-import buttonMeta from './button.stories'
-
-// Reuse the Button story's controls (size, variant, children, icon, disabled) and
-// add a `loading` toggle. The loader has no size of its own: it overlays the button
-// and fills it, so changing `size` resizes the button and the skeleton follows.
-type StoryProps = ComponentProps<typeof Button> & {
-  iconPosition: 'none' | 'left' | 'right'
-  loading: boolean
-}
-
+// `ButtonLoader` is the `loading` fallback shown while a submit button loads (e.g.
+// the dynamically imported ConnectEvmWallet). It has no props and bakes in its own
+// height, so it's framed in a box with a `small` button's shape (`h-8`, `rounded-lg`)
+// — `overflow-hidden` trims the loader to that size and the wrapper width sets it.
 const meta = {
-  ...buttonMeta,
-  args: {
-    ...buttonMeta.args,
-    loading: true,
-  },
-  argTypes: {
-    ...buttonMeta.argTypes,
-    loading: {
-      control: 'boolean',
-    },
-  },
-  render: ({ loading, ...args }) => (
-    <div className="relative inline-block">
-      {buttonMeta.render?.(args)}
-      {loading && (
-        <span aria-hidden className="pointer-events-none absolute inset-0">
-          <Skeleton
-            className={`block h-full ${
-              args.size === 'xSmall' ? 'rounded-md' : 'rounded-lg'
-            }`}
-            containerClassName="block h-full leading-none"
-          />
-        </span>
-      )}
-    </div>
-  ),
+  component: ButtonLoader,
+  decorators: [
+    Story => (
+      <div className="h-8 w-28 overflow-hidden rounded-lg">
+        <Story />
+      </div>
+    ),
+  ],
   title: 'Components/Button Loader',
-} satisfies Meta<StoryProps>
+} satisfies Meta<typeof ButtonLoader>
 
 export default meta
 
-type Story = StoryObj<StoryProps>
+type Story = StoryObj<typeof ButtonLoader>
 
 export const Default: Story = {}

--- a/portal/stories/buttonLoader.stories.tsx
+++ b/portal/stories/buttonLoader.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { ButtonLoader } from 'components/buttonLoader'
 
-// `ButtonLoader` is the `loading` fallback shown while a submit button loads (e.g.
-// the dynamically imported ConnectEvmWallet). It has no props and bakes in its own
-// height, so it's framed in a box with a `small` button's shape (`h-8`, `rounded-lg`)
-// — `overflow-hidden` trims the loader to that size and the wrapper width sets it.
+// `ButtonLoader` is the `loading` fallback for a dynamically imported submit button
+// (e.g. ConnectEvmWallet). It has no props and a fixed height (`containerClassName=
+// "h-11.5"`, ~46px, the xLarge size it stands in for). This story deliberately frames
+// it in a `small` button box (`h-8`, `rounded-lg`): `overflow-hidden` trims the
+// loader's fixed height to that shape and the wrapper width sizes it.
 const meta = {
   component: ButtonLoader,
   decorators: [

--- a/portal/stories/buttonLoader.stories.tsx
+++ b/portal/stories/buttonLoader.stories.tsx
@@ -1,20 +1,38 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Button } from 'components/button'
 import { ButtonLoader } from 'components/buttonLoader'
+import { useEffect, useState } from 'react'
 
-// `ButtonLoader` is the `loading` fallback for a dynamically imported submit button
-// (e.g. ConnectEvmWallet). It has no props and a fixed height (`containerClassName=
-// "h-11.5"`, ~46px, the xLarge size it stands in for). This story deliberately frames
-// it in a `small` button box (`h-8`, `rounded-lg`): `overflow-hidden` trims the
-// loader's fixed height to that shape and the wrapper width sizes it.
+const LoadingButtonDemo = function () {
+  const [loading, setLoading] = useState(true)
+
+  useEffect(
+    function () {
+      if (!loading) {
+        return undefined
+      }
+      const timeout = setTimeout(() => setLoading(false), 5000)
+      return () => clearTimeout(timeout)
+    },
+    [loading],
+  )
+
+  return (
+    <div className="h-8 w-32">
+      {loading ? (
+        <ButtonLoader />
+      ) : (
+        <Button onClick={() => setLoading(true)} size="small" type="button">
+          Connect Wallet
+        </Button>
+      )}
+    </div>
+  )
+}
+
 const meta = {
   component: ButtonLoader,
-  decorators: [
-    Story => (
-      <div className="h-8 w-28 overflow-hidden rounded-lg">
-        <Story />
-      </div>
-    ),
-  ],
+  render: () => <LoadingButtonDemo />,
   title: 'Components/Button Loader',
 } satisfies Meta<typeof ButtonLoader>
 

--- a/portal/stories/buttonLoader.stories.tsx
+++ b/portal/stories/buttonLoader.stories.tsx
@@ -29,7 +29,7 @@ const meta = {
     <div className="relative inline-block">
       {buttonMeta.render?.(args)}
       {loading && (
-        <span className="absolute inset-0">
+        <span aria-hidden className="pointer-events-none absolute inset-0">
           <Skeleton
             className={`block h-full ${
               args.size === 'xSmall' ? 'rounded-md' : 'rounded-lg'


### PR DESCRIPTION
### Description

Adds a Storybook story for the `ButtonLoader` component
(`components/buttonLoader`) — the `loading` fallback shown while a dynamically
imported submit button (e.g. `ConnectEvmWallet`) loads, then swapped for the
real button.

The component has no props, so a single `Default` story shows how it's used: an
inline demo renders the real `ButtonLoader` for 5s, then a `small` submit
button; clicking the button restarts the cycle.

- New `stories/buttonLoader.stories.tsx` — single `Default` story with the
  loader → button → restart cycle.
- `.storybook/preview.ts` — mirrors the app root layout: imports the
  `react-loading-skeleton` CSS (after `globals.css`, same order as
  `app/[locale]/layout.tsx`) and wraps stories in `SkeletonTheme`
  (`#E5E5E5` / `#FAFAFA`).

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/6d8f1f66-1c42-4a2e-a735-12b578d20d1e


### Related issue(s)

Related to #1993

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
