### PR TITLE
Add Chain Logo story to Storybook

### DIFF
--- a/portal/stories/chainLogo.stories.tsx
+++ b/portal/stories/chainLogo.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { bitcoinMainnet, bitcoinTestnet } from 'btc-wallet/chains'
+import { ChainLogo } from 'components/chainLogo'
+import { hemiMainnet } from 'networks/hemiMainnet'
+import { hemiTestnet } from 'networks/hemiTestnet'
+import { mainnet } from 'networks/mainnet'
+import { sepolia } from 'networks/sepolia'
+
+// The component takes a `chainId` and switches on it. An unknown id falls back to
+// the Hemi logo. There's no `size` prop, so the only control is the chain itself.
+const unknownChainId = 999999
+
+const labels = {
+  [bitcoinMainnet.id]: 'Bitcoin Mainnet',
+  [bitcoinTestnet.id]: 'Bitcoin Testnet',
+  [mainnet.id]: 'Ethereum Mainnet',
+  [sepolia.id]: 'Ethereum Sepolia',
+  [hemiMainnet.id]: 'Hemi Mainnet',
+  [hemiTestnet.id]: 'Hemi Testnet',
+  [unknownChainId]: 'Unknown (fallback)',
+}
+
+const meta = {
+  args: {
+    chainId: hemiMainnet.id,
+  },
+  argTypes: {
+    chainId: {
+      control: 'select',
+      labels,
+      options: [
+        bitcoinMainnet.id,
+        bitcoinTestnet.id,
+        mainnet.id,
+        sepolia.id,
+        hemiMainnet.id,
+        hemiTestnet.id,
+        unknownChainId,
+      ],
+    },
+  },
+  component: ChainLogo,
+  title: 'Components/Chain Logo',
+} satisfies Meta<typeof ChainLogo>
+
+export default meta
+
+type Story = StoryObj<typeof ChainLogo>
+
+export const Hemi: Story = {
+  args: { chainId: hemiMainnet.id },
+}
+
+export const Ethereum: Story = {
+  args: { chainId: mainnet.id },
+}
+
+export const Bitcoin: Story = {
+  args: { chainId: bitcoinMainnet.id },
+}
+
+// Any unrecognized id renders the Hemi logo (the component's default branch).
+export const Unknown: Story = {
+  args: { chainId: unknownChainId },
+}

--- a/portal/stories/chainLogo.stories.tsx
+++ b/portal/stories/chainLogo.stories.tsx
@@ -10,6 +10,16 @@ import { sepolia } from 'networks/sepolia'
 // the Hemi logo. There's no `size` prop, so the only control is the chain itself.
 const unknownChainId = 999999
 
+const chainOptions = [
+  bitcoinMainnet.id,
+  bitcoinTestnet.id,
+  mainnet.id,
+  sepolia.id,
+  hemiMainnet.id,
+  hemiTestnet.id,
+  unknownChainId,
+]
+
 const labels = {
   [bitcoinMainnet.id]: 'Bitcoin Mainnet',
   [bitcoinTestnet.id]: 'Bitcoin Testnet',
@@ -20,6 +30,11 @@ const labels = {
   [unknownChainId]: 'Unknown (fallback)',
 }
 
+// Storybook `select` controls emit the option as a string, so the numeric chain ids
+// would reach `ChainLogo` as strings (e.g. "1") and its `switch` would always fall
+// through to the Hemi default. `mapping` coerces each one back to its real id.
+const mapping = Object.fromEntries(chainOptions.map(id => [id, id]))
+
 const meta = {
   args: {
     chainId: hemiMainnet.id,
@@ -28,15 +43,8 @@ const meta = {
     chainId: {
       control: 'select',
       labels,
-      options: [
-        bitcoinMainnet.id,
-        bitcoinTestnet.id,
-        mainnet.id,
-        sepolia.id,
-        hemiMainnet.id,
-        hemiTestnet.id,
-        unknownChainId,
-      ],
+      mapping,
+      options: chainOptions,
     },
   },
   component: ChainLogo,
@@ -47,19 +55,6 @@ export default meta
 
 type Story = StoryObj<typeof ChainLogo>
 
-export const Hemi: Story = {
-  args: { chainId: hemiMainnet.id },
-}
-
-export const Ethereum: Story = {
-  args: { chainId: mainnet.id },
-}
-
-export const Bitcoin: Story = {
-  args: { chainId: bitcoinMainnet.id },
-}
-
-// Any unrecognized id renders the Hemi logo (the component's default branch).
-export const Unknown: Story = {
-  args: { chainId: unknownChainId },
-}
+// A single story for the component's only prop: pick a chain from the control to see
+// each logo (an unknown id falls back to the Hemi logo).
+export const Default: Story = {}


### PR DESCRIPTION
### Description

Adds a Storybook story for the `ChainLogo` component (`components/chainLogo`).

The portal's `ChainLogo` takes a `chainId` and switches on it to render the BTC,
Ethereum or Hemi logo, with an unknown id falling back to the Hemi logo. It has
no `size` prop, so the story documents it as-is: a single `chainId` select
control covering every supported chain (Bitcoin / Ethereum / Hemi, mainnet +
testnet) plus an unknown id that exercises the fallback branch. The component is
not modified.

- New `stories/chainLogo.stories.tsx` — `Hemi`, `Ethereum`, `Bitcoin` and
  `Unknown` stories, with a `chainId` select (friendly labels) wired to the real
  component API.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/6512182c-3a2f-46db-98b4-74f40bfa54ec



### Related issue(s)

Related to #1993

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
