### PR TITLE
Wire APY history endpoint and fix UTC chart dates

### DIFF
--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
@@ -81,10 +81,10 @@ const getPlaceholderXTicks = function (period: MetricPeriod) {
 }
 
 const formatShortTimestamp = (timestampMs: number, locale: string) =>
-  formatShortDate(new Date(timestampMs), locale)
+  formatShortDate(new Date(timestampMs), locale, 'UTC')
 
 const formatFullTimestamp = (timestampMs: number, locale: string) =>
-  formatDate(new Date(timestampMs), locale)
+  formatDate(new Date(timestampMs), locale, 'UTC')
 
 // 'compact' is meant for the axis ticks, where APY is rendered as a rounded
 // integer ("4%") to keep the axis readable. 'full' keeps the full precision

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useHistoricalMetrics.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useHistoricalMetrics.ts
@@ -76,5 +76,6 @@ export const useHistoricalMetrics = ({
       peggedToken.address,
       shareToken.chainId,
       shareToken.address as Address,
+      stakingVault,
     ],
   })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useHistoricalMetrics.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useHistoricalMetrics.ts
@@ -13,31 +13,19 @@ import {
 const apiUrl = process.env.NEXT_PUBLIC_VETRO_API_URL
 const isVetroApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
 
-// Temporary stub: there's no APY-history endpoint yet, so the `apy` metric still
-// renders mocked MetricDataPoint[]. Re-wire it once a time series is available.
+type ApyHistory = { apy: number; timestamp: number }[]
 
-const periodToMs: Record<MetricPeriod, number> = {
-  '1m': 30 * 24 * 60 * 60 * 1000,
-  '1w': 7 * 24 * 60 * 60 * 1000,
-  '1y': 365 * 24 * 60 * 60 * 1000,
-  '3m': 90 * 24 * 60 * 60 * 1000,
-}
-
-const generateMockMetric = function (
-  period: MetricPeriod,
-  metricType: MetricType,
-): MetricDataPoint[] {
-  const points = 30
-  const now = Date.now()
-  const span = periodToMs[period]
-  return Array.from({ length: points }, function (_, i) {
-    const x = now - span + (span * i) / (points - 1)
-    const noise = Math.sin(i + 100) * 10000
-    const random = noise - Math.floor(noise)
-    const y =
-      metricType === 'apy' ? 2 + random * 3 : 1_000_000 + random * 250_000
-    return { x, y }
-  })
+const fetchApyHistory = async function ({
+  period,
+  stakingVault,
+}: {
+  period: MetricPeriod
+  stakingVault: Address
+}): Promise<MetricDataPoint[]> {
+  const history = (await fetch(
+    `${apiUrl}/variable-stake/apy-history/${stakingVault}/${period}`,
+  )) as ApyHistory
+  return history.map(({ apy, timestamp }) => ({ x: timestamp, y: apy }))
 }
 
 type TotalDepositsHistory = { timestamp: number; totalDeposits: string }[]
@@ -76,10 +64,10 @@ export const useHistoricalMetrics = ({
   stakingVault,
 }: UseHistoricalMetrics) =>
   useQuery({
-    enabled: metricType === 'apy' || isVetroApiConfigured,
+    enabled: isVetroApiConfigured,
     queryFn: (): Promise<MetricDataPoint[]> =>
       metricType === 'apy'
-        ? Promise.resolve(generateMockMetric(period, metricType))
+        ? fetchApyHistory({ period, stakingVault })
         : fetchTotalDeposits({ peggedToken, period, stakingVault }),
     queryKey: [
       'historical-metrics',

--- a/portal/test/utils/format.test.ts
+++ b/portal/test/utils/format.test.ts
@@ -2,6 +2,7 @@ import {
   formatBtcAddress,
   formatCompactFiat,
   formatCompactFiatParts,
+  formatDate,
   formatEvmAddress,
   formatEvmHash,
   formatFutureTime,
@@ -311,6 +312,26 @@ describe('utils/format', function () {
 
     it('should zero-pad single-digit days', function () {
       expect(formatShortDate(december5, 'en')).toBe('Dec 05')
+    })
+
+    it('should format in the given time zone', function () {
+      // A UTC-midnight instant falls on the previous day in negative-offset
+      // zones; passing 'UTC' keeps it on Jun 25 regardless of the runner's tz.
+      const utcMidnight = new Date('2026-06-25T00:00:00Z')
+      expect(formatShortDate(utcMidnight, 'en', 'UTC')).toBe('Jun 25')
+      expect(formatShortDate(utcMidnight, 'en', 'America/New_York')).toBe(
+        'Jun 24',
+      )
+    })
+  })
+
+  describe('formatDate', function () {
+    it('should format in the given time zone', function () {
+      const utcMidnight = new Date('2026-06-25T00:00:00Z')
+      expect(formatDate(utcMidnight, 'en', 'UTC')).toBe('06/25/2026')
+      expect(formatDate(utcMidnight, 'en', 'America/New_York')).toBe(
+        '06/24/2026',
+      )
     })
   })
 

--- a/portal/utils/format.ts
+++ b/portal/utils/format.ts
@@ -128,14 +128,21 @@ export const formatCompactFiatParts = function (
   return { number, suffix }
 }
 
-export const formatDate = (date: Date, locale: string) =>
+export const formatDate = (date: Date, locale: string, timeZone?: string) =>
   new Intl.DateTimeFormat(locale, {
     day: '2-digit',
     month: '2-digit',
+    timeZone,
     year: 'numeric',
   }).format(date)
 
-export const formatShortDate = (date: Date, locale: string) =>
-  new Intl.DateTimeFormat(locale, { day: '2-digit', month: 'short' }).format(
-    date,
-  )
+export const formatShortDate = (
+  date: Date,
+  locale: string,
+  timeZone?: string,
+) =>
+  new Intl.DateTimeFormat(locale, {
+    day: '2-digit',
+    month: 'short',
+    timeZone,
+  }).format(date)


### PR DESCRIPTION
### Description

Wire the pool detail page's APY history chart to the real vetro `/variable-stake/apy-history/:stakingVault/:period` endpoint, replacing the mocked time series and dropping the now-unused mock generator. APY values arrive already as percentages, so they map straight onto the chart's `{ x: timestamp, y: apy }` points.

Also fix the chart's date labels, which were rendered in the browser's local timezone. The history points are daily buckets aligned to UTC midnight, so in negative-offset timezones a midnight bucket landed on the previous calendar day, making the axis appear to skip a day (e.g. `06/24 → 06/26`, missing `06/25`). `formatDate`/`formatShortDate` now take an optional `timeZone`, and the chart passes `'UTC'`. Mirrors vetro-protocol/vetro-monorepo#546.

### Screenshots

https://github.com/user-attachments/assets/857497d0-0f56-4908-9d0e-fe7fd34c8a61

### Related issue(s)

Related to #1967

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
