### PR TITLE
Add Spinner story to Storybook

### DIFF
--- a/portal/stories/spinner.stories.tsx
+++ b/portal/stories/spinner.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Spinner } from 'components/spinner'
+
+// Backgrounds mirror where each variant is actually used in the app:
+// - `light` (#FFF7F0, near-white) is the loading state inside primary buttons, whose surface is
+//   `bg-orange-600` (see components/button/button.css) — so it's shown on orange here.
+// - `orange` sits on white/neutral surfaces (review screens, pages) — so it's shown on white.
+// The numeric `size` is omitted from the control (the named sizes cover the documented cases).
+
+const meta = {
+  args: {
+    size: 'medium',
+    variant: 'light',
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['xSmall', 'small', 'medium', 'large'],
+    },
+    variant: {
+      control: 'inline-radio',
+      options: ['light', 'orange'],
+    },
+  },
+  component: Spinner,
+  title: 'Components/Spinner',
+} satisfies Meta<typeof Spinner>
+
+export default meta
+
+type Story = StoryObj<typeof Spinner>
+
+// Playground: the backdrop follows the selected variant's real surface in the app.
+export const Default: Story = {
+  render: ({ variant, ...args }) => (
+    <div
+      className={`flex items-center justify-center rounded-lg p-6 ${
+        variant === 'orange' ? 'bg-white' : 'bg-orange-600'
+      }`}
+    >
+      <Spinner variant={variant} {...args} />
+    </div>
+  ),
+}
+
+// Render-only showcase of every named size (orange on white, controls disabled).
+export const Sizes: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex items-center gap-x-4">
+      <Spinner size="xSmall" variant="orange" />
+      <Spinner size="small" variant="orange" />
+      <Spinner size="medium" variant="orange" />
+      <Spinner size="large" variant="orange" />
+    </div>
+  ),
+}


### PR DESCRIPTION
### Description

Adds a Storybook story for the `Spinner` component (`components/spinner`).

The portal's `Spinner` is a pure SVG with a `size` (`xSmall` | `small` | `medium` |
`large`, or a number) and a `variant` (`light` | `orange`). Following the single
playground + showcase model, the story documents it as-is with a `size` select and a
`variant` radio wired to the real props. Backgrounds mirror where each variant is
actually used in the app: `light` (`#FFF7F0`, near-white) is the loading state inside
primary buttons (`bg-orange-600`, see `components/button/button.css`) so it renders on
orange, while `orange` sits on white/neutral surfaces. The numeric `size` is omitted
from the control since the named sizes cover the documented cases. The component is not
modified.

- New `stories/spinner.stories.tsx` — a `Default` playground (the backdrop follows the
  selected variant's real surface) and a render-only `Sizes` showcase of every named
  size, with `size` and `variant` controls wired to the real component API.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
Brower
<img  alt="components-spinner--default--ui" src="https://github.com/user-attachments/assets/4ed5b8c8-c52f-479b-86b4-c7d80b3395a0" />

Light
<img  alt="components-spinner--default" src="https://github.com/user-attachments/assets/da31c77b-77ed-4ba0-9382-a97d0ee453a1" />

Orange - Sizes
<img  alt="components-spinner--sizes" src="https://github.com/user-attachments/assets/b2e97aac-b1c6-4e3d-ac1e-84e3f451e278" />


### Related issue(s)

Related to #1993

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
