### PR TITLE
Add Vertical Lines story to Storybook

### DIFF
--- a/portal/stories/verticalLines.stories.tsx
+++ b/portal/stories/verticalLines.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { LongVerticalLine, ShortVerticalLine } from 'components/verticalLines'
+import { ComponentProps } from 'react'
+
+// Connector lines drawn between steps in the review / get-started flows, which sit on white card
+// surfaces — so the stories render on the default light canvas. There are two exported lengths
+// (Short 24px, Long 68px); a synthetic `length` control switches between them. `stroke` and
+// `dashed` map straight to the real props.
+type LineProps = ComponentProps<typeof LongVerticalLine>
+
+const strokeOptions: LineProps['stroke'][] = [
+  'stroke-neutral-300',
+  'stroke-neutral-300/55',
+  'stroke-orange-600',
+  'stroke-rose-500',
+]
+
+type StoryProps = LineProps & { length: 'short' | 'long' }
+
+const meta = {
+  args: {
+    dashed: true,
+    length: 'long',
+    stroke: 'stroke-neutral-300',
+  },
+  argTypes: {
+    dashed: {
+      control: 'boolean',
+    },
+    length: {
+      control: 'inline-radio',
+      options: ['short', 'long'],
+    },
+    stroke: {
+      control: 'select',
+      // Friendly labels — the value is the real Tailwind class the prop expects.
+      labels: Object.fromEntries(
+        strokeOptions.map(stroke => [stroke, stroke.replace('stroke-', '')]),
+      ),
+      options: strokeOptions,
+    },
+  },
+  component: LongVerticalLine,
+  title: 'Components/Vertical Lines',
+} satisfies Meta<StoryProps>
+
+export default meta
+
+type Story = StoryObj<StoryProps>
+
+// Playground: pick length (Short/Long), stroke and dashed from the controls.
+export const Default: Story = {
+  render: ({ length, ...props }) =>
+    length === 'short' ? (
+      <ShortVerticalLine {...props} />
+    ) : (
+      <LongVerticalLine {...props} />
+    ),
+}
+
+// Render-only showcase: every stroke, solid (left) and dashed (right), on the Long line.
+export const Strokes: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex gap-x-4">
+      {strokeOptions.map(stroke => (
+        <div className="flex w-28 flex-col items-center gap-y-2" key={stroke}>
+          <div className="flex gap-x-3">
+            <LongVerticalLine dashed={false} stroke={stroke} />
+            <LongVerticalLine stroke={stroke} />
+          </div>
+          <span className="text-xs text-neutral-500">
+            {stroke.replace('stroke-', '')}
+          </span>
+        </div>
+      ))}
+    </div>
+  ),
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds a Storybook story for the `ShortVerticalLine` and `LongVerticalLine` components
(`components/verticalLines`).

These are the thin connector lines drawn between steps in the review and Get Started
flows. The story documents them with a `Default` playground — a `length` toggle picks the
Short (24px) or Long (68px) line, and `stroke` and `dashed` map straight to the real props
— plus a render-only `Strokes` showcase that lays out every stroke (solid and dashed) with
a label. They render on the default light canvas, matching the white surfaces where they're
used in the app. The components are not modified.

- New `stories/verticalLines.stories.tsx` — a `Default` playground (length / stroke /
  dashed controls) and a `Strokes` showcase, wired to the real component API.
  

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img alt="components-vertical-lines--default--ui" src="https://github.com/user-attachments/assets/e817cd64-810a-4067-8400-82dfe15b26fb" />

<img alt="components-vertical-lines--default" src="https://github.com/user-attachments/assets/18e6688e-e736-403d-8d77-214b6c99e999" />

<img alt="components-vertical-lines--strokes--ui" src="https://github.com/user-attachments/assets/453f4b62-82fb-401a-9bc7-1ba021469cff" />

<img alt="components-vertical-lines--strokes" src="https://github.com/user-attachments/assets/89a5b064-991b-440d-b16d-1f742a9a236a" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Fixes #
Related to #1993 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
