### PR TITLE
Add Warning Box story to Storybook

### DIFF
--- a/portal/stories/warningBox.stories.tsx
+++ b/portal/stories/warningBox.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { ExternalLink } from 'components/externalLink'
+import { Chevron } from 'components/icons/chevron'
+import { WarningBox } from 'components/warningBox'
+import { ComponentProps } from 'react'
+
+// Informational box used inside drawers / review screens (e.g. the unstake-ETH disclaimer). It
+// brings its own `bg-neutral-50` surface and sits on white panels, so the stories render on the
+// default light canvas, width-constrained to match the narrow drawers where it appears. `heading`
+// and `subheading` are text controls; a synthetic `withClose` toggles the optional close button.
+type StoryProps = ComponentProps<typeof WarningBox> & { withClose: boolean }
+
+const meta = {
+  args: {
+    heading: 'Unstake ETH as WETH',
+    subheading:
+      'Unstaking returns WETH, not native ETH. You can unwrap it afterwards.',
+    withClose: false,
+  },
+  argTypes: {
+    heading: { control: 'text' },
+    subheading: { control: 'text' },
+    withClose: { control: 'boolean' },
+  },
+  component: WarningBox,
+  decorators: [
+    Story => (
+      <div className="w-96">
+        <Story />
+      </div>
+    ),
+  ],
+  title: 'Components/Warning Box',
+} satisfies Meta<StoryProps>
+
+export default meta
+
+type Story = StoryObj<StoryProps>
+
+// Playground: edit the texts and toggle the close button from the controls.
+export const Default: Story = {
+  render: ({ withClose, ...args }) => (
+    <WarningBox {...args} onClose={withClose ? () => undefined : undefined} />
+  ),
+}
+
+// Render-only showcase: a warning box with rich `children` (a link), mirroring the app usage.
+export const WithChildren: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <WarningBox
+      heading="Unstake ETH as WETH"
+      subheading="Unstaking returns WETH, not native ETH."
+    >
+      <ExternalLink
+        className="group/disclaimer flex cursor-pointer items-center gap-x-1 text-sm"
+        href="https://pure.finance/en/wrap-eth/"
+      >
+        <span className="text-orange-600 group-hover/disclaimer:text-orange-700">
+          Unwrap
+        </span>
+        <Chevron.Right className="[&>path]:fill-orange-600 group-hover/disclaimer:[&>path]:fill-orange-700" />
+      </ExternalLink>
+    </WarningBox>
+  ),
+}

--- a/portal/stories/warningBox.stories.tsx
+++ b/portal/stories/warningBox.stories.tsx
@@ -4,10 +4,6 @@ import { Chevron } from 'components/icons/chevron'
 import { WarningBox } from 'components/warningBox'
 import { ComponentProps } from 'react'
 
-// Informational box used inside drawers / review screens (e.g. the unstake-ETH disclaimer). It
-// brings its own `bg-neutral-50` surface and sits on white panels, so the stories render on the
-// default light canvas, width-constrained to match the narrow drawers where it appears. `heading`
-// and `subheading` are text controls; a synthetic `withClose` toggles the optional close button.
 type StoryProps = ComponentProps<typeof WarningBox> & { withClose: boolean }
 
 const meta = {
@@ -37,14 +33,12 @@ export default meta
 
 type Story = StoryObj<StoryProps>
 
-// Playground: edit the texts and toggle the close button from the controls.
 export const Default: Story = {
   render: ({ withClose, ...args }) => (
     <WarningBox {...args} onClose={withClose ? () => undefined : undefined} />
   ),
 }
 
-// Render-only showcase: a warning box with rich `children` (a link), mirroring the app usage.
 export const WithChildren: Story = {
   parameters: {
     controls: { disable: true },


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds a Storybook story for the `WarningBox` component (`components/warningBox`).

`WarningBox` is the informational box shown inside drawers and review screens (e.g. the
unstake-ETH disclaimer): an icon, a heading and a subheading, with an optional close button
and optional rich children. The story documents it with a `Default` playground — `heading`
and `subheading` text controls plus a `withClose` toggle for the close button — and a
render-only `WithChildren` showcase that adds a link, mirroring the app usage. It renders on
the default light canvas, width-constrained to match the narrow drawers where it appears. The
component is not modified.

- New `stories/warningBox.stories.tsx` — a `Default` playground (heading / subheading /
  withClose controls) and a `WithChildren` showcase, wired to the real component API.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img alt="components-warning-box--default--ui" src="https://github.com/user-attachments/assets/9cf4e826-1d0f-420d-a186-6eafb77aa941" />

<img alt="components-warning-box--default" src="https://github.com/user-attachments/assets/8e87107e-0dac-4262-b276-09a37dd92573" />

<img alt="components-warning-box--with-children--ui" src="https://github.com/user-attachments/assets/f1250c46-6112-4662-ad35-f1f0e5778e92" />

<img alt="components-warning-box--with-children" src="https://github.com/user-attachments/assets/b00b7ba9-5d44-4a71-b43f-d9c43ebcb79e" />






### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Fixes #
Related to #1993 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ x] Manual testing passed.
- [ x] Automated tests added, or N/A.
- [ x] Documentation updated, or N/A.
- [ x] Environment variables set in CI, or N/A.
