### PR TITLE
Add Typography stories to Storybook

### DIFF
--- a/portal/stories/typography.stories.tsx
+++ b/portal/stories/typography.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { ReactNode } from 'react'
+
+// "Not really a component" (issue #1993): the typography lives as global styles in
+// styles/globals.css (already imported in preview.ts). Organized like vetro (a `Typography/`
+// section) but each story uses the designer's Figma format (Hemi Portal, node 15283-17016): a card
+// whose rows pair the design-system name, a live sample and the size/line-height. Subtitle and
+// Caption are de-emphasized exactly as in the Figma.
+const meta = {
+  parameters: {
+    controls: { disable: true },
+  },
+  title: 'Typography',
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj
+
+const SAMPLE = 'Put your temper to more use'
+
+const Row = ({
+  children,
+  name,
+  size,
+}: {
+  children: ReactNode
+  name: string
+  size: string
+}) => (
+  <div className="flex items-center gap-x-6 border-b border-neutral-200 px-5 py-4 last:border-b-0">
+    <span className="w-16 shrink-0 text-sm text-neutral-500">{name}</span>
+    <div className="min-w-0 flex-1">{children}</div>
+    <span className="shrink-0 text-sm text-neutral-400">{size}</span>
+  </div>
+)
+
+// `muted` mirrors the Figma, where Subtitle and Caption are shown de-emphasized.
+const Card = ({
+  children,
+  muted = false,
+}: {
+  children: ReactNode
+  muted?: boolean
+}) => (
+  <div
+    className={`max-w-3xl rounded-xl border border-neutral-200 ${
+      muted ? 'opacity-50' : ''
+    }`}
+  >
+    {children}
+  </div>
+)
+
+export const Headers: Story = {
+  render: () => (
+    <Card>
+      <Row name="H1" size="36/40">
+        <h1>{SAMPLE}</h1>
+      </Row>
+      <Row name="H2" size="24/32">
+        <h2>{SAMPLE}</h2>
+      </Row>
+      <Row name="H3" size="17/24">
+        <h3>{SAMPLE}</h3>
+      </Row>
+      <Row name="H4" size="13/18">
+        <h4>{SAMPLE}</h4>
+      </Row>
+    </Card>
+  ),
+}
+
+export const Subtitle: Story = {
+  render: () => (
+    <Card muted>
+      <Row name="S1" size="13/18">
+        <span className="body-text-normal text-neutral-500">{SAMPLE}</span>
+      </Row>
+    </Card>
+  ),
+}
+
+export const Body: Story = {
+  render: () => (
+    <Card>
+      <Row name="B" size="13/18">
+        <span className="body-text-normal">{SAMPLE}</span>
+      </Row>
+      <Row name="B-M" size="13/18">
+        <span className="body-text-medium">{SAMPLE}</span>
+      </Row>
+      <Row name="B-SB" size="13/18">
+        <span className="body-text-semibold">{SAMPLE}</span>
+      </Row>
+    </Card>
+  ),
+}
+
+export const Caption: Story = {
+  render: () => (
+    <Card muted>
+      <Row name="C1" size="11/16">
+        <span className="body-text-caption">{SAMPLE}</span>
+      </Row>
+    </Card>
+  ),
+}
+
+export const Button: Story = {
+  render: () => (
+    <Card>
+      <Row name="XL" size="15/22">
+        <span className="text-mid font-semibold">Button</span>
+      </Row>
+      <Row name="S" size="13/18">
+        <span className="text-sm font-semibold">Button</span>
+      </Row>
+      <Row name="XS" size="12/16">
+        <span className="text-xs font-semibold">Button</span>
+      </Row>
+    </Card>
+  ),
+}

--- a/portal/stories/typography.stories.tsx
+++ b/portal/stories/typography.stories.tsx
@@ -119,7 +119,7 @@ export const Button: Story = {
       <Row name="S" size="13/18">
         <span className="text-sm font-semibold">Button</span>
       </Row>
-      <Row name="XS" size="12/16">
+      <Row name="XS" size="12/17">
         <span className="text-xs font-semibold">Button</span>
       </Row>
     </Card>

--- a/portal/stories/typography.stories.tsx
+++ b/portal/stories/typography.stories.tsx
@@ -6,16 +6,19 @@ import { ReactNode } from 'react'
 // section) but each story uses the designer's Figma format (Hemi Portal, node 15283-17016): a card
 // whose rows pair the design-system name, a live sample and the size/line-height. Subtitle and
 // Caption are de-emphasized exactly as in the Figma.
+// Render-only stories with no component/args, so the args shape is the empty object.
+type StoryProps = Record<string, never>
+
 const meta = {
   parameters: {
     controls: { disable: true },
   },
   title: 'Typography',
-} satisfies Meta
+} satisfies Meta<StoryProps>
 
 export default meta
 
-type Story = StoryObj
+type Story = StoryObj<StoryProps>
 
 const SAMPLE = 'Put your temper to more use'
 

--- a/portal/stories/typography.stories.tsx
+++ b/portal/stories/typography.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
-import { ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 // "Not really a component" (issue #1993): the typography lives as global styles in
 // styles/globals.css (already imported in preview.ts). Organized like vetro (a `Typography/`


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds Storybook stories documenting the global typography styles defined in
`styles/globals.css`.

As noted in the issue, this is "not really a component" — there's nothing to import, so the
stories render plain markup that inherits the global element styles (`h1`–`h4`) and the
`body-text-*` utility classes, exactly as they apply across the app. The organization follows
vetro's Storybook (a dedicated `Typography/` section), and each story uses the designer's Figma
format: a card whose rows pair the design-system name (H1, B-M, C1…) with a live sample and its
size/line-height. It covers every section of the design — `Headers`, `Subtitle`, `Body`,
`Caption` and `Button` — with Subtitle and Caption de-emphasized just like the Figma. No styles
or components are modified.

- New `stories/typography.stories.tsx` — `Headers`, `Subtitle`, `Body`, `Caption` and `Button`
  stories under the `Typography` section.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img alt="typography--headers--ui" src="https://github.com/user-attachments/assets/45c68e44-81dc-41af-8a59-35f1060668c9" />

<img alt="typography--headers" src="https://github.com/user-attachments/assets/f8f6738e-8c46-4f06-b635-8a90be7fe6c9" />

<img  alt="typography--body--ui" src="https://github.com/user-attachments/assets/ce645506-b2af-446f-b3da-b7cbd474d275" />

<img alt="typography--body" src="https://github.com/user-attachments/assets/e596c823-ef96-402e-99dd-0e3f0cd3e81e" />

<img  alt="typography--caption--ui" src="https://github.com/user-attachments/assets/c5cc31c7-d42d-452d-b345-8a563103e2bd" />

<img  alt="typography--caption" src="https://github.com/user-attachments/assets/7697cf7e-7282-4525-92ee-633c1c80f6af" />

<img alt="typography--subtitle--ui" src="https://github.com/user-attachments/assets/9c7121cb-bdba-4293-9539-3f9f4d4c687b" />

<img alt="typography--subtitle" src="https://github.com/user-attachments/assets/053cd747-8190-4e7e-b647-44da8185cab8" />

<img alt="typography--button--ui" src="https://github.com/user-attachments/assets/8f999bf6-ecd4-4218-bc4c-69709fb175af" />






### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Fixes #
Related to #1993 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ x] Manual testing passed.
- [ x] Automated tests added, or N/A.
- [ x] Documentation updated, or N/A.
- [ x] Environment variables set in CI, or N/A.
