### PR TITLE
Add story link

### DIFF
--- a/portal/stories/link.stories.tsx
+++ b/portal/stories/link.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Link } from 'components/link'
+import { NextIntlClientProvider } from 'next-intl'
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
+
+const meta = {
+  argTypes: {
+    children: { control: 'text' },
+    href: { control: 'text' },
+  },
+  component: Link,
+  decorators: [
+    Story => (
+      <NextIntlClientProvider locale="en" messages={{}}>
+        <NuqsTestingAdapter>
+          <Story />
+        </NuqsTestingAdapter>
+      </NextIntlClientProvider>
+    ),
+  ],
+  title: 'Components/Link',
+} satisfies Meta<typeof Link>
+
+export default meta
+
+type Story = StoryObj<typeof Link>
+
+export const Default: Story = {
+  args: {
+    children: 'Go to Tunnel',
+    className: 'hoverable-text',
+    href: '/tunnel',
+  },
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds a Storybook story for the `Link` component (`components/link`).

`Link` wraps the next-intl navigation `Link` and appends the `networkType` query param when it
differs from the default. The `Default` story renders it with sample text and an href. Because the
component relies on next-intl navigation and `useNetworkType` (nuqs), the story wraps it in a
`NextIntlClientProvider` and a `NuqsTestingAdapter` so it renders standalone (the resulting anchor
includes the locale prefix, e.g. `/en/tunnel`). The component is not modified.

- New `stories/link.stories.tsx` — a `Default` story with `children`/`href` controls.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img alt="components-link--default--ui" src="https://github.com/user-attachments/assets/7ef7fee3-c61a-4543-9e1e-0bf8c6f78f04" />

<img  alt="components-link--default" src="https://github.com/user-attachments/assets/8f6bfe18-7b49-45a9-a576-66b14a1533cd" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Fixes #
Related to #1993 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ x] Manual testing passed.
- [ x] Automated tests added, or N/A.
- [ x] Documentation updated, or N/A.
- [ x] Environment variables set in CI, or N/A.
