### PR TITLE
Sort locale message keys alphabetically

### DIFF
--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -1,177 +1,4 @@
 {
-  "hemi-earn": {
-    "heading": "Earn yield with Hemi Earn",
-    "info": {
-      "earned-amount": "Your earned amount",
-      "from-pools": "{count, plural, one {From # pool} other {From # pools}}",
-      "staked-balance": "Your staked balance"
-    },
-    "navigation": {
-      "back": "Back",
-      "hemi-earn": "Hemi Earn",
-      "pool-name": "{tokenSymbol} pool"
-    },
-    "pool": {
-      "apy": "APY",
-      "composition": {
-        "amount": "Amount",
-        "by-protocol": "By protocol",
-        "by-token": "By token",
-        "position": "Position",
-        "protocols-count": "{count, plural, one {# protocol} other {# protocols}}",
-        "reserve-buffer": "Reserve Buffer",
-        "share": "Share",
-        "title": "Composition",
-        "tokens-count": "{count, plural, one {# token} other {# tokens}}"
-      },
-      "deposit-successful": "Deposit successful",
-      "drawer": {
-        "approving": "Approving {symbol}",
-        "deposit": {
-          "heading": "Review stake deposit",
-          "subheading": "Your transaction has been submitted and is awaiting confirmation on the blockchain."
-        },
-        "cooldown-ended": "Cooldown period complete",
-        "stake-token": "Stake {symbol}",
-        "get-share-tokens": "Get share tokens",
-        "funds-returned": "Funds returned",
-        "funds-to-recover": "Funds to recover",
-        "shares-returned": "Shares returned",
-        "shares-to-recover": "Shares to recover",
-        "receive-token": "Receive {symbol}",
-        "unstake-token": "Unstake {symbol}",
-        "wait-cooldown-countdown": "{days, plural, =0 {Cooldown ends in {hours}h} other {Cooldown ends in #d {hours}h}}",
-        "wait-cooldown-countdown-soon": "Cooldown ends in less than an hour",
-        "wait-cooldown-pending": "Wait for the {days, plural, one {# day} other {# days}} cooldown period",
-        "withdraw": {
-          "heading": "Review stake withdrawal",
-          "subheading": "Your transaction has been submitted and is awaiting confirmation on the blockchain."
-        }
-      },
-      "form": {
-        "amount-too-small": "Amount too small",
-        "asset-unavailable": "Asset unavailable",
-        "available-to-withdraw": "Available to withdraw",
-        "bridging-fees": "Bridging fees",
-        "cooldown-warning": "Withdrawing funds takes {days, plural, one {# day} other {# days}} to complete.",
-        "cooldown-warning-fallback": "Withdrawing funds takes several days to complete.",
-        "network-error": "Preview failed — try again",
-        "total-fee": "Total gas fee",
-        "withdraw-share-tokens-as": "Withdraw share tokens as",
-        "withdrawing": "Withdrawing...",
-        "you-will-receive": "You'll receive"
-      },
-      "here-is-your-tx": "Here's your transaction:",
-      "historical-metrics": {
-        "1-week": "1 week",
-        "1-year": "1 year",
-        "apy": "APY",
-        "month": "{count, plural, one {# month} other {# months}}",
-        "pool-deposits": "Pool deposits",
-        "title": "Historical metrics"
-      },
-      "total-deposits": "Pool total deposits",
-      "withdraw-successful": "Withdraw successful"
-    },
-    "subheading": "One click earn for your assets",
-    "pool-info": {
-      "apy": "APY",
-      "manage": "Manage",
-      "pool-contract": "Pool Contract",
-      "share-token": "Share token",
-      "total-deposits": "Total deposits"
-    },
-    "transactions": {
-      "banner": {
-        "cancelled": {
-          "heading": "Withdrawal cancelled",
-          "subheading": "We're returning your share tokens to your wallet."
-        },
-        "claim-funds": {
-          "heading": "We couldn't claim your funds automatically",
-          "subheading": "Click on 'Claim funds' to get your funds."
-        },
-        "claim-shares": {
-          "heading": "We couldn't claim your share tokens automatically",
-          "subheading": "Click on 'Claim share tokens' to get your tokens."
-        },
-        "recover-funds": {
-          "heading": "Transaction failed",
-          "subheading": "Something went wrong. Use the button below to return your funds to your wallet."
-        },
-        "recover-shares": {
-          "heading": "Transaction failed",
-          "subheading": "Something went wrong. Use the button below to return your share tokens to your wallet."
-        }
-      },
-      "claim-funds": "Claim funds",
-      "claim-share-tokens": "Claim share tokens",
-      "claiming": "Claiming...",
-      "column": {
-        "amount": "Amount",
-        "date": "Date",
-        "status": "Status",
-        "tx-hash": "Tx Hash",
-        "type": "Type"
-      },
-      "cancel-modal": {
-        "cancelling": "Cancelling...",
-        "confirm": "Cancel withdrawal",
-        "description": "If you cancel it, your funds will go back to being staked and will no longer be in the cooldown lock.",
-        "keep": "Keep withdrawal",
-        "title": "Cancel withdrawal"
-      },
-      "cancel-withdraw": "Cancel withdrawal",
-      "connect-to-view": "Connect your wallet to view your earn transactions.",
-      "deposit": "Deposit",
-      "drawer": {
-        "deposit-heading": "Stake deposit details",
-        "deposit-subheading": "Review your stake deposit transaction.",
-        "step": {
-          "approval-needed": "Approval needed",
-          "approve-token": "Approve {symbol}",
-          "stake-token": "Stake {symbol}",
-          "get-share-tokens": "Get share tokens",
-          "funds-returned": "Funds returned",
-          "funds-to-recover": "Funds to recover",
-          "unstake-token": "Unstake {symbol}",
-          "receive-token": "Receive {symbol}",
-          "shares-returned": "Shares returned",
-          "shares-to-recover": "Shares to recover"
-        },
-        "withdraw-heading": "Stake withdrawal details",
-        "withdraw-subheading": "Review your stake withdrawal transaction."
-      },
-      "nothing-here": "Nothing here yet",
-      "nothing-here-subtitle": "Your transactions will appear once you get started.",
-      "recover-funds": "Recover funds",
-      "recover-shares": "Recover shares",
-      "recovering": "Recovering...",
-      "status": {
-        "cancelling": "Cancelling withdrawal",
-        "cooldown-ready-in-days": "Cooldown · ready in {value}d",
-        "cooldown-ready-in-hours": "Cooldown · ready in {value}h",
-        "cooldown-ready-in-minutes": "Cooldown · ready in {value}m",
-        "cooldown-ready-soon": "Cooldown · ready in < 1m",
-        "deposited": "Deposited",
-        "funds-returned": "Funds returned",
-        "in-progress": "In progress",
-        "manual-claim-needed": "In progress - Manual claim needed",
-        "ready-to-claim": "Ready to claim",
-        "recover-funds-needed": "Something went wrong - Recover funds",
-        "recover-shares-cancelled": "Withdrawal cancelled - Recover shares",
-        "recover-shares-needed": "Something went wrong - Recover shares",
-        "returned": "Returned",
-        "shares-returned": "Shares returned",
-        "tx-failed": "Tx Failed",
-        "withdrawn": "Withdrawn"
-      },
-      "subtitle": "Track the status of your deposits and withdrawals.",
-      "title": "My earn transactions",
-      "view": "View",
-      "withdrawal": "Withdrawal"
-    }
-  },
   "bitcoin-yield": {
     "bridge-btc-and-receive": "Bridge your BTC through the tunnel and receive {symbol}",
     "drawer": {
@@ -282,8 +109,8 @@
       "pending": "Pending",
       "rejected": "Rejected"
     },
-    "tunnel-fees": "Tunnel fees",
     "try-again": "Try again",
+    "tunnel-fees": "Tunnel fees",
     "unexpected-error": "An unexpected error has occurred. Please try again.",
     "unstake": "Unstake",
     "unsupported-chain-heading": "You're not connected to a supported chain",
@@ -338,26 +165,25 @@
   },
   "error-pages": {
     "not-found": {
-      "title": "Oops! Page not found",
+      "action": "Go back home",
       "description": "We can't find the page you're looking for.",
-      "action": "Go back home"
+      "title": "Oops! Page not found"
     },
     "unhandled-error": {
-      "title": "Something Went Wrong",
-      "description": "An unexpected error has occurred. Please try again or <link>contact us</link> if the problem persists."
+      "description": "An unexpected error has occurred. Please try again or <link>contact us</link> if the problem persists.",
+      "title": "Something Went Wrong"
     }
   },
   "genesis-drop": {
     "add-hemi-to-your-wallet": "Add {symbol} to your wallet",
-    "apy-in-staked-hemi": "APY in ${symbol}",
     "apy-in-hemi-up-to": "Up to {percentage}%",
-    "claimed": "Claimed",
+    "apy-in-staked-hemi": "APY in ${symbol}",
     "claim-and-stake-successful": "Claim and Stake successful",
     "claim-details": "Claim details",
     "claim-groups": {
       "genesis-drop": "Hemi Genesis Drop",
-      "spectra-and-dodo": "Spectra + Dodo",
-      "other-drop": "Other Drop"
+      "other-drop": "Other Drop",
+      "spectra-and-dodo": "Spectra + Dodo"
     },
     "claim-name": "Claim name:",
     "claim-options": {
@@ -366,15 +192,15 @@
       "bonus-staked-for-months": "<amount></amount> $<symbol></symbol> tokens staked for <months></months> months",
       "bonus-tokens": "Bonus tokens",
       "claim": "Claim",
-      "claim-title-6": "Genesis Voyager",
       "claim-title-24": "Genesis Guardian",
       "claim-title-48": "Genesis Legend",
+      "claim-title-6": "Genesis Voyager",
       "claiming": "Claiming...",
       "future-incentives-from": "Future incentives from",
-      "more-info-description": "Of your total earned tokens, a portion will be claimable immediately (\"available now\") while the rest will be staked automatically for a set lock-up period.",
-      "more-rewards": "+<bonus></bonus>% more ${symbol}",
       "liquid-hemi": "Liquid ${symbol}",
       "lockup-period-months": "{months} months",
+      "more-info-description": "Of your total earned tokens, a portion will be claimable immediately (\"available now\") while the rest will be staked automatically for a set lock-up period.",
+      "more-rewards": "+<bonus></bonus>% more ${symbol}",
       "plus-staked-tokens": "Plus <amount></amount> $<symbol></symbol> tokens staked<break></break>for <period></period>.",
       "potential-staked-rewards": "Potential rewards for your staked ${symbol}",
       "recommended": "Recommended",
@@ -387,21 +213,22 @@
       "up-to-multiplier-rewards": "Up to {multiplier}x multiplier on staked rewards"
     },
     "claim-rewards": "Claim rewards",
+    "claimed": "Claimed",
     "claiming-your-rewards": "Claiming your rewards",
     "connect-demos-wallet": "Make sure to connect your Demos verified wallet.",
+    "go-to-staking-dashboard": "Go to staking dashboard",
+    "have-questions": "Make sure you're connected to your Demos-verified wallet. If you have questions, open a ticket on <discordLink>Discord</discordLink>, check <absintheLink>Absinthe</absintheLink> or try another wallet.",
     "hemi-token-added": "{symbol} added to your wallet",
     "here-is-your-claim-tx": "Here's your claim transaction:",
-    "have-questions": "Make sure you're connected to your Demos-verified wallet. If you have questions, open a ticket on <discordLink>Discord</discordLink>, check <absintheLink>Absinthe</absintheLink> or try another wallet.",
-    "go-to-staking-dashboard": "Go to staking dashboard",
     "not-eligible": "Not eligible",
     "rewards-multiplier": "Rewards multiplier",
-    "staked-for-months": "{amount} for {months} months",
+    "share-x-text": "I am eligible for {amount} ${symbol} in the TGE Genesis drop of Hemi! 🎉 Check if you are eligible:",
     "stake-hemi": "Stake {symbol}",
+    "staked-for-months": "{amount} for {months} months",
     "switch-to-start-claiming": "You can switch networks to start claiming your HEMI.",
     "terms-and-conditions": {
       "title": "Hemi Genesis Drop Terms and Conditions"
     },
-    "share-x-text": "I am eligible for {amount} ${symbol} in the TGE Genesis drop of Hemi! 🎉 Check if you are eligible:",
     "title": "Rewards Program",
     "up-to-multiplier": "Up to {multiplier}x",
     "view-tx-on-explorer": "View TX on explorer",
@@ -409,20 +236,26 @@
     "your-rewards-are-on-their-way": "Your rewards are on their way!"
   },
   "get-started": {
-    "add-hemi-network-to-your-wallet": "Add Hemi network to your wallet",
+    "action": "Action",
     "add-hemi-network-description": "This lets your wallet interact with Hemi for transactions, bridges, and dApps.",
+    "add-hemi-network-to-your-wallet": "Add Hemi network to your wallet",
     "add-hemi-tokens": "Add Hemi tokens",
     "add-hemi-tokens-description": "Hemi tokens are paired with their ERC-20 versions on Ethereum. To see and use an asset on Hemi, your wallet needs the Hemi (L2) token address.",
+    "add-networks": {
+      "automatic": "Automatically",
+      "manual": "Manually"
+    },
+    "add-to-wallet": "Add network",
     "add-token": "Add token",
     "add-token-error-description": "Please try again.",
     "add-token-error-title": "Couldn't add token to your wallet",
-    "action": "Action",
-    "add-to-wallet": "Add network",
     "adding-chain": "Adding...",
     "block-explorer-url": "Block explorer URL",
     "chain-id": "Chain ID",
     "currency-symbol": "Currency symbol",
     "heading": "Get started on Hemi",
+    "l1-address": "L1 address",
+    "l2-address": "L2 address",
     "layer": "Layer {layer}",
     "learn-how-to-use-hemi": "Learn how to use Hemi",
     "learn-more-tutorials": {
@@ -433,20 +266,275 @@
       "set-up-evm-wallet": "Set up an EVM wallet",
       "tunnel-assets-to-hemi": "Tunnel assets to Hemi"
     },
-    "l1-address": "L1 address",
-    "l2-address": "L2 address",
     "no-matching-tokens": "No matching tokens",
     "no-matching-tokens-hint": "Check the spelling or try another token name or symbol.",
     "rpc-url": "RPC URL",
     "search-tokens-placeholder": "Search tokens...",
-    "token": "Token",
     "subheading": "Activate compliant Bitcoin yield without leaving custody.",
+    "token": "Token",
     "tutorials-subheading": "New to Hemi? Our step-by-step tutorials walk you through everything you need to know, from setting up your wallet to bridging tokens and using dApps.",
-    "view-all-tutorials": "View all tutorials",
-    "add-networks": {
-      "automatic": "Automatically",
-      "manual": "Manually"
+    "view-all-tutorials": "View all tutorials"
+  },
+  "hemi-earn": {
+    "heading": "Earn yield with Hemi Earn",
+    "info": {
+      "earned-amount": "Your earned amount",
+      "from-pools": "{count, plural, one {From # pool} other {From # pools}}",
+      "staked-balance": "Your staked balance"
+    },
+    "navigation": {
+      "back": "Back",
+      "hemi-earn": "Hemi Earn",
+      "pool-name": "{tokenSymbol} pool"
+    },
+    "pool": {
+      "apy": "APY",
+      "composition": {
+        "amount": "Amount",
+        "by-protocol": "By protocol",
+        "by-token": "By token",
+        "position": "Position",
+        "protocols-count": "{count, plural, one {# protocol} other {# protocols}}",
+        "reserve-buffer": "Reserve Buffer",
+        "share": "Share",
+        "title": "Composition",
+        "tokens-count": "{count, plural, one {# token} other {# tokens}}"
+      },
+      "deposit-successful": "Deposit successful",
+      "drawer": {
+        "approving": "Approving {symbol}",
+        "cooldown-ended": "Cooldown period complete",
+        "deposit": {
+          "heading": "Review stake deposit",
+          "subheading": "Your transaction has been submitted and is awaiting confirmation on the blockchain."
+        },
+        "funds-returned": "Funds returned",
+        "funds-to-recover": "Funds to recover",
+        "get-share-tokens": "Get share tokens",
+        "receive-token": "Receive {symbol}",
+        "shares-returned": "Shares returned",
+        "shares-to-recover": "Shares to recover",
+        "stake-token": "Stake {symbol}",
+        "unstake-token": "Unstake {symbol}",
+        "wait-cooldown-countdown": "{days, plural, =0 {Cooldown ends in {hours}h} other {Cooldown ends in #d {hours}h}}",
+        "wait-cooldown-countdown-soon": "Cooldown ends in less than an hour",
+        "wait-cooldown-pending": "Wait for the {days, plural, one {# day} other {# days}} cooldown period",
+        "withdraw": {
+          "heading": "Review stake withdrawal",
+          "subheading": "Your transaction has been submitted and is awaiting confirmation on the blockchain."
+        }
+      },
+      "form": {
+        "amount-too-small": "Amount too small",
+        "asset-unavailable": "Asset unavailable",
+        "available-to-withdraw": "Available to withdraw",
+        "bridging-fees": "Bridging fees",
+        "cooldown-warning": "Withdrawing funds takes {days, plural, one {# day} other {# days}} to complete.",
+        "cooldown-warning-fallback": "Withdrawing funds takes several days to complete.",
+        "network-error": "Preview failed — try again",
+        "total-fee": "Total gas fee",
+        "withdraw-share-tokens-as": "Withdraw share tokens as",
+        "withdrawing": "Withdrawing...",
+        "you-will-receive": "You'll receive"
+      },
+      "here-is-your-tx": "Here's your transaction:",
+      "historical-metrics": {
+        "1-week": "1 week",
+        "1-year": "1 year",
+        "apy": "APY",
+        "month": "{count, plural, one {# month} other {# months}}",
+        "pool-deposits": "Pool deposits",
+        "title": "Historical metrics"
+      },
+      "total-deposits": "Pool total deposits",
+      "withdraw-successful": "Withdraw successful"
+    },
+    "pool-info": {
+      "apy": "APY",
+      "manage": "Manage",
+      "pool-contract": "Pool Contract",
+      "share-token": "Share token",
+      "total-deposits": "Total deposits"
+    },
+    "subheading": "One click earn for your assets",
+    "transactions": {
+      "banner": {
+        "cancelled": {
+          "heading": "Withdrawal cancelled",
+          "subheading": "We're returning your share tokens to your wallet."
+        },
+        "claim-funds": {
+          "heading": "We couldn't claim your funds automatically",
+          "subheading": "Click on 'Claim funds' to get your funds."
+        },
+        "claim-shares": {
+          "heading": "We couldn't claim your share tokens automatically",
+          "subheading": "Click on 'Claim share tokens' to get your tokens."
+        },
+        "recover-funds": {
+          "heading": "Transaction failed",
+          "subheading": "Something went wrong. Use the button below to return your funds to your wallet."
+        },
+        "recover-shares": {
+          "heading": "Transaction failed",
+          "subheading": "Something went wrong. Use the button below to return your share tokens to your wallet."
+        }
+      },
+      "cancel-modal": {
+        "cancelling": "Cancelling...",
+        "confirm": "Cancel withdrawal",
+        "description": "If you cancel it, your funds will go back to being staked and will no longer be in the cooldown lock.",
+        "keep": "Keep withdrawal",
+        "title": "Cancel withdrawal"
+      },
+      "cancel-withdraw": "Cancel withdrawal",
+      "claim-funds": "Claim funds",
+      "claim-share-tokens": "Claim share tokens",
+      "claiming": "Claiming...",
+      "column": {
+        "amount": "Amount",
+        "date": "Date",
+        "status": "Status",
+        "tx-hash": "Tx Hash",
+        "type": "Type"
+      },
+      "connect-to-view": "Connect your wallet to view your earn transactions.",
+      "deposit": "Deposit",
+      "drawer": {
+        "deposit-heading": "Stake deposit details",
+        "deposit-subheading": "Review your stake deposit transaction.",
+        "step": {
+          "approval-needed": "Approval needed",
+          "approve-token": "Approve {symbol}",
+          "funds-returned": "Funds returned",
+          "funds-to-recover": "Funds to recover",
+          "get-share-tokens": "Get share tokens",
+          "receive-token": "Receive {symbol}",
+          "shares-returned": "Shares returned",
+          "shares-to-recover": "Shares to recover",
+          "stake-token": "Stake {symbol}",
+          "unstake-token": "Unstake {symbol}"
+        },
+        "withdraw-heading": "Stake withdrawal details",
+        "withdraw-subheading": "Review your stake withdrawal transaction."
+      },
+      "nothing-here": "Nothing here yet",
+      "nothing-here-subtitle": "Your transactions will appear once you get started.",
+      "recover-funds": "Recover funds",
+      "recover-shares": "Recover shares",
+      "recovering": "Recovering...",
+      "status": {
+        "cancelling": "Cancelling withdrawal",
+        "cooldown-ready-in-days": "Cooldown · ready in {value}d",
+        "cooldown-ready-in-hours": "Cooldown · ready in {value}h",
+        "cooldown-ready-in-minutes": "Cooldown · ready in {value}m",
+        "cooldown-ready-soon": "Cooldown · ready in < 1m",
+        "deposited": "Deposited",
+        "funds-returned": "Funds returned",
+        "in-progress": "In progress",
+        "manual-claim-needed": "In progress - Manual claim needed",
+        "ready-to-claim": "Ready to claim",
+        "recover-funds-needed": "Something went wrong - Recover funds",
+        "recover-shares-cancelled": "Withdrawal cancelled - Recover shares",
+        "recover-shares-needed": "Something went wrong - Recover shares",
+        "returned": "Returned",
+        "shares-returned": "Shares returned",
+        "tx-failed": "Tx Failed",
+        "withdrawn": "Withdrawn"
+      },
+      "subtitle": "Track the status of your deposits and withdrawals.",
+      "title": "My earn transactions",
+      "view": "View",
+      "withdrawal": "Withdrawal"
     }
+  },
+  "metadata": {
+    "title": "Hemi Portal"
+  },
+  "navbar": {
+    "agree-to-terms-and-policy": "By using this application, you agree to the <terms>Terms of Use</terms> and <policy>Privacy Policy</policy>",
+    "bitcoinkit": "Hemi Bitcoin Kit",
+    "boost-staking": "Boost staking",
+    "data-attribution": "Data provided by <link>CoinMarketCap.com</link>",
+    "dex": {
+      "aggregators": "Aggregators",
+      "subtitle": "DEXs",
+      "title": "DEXs"
+    },
+    "docs": "Documentation",
+    "ecosystem": "Demos",
+    "explorer": "Explorer",
+    "follow-us": "Follow us",
+    "genesis-drop": "Genesis Drop",
+    "get-started": "Get started",
+    "governance-staking": "Governance staking",
+    "help": {
+      "language": "Language",
+      "legal-and-privacy": "Legal and Privacy"
+    },
+    "network": "Network",
+    "network-status": "Network status",
+    "stake": "Stake",
+    "swap": "Swap",
+    "tools": "Tools",
+    "tunnel": "Tunnel",
+    "tvl": "TVL on Hemi"
+  },
+  "stake-page": {
+    "action": "Action",
+    "asset": "Asset",
+    "change-to-mainnet": "Change to Mainnet and stake",
+    "dashboard": {
+      "coming-soon": "Coming Soon",
+      "heading": "Boost staking",
+      "stake-more": "Stake more",
+      "staked": "Staked",
+      "staking-assets": "Staking assets",
+      "subtitle": "Monitor your boost staking positions.",
+      "title": "Dashboard",
+      "total-earned-points": "Total Hemi points earned",
+      "total-earned-points-description": "Season ended.",
+      "total-staked-on-hemi": "Total Staked on Hemi",
+      "your-stake": "Your Stake"
+    },
+    "drawer": {
+      "approve-and-stake": "Approve and Stake",
+      "description-manage-stake": "Top up your stake, or withdraw anytime—you're in full control!",
+      "manage-your-stake": "Manage your stake",
+      "stake-and-earn-rewards": "Stake {symbol} to boost your participation.",
+      "stake-token": "Stake {symbol}",
+      "staking": "Staking...",
+      "strategy-details": {
+        "heading": "Strategy Details",
+        "tvl": "TVL (on Hemi)",
+        "website": "Website"
+      },
+      "unstake-eth-as-weth-heading": "Unstaked ETH will be received as WETH",
+      "unstake-eth-as-weth-subheading": "When you stake ETH, it is automatically converted to WETH. Upon unstaking, you'll receive WETH, which you can unwrap back to ETH if desired.",
+      "unstake-token": "Unstake {symbol}",
+      "unstaking": "Unstaking...",
+      "unwrap": "Unwrap",
+      "you-can-unstake-anytime": "You can unstake any time."
+    },
+    "protocol": "Protocol",
+    "ready-to-earn": "Ready to stake? Use supported assets and start staking.",
+    "rewards": "Rewards",
+    "stake": {
+      "action": "Action",
+      "heading": "Stake for boost",
+      "subheading": "Stake your tokens.",
+      "title": "Stake"
+    },
+    "start-staking-earn-points": "Start staking",
+    "toast": {
+      "go-staking-dashboard": "View your staking dashboard",
+      "here-your-stake-tx": "Here’s your {type} transaction:",
+      "staking": "staking",
+      "staking-successful": "Staking successful",
+      "unstaking": "unstaking",
+      "unstaking-successful": "Unstaking successful"
+    },
+    "wallet-balance": "Wallet balance"
   },
   "staking-dashboard": {
     "amount": "Amount",
@@ -495,10 +583,10 @@
       "years": "{years, plural, one {{years} year} other {{years} years}}"
     },
     "heading": "Governance staking",
-    "subheading": "Stake your ${symbol} to participate in governance and earn staking rewards.",
     "here-is-your-tx": "Here's your transaction:",
     "lockup-period": "Lockup period",
     "stake-successful": "Stake successful",
+    "subheading": "Stake your ${symbol} to participate in governance and earn staking rewards.",
     "switch-to-start-staking": "You can switch networks to start staking your HEMI.",
     "table": {
       "active": "Active",
@@ -530,94 +618,6 @@
     "voting-power": "Voting Power",
     "your-positions": "Your positions"
   },
-  "metadata": {
-    "title": "Hemi Portal"
-  },
-  "navbar": {
-    "agree-to-terms-and-policy": "By using this application, you agree to the <terms>Terms of Use</terms> and <policy>Privacy Policy</policy>",
-    "bitcoinkit": "Hemi Bitcoin Kit",
-    "boost-staking": "Boost staking",
-    "data-attribution": "Data provided by <link>CoinMarketCap.com</link>",
-    "dex": {
-      "aggregators": "Aggregators",
-      "subtitle": "DEXs",
-      "title": "DEXs"
-    },
-    "docs": "Documentation",
-    "ecosystem": "Demos",
-    "explorer": "Explorer",
-    "follow-us": "Follow us",
-    "genesis-drop": "Genesis Drop",
-    "get-started": "Get started",
-    "governance-staking": "Governance staking",
-    "help": {
-      "language": "Language",
-      "legal-and-privacy": "Legal and Privacy"
-    },
-    "network": "Network",
-    "network-status": "Network status",
-    "swap": "Swap",
-    "stake": "Stake",
-    "tools": "Tools",
-    "tunnel": "Tunnel",
-    "tvl": "TVL on Hemi"
-  },
-  "stake-page": {
-    "action": "Action",
-    "asset": "Asset",
-    "change-to-mainnet": "Change to Mainnet and stake",
-    "dashboard": {
-      "coming-soon": "Coming Soon",
-      "staked": "Staked",
-      "stake-more": "Stake more",
-      "staking-assets": "Staking assets",
-      "subtitle": "Monitor your boost staking positions.",
-      "heading": "Boost staking",
-      "title": "Dashboard",
-      "total-earned-points": "Total Hemi points earned",
-      "total-earned-points-description": "Season ended.",
-      "total-staked-on-hemi": "Total Staked on Hemi",
-      "your-stake": "Your Stake"
-    },
-    "drawer": {
-      "approve-and-stake": "Approve and Stake",
-      "description-manage-stake": "Top up your stake, or withdraw anytime—you're in full control!",
-      "manage-your-stake": "Manage your stake",
-      "stake-and-earn-rewards": "Stake {symbol} to boost your participation.",
-      "stake-token": "Stake {symbol}",
-      "staking": "Staking...",
-      "strategy-details": {
-        "heading": "Strategy Details",
-        "tvl": "TVL (on Hemi)",
-        "website": "Website"
-      },
-      "unstake-eth-as-weth-heading": "Unstaked ETH will be received as WETH",
-      "unstake-eth-as-weth-subheading": "When you stake ETH, it is automatically converted to WETH. Upon unstaking, you'll receive WETH, which you can unwrap back to ETH if desired.",
-      "unstake-token": "Unstake {symbol}",
-      "unstaking": "Unstaking...",
-      "unwrap": "Unwrap",
-      "you-can-unstake-anytime": "You can unstake any time."
-    },
-    "protocol": "Protocol",
-    "ready-to-earn": "Ready to stake? Use supported assets and start staking.",
-    "rewards": "Rewards",
-    "stake": {
-      "action": "Action",
-      "heading": "Stake for boost",
-      "subheading": "Stake your tokens.",
-      "title": "Stake"
-    },
-    "start-staking-earn-points": "Start staking",
-    "toast": {
-      "go-staking-dashboard": "View your staking dashboard",
-      "here-your-stake-tx": "Here’s your {type} transaction:",
-      "staking": "staking",
-      "staking-successful": "Staking successful",
-      "unstaking": "unstaking",
-      "unstaking-successful": "Unstaking successful"
-    },
-    "wallet-balance": "Wallet balance"
-  },
   "token-custom-drawer": {
     "add-contract-to-preview": "Add a contract address to preview the token...",
     "add-this-pair": "Add this pair to Hemi's token list for everyone to tunnel",
@@ -626,13 +626,13 @@
     "address-does-not-match-l2": "Doesn't match the L1 pair",
     "heading": "Tunnel an existing ERC-20 token",
     "i-am-sure-to-tunnel": "I'm sure I want to tunnel with this token.",
+    "l1-address-not-configured": "L1 address not configured in the contract",
     "layer-token-address": "Layer {layer} token address",
     "make-a-request-to-add": "If you'd like to add this ERC-20 token pair to Hemi's approved tokens list, <link>make a request</link>.",
     "see-on-explorer": "See on {explorer}",
     "subheading": "You need to input the pair of contract addresses from both Ethereum and Hemi to tunnel with this token.",
     "this-address-is-not-valid": "This address is not valid",
-    "this-address-is-valid": "This address is valid",
-    "l1-address-not-configured": "L1 address not configured in the contract"
+    "this-address-is-valid": "This address is valid"
   },
   "token-selector": {
     "all-tokens": "All tokens",
@@ -680,15 +680,15 @@
       "add-token-to-wallet-success": "Token contract added to your wallet",
       "approve-confirmed": "Approve confirmed",
       "approve-initiated": "Approve initiated",
+      "approve-on": "Approve on {networkName}",
       "btc-deposit-come-back-delay-note": "If you do not receive your deposit after {hours} hours return to this page to manually claim.",
-      "deposit-completed": "Deposit completed",
       "click-to-confirm": "Click on 'Confirm Deposit Manually' to deposit your Bitcoin to Hemi.",
       "confirm-deposit-on": "Confirm deposit on {networkName}",
+      "deposit-completed": "Deposit completed",
       "deposit-finalized": "Deposit finalized",
       "deposit-on-its-way": "Your deposit is on its way! Please wait while the blockchain finalizes the transaction.",
       "get-your-funds-on": "Get your funds on {networkName}",
       "initiate-deposit": "Initiate deposit",
-      "approve-on": "Approve on {networkName}",
       "review-deposit": "Review Deposit",
       "start-on": "Start on {networkName}",
       "we-could-not-process-this-deposit": "We couldn't process this deposit automatically",
@@ -697,8 +697,8 @@
     "review-withdrawal": {
       "challenge-to-get-bitcoins-back": "Click 'Challenge withdrawal' to reclaim your BTC and send it back to your Hemi address.",
       "challenge-withdrawal": "Challenge Withdrawal",
-      "claim-your-funds": "Claim your funds on {networkName}",
       "claim-withdrawal": "Claim withdrawal",
+      "claim-your-funds": "Claim your funds on {networkName}",
       "get-funds-back": "Get my funds back to {networkName}",
       "heading": "Review Withdrawal",
       "initiate-withdrawal": "Initiate withdrawal",
@@ -717,8 +717,8 @@
       "challenging": "Challenging...",
       "claim-withdrawal": "Claim Withdrawal",
       "claiming-withdrawal": "Claiming Withdrawal...",
-      "confirming-deposit-manually": "Confirming deposit manually...",
       "confirm-deposit-manually": "Confirm deposit manually",
+      "confirming-deposit-manually": "Confirming deposit manually...",
       "connect-both-wallets": "Connect your BTC and EVM wallets",
       "connect-btc-wallet": "Connect your BTC wallet",
       "deposit": "Deposit",
@@ -748,16 +748,6 @@
         "type": "Type"
       },
       "deposit": "Deposit",
-      "no-transactions": "No transactions made",
-      "no-transactions-get-started": "Get started by tunneling assets from and to hemi",
-      "subtitle": "Track the status and details of your Hemi transactions.",
-      "title": "Transaction history",
-      "top-bar": {
-        "all": "All",
-        "bitcoin": "Bitcoin",
-        "ethereum": "Ethereum",
-        "recent-transactions": "Recent Transactions"
-      },
       "filters": {
         "actions": {
           "all": "All actions",
@@ -768,6 +758,16 @@
           "deposits": "Deposits",
           "withdrawals": "Withdrawals"
         }
+      },
+      "no-transactions": "No transactions made",
+      "no-transactions-get-started": "Get started by tunneling assets from and to hemi",
+      "subtitle": "Track the status and details of your Hemi transactions.",
+      "title": "Transaction history",
+      "top-bar": {
+        "all": "All",
+        "bitcoin": "Bitcoin",
+        "ethereum": "Ethereum",
+        "recent-transactions": "Recent Transactions"
       },
       "tunnel-assets": "Tunnel assets",
       "withdraw": "Withdraw"

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -628,7 +628,7 @@
     "i-am-sure-to-tunnel": "Estoy seguro que quiero tunelizar este token.",
     "l1-address-not-configured": "Dirección L1 no configurada en el contrato",
     "layer-token-address": "Dirección de contrato del token de capa {layer}",
-    "make-a-request-to-add": "Si deseas agregar este par de tokens ERC-20 a la lista de tokens aprobados de Hemi, <link>haz una solicitud</link>.",
+    "make-a-request-to-add": "Si desea agregar este par de tokens ERC-20 a la lista de tokens aprobados de Hemi, <link>haga una solicitud</link>.",
     "see-on-explorer": "Ver en {explorer}",
     "subheading": "Necesitas ingresar el par de direcciones de contrato tanto de Ethereum como de Hemi para tunelear con este token.",
     "this-address-is-not-valid": "Esta dirección es inválida",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -272,7 +272,7 @@
     "search-tokens-placeholder": "Buscar tokens...",
     "subheading": "Active rendimiento de Bitcoin compatible sin renunciar a la custodia.",
     "token": "Token",
-    "tutorials-subheading": "¿Nuevo en Hemi? Nuestros tutoriales paso a paso te guían en todo lo que necesitas saber, desde configurar tu billetera hasta hacer bridge de tokens y usar dApps.",
+    "tutorials-subheading": "¿Nuevo en Hemi? Nuestros tutoriales paso a paso le guían en todo lo que necesita saber, desde configurar su billetera hasta hacer bridge de tokens y usar dApps.",
     "view-all-tutorials": "Ver todos los tutoriales"
   },
   "hemi-earn": {

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -222,7 +222,7 @@
     "here-is-your-claim-tx": "Aquí está su transacción de reclamo:",
     "not-eligible": "No elegible",
     "rewards-multiplier": "Multiplicador de recompensas",
-    "share-x-text": "¡Soy elegible para {amount} ${symbol} del lanzamiento Génesis TGE de Hemi! 🎉 Verifique si eres elegible:",
+    "share-x-text": "¡Soy elegible para {amount} ${symbol} del lanzamiento Génesis TGE de Hemi! 🎉 Verifique si es elegible:",
     "stake-hemi": "Hacer Stake de {symbol}",
     "staked-for-months": "{amount} por {months} meses",
     "switch-to-start-claiming": "Puede cambiar de red para comenzar a reclamar su HEMI.",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -630,7 +630,7 @@
     "layer-token-address": "Dirección de contrato del token de capa {layer}",
     "make-a-request-to-add": "Si desea agregar este par de tokens ERC-20 a la lista de tokens aprobados de Hemi, <link>haga una solicitud</link>.",
     "see-on-explorer": "Ver en {explorer}",
-    "subheading": "Necesitas ingresar el par de direcciones de contrato tanto de Ethereum como de Hemi para tunelear con este token.",
+    "subheading": "Necesita ingresar el par de direcciones de contrato tanto de Ethereum como de Hemi para tunelear con este token.",
     "this-address-is-not-valid": "Esta dirección es inválida",
     "this-address-is-valid": "Esta dirección es válida"
   },

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -698,7 +698,7 @@
       "challenge-to-get-bitcoins-back": "Haga clic en 'Disputar Retiro' para reclamar su BTC y enviarlo de vuelta a su dirección de Hemi.",
       "challenge-withdrawal": "Disputar Retiro",
       "claim-withdrawal": "Reclamar retiro",
-      "claim-your-funds": "Reclama tus fondos en {networkName}",
+      "claim-your-funds": "Reclame sus fondos en {networkName}",
       "get-funds-back": "Devolver mis fondos a {networkName}",
       "heading": "Revisar Retiro",
       "initiate-withdrawal": "Iniciar retiro",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -1,177 +1,4 @@
 {
-  "hemi-earn": {
-    "heading": "Obtenga rendimiento con Hemi Earn",
-    "info": {
-      "earned-amount": "Cantidad ganada",
-      "from-pools": "{count, plural, one {De # fondo} other {De # fondos}}",
-      "staked-balance": "Su saldo invertido"
-    },
-    "navigation": {
-      "back": "Atrás",
-      "hemi-earn": "Hemi Earn",
-      "pool-name": "fondo {tokenSymbol}"
-    },
-    "pool": {
-      "apy": "TEA",
-      "composition": {
-        "amount": "Monto",
-        "by-protocol": "Por protocolo",
-        "by-token": "Por token",
-        "position": "Posición",
-        "protocols-count": "{count, plural, one {# protocolo} other {# protocolos}}",
-        "reserve-buffer": "Reserva de liquidez",
-        "share": "Participación",
-        "title": "Composición",
-        "tokens-count": "{count, plural, one {# token} other {# tokens}}"
-      },
-      "deposit-successful": "Depósito exitoso",
-      "drawer": {
-        "approving": "Aprobando {symbol}",
-        "deposit": {
-          "heading": "Revisar depósito de stake",
-          "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."
-        },
-        "cooldown-ended": "Período de espera completado",
-        "stake-token": "Hacer stake de {symbol}",
-        "get-share-tokens": "Recibir share tokens",
-        "funds-returned": "Fondos devueltos",
-        "funds-to-recover": "Fondos por recuperar",
-        "shares-returned": "Shares devueltas",
-        "shares-to-recover": "Shares por recuperar",
-        "receive-token": "Recibir {symbol}",
-        "unstake-token": "Hacer unstake de {symbol}",
-        "wait-cooldown-countdown": "{days, plural, =0 {El período de espera termina en {hours}h} other {El período de espera termina en #d {hours}h}}",
-        "wait-cooldown-countdown-soon": "El período de espera termina en menos de una hora",
-        "wait-cooldown-pending": "El período de espera es de {days, plural, one {# día} other {# días}}",
-        "withdraw": {
-          "heading": "Revisar retiro de stake",
-          "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."
-        }
-      },
-      "form": {
-        "amount-too-small": "Monto demasiado pequeño",
-        "asset-unavailable": "Activo no disponible",
-        "available-to-withdraw": "Disponible para retirar",
-        "bridging-fees": "Tarifas de bridge",
-        "cooldown-warning": "Retirar fondos tarda {days, plural, one {# día} other {# días}} en completarse.",
-        "cooldown-warning-fallback": "Retirar fondos tarda algunos días en completarse.",
-        "network-error": "Error al previsualizar — reintente",
-        "total-fee": "Costo total de gas",
-        "withdraw-share-tokens-as": "Retirar tokens de participación como",
-        "withdrawing": "Retirando...",
-        "you-will-receive": "Recibirá"
-      },
-      "here-is-your-tx": "Aquí está su transacción:",
-      "historical-metrics": {
-        "1-week": "1 semana",
-        "1-year": "1 año",
-        "apy": "TEA",
-        "month": "{count, plural, one {# mes} other {# meses}}",
-        "pool-deposits": "Depósitos del fondo",
-        "title": "Métricas históricas"
-      },
-      "total-deposits": "Depósitos totales del fondo",
-      "withdraw-successful": "Retiro exitoso"
-    },
-    "subheading": "Gane rendimiento con sus activos en un solo clic",
-    "pool-info": {
-      "apy": "TEA",
-      "manage": "Gestionar",
-      "pool-contract": "Contrato del fondo",
-      "share-token": "Token de participación",
-      "total-deposits": "Depósitos totales"
-    },
-    "transactions": {
-      "banner": {
-        "cancelled": {
-          "heading": "Retiro cancelado",
-          "subheading": "Estamos devolviendo sus share tokens a su billetera."
-        },
-        "claim-funds": {
-          "heading": "No pudimos recibir sus fondos automáticamente",
-          "subheading": "Haga clic en 'Recibir fondos' para recibir sus fondos."
-        },
-        "claim-shares": {
-          "heading": "No pudimos recibir sus share tokens automáticamente",
-          "subheading": "Haga clic en 'Recibir share tokens' para recibir sus tokens."
-        },
-        "recover-funds": {
-          "heading": "La transacción falló",
-          "subheading": "Algo salió mal. Use el botón de abajo para devolver sus fondos a su billetera."
-        },
-        "recover-shares": {
-          "heading": "La transacción falló",
-          "subheading": "Algo salió mal. Use el botón de abajo para devolver sus share tokens a su billetera."
-        }
-      },
-      "claim-funds": "Recibir fondos",
-      "claim-share-tokens": "Recibir share tokens",
-      "claiming": "Recibiendo...",
-      "column": {
-        "amount": "Cantidad",
-        "date": "Fecha",
-        "status": "Estado",
-        "tx-hash": "Hash de Tx",
-        "type": "Tipo"
-      },
-      "cancel-modal": {
-        "cancelling": "Cancelando...",
-        "confirm": "Cancelar retiro",
-        "description": "Si lo cancela, sus fondos volverán a estar en stake y dejarán de estar en el período de espera.",
-        "keep": "Mantener retiro",
-        "title": "Cancelar retiro"
-      },
-      "cancel-withdraw": "Cancelar retiro",
-      "connect-to-view": "Conecte su billetera para ver sus transacciones de earn.",
-      "deposit": "Depósito",
-      "drawer": {
-        "deposit-heading": "Detalles del depósito de stake",
-        "deposit-subheading": "Revise su transacción de depósito de stake.",
-        "step": {
-          "approval-needed": "Aprobación necesaria",
-          "approve-token": "Aprobar {symbol}",
-          "stake-token": "Hacer stake de {symbol}",
-          "get-share-tokens": "Recibir share tokens",
-          "funds-returned": "Fondos devueltos",
-          "funds-to-recover": "Fondos por recuperar",
-          "unstake-token": "Retirar {symbol}",
-          "receive-token": "Recibir {symbol}",
-          "shares-returned": "Shares devueltas",
-          "shares-to-recover": "Shares por recuperar"
-        },
-        "withdraw-heading": "Detalles del retiro de stake",
-        "withdraw-subheading": "Revise su transacción de retiro de stake."
-      },
-      "nothing-here": "Aún no hay nada aquí",
-      "nothing-here-subtitle": "Sus transacciones aparecerán una vez que comience.",
-      "recover-funds": "Recuperar fondos",
-      "recover-shares": "Recuperar shares",
-      "recovering": "Recuperando...",
-      "status": {
-        "cancelling": "Cancelando retiro",
-        "cooldown-ready-in-days": "Cooldown · listo en {value}d",
-        "cooldown-ready-in-hours": "Cooldown · listo en {value}h",
-        "cooldown-ready-in-minutes": "Cooldown · listo en {value}m",
-        "cooldown-ready-soon": "Cooldown · listo en < 1m",
-        "deposited": "Depositado",
-        "funds-returned": "Fondos devueltos",
-        "in-progress": "En progreso",
-        "manual-claim-needed": "En progreso - Reclamo manual necesario",
-        "ready-to-claim": "Listo para recibir",
-        "recover-funds-needed": "Algo salió mal - Recuperar fondos",
-        "recover-shares-cancelled": "Retiro cancelado - Recuperar shares",
-        "recover-shares-needed": "Algo salió mal - Recuperar shares",
-        "returned": "Devuelto",
-        "shares-returned": "Shares devueltas",
-        "tx-failed": "Tx fallida",
-        "withdrawn": "Retirado"
-      },
-      "subtitle": "Realice un seguimiento del estado de sus depósitos y retiros.",
-      "title": "Mis transacciones de earn",
-      "view": "Ver",
-      "withdrawal": "Retiro"
-    }
-  },
   "bitcoin-yield": {
     "bridge-btc-and-receive": "Transfiera su BTC a través del túnel y reciba {symbol}",
     "drawer": {
@@ -282,8 +109,8 @@
       "pending": "Pendiente",
       "rejected": "Rechazada"
     },
-    "tunnel-fees": "Tarifas del túnel",
     "try-again": "Intente Nuevamente",
+    "tunnel-fees": "Tarifas del túnel",
     "unexpected-error": "Ocurrió un error inesperado. Por favor inténtelo de nuevo.",
     "unstake": "Desbloquear",
     "unsupported-chain-heading": "Usted no se encuentra conectado a una red soportada",
@@ -338,26 +165,25 @@
   },
   "error-pages": {
     "not-found": {
-      "title": "¡Ups! Página no encontrada",
+      "action": "Volver al inicio",
       "description": "No podemos encontrar la página que estás buscando.",
-      "action": "Volver al inicio"
+      "title": "¡Ups! Página no encontrada"
     },
     "unhandled-error": {
-      "title": "Algo salió mal",
-      "description": "Ha ocurrido un error inesperado. Por favor, inténtelo de nuevo o <link>contáctenos</link> si el problema persiste."
+      "description": "Ha ocurrido un error inesperado. Por favor, inténtelo de nuevo o <link>contáctenos</link> si el problema persiste.",
+      "title": "Algo salió mal"
     }
   },
   "genesis-drop": {
     "add-hemi-to-your-wallet": "Agregar {symbol} a su billetera",
-    "apy-in-staked-hemi": "TEA en ${symbol}",
     "apy-in-hemi-up-to": "Hasta {percentage}%",
-    "claimed": "Reclamado",
+    "apy-in-staked-hemi": "TEA en ${symbol}",
     "claim-and-stake-successful": "Reclamo y Stake exitoso",
     "claim-details": "Detalles del reclamo",
     "claim-groups": {
       "genesis-drop": "Lanzamiento Génesis de Hemi",
-      "spectra-and-dodo": "Spectra + Dodo",
-      "other-drop": "Otro Lanzamiento"
+      "other-drop": "Otro Lanzamiento",
+      "spectra-and-dodo": "Spectra + Dodo"
     },
     "claim-name": "Nombre del reclamo:",
     "claim-options": {
@@ -366,15 +192,15 @@
       "bonus-staked-for-months": "<amount></amount> $<symbol></symbol> tokens en stake por <months></months> meses",
       "bonus-tokens": "Tokens extra",
       "claim": "Reclamar",
-      "claim-title-6": "Génesis Viajero",
       "claim-title-24": "Génesis Guardián",
       "claim-title-48": "Génesis Leyenda",
+      "claim-title-6": "Génesis Viajero",
       "claiming": "Reclamando...",
       "future-incentives-from": "Futuros incentivos de",
-      "more-info-description": "De sus tokens totales ganados, una parte será reclamable inmediatamente (\"disponible ahora\") mientras que el resto será puesto automáticamente en stake por un período de bloqueo establecido.",
-      "more-rewards": "+<bonus></bonus>% mas ${symbol}",
       "liquid-hemi": "${symbol} líquidos",
       "lockup-period-months": "{months} meses",
+      "more-info-description": "De sus tokens totales ganados, una parte será reclamable inmediatamente (\"disponible ahora\") mientras que el resto será puesto automáticamente en stake por un período de bloqueo establecido.",
+      "more-rewards": "+<bonus></bonus>% mas ${symbol}",
       "plus-staked-tokens": "Más <amount></amount> $<symbol></symbol> tokens en stake<break></break>por <period></period>.",
       "potential-staked-rewards": "Recompensas potenciales para sus tokens ${symbol} en stake",
       "recommended": "Recomendado",
@@ -387,21 +213,22 @@
       "up-to-multiplier-rewards": "Hasta {multiplier}x multiplicador en recompensas en stake"
     },
     "claim-rewards": "Reclamar recompensas",
+    "claimed": "Reclamado",
     "claiming-your-rewards": "Reclamando sus recompensas",
     "connect-demos-wallet": "Asegúrese de conectar su billetera verificada de Demos.",
+    "go-to-staking-dashboard": "Ir al panel de control de staking",
+    "have-questions": "Asegúrese de estar conectado con su billetera verificada de Demos. Si tiene preguntas, abra un ticket en <discordLink>Discord</discordLink>, consulte <absintheLink>Absinthe</absintheLink> o pruebe con otra billetera.",
     "hemi-token-added": "{symbol} agregado a su billetera",
     "here-is-your-claim-tx": "Aquí está su transacción de reclamo:",
-    "have-questions": "Asegúrese de estar conectado con su billetera verificada de Demos. Si tiene preguntas, abra un ticket en <discordLink>Discord</discordLink>, consulte <absintheLink>Absinthe</absintheLink> o pruebe con otra billetera.",
-    "go-to-staking-dashboard": "Ir al panel de control de staking",
     "not-eligible": "No elegible",
     "rewards-multiplier": "Multiplicador de recompensas",
-    "staked-for-months": "{amount} por {months} meses",
+    "share-x-text": "¡Soy elegible para {amount} ${symbol} del lanzamiento Génesis TGE de Hemi! 🎉 Verifique si eres elegible:",
     "stake-hemi": "Hacer Stake de {symbol}",
+    "staked-for-months": "{amount} por {months} meses",
     "switch-to-start-claiming": "Puede cambiar de red para comenzar a reclamar su HEMI.",
     "terms-and-conditions": {
       "title": "Términos y Condiciones del programa Lanzamiento Génesis de Hemi"
     },
-    "share-x-text": "¡Soy elegible para {amount} ${symbol} del lanzamiento Génesis TGE de Hemi! 🎉 Verifique si eres elegible:",
     "title": "Programa de Recompensas",
     "up-to-multiplier": "Hasta {multiplier}x",
     "view-tx-on-explorer": "Ver TX en el explorador",
@@ -409,20 +236,26 @@
     "your-rewards-are-on-their-way": "¡Sus recompensas están en camino!"
   },
   "get-started": {
-    "add-hemi-network-to-your-wallet": "Agregue la red Hemi a su billetera",
+    "action": "Acción",
     "add-hemi-network-description": "Esto permite que su billetera interactúe con Hemi para transacciones, bridges y dApps.",
+    "add-hemi-network-to-your-wallet": "Agregue la red Hemi a su billetera",
     "add-hemi-tokens": "Agregar tokens de Hemi",
     "add-hemi-tokens-description": "Los tokens de Hemi están emparejados con sus versiones ERC-20 en Ethereum. Para ver y usar un activo en Hemi, su billetera necesita la dirección del token de Hemi (L2).",
+    "add-networks": {
+      "automatic": "Automáticamente",
+      "manual": "Manualmente"
+    },
+    "add-to-wallet": "Agregar red",
     "add-token": "Añadir token",
     "add-token-error-description": "Por favor, inténtelo de nuevo.",
     "add-token-error-title": "No se pudo agregar el token a su billetera",
-    "action": "Acción",
-    "add-to-wallet": "Agregar red",
     "adding-chain": "Añadiendo...",
     "block-explorer-url": "URL del explorador de bloques",
     "chain-id": "ID de la red",
     "currency-symbol": "Símbolo de la moneda nativa",
     "heading": "Comience a usar Hemi",
+    "l1-address": "Dirección L1",
+    "l2-address": "Dirección L2",
     "layer": "Capa {layer}",
     "learn-how-to-use-hemi": "Aprenda a usar Hemi",
     "learn-more-tutorials": {
@@ -433,20 +266,275 @@
       "set-up-evm-wallet": "Configure una billetera EVM",
       "tunnel-assets-to-hemi": "Tunelice activos a Hemi"
     },
-    "l1-address": "Dirección L1",
-    "l2-address": "Dirección L2",
     "no-matching-tokens": "No hay tokens coincidentes",
     "no-matching-tokens-hint": "Revise la ortografía o pruebe con otro nombre o símbolo de token.",
     "rpc-url": "URL de RPC",
     "search-tokens-placeholder": "Buscar tokens...",
-    "token": "Token",
     "subheading": "Active rendimiento de Bitcoin compatible sin renunciar a la custodia.",
+    "token": "Token",
     "tutorials-subheading": "¿Nuevo en Hemi? Nuestros tutoriales paso a paso te guían en todo lo que necesitas saber, desde configurar tu billetera hasta hacer bridge de tokens y usar dApps.",
-    "view-all-tutorials": "Ver todos los tutoriales",
-    "add-networks": {
-      "automatic": "Automáticamente",
-      "manual": "Manualmente"
+    "view-all-tutorials": "Ver todos los tutoriales"
+  },
+  "hemi-earn": {
+    "heading": "Obtenga rendimiento con Hemi Earn",
+    "info": {
+      "earned-amount": "Cantidad ganada",
+      "from-pools": "{count, plural, one {De # fondo} other {De # fondos}}",
+      "staked-balance": "Su saldo invertido"
+    },
+    "navigation": {
+      "back": "Atrás",
+      "hemi-earn": "Hemi Earn",
+      "pool-name": "fondo {tokenSymbol}"
+    },
+    "pool": {
+      "apy": "TEA",
+      "composition": {
+        "amount": "Monto",
+        "by-protocol": "Por protocolo",
+        "by-token": "Por token",
+        "position": "Posición",
+        "protocols-count": "{count, plural, one {# protocolo} other {# protocolos}}",
+        "reserve-buffer": "Reserva de liquidez",
+        "share": "Participación",
+        "title": "Composición",
+        "tokens-count": "{count, plural, one {# token} other {# tokens}}"
+      },
+      "deposit-successful": "Depósito exitoso",
+      "drawer": {
+        "approving": "Aprobando {symbol}",
+        "cooldown-ended": "Período de espera completado",
+        "deposit": {
+          "heading": "Revisar depósito de stake",
+          "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."
+        },
+        "funds-returned": "Fondos devueltos",
+        "funds-to-recover": "Fondos por recuperar",
+        "get-share-tokens": "Recibir share tokens",
+        "receive-token": "Recibir {symbol}",
+        "shares-returned": "Shares devueltas",
+        "shares-to-recover": "Shares por recuperar",
+        "stake-token": "Hacer stake de {symbol}",
+        "unstake-token": "Hacer unstake de {symbol}",
+        "wait-cooldown-countdown": "{days, plural, =0 {El período de espera termina en {hours}h} other {El período de espera termina en #d {hours}h}}",
+        "wait-cooldown-countdown-soon": "El período de espera termina en menos de una hora",
+        "wait-cooldown-pending": "El período de espera es de {days, plural, one {# día} other {# días}}",
+        "withdraw": {
+          "heading": "Revisar retiro de stake",
+          "subheading": "Su transacción ha sido enviada y está esperando confirmación en la blockchain."
+        }
+      },
+      "form": {
+        "amount-too-small": "Monto demasiado pequeño",
+        "asset-unavailable": "Activo no disponible",
+        "available-to-withdraw": "Disponible para retirar",
+        "bridging-fees": "Tarifas de bridge",
+        "cooldown-warning": "Retirar fondos tarda {days, plural, one {# día} other {# días}} en completarse.",
+        "cooldown-warning-fallback": "Retirar fondos tarda algunos días en completarse.",
+        "network-error": "Error al previsualizar — reintente",
+        "total-fee": "Costo total de gas",
+        "withdraw-share-tokens-as": "Retirar tokens de participación como",
+        "withdrawing": "Retirando...",
+        "you-will-receive": "Recibirá"
+      },
+      "here-is-your-tx": "Aquí está su transacción:",
+      "historical-metrics": {
+        "1-week": "1 semana",
+        "1-year": "1 año",
+        "apy": "TEA",
+        "month": "{count, plural, one {# mes} other {# meses}}",
+        "pool-deposits": "Depósitos del fondo",
+        "title": "Métricas históricas"
+      },
+      "total-deposits": "Depósitos totales del fondo",
+      "withdraw-successful": "Retiro exitoso"
+    },
+    "pool-info": {
+      "apy": "TEA",
+      "manage": "Gestionar",
+      "pool-contract": "Contrato del fondo",
+      "share-token": "Token de participación",
+      "total-deposits": "Depósitos totales"
+    },
+    "subheading": "Gane rendimiento con sus activos en un solo clic",
+    "transactions": {
+      "banner": {
+        "cancelled": {
+          "heading": "Retiro cancelado",
+          "subheading": "Estamos devolviendo sus share tokens a su billetera."
+        },
+        "claim-funds": {
+          "heading": "No pudimos recibir sus fondos automáticamente",
+          "subheading": "Haga clic en 'Recibir fondos' para recibir sus fondos."
+        },
+        "claim-shares": {
+          "heading": "No pudimos recibir sus share tokens automáticamente",
+          "subheading": "Haga clic en 'Recibir share tokens' para recibir sus tokens."
+        },
+        "recover-funds": {
+          "heading": "La transacción falló",
+          "subheading": "Algo salió mal. Use el botón de abajo para devolver sus fondos a su billetera."
+        },
+        "recover-shares": {
+          "heading": "La transacción falló",
+          "subheading": "Algo salió mal. Use el botón de abajo para devolver sus share tokens a su billetera."
+        }
+      },
+      "cancel-modal": {
+        "cancelling": "Cancelando...",
+        "confirm": "Cancelar retiro",
+        "description": "Si lo cancela, sus fondos volverán a estar en stake y dejarán de estar en el período de espera.",
+        "keep": "Mantener retiro",
+        "title": "Cancelar retiro"
+      },
+      "cancel-withdraw": "Cancelar retiro",
+      "claim-funds": "Recibir fondos",
+      "claim-share-tokens": "Recibir share tokens",
+      "claiming": "Recibiendo...",
+      "column": {
+        "amount": "Cantidad",
+        "date": "Fecha",
+        "status": "Estado",
+        "tx-hash": "Hash de Tx",
+        "type": "Tipo"
+      },
+      "connect-to-view": "Conecte su billetera para ver sus transacciones de earn.",
+      "deposit": "Depósito",
+      "drawer": {
+        "deposit-heading": "Detalles del depósito de stake",
+        "deposit-subheading": "Revise su transacción de depósito de stake.",
+        "step": {
+          "approval-needed": "Aprobación necesaria",
+          "approve-token": "Aprobar {symbol}",
+          "funds-returned": "Fondos devueltos",
+          "funds-to-recover": "Fondos por recuperar",
+          "get-share-tokens": "Recibir share tokens",
+          "receive-token": "Recibir {symbol}",
+          "shares-returned": "Shares devueltas",
+          "shares-to-recover": "Shares por recuperar",
+          "stake-token": "Hacer stake de {symbol}",
+          "unstake-token": "Retirar {symbol}"
+        },
+        "withdraw-heading": "Detalles del retiro de stake",
+        "withdraw-subheading": "Revise su transacción de retiro de stake."
+      },
+      "nothing-here": "Aún no hay nada aquí",
+      "nothing-here-subtitle": "Sus transacciones aparecerán una vez que comience.",
+      "recover-funds": "Recuperar fondos",
+      "recover-shares": "Recuperar shares",
+      "recovering": "Recuperando...",
+      "status": {
+        "cancelling": "Cancelando retiro",
+        "cooldown-ready-in-days": "Cooldown · listo en {value}d",
+        "cooldown-ready-in-hours": "Cooldown · listo en {value}h",
+        "cooldown-ready-in-minutes": "Cooldown · listo en {value}m",
+        "cooldown-ready-soon": "Cooldown · listo en < 1m",
+        "deposited": "Depositado",
+        "funds-returned": "Fondos devueltos",
+        "in-progress": "En progreso",
+        "manual-claim-needed": "En progreso - Reclamo manual necesario",
+        "ready-to-claim": "Listo para recibir",
+        "recover-funds-needed": "Algo salió mal - Recuperar fondos",
+        "recover-shares-cancelled": "Retiro cancelado - Recuperar shares",
+        "recover-shares-needed": "Algo salió mal - Recuperar shares",
+        "returned": "Devuelto",
+        "shares-returned": "Shares devueltas",
+        "tx-failed": "Tx fallida",
+        "withdrawn": "Retirado"
+      },
+      "subtitle": "Realice un seguimiento del estado de sus depósitos y retiros.",
+      "title": "Mis transacciones de earn",
+      "view": "Ver",
+      "withdrawal": "Retiro"
     }
+  },
+  "metadata": {
+    "title": "Portal de Hemi"
+  },
+  "navbar": {
+    "agree-to-terms-and-policy": "Al usar esta aplicación, usted acepta los <terms>Términos de Uso</terms> y la <policy>Política de Privacidad</policy>",
+    "bitcoinkit": "Kit de Hemi Bitcoin",
+    "boost-staking": "Boost staking",
+    "data-attribution": "Datos proporcionados por <link>CoinMarketCap.com</link>",
+    "dex": {
+      "aggregators": "Agregadores",
+      "subtitle": "DEXs",
+      "title": "DEXs"
+    },
+    "docs": "Documentación",
+    "ecosystem": "Demos",
+    "explorer": "Explorador",
+    "follow-us": "Síganos",
+    "genesis-drop": "Lanzamiento Génesis",
+    "get-started": "Comenzar",
+    "governance-staking": "Stake de gobernanza",
+    "help": {
+      "language": "Idioma",
+      "legal-and-privacy": "Privacidad y Legales"
+    },
+    "network": "Red",
+    "network-status": "Estado de la red",
+    "stake": "Stake",
+    "swap": "Intercambiar",
+    "tools": "Herramientas",
+    "tunnel": "Túnel",
+    "tvl": "TVL en Hemi"
+  },
+  "stake-page": {
+    "action": "Acción",
+    "asset": "Activo",
+    "change-to-mainnet": "Cambie a Mainnet y haga stake",
+    "dashboard": {
+      "coming-soon": "Próximamente",
+      "heading": "Boost staking",
+      "stake-more": "Hacer más stake",
+      "staked": "Staked",
+      "staking-assets": "Activos en stake",
+      "subtitle": "Visualice sus posiciones activas de boost staking.",
+      "title": "Panel",
+      "total-earned-points": "Total de puntos Hemi ganados",
+      "total-earned-points-description": "Temporada finalizada.",
+      "total-staked-on-hemi": "Total en stake en Hemi",
+      "your-stake": "Su Stake"
+    },
+    "drawer": {
+      "approve-and-stake": "Aprobar y Hacer Stake",
+      "description-manage-stake": "Recargue su stake o retire en cualquier momento— ¡Usted tiene el control total!",
+      "manage-your-stake": "Gestione su stake",
+      "stake-and-earn-rewards": "Haga stake de {symbol} para potenciar su participación.",
+      "stake-token": "Hacer stake de {symbol}",
+      "staking": "Haciendo stake...",
+      "strategy-details": {
+        "heading": "Detalles de la Estrategia",
+        "tvl": "TVL (en Hemi)",
+        "website": "Sitio web"
+      },
+      "unstake-eth-as-weth-heading": "El ETH desbloqueado se recibirá como WETH",
+      "unstake-eth-as-weth-subheading": "Cuando hace stake con ETH, es automáticamente convertido a WETH. Al desbloquear, recibirá WETH, que puede convertir de nuevo a ETH si lo desea.",
+      "unstake-token": "Desbloquear {symbol}",
+      "unstaking": "Desbloqueando...",
+      "unwrap": "Convertir",
+      "you-can-unstake-anytime": "Puede retirar en cualquier momento."
+    },
+    "protocol": "Protocolo",
+    "ready-to-earn": "¿Listo para hacer stake? Utilice activos disponibles para comenzar a hacer stake.",
+    "rewards": "Recompensas",
+    "stake": {
+      "action": "Acción",
+      "heading": "Stake for boost",
+      "subheading": "Haga stake de sus tokens.",
+      "title": "Stake"
+    },
+    "start-staking-earn-points": "Empiece a hacer stake",
+    "toast": {
+      "go-staking-dashboard": "Vea su panel de control de sus stakes",
+      "here-your-stake-tx": "Aquí está su transacción de {type}:",
+      "staking": "stake",
+      "staking-successful": "Stake exitoso",
+      "unstaking": "retiro",
+      "unstaking-successful": "Retiro exitoso"
+    },
+    "wallet-balance": "Saldo de la billetera"
   },
   "staking-dashboard": {
     "amount": "Cantidad",
@@ -495,10 +583,10 @@
       "years": "{years, plural, one {{years} año} other {{years} años}}"
     },
     "heading": "Governance staking",
-    "subheading": "Haga staking de ${symbol} para participar en la gobernanza del protocolo y recibir recompensas.",
     "here-is-your-tx": "Aquí está su transacción:",
     "lockup-period": "Período de bloqueo",
     "stake-successful": "Stake exitoso",
+    "subheading": "Haga staking de ${symbol} para participar en la gobernanza del protocolo y recibir recompensas.",
     "switch-to-start-staking": "Puede cambiar de red para comenzar a hacer staking de su HEMI.",
     "table": {
       "active": "Activo",
@@ -530,94 +618,6 @@
     "voting-power": "Poder de Voto",
     "your-positions": "Sus posiciones"
   },
-  "metadata": {
-    "title": "Portal de Hemi"
-  },
-  "navbar": {
-    "agree-to-terms-and-policy": "Al usar esta aplicación, usted acepta los <terms>Términos de Uso</terms> y la <policy>Política de Privacidad</policy>",
-    "bitcoinkit": "Kit de Hemi Bitcoin",
-    "boost-staking": "Boost staking",
-    "data-attribution": "Datos proporcionados por <link>CoinMarketCap.com</link>",
-    "dex": {
-      "aggregators": "Agregadores",
-      "subtitle": "DEXs",
-      "title": "DEXs"
-    },
-    "docs": "Documentación",
-    "ecosystem": "Demos",
-    "explorer": "Explorador",
-    "follow-us": "Síganos",
-    "genesis-drop": "Lanzamiento Génesis",
-    "get-started": "Comenzar",
-    "governance-staking": "Stake de gobernanza",
-    "help": {
-      "language": "Idioma",
-      "legal-and-privacy": "Privacidad y Legales"
-    },
-    "network": "Red",
-    "network-status": "Estado de la red",
-    "swap": "Intercambiar",
-    "stake": "Stake",
-    "tools": "Herramientas",
-    "tunnel": "Túnel",
-    "tvl": "TVL en Hemi"
-  },
-  "stake-page": {
-    "action": "Acción",
-    "asset": "Activo",
-    "change-to-mainnet": "Cambie a Mainnet y haga stake",
-    "dashboard": {
-      "coming-soon": "Próximamente",
-      "staked": "Staked",
-      "stake-more": "Hacer más stake",
-      "staking-assets": "Activos en stake",
-      "subtitle": "Visualice sus posiciones activas de boost staking.",
-      "heading": "Boost staking",
-      "title": "Panel",
-      "total-earned-points": "Total de puntos Hemi ganados",
-      "total-earned-points-description": "Temporada finalizada.",
-      "total-staked-on-hemi": "Total en stake en Hemi",
-      "your-stake": "Su Stake"
-    },
-    "drawer": {
-      "approve-and-stake": "Aprobar y Hacer Stake",
-      "description-manage-stake": "Recargue su stake o retire en cualquier momento— ¡Usted tiene el control total!",
-      "manage-your-stake": "Gestione su stake",
-      "stake-and-earn-rewards": "Haga stake de {symbol} para potenciar su participación.",
-      "stake-token": "Hacer stake de {symbol}",
-      "staking": "Haciendo stake...",
-      "strategy-details": {
-        "heading": "Detalles de la Estrategia",
-        "tvl": "TVL (en Hemi)",
-        "website": "Sitio web"
-      },
-      "unstake-eth-as-weth-heading": "El ETH desbloqueado se recibirá como WETH",
-      "unstake-eth-as-weth-subheading": "Cuando hace stake con ETH, es automáticamente convertido a WETH. Al desbloquear, recibirá WETH, que puede convertir de nuevo a ETH si lo desea.",
-      "unstake-token": "Desbloquear {symbol}",
-      "unstaking": "Desbloqueando...",
-      "unwrap": "Convertir",
-      "you-can-unstake-anytime": "Puede retirar en cualquier momento."
-    },
-    "protocol": "Protocolo",
-    "ready-to-earn": "¿Listo para hacer stake? Utilice activos disponibles para comenzar a hacer stake.",
-    "rewards": "Recompensas",
-    "stake": {
-      "action": "Acción",
-      "heading": "Stake for boost",
-      "subheading": "Haga stake de sus tokens.",
-      "title": "Stake"
-    },
-    "start-staking-earn-points": "Empiece a hacer stake",
-    "toast": {
-      "go-staking-dashboard": "Vea su panel de control de sus stakes",
-      "here-your-stake-tx": "Aquí está su transacción de {type}:",
-      "staking": "stake",
-      "staking-successful": "Stake exitoso",
-      "unstaking": "retiro",
-      "unstaking-successful": "Retiro exitoso"
-    },
-    "wallet-balance": "Saldo de la billetera"
-  },
   "token-custom-drawer": {
     "add-contract-to-preview": "Añada una dirección de contrato para previsualizar el token...",
     "add-this-pair": "Agregue este par a la lista de tokens de Hemi para que todos puedan tunelizarlos",
@@ -626,13 +626,13 @@
     "address-does-not-match-l2": "No coincide con el par de L1",
     "heading": "Tunelizar un token ERC-20 existente",
     "i-am-sure-to-tunnel": "Estoy seguro que quiero tunelizar este token.",
+    "l1-address-not-configured": "Dirección L1 no configurada en el contrato",
     "layer-token-address": "Dirección de contrato del token de capa {layer}",
     "make-a-request-to-add": "Si deseas agregar este par de tokens ERC-20 a la lista de tokens aprobados de Hemi, <link>haz una solicitud</link>.",
     "see-on-explorer": "Ver en {explorer}",
     "subheading": "Necesitas ingresar el par de direcciones de contrato tanto de Ethereum como de Hemi para tunelear con este token.",
     "this-address-is-not-valid": "Esta dirección es inválida",
-    "this-address-is-valid": "Esta dirección es válida",
-    "l1-address-not-configured": "Dirección L1 no configurada en el contrato"
+    "this-address-is-valid": "Esta dirección es válida"
   },
   "token-selector": {
     "all-tokens": "Todos los tokens",
@@ -680,15 +680,15 @@
       "add-token-to-wallet-success": "El contrato del token fue agregado a su billetera",
       "approve-confirmed": "Aprobación confirmada",
       "approve-initiated": "Aprobación iniciada",
+      "approve-on": "Aprobar en {networkName}",
       "btc-deposit-come-back-delay-note": "Si usted no recibe su depósito después de {hours} horas regrese a esta pagina para reclamarlo manualmente.",
-      "deposit-completed": "Depósito completado",
       "click-to-confirm": "Haga clic en 'Confirmar Depósito Manualmente' para depositar su Bitcoin en Hemi.",
       "confirm-deposit-on": "Confirmar depósito en {networkName}",
+      "deposit-completed": "Depósito completado",
       "deposit-finalized": "Depósito finalizado",
       "deposit-on-its-way": "¡Su depósito está en camino! Por favor espere mientras la blockchain confirma la transacción.",
       "get-your-funds-on": "Obtenga sus fondos en {networkName}",
       "initiate-deposit": "Iniciar depósito",
-      "approve-on": "Aprobar en {networkName}",
       "review-deposit": "Revisar Depósito",
       "start-on": "Iniciar en {networkName}",
       "we-could-not-process-this-deposit": "No pudimos procesar su depósito automáticamente",
@@ -697,8 +697,8 @@
     "review-withdrawal": {
       "challenge-to-get-bitcoins-back": "Haga clic en 'Disputar Retiro' para reclamar su BTC y enviarlo de vuelta a su dirección de Hemi.",
       "challenge-withdrawal": "Disputar Retiro",
-      "claim-your-funds": "Reclama tus fondos en {networkName}",
       "claim-withdrawal": "Reclamar retiro",
+      "claim-your-funds": "Reclama tus fondos en {networkName}",
       "get-funds-back": "Devolver mis fondos a {networkName}",
       "heading": "Revisar Retiro",
       "initiate-withdrawal": "Iniciar retiro",
@@ -717,8 +717,8 @@
       "challenging": "Disputando...",
       "claim-withdrawal": "Reclamar Retiro",
       "claiming-withdrawal": "Reclamando Retiro...",
-      "confirming-deposit-manually": "Confirmando depósito manualmente...",
       "confirm-deposit-manually": "Confirmar depósito manualmente",
+      "confirming-deposit-manually": "Confirmando depósito manualmente...",
       "connect-both-wallets": "Conecte sus billeteras BTC y EVM",
       "connect-btc-wallet": "Conecte su billetera BTC",
       "deposit": "Depositar",
@@ -748,16 +748,6 @@
         "type": "Tipo"
       },
       "deposit": "Depósito",
-      "no-transactions": "No se han realizado transacciones",
-      "no-transactions-get-started": "Comience tunelizando activos desde y hacia hemi.",
-      "subtitle": "Consulte el estado y la información detallada de sus transacciones en Hemi.",
-      "title": "Historial de transacciones",
-      "top-bar": {
-        "all": "Todos",
-        "bitcoin": "Bitcoin",
-        "ethereum": "Ethereum",
-        "recent-transactions": "Transacciones Recientes"
-      },
       "filters": {
         "actions": {
           "all": "Todas las Acciones",
@@ -768,6 +758,16 @@
           "deposits": "Depósitos",
           "withdrawals": "Retiros"
         }
+      },
+      "no-transactions": "No se han realizado transacciones",
+      "no-transactions-get-started": "Comience tunelizando activos desde y hacia hemi.",
+      "subtitle": "Consulte el estado y la información detallada de sus transacciones en Hemi.",
+      "title": "Historial de transacciones",
+      "top-bar": {
+        "all": "Todos",
+        "bitcoin": "Bitcoin",
+        "ethereum": "Ethereum",
+        "recent-transactions": "Transacciones Recientes"
       },
       "tunnel-assets": "Tunelizar activos",
       "withdraw": "Retiro"

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -1,177 +1,4 @@
 {
-  "hemi-earn": {
-    "heading": "Obtenha rendimento com Hemi Earn",
-    "info": {
-      "earned-amount": "Valor ganho",
-      "from-pools": "{count, plural, one {De # fundo} other {De # fundos}}",
-      "staked-balance": "Seu saldo aplicado"
-    },
-    "navigation": {
-      "back": "Voltar",
-      "hemi-earn": "Hemi Earn",
-      "pool-name": "fundo {tokenSymbol}"
-    },
-    "pool": {
-      "apy": "TEA",
-      "composition": {
-        "amount": "Valor",
-        "by-protocol": "Por protocolo",
-        "by-token": "Por token",
-        "position": "Posição",
-        "protocols-count": "{count, plural, one {# protocolo} other {# protocolos}}",
-        "reserve-buffer": "Reserva de liquidez",
-        "share": "Participação",
-        "title": "Composição",
-        "tokens-count": "{count, plural, one {# token} other {# tokens}}"
-      },
-      "deposit-successful": "Depósito realizado com sucesso",
-      "drawer": {
-        "approving": "Aprovando {symbol}",
-        "deposit": {
-          "heading": "Revisar depósito de stake",
-          "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."
-        },
-        "cooldown-ended": "Período de espera concluído",
-        "stake-token": "Fazer stake de {symbol}",
-        "get-share-tokens": "Receber share tokens",
-        "funds-returned": "Fundos devolvidos",
-        "funds-to-recover": "Fundos a recuperar",
-        "shares-returned": "Shares devolvidas",
-        "shares-to-recover": "Shares a recuperar",
-        "receive-token": "Receber {symbol}",
-        "unstake-token": "Fazer unstake de {symbol}",
-        "wait-cooldown-countdown": "{days, plural, =0 {O período de espera termina em {hours}h} other {O período de espera termina em #d {hours}h}}",
-        "wait-cooldown-countdown-soon": "O período de espera termina em menos de uma hora",
-        "wait-cooldown-pending": "O período de espera é de {days, plural, one {# dia} other {# dias}}",
-        "withdraw": {
-          "heading": "Revisar saque de stake",
-          "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."
-        }
-      },
-      "form": {
-        "amount-too-small": "Valor muito pequeno",
-        "asset-unavailable": "Ativo indisponível",
-        "available-to-withdraw": "Disponível para sacar",
-        "bridging-fees": "Taxas de bridge",
-        "cooldown-warning": "Sacar fundos leva {days, plural, one {# dia} other {# dias}} para concluir.",
-        "cooldown-warning-fallback": "Sacar fundos leva alguns dias para concluir.",
-        "network-error": "Falha no preview — tente de novo",
-        "total-fee": "Custo total de gás",
-        "withdraw-share-tokens-as": "Sacar tokens de participação como",
-        "withdrawing": "Sacando...",
-        "you-will-receive": "Você vai receber"
-      },
-      "here-is-your-tx": "Aqui está sua transação:",
-      "historical-metrics": {
-        "1-week": "1 semana",
-        "1-year": "1 ano",
-        "apy": "TEA",
-        "month": "{count, plural, one {# mês} other {# meses}}",
-        "pool-deposits": "Depósitos do fundo",
-        "title": "Métricas históricas"
-      },
-      "total-deposits": "Depósitos totais do fundo",
-      "withdraw-successful": "Saque realizado com sucesso"
-    },
-    "subheading": "Ganhe rendimento com seus ativos em um clique",
-    "pool-info": {
-      "apy": "TEA",
-      "manage": "Gerenciar",
-      "pool-contract": "Contrato do fundo",
-      "share-token": "Token de participação",
-      "total-deposits": "Depósitos totais"
-    },
-    "transactions": {
-      "banner": {
-        "cancelled": {
-          "heading": "Saque cancelado",
-          "subheading": "Estamos devolvendo seus share tokens à sua carteira."
-        },
-        "claim-funds": {
-          "heading": "Não foi possível receber seus fundos automaticamente",
-          "subheading": "Clique em 'Receber fundos' para receber seus fundos."
-        },
-        "claim-shares": {
-          "heading": "Não foi possível receber seus share tokens automaticamente",
-          "subheading": "Clique em 'Receber share tokens' para receber seus tokens."
-        },
-        "recover-funds": {
-          "heading": "Transação falhou",
-          "subheading": "Algo deu errado. Use o botão abaixo para devolver seus fundos à sua carteira."
-        },
-        "recover-shares": {
-          "heading": "Transação falhou",
-          "subheading": "Algo deu errado. Use o botão abaixo para devolver seus share tokens à sua carteira."
-        }
-      },
-      "claim-funds": "Receber fundos",
-      "claim-share-tokens": "Receber share tokens",
-      "claiming": "Recebendo...",
-      "column": {
-        "amount": "Quantia",
-        "date": "Data",
-        "status": "Status",
-        "tx-hash": "Hash da Tx",
-        "type": "Tipo"
-      },
-      "cancel-modal": {
-        "cancelling": "Cancelando...",
-        "confirm": "Cancelar saque",
-        "description": "Se você cancelar, seus fundos voltam a ficar em stake e saem do período de espera.",
-        "keep": "Manter saque",
-        "title": "Cancelar saque"
-      },
-      "cancel-withdraw": "Cancelar saque",
-      "connect-to-view": "Conecte sua carteira para ver suas transações de earn.",
-      "deposit": "Depósito",
-      "drawer": {
-        "deposit-heading": "Detalhes do depósito de stake",
-        "deposit-subheading": "Revise sua transação de depósito de stake.",
-        "step": {
-          "approval-needed": "Aprovação necessária",
-          "approve-token": "Aprovar {symbol}",
-          "stake-token": "Fazer stake de {symbol}",
-          "get-share-tokens": "Receber share tokens",
-          "funds-returned": "Fundos devolvidos",
-          "funds-to-recover": "Fundos a recuperar",
-          "unstake-token": "Sacar {symbol}",
-          "receive-token": "Receber {symbol}",
-          "shares-returned": "Shares devolvidas",
-          "shares-to-recover": "Shares a recuperar"
-        },
-        "withdraw-heading": "Detalhes do saque de stake",
-        "withdraw-subheading": "Revise sua transação de saque de stake."
-      },
-      "nothing-here": "Nada por aqui ainda",
-      "nothing-here-subtitle": "Suas transações aparecerão assim que você começar.",
-      "recover-funds": "Recuperar fundos",
-      "recover-shares": "Recuperar shares",
-      "recovering": "Recuperando...",
-      "status": {
-        "cancelling": "Cancelando saque",
-        "cooldown-ready-in-days": "Cooldown · pronto em {value}d",
-        "cooldown-ready-in-hours": "Cooldown · pronto em {value}h",
-        "cooldown-ready-in-minutes": "Cooldown · pronto em {value}m",
-        "cooldown-ready-soon": "Cooldown · pronto em < 1m",
-        "deposited": "Depositado",
-        "funds-returned": "Fundos devolvidos",
-        "in-progress": "Em andamento",
-        "manual-claim-needed": "Em andamento - Resgate manual necessário",
-        "ready-to-claim": "Pronto para receber",
-        "recover-funds-needed": "Algo deu errado - Recuperar fundos",
-        "recover-shares-cancelled": "Saque cancelado - Recuperar shares",
-        "recover-shares-needed": "Algo deu errado - Recuperar shares",
-        "returned": "Devolvido",
-        "shares-returned": "Shares devolvidas",
-        "tx-failed": "Tx falhou",
-        "withdrawn": "Sacado"
-      },
-      "subtitle": "Acompanhe o status de seus depósitos e saques.",
-      "title": "Minhas transações de earn",
-      "view": "Ver",
-      "withdrawal": "Saque"
-    }
-  },
   "bitcoin-yield": {
     "bridge-btc-and-receive": "Transfira seu BTC através do túnel e receba {symbol}",
     "drawer": {
@@ -282,8 +109,8 @@
       "pending": "Pendente",
       "rejected": "Rejeitado"
     },
-    "tunnel-fees": "Taxas de túnel",
     "try-again": "Tentar novamente",
+    "tunnel-fees": "Taxas de túnel",
     "unexpected-error": "Ocorreu um erro inesperado. Por favor, tente novamente.",
     "unstake": "Desbloquear",
     "unsupported-chain-heading": "Não está conectado a uma rede suportada",
@@ -338,26 +165,25 @@
   },
   "error-pages": {
     "not-found": {
-      "title": "Oops! Página não encontrada",
+      "action": "Voltar à página inicial",
       "description": "Não conseguimos encontrar a página que procura.",
-      "action": "Voltar à página inicial"
+      "title": "Oops! Página não encontrada"
     },
     "unhandled-error": {
-      "title": "Algo correu mal",
-      "description": "Ocorreu um erro inesperado. Por favor, tente novamente ou <link>contacte-nos</link> se o problema persistir."
+      "description": "Ocorreu um erro inesperado. Por favor, tente novamente ou <link>contacte-nos</link> se o problema persistir.",
+      "title": "Algo correu mal"
     }
   },
   "genesis-drop": {
     "add-hemi-to-your-wallet": "Adicionar {symbol} à sua carteira",
-    "apy-in-staked-hemi": "TEA em ${symbol}",
     "apy-in-hemi-up-to": "Até {percentage}%",
-    "claimed": "Reivindicado",
+    "apy-in-staked-hemi": "TEA em ${symbol}",
     "claim-and-stake-successful": "Reivindicação e Stake bem-sucedidos",
     "claim-details": "Detalhes da reivindicação",
     "claim-groups": {
       "genesis-drop": "Lançamento Gênesis do Hemi",
-      "spectra-and-dodo": "Spectra + Dodo",
-      "other-drop": "Outro Lançamento"
+      "other-drop": "Outro Lançamento",
+      "spectra-and-dodo": "Spectra + Dodo"
     },
     "claim-name": "Nome da reivindicação:",
     "claim-options": {
@@ -366,15 +192,15 @@
       "bonus-staked-for-months": "<amount></amount> $<symbol></symbol> tokens em stake por <months></months> meses",
       "bonus-tokens": "Tokens de bônus",
       "claim": "Reivindicar",
-      "claim-title-6": "Gênesis Viajante",
       "claim-title-24": "Gênesis Guardião",
       "claim-title-48": "Gênesis Lenda",
+      "claim-title-6": "Gênesis Viajante",
       "claiming": "A reivindicar...",
       "future-incentives-from": "Incentivos futuros de",
-      "more-info-description": "Do total de tokens ganhos, uma parte estará disponível para reivindicação imediata (\"disponível agora\") enquanto o resto será automaticamente colocado em stake por um período de bloqueio definido.",
-      "more-rewards": "+<bonus></bonus>% mais ${symbol}",
       "liquid-hemi": "${symbol} líquidos",
       "lockup-period-months": "{months} meses",
+      "more-info-description": "Do total de tokens ganhos, uma parte estará disponível para reivindicação imediata (\"disponível agora\") enquanto o resto será automaticamente colocado em stake por um período de bloqueio definido.",
+      "more-rewards": "+<bonus></bonus>% mais ${symbol}",
       "plus-staked-tokens": "Mais <amount></amount> $<symbol></symbol> tokens em stake<break></break>por <period></period>.",
       "potential-staked-rewards": "Recompensas potenciais para seus tokens ${symbol} em stake",
       "recommended": "Recomendado",
@@ -387,21 +213,22 @@
       "up-to-multiplier-rewards": "Multiplicador de até {multiplier}x nas recompensas em stake"
     },
     "claim-rewards": "Reivindicar recompensas",
+    "claimed": "Reivindicado",
     "claiming-your-rewards": "Reivindicando suas recompensas",
     "connect-demos-wallet": "Certifique-se de conectar sua carteira verificada Demos.",
+    "go-to-staking-dashboard": "Ir para o painel de stake",
+    "have-questions": "Certifique-se de que está conectado à sua carteira verificada Demos. Se tiver dúvidas, abra um ticket no <discordLink>Discord</discordLink>, verifique <absintheLink>Absinthe</absintheLink> ou tente outra carteira.",
     "hemi-token-added": "{symbol} adicionado à sua carteira",
     "here-is-your-claim-tx": "Aqui está a sua transação de reivindicação:",
-    "have-questions": "Certifique-se de que está conectado à sua carteira verificada Demos. Se tiver dúvidas, abra um ticket no <discordLink>Discord</discordLink>, verifique <absintheLink>Absinthe</absintheLink> ou tente outra carteira.",
-    "go-to-staking-dashboard": "Ir para o painel de stake",
     "not-eligible": "Não elegível",
     "rewards-multiplier": "Multiplicador de recompensas",
-    "staked-for-months": "{amount} por {months} meses",
+    "share-x-text": "Sou elegível para {amount} ${symbol} no TGE Genesis drop do Hemi! 🎉 Verifique se você é elegível:",
     "stake-hemi": "Faça stake de {symbol}",
+    "staked-for-months": "{amount} por {months} meses",
     "switch-to-start-claiming": "Pode mudar de rede para começar a reivindicar o seu HEMI.",
     "terms-and-conditions": {
       "title": "Termos e condições do Lançamento Genesis Hemi"
     },
-    "share-x-text": "Sou elegível para {amount} ${symbol} no TGE Genesis drop do Hemi! 🎉 Verifique se você é elegível:",
     "title": "Programa de Recompensas",
     "up-to-multiplier": "Até {multiplier}x",
     "view-tx-on-explorer": "Ver TX no explorador",
@@ -409,20 +236,26 @@
     "your-rewards-are-on-their-way": "Suas recompensas estão a caminho!"
   },
   "get-started": {
-    "add-hemi-network-to-your-wallet": "Adicionar a rede Hemi à sua carteira",
+    "action": "Ação",
     "add-hemi-network-description": "Isto permite que a sua carteira interaja com a Hemi para transações, bridges e dApps.",
+    "add-hemi-network-to-your-wallet": "Adicionar a rede Hemi à sua carteira",
     "add-hemi-tokens": "Adicionar tokens Hemi",
     "add-hemi-tokens-description": "Os tokens Hemi estão emparelhados com as suas versões ERC-20 na Ethereum. Para ver e usar um ativo na Hemi, a sua carteira precisa do endereço do token Hemi (L2).",
+    "add-networks": {
+      "automatic": "Automaticamente",
+      "manual": "Manualmente"
+    },
+    "add-to-wallet": "Adicionar rede",
     "add-token": "Adicionar token",
     "add-token-error-description": "Por favor, tente novamente.",
     "add-token-error-title": "Não foi possível adicionar o token à sua carteira",
-    "action": "Ação",
-    "add-to-wallet": "Adicionar rede",
     "adding-chain": "A adicionar...",
     "block-explorer-url": "URL do explorador de blocos",
     "chain-id": "ID da Rede",
     "currency-symbol": "Símbolo da Moeda",
     "heading": "Comece a usar a Hemi",
+    "l1-address": "Endereço L1",
+    "l2-address": "Endereço L2",
     "layer": "Camada {layer}",
     "learn-how-to-use-hemi": "Aprenda a usar o Hemi",
     "learn-more-tutorials": {
@@ -433,20 +266,275 @@
       "set-up-evm-wallet": "Configure uma carteira EVM",
       "tunnel-assets-to-hemi": "Tunelar ativos para o Hemi"
     },
-    "l1-address": "Endereço L1",
-    "l2-address": "Endereço L2",
     "no-matching-tokens": "Nenhum token correspondente",
     "no-matching-tokens-hint": "Verifique a ortografia ou tente outro nome ou símbolo de token.",
     "rpc-url": "URL RPC",
     "search-tokens-placeholder": "Pesquisar tokens...",
-    "token": "Token",
     "subheading": "Ative rendimento Bitcoin compatível sem sair da custódia.",
+    "token": "Token",
     "tutorials-subheading": "Novo no Hemi? Nossos tutoriais passo a passo orientam você em tudo o que precisa saber, desde configurar sua carteira até fazer bridge de tokens e usar dApps.",
-    "view-all-tutorials": "Ver todos os tutoriais",
-    "add-networks": {
-      "automatic": "Automaticamente",
-      "manual": "Manualmente"
+    "view-all-tutorials": "Ver todos os tutoriais"
+  },
+  "hemi-earn": {
+    "heading": "Obtenha rendimento com Hemi Earn",
+    "info": {
+      "earned-amount": "Valor ganho",
+      "from-pools": "{count, plural, one {De # fundo} other {De # fundos}}",
+      "staked-balance": "Seu saldo aplicado"
+    },
+    "navigation": {
+      "back": "Voltar",
+      "hemi-earn": "Hemi Earn",
+      "pool-name": "fundo {tokenSymbol}"
+    },
+    "pool": {
+      "apy": "TEA",
+      "composition": {
+        "amount": "Valor",
+        "by-protocol": "Por protocolo",
+        "by-token": "Por token",
+        "position": "Posição",
+        "protocols-count": "{count, plural, one {# protocolo} other {# protocolos}}",
+        "reserve-buffer": "Reserva de liquidez",
+        "share": "Participação",
+        "title": "Composição",
+        "tokens-count": "{count, plural, one {# token} other {# tokens}}"
+      },
+      "deposit-successful": "Depósito realizado com sucesso",
+      "drawer": {
+        "approving": "Aprovando {symbol}",
+        "cooldown-ended": "Período de espera concluído",
+        "deposit": {
+          "heading": "Revisar depósito de stake",
+          "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."
+        },
+        "funds-returned": "Fundos devolvidos",
+        "funds-to-recover": "Fundos a recuperar",
+        "get-share-tokens": "Receber share tokens",
+        "receive-token": "Receber {symbol}",
+        "shares-returned": "Shares devolvidas",
+        "shares-to-recover": "Shares a recuperar",
+        "stake-token": "Fazer stake de {symbol}",
+        "unstake-token": "Fazer unstake de {symbol}",
+        "wait-cooldown-countdown": "{days, plural, =0 {O período de espera termina em {hours}h} other {O período de espera termina em #d {hours}h}}",
+        "wait-cooldown-countdown-soon": "O período de espera termina em menos de uma hora",
+        "wait-cooldown-pending": "O período de espera é de {days, plural, one {# dia} other {# dias}}",
+        "withdraw": {
+          "heading": "Revisar saque de stake",
+          "subheading": "Sua transação foi enviada e está aguardando confirmação na blockchain."
+        }
+      },
+      "form": {
+        "amount-too-small": "Valor muito pequeno",
+        "asset-unavailable": "Ativo indisponível",
+        "available-to-withdraw": "Disponível para sacar",
+        "bridging-fees": "Taxas de bridge",
+        "cooldown-warning": "Sacar fundos leva {days, plural, one {# dia} other {# dias}} para concluir.",
+        "cooldown-warning-fallback": "Sacar fundos leva alguns dias para concluir.",
+        "network-error": "Falha no preview — tente de novo",
+        "total-fee": "Custo total de gás",
+        "withdraw-share-tokens-as": "Sacar tokens de participação como",
+        "withdrawing": "Sacando...",
+        "you-will-receive": "Você vai receber"
+      },
+      "here-is-your-tx": "Aqui está sua transação:",
+      "historical-metrics": {
+        "1-week": "1 semana",
+        "1-year": "1 ano",
+        "apy": "TEA",
+        "month": "{count, plural, one {# mês} other {# meses}}",
+        "pool-deposits": "Depósitos do fundo",
+        "title": "Métricas históricas"
+      },
+      "total-deposits": "Depósitos totais do fundo",
+      "withdraw-successful": "Saque realizado com sucesso"
+    },
+    "pool-info": {
+      "apy": "TEA",
+      "manage": "Gerenciar",
+      "pool-contract": "Contrato do fundo",
+      "share-token": "Token de participação",
+      "total-deposits": "Depósitos totais"
+    },
+    "subheading": "Ganhe rendimento com seus ativos em um clique",
+    "transactions": {
+      "banner": {
+        "cancelled": {
+          "heading": "Saque cancelado",
+          "subheading": "Estamos devolvendo seus share tokens à sua carteira."
+        },
+        "claim-funds": {
+          "heading": "Não foi possível receber seus fundos automaticamente",
+          "subheading": "Clique em 'Receber fundos' para receber seus fundos."
+        },
+        "claim-shares": {
+          "heading": "Não foi possível receber seus share tokens automaticamente",
+          "subheading": "Clique em 'Receber share tokens' para receber seus tokens."
+        },
+        "recover-funds": {
+          "heading": "Transação falhou",
+          "subheading": "Algo deu errado. Use o botão abaixo para devolver seus fundos à sua carteira."
+        },
+        "recover-shares": {
+          "heading": "Transação falhou",
+          "subheading": "Algo deu errado. Use o botão abaixo para devolver seus share tokens à sua carteira."
+        }
+      },
+      "cancel-modal": {
+        "cancelling": "Cancelando...",
+        "confirm": "Cancelar saque",
+        "description": "Se você cancelar, seus fundos voltam a ficar em stake e saem do período de espera.",
+        "keep": "Manter saque",
+        "title": "Cancelar saque"
+      },
+      "cancel-withdraw": "Cancelar saque",
+      "claim-funds": "Receber fundos",
+      "claim-share-tokens": "Receber share tokens",
+      "claiming": "Recebendo...",
+      "column": {
+        "amount": "Quantia",
+        "date": "Data",
+        "status": "Status",
+        "tx-hash": "Hash da Tx",
+        "type": "Tipo"
+      },
+      "connect-to-view": "Conecte sua carteira para ver suas transações de earn.",
+      "deposit": "Depósito",
+      "drawer": {
+        "deposit-heading": "Detalhes do depósito de stake",
+        "deposit-subheading": "Revise sua transação de depósito de stake.",
+        "step": {
+          "approval-needed": "Aprovação necessária",
+          "approve-token": "Aprovar {symbol}",
+          "funds-returned": "Fundos devolvidos",
+          "funds-to-recover": "Fundos a recuperar",
+          "get-share-tokens": "Receber share tokens",
+          "receive-token": "Receber {symbol}",
+          "shares-returned": "Shares devolvidas",
+          "shares-to-recover": "Shares a recuperar",
+          "stake-token": "Fazer stake de {symbol}",
+          "unstake-token": "Sacar {symbol}"
+        },
+        "withdraw-heading": "Detalhes do saque de stake",
+        "withdraw-subheading": "Revise sua transação de saque de stake."
+      },
+      "nothing-here": "Nada por aqui ainda",
+      "nothing-here-subtitle": "Suas transações aparecerão assim que você começar.",
+      "recover-funds": "Recuperar fundos",
+      "recover-shares": "Recuperar shares",
+      "recovering": "Recuperando...",
+      "status": {
+        "cancelling": "Cancelando saque",
+        "cooldown-ready-in-days": "Cooldown · pronto em {value}d",
+        "cooldown-ready-in-hours": "Cooldown · pronto em {value}h",
+        "cooldown-ready-in-minutes": "Cooldown · pronto em {value}m",
+        "cooldown-ready-soon": "Cooldown · pronto em < 1m",
+        "deposited": "Depositado",
+        "funds-returned": "Fundos devolvidos",
+        "in-progress": "Em andamento",
+        "manual-claim-needed": "Em andamento - Resgate manual necessário",
+        "ready-to-claim": "Pronto para receber",
+        "recover-funds-needed": "Algo deu errado - Recuperar fundos",
+        "recover-shares-cancelled": "Saque cancelado - Recuperar shares",
+        "recover-shares-needed": "Algo deu errado - Recuperar shares",
+        "returned": "Devolvido",
+        "shares-returned": "Shares devolvidas",
+        "tx-failed": "Tx falhou",
+        "withdrawn": "Sacado"
+      },
+      "subtitle": "Acompanhe o status de seus depósitos e saques.",
+      "title": "Minhas transações de earn",
+      "view": "Ver",
+      "withdrawal": "Saque"
     }
+  },
+  "metadata": {
+    "title": "Portal Hemi"
+  },
+  "navbar": {
+    "agree-to-terms-and-policy": "Ao utilizar esta aplicação, concorda com os <terms>Termos de Utilização</terms> e a <policy>Política de Privacidade</policy>",
+    "bitcoinkit": "Hemi Bitcoin Kit",
+    "boost-staking": "Boost staking",
+    "data-attribution": "Dados fornecidos por <link>CoinMarketCap.com</link>",
+    "dex": {
+      "aggregators": "Agregadores",
+      "subtitle": "DEXs",
+      "title": "DEX"
+    },
+    "docs": "Documentação",
+    "ecosystem": "Demonstrações",
+    "explorer": "Explorador",
+    "follow-us": "Siga-nos",
+    "genesis-drop": "Lançamento Génesis",
+    "get-started": "Começar",
+    "governance-staking": "Stake de governança",
+    "help": {
+      "language": "Idioma",
+      "legal-and-privacy": "Legal e Privacidade"
+    },
+    "network": "Rede",
+    "network-status": "Estado da rede",
+    "stake": "Stake",
+    "swap": "Troca",
+    "tools": "Ferramentas",
+    "tunnel": "Túnel",
+    "tvl": "TVL na Hemi"
+  },
+  "stake-page": {
+    "action": "Ação",
+    "asset": "Ativo",
+    "change-to-mainnet": "Mudar para Mainnet e faça stake",
+    "dashboard": {
+      "coming-soon": "Brevemente",
+      "heading": "Boost staking",
+      "stake-more": "Faça mais stake",
+      "staked": "Staked",
+      "staking-assets": "Ativos em stake",
+      "subtitle": "Visualize suas posições ativas de boost staking.",
+      "title": "Painel",
+      "total-earned-points": "Total de pontos Hemi ganhos",
+      "total-earned-points-description": "Temporada encerrada.",
+      "total-staked-on-hemi": "Total em stake em Hemi",
+      "your-stake": "O seu Stake"
+    },
+    "drawer": {
+      "approve-and-stake": "Aprovar e Fazer Stake",
+      "description-manage-stake": "Aumente o seu stake ou levante a qualquer momento— tem controle total!",
+      "manage-your-stake": "Gerir o seu stake",
+      "stake-and-earn-rewards": "Faça stake de {symbol} para aumentar a sua participação.",
+      "stake-token": "Faça stake de {symbol}",
+      "staking": "A fazer stake...",
+      "strategy-details": {
+        "heading": "Detalhes da Estratégia",
+        "tvl": "TVL (no Hemi)",
+        "website": "Website"
+      },
+      "unstake-eth-as-weth-heading": "ETH desbloqueado será recebido como WETH",
+      "unstake-eth-as-weth-subheading": "Quando fazer stake com ETH, este é automaticamente convertido em WETH. Ao desbloquear, receberá WETH, que pode converter novamente em ETH, se desejar.",
+      "unstake-token": "Desbloquear {symbol}",
+      "unstaking": "A desbloquear...",
+      "unwrap": "Desembrulhar",
+      "you-can-unstake-anytime": "Pode desbloquear a qualquer momento."
+    },
+    "protocol": "Protocolo",
+    "ready-to-earn": "Pronto para fazer stake? Utilize ativos disponíveis para começar a fazer stake.",
+    "rewards": "Recompensas",
+    "stake": {
+      "action": "Ação",
+      "heading": "Stake for boost",
+      "subheading": "Faça stake dos seus tokens.",
+      "title": "Stake"
+    },
+    "start-staking-earn-points": "Comece a fazer stake",
+    "toast": {
+      "go-staking-dashboard": "Ver o seu painel de stake",
+      "here-your-stake-tx": "Aqui está a sua transação de {type}:",
+      "staking": "stake",
+      "staking-successful": "Stake bem-sucedido",
+      "unstaking": "desbloqueio",
+      "unstaking-successful": "Desbloqueio bem-sucedido"
+    },
+    "wallet-balance": "Saldo da carteira"
   },
   "staking-dashboard": {
     "amount": "Quantidade",
@@ -495,10 +583,10 @@
       "years": "{years, plural, one {{years} ano} other {{years} anos}}"
     },
     "heading": "Governance staking",
-    "subheading": "Faça staking de ${symbol} para participar da governança do protocolo e receber recompensas.",
     "here-is-your-tx": "Aqui está a sua transação:",
     "lockup-period": "Período de bloqueio",
     "stake-successful": "Stake bem-sucedido",
+    "subheading": "Faça staking de ${symbol} para participar da governança do protocolo e receber recompensas.",
     "switch-to-start-staking": "Você pode mudar de rede para começar a fazer staking do seu HEMI.",
     "table": {
       "active": "Ativo",
@@ -530,94 +618,6 @@
     "voting-power": "Poder de Voto",
     "your-positions": "Suas posições"
   },
-  "metadata": {
-    "title": "Portal Hemi"
-  },
-  "navbar": {
-    "agree-to-terms-and-policy": "Ao utilizar esta aplicação, concorda com os <terms>Termos de Utilização</terms> e a <policy>Política de Privacidade</policy>",
-    "bitcoinkit": "Hemi Bitcoin Kit",
-    "boost-staking": "Boost staking",
-    "data-attribution": "Dados fornecidos por <link>CoinMarketCap.com</link>",
-    "dex": {
-      "aggregators": "Agregadores",
-      "subtitle": "DEXs",
-      "title": "DEX"
-    },
-    "docs": "Documentação",
-    "ecosystem": "Demonstrações",
-    "explorer": "Explorador",
-    "follow-us": "Siga-nos",
-    "genesis-drop": "Lançamento Génesis",
-    "get-started": "Começar",
-    "governance-staking": "Stake de governança",
-    "help": {
-      "language": "Idioma",
-      "legal-and-privacy": "Legal e Privacidade"
-    },
-    "network": "Rede",
-    "network-status": "Estado da rede",
-    "swap": "Troca",
-    "stake": "Stake",
-    "tools": "Ferramentas",
-    "tunnel": "Túnel",
-    "tvl": "TVL na Hemi"
-  },
-  "stake-page": {
-    "action": "Ação",
-    "asset": "Ativo",
-    "change-to-mainnet": "Mudar para Mainnet e faça stake",
-    "dashboard": {
-      "coming-soon": "Brevemente",
-      "staked": "Staked",
-      "stake-more": "Faça mais stake",
-      "staking-assets": "Ativos em stake",
-      "subtitle": "Visualize suas posições ativas de boost staking.",
-      "heading": "Boost staking",
-      "title": "Painel",
-      "total-earned-points": "Total de pontos Hemi ganhos",
-      "total-earned-points-description": "Temporada encerrada.",
-      "total-staked-on-hemi": "Total em stake em Hemi",
-      "your-stake": "O seu Stake"
-    },
-    "drawer": {
-      "approve-and-stake": "Aprovar e Fazer Stake",
-      "description-manage-stake": "Aumente o seu stake ou levante a qualquer momento— tem controle total!",
-      "manage-your-stake": "Gerir o seu stake",
-      "stake-and-earn-rewards": "Faça stake de {symbol} para aumentar a sua participação.",
-      "stake-token": "Faça stake de {symbol}",
-      "staking": "A fazer stake...",
-      "strategy-details": {
-        "heading": "Detalhes da Estratégia",
-        "tvl": "TVL (no Hemi)",
-        "website": "Website"
-      },
-      "unstake-eth-as-weth-heading": "ETH desbloqueado será recebido como WETH",
-      "unstake-eth-as-weth-subheading": "Quando fazer stake com ETH, este é automaticamente convertido em WETH. Ao desbloquear, receberá WETH, que pode converter novamente em ETH, se desejar.",
-      "unstake-token": "Desbloquear {symbol}",
-      "unstaking": "A desbloquear...",
-      "unwrap": "Desembrulhar",
-      "you-can-unstake-anytime": "Pode desbloquear a qualquer momento."
-    },
-    "protocol": "Protocolo",
-    "ready-to-earn": "Pronto para fazer stake? Utilize ativos disponíveis para começar a fazer stake.",
-    "rewards": "Recompensas",
-    "stake": {
-      "action": "Ação",
-      "heading": "Stake for boost",
-      "subheading": "Faça stake dos seus tokens.",
-      "title": "Stake"
-    },
-    "start-staking-earn-points": "Comece a fazer stake",
-    "toast": {
-      "go-staking-dashboard": "Ver o seu painel de stake",
-      "here-your-stake-tx": "Aqui está a sua transação de {type}:",
-      "staking": "stake",
-      "staking-successful": "Stake bem-sucedido",
-      "unstaking": "desbloqueio",
-      "unstaking-successful": "Desbloqueio bem-sucedido"
-    },
-    "wallet-balance": "Saldo da carteira"
-  },
   "token-custom-drawer": {
     "add-contract-to-preview": "Adicione um endereço de contrato para visualizar o token...",
     "add-this-pair": "Adicionar este par à lista de tokens da Hemi para todos tunelarem",
@@ -626,13 +626,13 @@
     "address-does-not-match-l2": "Não corresponde ao par L1",
     "heading": "Tunelar um token ERC-20 existente",
     "i-am-sure-to-tunnel": "Tenho a certeza de que quero tunelar com este token.",
+    "l1-address-not-configured": "Endereço L1 não configurado no contrato",
     "layer-token-address": "Endereço do token da Camada {layer}",
     "make-a-request-to-add": "Se deseja adicionar este par de tokens ERC-20 à lista de tokens aprovados da Hemi, <link>faça um pedido</link>.",
     "see-on-explorer": "Ver no {explorer}",
     "subheading": "Precisa de inserir o par de endereços de contrato de Ethereum e Hemi para tunelar com este token.",
     "this-address-is-not-valid": "Este endereço não é válido",
-    "this-address-is-valid": "Este endereço é válido",
-    "l1-address-not-configured": "Endereço L1 não configurado no contrato"
+    "this-address-is-valid": "Este endereço é válido"
   },
   "token-selector": {
     "all-tokens": "Todos os tokens",
@@ -680,15 +680,15 @@
       "add-token-to-wallet-success": "Contrato do token adicionado à sua carteira",
       "approve-confirmed": "Aprovação confirmada",
       "approve-initiated": "Aprovação iniciada",
+      "approve-on": "Aprovar em {networkName}",
       "btc-deposit-come-back-delay-note": "Se não receber o seu depósito após {hours} horas, regresse a esta página para reclamar manualmente.",
-      "deposit-completed": "Depósito concluído",
       "click-to-confirm": "Clique em 'Confirmar Depósito Manualmente' para depositar o seu Bitcoin no Hemi.",
       "confirm-deposit-on": "Confirmar depósito em {networkName}",
+      "deposit-completed": "Depósito concluído",
       "deposit-finalized": "Depósito finalizado",
       "deposit-on-its-way": "O seu depósito está a caminho! Aguarde enquanto a blockchain finaliza a transação.",
       "get-your-funds-on": "Obtenha os seus fundos em {networkName}",
       "initiate-deposit": "Iniciar depósito",
-      "approve-on": "Aprovar em {networkName}",
       "review-deposit": "Rever Depósito",
       "start-on": "Iniciar em {networkName}",
       "we-could-not-process-this-deposit": "Não conseguimos processar este depósito automaticamente",
@@ -697,8 +697,8 @@
     "review-withdrawal": {
       "challenge-to-get-bitcoins-back": "Clique em 'Desafiar Retirada' para reclamar o seu BTC e enviá-lo de volta para o seu endereço Hemi.",
       "challenge-withdrawal": "Desafiar Retirada",
-      "claim-your-funds": "Reclame os seus fundos em {networkName}",
       "claim-withdrawal": "Reclamar Retirada",
+      "claim-your-funds": "Reclame os seus fundos em {networkName}",
       "get-funds-back": "Recuperar os meus fundos para {networkName}",
       "heading": "Rever Retirada",
       "initiate-withdrawal": "Iniciar Retirada",
@@ -717,8 +717,8 @@
       "challenging": "A desafiar...",
       "claim-withdrawal": "Reclamar Retirada",
       "claiming-withdrawal": "A reclamar retirada...",
-      "confirming-deposit-manually": "A confirmar depósito manualmente...",
       "confirm-deposit-manually": "Confirmar depósito manualmente",
+      "confirming-deposit-manually": "A confirmar depósito manualmente...",
       "connect-both-wallets": "Conectar as suas carteiras BTC e EVM",
       "connect-btc-wallet": "Conectar a sua carteira BTC",
       "deposit": "Depositar",
@@ -748,16 +748,6 @@
         "type": "Tipo"
       },
       "deposit": "Depósito",
-      "no-transactions": "Nenhuma transação efetuada",
-      "no-transactions-get-started": "Comece por tunelar ativos de e para o Hemi",
-      "subtitle": "Consulte o status e as informações detalhadas das suas transações na Hemi.",
-      "title": "Histórico de Transações",
-      "top-bar": {
-        "all": "Todas",
-        "bitcoin": "Bitcoin",
-        "ethereum": "Ethereum",
-        "recent-transactions": "Transações Recentes"
-      },
       "filters": {
         "actions": {
           "all": "Todas as ações",
@@ -768,6 +758,16 @@
           "deposits": "Depósitos",
           "withdrawals": "Retiradas"
         }
+      },
+      "no-transactions": "Nenhuma transação efetuada",
+      "no-transactions-get-started": "Comece por tunelar ativos de e para o Hemi",
+      "subtitle": "Consulte o status e as informações detalhadas das suas transações na Hemi.",
+      "title": "Histórico de Transações",
+      "top-bar": {
+        "all": "Todas",
+        "bitcoin": "Bitcoin",
+        "ethereum": "Ethereum",
+        "recent-transactions": "Transações Recentes"
       },
       "tunnel-assets": "Tunelar ativos",
       "withdraw": "Retirar"

--- a/portal/test/locale.test.ts
+++ b/portal/test/locale.test.ts
@@ -2,13 +2,24 @@ import { readdir, readFile } from 'fs/promises'
 import path from 'path'
 import { describe, expect, it } from 'vitest'
 
-const getFullKeys = (obj: Record<string, string> | string, prefix?: string) =>
-  Object.keys(obj).flatMap(function (key) {
-    const fullKey = prefix ? `${prefix}.${key}` : key
-    return typeof obj[key] === 'object' && obj[key] !== null
-      ? getFullKeys(obj[key], fullKey)
-      : fullKey
-  })
+// Flatten nested keys into dotted paths. When `sort` is true, each object's
+// keys are sorted alphabetically before recursing, yielding the expected order
+// when keys are sorted per-object (the repo convention).
+const getFullKeys = function (
+  obj: Record<string, string> | string,
+  { sort = false }: { sort?: boolean } = {},
+) {
+  const collect = (node: Record<string, string> | string, prefix?: string) =>
+    (sort ? Object.keys(node).sort() : Object.keys(node)).flatMap(
+      function (key) {
+        const fullKey = prefix ? `${prefix}.${key}` : key
+        return typeof node[key] === 'object' && node[key] !== null
+          ? collect(node[key], fullKey)
+          : fullKey
+      },
+    )
+  return collect(obj)
+}
 
 describe('locale messages', function () {
   describe('All locale resource files should have the same keys in the same order', function () {
@@ -28,6 +39,17 @@ describe('locale messages', function () {
 
       // compare all keys arrays with the first one - by transitivity, all should be equal
       keysArrays.forEach(keysArray => expect(keysArray).toEqual(keysArrays[0]))
+    })
+  })
+
+  describe('English locale keys should be sorted alphabetically', function () {
+    it('should have all keys sorted alphabetically', async function () {
+      const englishFilePath = path.resolve(__dirname, '../messages/en.json')
+      const content = JSON.parse(await readFile(englishFilePath, 'utf-8'))
+      const keys = getFullKeys(content)
+      const sortedKeys = getFullKeys(content, { sort: true })
+
+      expect(keys).toEqual(sortedKeys)
     })
   })
 })


### PR DESCRIPTION
### Description

Reorder the keys in the `en`/`es`/`pt` message files so each object's keys are alphabetically sorted, matching the repo convention. Only the ordering changed — no translation values were modified.

Also add a test asserting `en.json`'s keys are sorted alphabetically. The `es` and `pt` files are covered transitively by the existing "same keys in the same order" check, so sorting `en` enforces sorting across all locales.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.