### PR TITLE
Add Tooltip stories to Storybook

### DIFF
--- a/portal/stories/tooltip.stories.tsx
+++ b/portal/stories/tooltip.stories.tsx
@@ -21,6 +21,7 @@ const meta = {
     },
     text: { control: 'text' },
     variant: { control: false },
+    visible: { control: false },
   },
   component: Tooltip,
   decorators: [

--- a/portal/stories/tooltip.stories.tsx
+++ b/portal/stories/tooltip.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { Tooltip } from 'components/tooltip'
 
-const INFO_TEXT =
+const infoText =
   'By activating 10x approval we automatically add 10x the amount of this transaction as allowance for future ones, saving you money on gas fees and time.'
-const RICH_TITLE = 'Approve 10x the amount of this deposit'
+const richTitle = 'Approve 10x the amount of this deposit'
 
 const Trigger = ({ label }: { label: string }) => (
   <span className="rounded-md border border-neutral-300 px-3 py-1 text-sm font-medium text-neutral-700">
@@ -51,7 +51,7 @@ export const Info: Story = {
   args: {
     children: <Trigger label="Info" />,
     placement: 'top',
-    text: INFO_TEXT,
+    text: infoText,
     variant: 'info',
     visible: true,
   },
@@ -61,8 +61,8 @@ export const Rich: Story = {
   args: {
     children: <Trigger label="Rich" />,
     placement: 'top',
-    text: INFO_TEXT,
-    title: RICH_TITLE,
+    text: infoText,
+    title: richTitle,
     variant: 'rich',
     visible: true,
   },

--- a/portal/stories/tooltip.stories.tsx
+++ b/portal/stories/tooltip.stories.tsx
@@ -37,6 +37,15 @@ export default meta
 
 type Story = StoryObj<typeof Tooltip>
 
+export const Interactive: Story = {
+  args: {
+    children: <Trigger label="Hover me" />,
+    placement: 'top',
+    text: 'Copy',
+    variant: 'simple',
+  },
+}
+
 export const Simple: Story = {
   args: {
     children: <Trigger label="Copy" />,

--- a/portal/stories/tooltip.stories.tsx
+++ b/portal/stories/tooltip.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Tooltip } from 'components/tooltip'
+
+const INFO_TEXT =
+  'By activating 10x approval we automatically add 10x the amount of this transaction as allowance for future ones, saving you money on gas fees and time.'
+const RICH_TITLE = 'Approve 10x the amount of this deposit'
+
+const Trigger = ({ label }: { label: string }) => (
+  <span className="rounded-md border border-neutral-300 px-3 py-1 text-sm font-medium text-neutral-700">
+    {label}
+  </span>
+)
+
+const meta = {
+  argTypes: {
+    borderRadius: { control: 'inline-radio', options: ['4px', '6px', '12px'] },
+    children: { control: false },
+    placement: {
+      control: 'select',
+      options: ['top', 'bottom', 'left', 'right'],
+    },
+    text: { control: 'text' },
+    variant: { control: false },
+  },
+  component: Tooltip,
+  decorators: [
+    Story => (
+      <div className="flex min-h-screen items-center justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+  title: 'Components/Tooltip',
+} satisfies Meta<typeof Tooltip>
+
+export default meta
+
+type Story = StoryObj<typeof Tooltip>
+
+export const Simple: Story = {
+  args: {
+    children: <Trigger label="Copy" />,
+    placement: 'top',
+    text: 'Copy',
+    variant: 'simple',
+    visible: true,
+  },
+}
+
+export const Info: Story = {
+  args: {
+    children: <Trigger label="Info" />,
+    placement: 'top',
+    text: INFO_TEXT,
+    variant: 'info',
+    visible: true,
+  },
+}
+
+export const Rich: Story = {
+  args: {
+    children: <Trigger label="Rich" />,
+    placement: 'top',
+    text: INFO_TEXT,
+    title: RICH_TITLE,
+    variant: 'rich',
+    visible: true,
+  },
+}


### PR DESCRIPTION
### Description

Adds Storybook stories for the `Tooltip` component (`components/tooltip`), following vetro's
tooltip story (args-based) and the Figma design.

`Tooltip` renders a dark overlay in three variants — `simple`, `info` and `rich` (the last with a
`title`). The `Simple`, `Info` and `Rich` stories use the design's example copy and are forced open
(`visible`) so the overlay shows without hovering, while an `Interactive` story drops `visible` so the
tooltip uses the real trigger (hover/click). The `variant` and `visible` controls are disabled so a
story can't be contradicted from the panel; `text`, `placement` and `borderRadius` stay editable. The
overlay is portaled to the body, so the full-page screenshots capture it. The component is not modified.

- New `stories/tooltip.stories.tsx` — `Interactive`, `Simple`, `Info` and `Rich` stories.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img  alt="components-tooltip--info--ui" src="https://github.com/user-attachments/assets/a6c414c0-7c77-439f-ac69-ae38f7d3e9cd" />

<img alt="components-tooltip--info" src="https://github.com/user-attachments/assets/39dcfac0-492b-41a4-8c0c-e10e6de303f4" />

<img alt="components-tooltip--rich--ui" src="https://github.com/user-attachments/assets/7136af86-9f8a-4293-a121-f6dd7f00643f" />

<img alt="components-tooltip--rich" src="https://github.com/user-attachments/assets/38a13b96-6260-4ffa-9d12-831b643ec4cc" />

<img  alt="components-tooltip--simple--ui" src="https://github.com/user-attachments/assets/ec5a663f-ba2a-4685-9244-76d602f2518d" />

<img  alt="components-tooltip--simple" src="https://github.com/user-attachments/assets/7687bf65-25f8-40b4-902d-72b77d406c4c" />

### Related issue(s)

Related to #1993

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
