### PR TITLE
Add Tabs story to Storybook

### DIFF
--- a/portal/stories/tabs.stories.tsx
+++ b/portal/stories/tabs.stories.tsx
@@ -1,30 +1,44 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { Tab, Tabs } from 'components/tabs'
+import type { ComponentProps } from 'react'
 import { useState } from 'react'
 
+type StoryProps = ComponentProps<typeof Tabs> & {
+  size: ComponentProps<typeof Tab>['size']
+}
+
 const meta = {
-  component: Tabs,
-  parameters: {
-    controls: { disable: true },
+  args: {
+    size: 'xSmall',
   },
+  argTypes: {
+    children: { control: false },
+    size: { control: 'inline-radio', options: ['xSmall', 'small'] },
+  },
+  component: Tabs,
   title: 'Components/Tabs',
-} satisfies Meta<typeof Tabs>
+} satisfies Meta<StoryProps>
 
 export default meta
 
-type Story = StoryObj<typeof Tabs>
+type Story = StoryObj<StoryProps>
 
 export const Default: Story = {
-  render: function Render() {
+  render: function Render({ size }) {
     const [filter, setFilter] = useState<'active' | 'withdrawn'>('active')
     return (
       <Tabs>
-        <Tab onClick={() => setFilter('active')} selected={filter === 'active'}>
+        <Tab
+          onClick={() => setFilter('active')}
+          selected={filter === 'active'}
+          size={size}
+        >
           Active
         </Tab>
         <Tab
           onClick={() => setFilter('withdrawn')}
           selected={filter === 'withdrawn'}
+          size={size}
         >
           Withdrawn
         </Tab>

--- a/portal/stories/tabs.stories.tsx
+++ b/portal/stories/tabs.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Tab, Tabs } from 'components/tabs'
+import { useState } from 'react'
+
+const meta = {
+  component: Tabs,
+  parameters: {
+    controls: { disable: true },
+  },
+  title: 'Components/Tabs',
+} satisfies Meta<typeof Tabs>
+
+export default meta
+
+type Story = StoryObj<typeof Tabs>
+
+export const Default: Story = {
+  render: function Render() {
+    const [filter, setFilter] = useState<'active' | 'withdrawn'>('active')
+    return (
+      <Tabs>
+        <Tab onClick={() => setFilter('active')} selected={filter === 'active'}>
+          Active
+        </Tab>
+        <Tab
+          onClick={() => setFilter('withdrawn')}
+          selected={filter === 'withdrawn'}
+        >
+          Withdrawn
+        </Tab>
+      </Tabs>
+    )
+  },
+}


### PR DESCRIPTION
### Description

Adds a Storybook story for the `Tabs`/`Tab` components (`components/tabs`).

The `Default` story is based on a real usage in the app (the Active/Withdrawn filter in
`stakeTableFilter`, and `tunnelProviderToggle`): an interactive set of tabs using the `onClick`
variant with a `selected` state, so clicking a tab selects it. The link (`href`) variant looks
identical and only differs in navigation, so the story uses the router-free `onClick` variant. The
components are not modified.

- New `stories/tabs.stories.tsx` — an interactive `Default` story (state-driven selection).

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img alt="components-tabs--default--ui" src="https://github.com/user-attachments/assets/178aa93a-2dfa-4fd8-a40f-eebabd74bf03" />

<img  alt="components-tabs--default--withdrawn" src="https://github.com/user-attachments/assets/5ddc722d-60d3-4929-bd4c-5602d348dbbe" />

<img alt="components-tabs--default" src="https://github.com/user-attachments/assets/60f31182-fd4d-4386-bf08-85e1718533fd" />


### Related issue(s)

Related to #1993

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
