### PR TITLE
Add Drawer story to Storybook

### DIFF
--- a/portal/stories/drawer.stories.tsx
+++ b/portal/stories/drawer.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Button } from 'components/button'
+import {
+  Drawer,
+  DrawerParagraph,
+  DrawerSection,
+  DrawerTopSection,
+} from 'components/drawer'
+import { useState } from 'react'
+
+const meta = {
+  args: {
+    position: 'right',
+  },
+  argTypes: {
+    children: { control: false },
+    position: { control: 'inline-radio', options: ['left', 'right'] },
+  },
+  component: Drawer,
+  title: 'Components/Drawer',
+} satisfies Meta<typeof Drawer>
+
+export default meta
+
+type Story = StoryObj<typeof Drawer>
+
+export const Default: Story = {
+  render: function Render({ position }) {
+    const [open, setOpen] = useState(false)
+    return (
+      <>
+        <Button onClick={() => setOpen(true)} size="small">
+          Open drawer
+        </Button>
+        {open && (
+          <Drawer onClose={() => setOpen(false)} position={position}>
+            <div className="drawer-content h-[80dvh] md:h-full">
+              <DrawerTopSection heading="Claim rewards" />
+              <DrawerParagraph>Your rewards are on their way.</DrawerParagraph>
+              <DrawerSection>
+                <p>Review the details before continuing.</p>
+              </DrawerSection>
+            </div>
+          </Drawer>
+        )}
+      </>
+    )
+  },
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds a Storybook story for the `Drawer` component (`components/drawer`).

Following vetro's drawer story, the `Default` story is interactive: an "Open drawer" button toggles
the `Drawer` open (state-driven), and it closes on the X, click-outside or Escape. The content uses
the drawer's own primitives (`DrawerTopSection`, `DrawerParagraph`, `DrawerSection`) inside the real
`drawer-content` wrapper, mirroring the app usage (e.g. the genesis claim drawer). A `position`
Control switches the panel side (left/right). The component is not modified.

- New `stories/drawer.stories.tsx` — an interactive `Default` story with a `position` control.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img  alt="components-drawer--closed" src="https://github.com/user-attachments/assets/e7cc9633-df47-4d04-9328-80cf50aa3613" />

<img alt="components-drawer--open" src="https://github.com/user-attachments/assets/5a1c4d05-1d1c-4211-aebc-9a9c48182efe" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Fixes #
Related to #1993 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ x] Manual testing passed.
- [ x] Automated tests added, or N/A.
- [ x] Documentation updated, or N/A.
- [ x] Environment variables set in CI, or N/A.
