### PR TITLE
Patch vulns

### DIFF
--- a/portal-backend/api/Dockerfile
+++ b/portal-backend/api/Dockerfile
@@ -31,8 +31,10 @@ FROM node:24.14.0-alpine3.23
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
 RUN apk add --upgrade openssl=3.5.7-r0
-RUN npm install --global npm@11.12.0
 RUN corepack enable
+# npm is unused at runtime (the app uses pnpm); removing it shrinks the image
+# and eliminates its transitive vulnerabilities (e.g. sigstore).
+RUN npm uninstall --global npm
 # Skip corepack's interactive download prompt so the `node` user can fetch
 # pnpm on first container start without a TTY to approve it.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/portal-backend/cron/hemi-supply/Dockerfile
+++ b/portal-backend/cron/hemi-supply/Dockerfile
@@ -22,8 +22,10 @@ FROM node:24.14.0-alpine3.23
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
 RUN apk add --upgrade openssl=3.5.7-r0
-RUN npm install --global npm@11.12.0
 RUN corepack enable
+# npm is unused at runtime (the app uses pnpm); removing it shrinks the image
+# and eliminates its transitive vulnerabilities (e.g. sigstore).
+RUN npm uninstall --global npm
 # Skip corepack's interactive download prompt so the `node` user can fetch
 # pnpm on first container start without a TTY to approve it.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/portal-backend/cron/token-prices/Dockerfile
+++ b/portal-backend/cron/token-prices/Dockerfile
@@ -22,8 +22,10 @@ FROM node:24.14.0-alpine3.23
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
 RUN apk add --upgrade openssl=3.5.7-r0
-RUN npm install --global npm@11.12.0
 RUN corepack enable
+# npm is unused at runtime (the app uses pnpm); removing it shrinks the image
+# and eliminates its transitive vulnerabilities (e.g. sigstore).
+RUN npm uninstall --global npm
 # Skip corepack's interactive download prompt so the `node` user can fetch
 # pnpm on first container start without a TTY to approve it.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/portal-backend/cron/vaults-monitor/Dockerfile
+++ b/portal-backend/cron/vaults-monitor/Dockerfile
@@ -22,8 +22,10 @@ FROM node:24.14.0-alpine3.23
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
 RUN apk add --upgrade openssl=3.5.7-r0
-RUN npm install --global npm@11.12.0
 RUN corepack enable
+# npm is unused at runtime (the app uses pnpm); removing it shrinks the image
+# and eliminates its transitive vulnerabilities (e.g. sigstore).
+RUN npm uninstall --global npm
 # Skip corepack's interactive download prompt so the `node` user can fetch
 # pnpm on first container start without a TTY to approve it.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/vex.json
+++ b/vex.json
@@ -4,14 +4,14 @@
   "statements": [
     {
       "justification": "vulnerable_code_not_in_execute_path",
-      "products": [{ "@id": "pkg:npm/picomatch@4.0.3" }],
+      "products": [{ "@id": "pkg:npm/ws@8.18.1" }],
       "status": "not_affected",
-      "timestamp": "2026-04-07T22:21:43.152Z",
+      "timestamp": "2026-07-02T00:00:00.000Z",
       "vulnerability": {
-        "name": "CVE-2026-33671"
+        "name": "CVE-2026-48779"
       }
     }
   ],
-  "timestamp": "2026-04-07T22:21:43.152Z",
+  "timestamp": "2026-07-02T00:00:00.000Z",
   "version": 1
 }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Fixes 2 HIGH vulnerabilities flagged by Docker Scout:

- **CVE-2026-48779** (ws 8.18.1): VEX exception — portal-backend only uses HTTP transports, WebSocket code is unreachable.
- **CVE-2026-48815** (sigstore 4.1.0): Removed npm from all runtime images — the app uses pnpm exclusively.

Also removed a stale `picomatch@4.0.3` VEX entry (already upgraded to 4.0.4).

#### Details

This pull request focuses on improving the security and efficiency of multiple Docker images by removing the unused global `npm` installation, and updates the VEX (Vulnerability Exploitability eXchange) statement to reflect a different package and vulnerability status. The most important changes are grouped below:

**Dockerfile security and image optimization:**

* Removed the global installation of `npm` and added an explicit uninstall step in all relevant Dockerfiles (`portal-backend/api/Dockerfile`, `portal-backend/cron/hemi-supply/Dockerfile`, `portal-backend/cron/token-prices/Dockerfile`, `portal-backend/cron/vaults-monitor/Dockerfile`). This reduces image size and eliminates transitive vulnerabilities, since the applications use `pnpm` instead of `npm`. [[1]](diffhunk://#diff-485ba51570cbe0623691c60cfddcc01541337b900de3cca2dd8c09503075e365L34-R37) [[2]](diffhunk://#diff-8d0262d8af22684b7a8fda827443a53b79feb05f706adad89b794352c2029868L25-R28) [[3]](diffhunk://#diff-71e17bcbaa7078e3765ac2bbc5e06707260fb3e78a36836752ee04ff46a7b010L25-R28) [[4]](diffhunk://#diff-7e52e317d4f7a7143bbb9ed9410155dbcf1e9acad4434458a9bd22c418d95710L25-R28)

**VEX statement update:**

* Updated `vex.json` to change the affected product from `picomatch` to `ws`, the vulnerability from `CVE-2026-33671` to `CVE-2026-48779`, and refreshed the relevant timestamps. This clarifies the vulnerability status for the new package.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
