### PR TITLE
Add Storybook story for Toast

### DIFF
--- a/portal/stories/toast.stories.tsx
+++ b/portal/stories/toast.stories.tsx
@@ -46,3 +46,24 @@ export const WithTransaction: Story = {
     />
   ),
 }
+
+export const WithGoTo: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <Toast
+      autoCloseMs={0}
+      description="Here's your staking transaction:"
+      goTo={{
+        href: '/stake/dashboard',
+        label: 'Go to staking dashboard',
+      }}
+      title="Staking successful"
+      tx={{
+        href: 'https://explorer.hemi.xyz/tx/0x1234abcd5678ef90',
+        label: '0x1234…ef90',
+      }}
+    />
+  ),
+}

--- a/portal/stories/toast.stories.tsx
+++ b/portal/stories/toast.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Toast } from 'components/toast'
+
+const meta = {
+  args: {
+    autoCloseMs: 0,
+    description: 'Your deposit was received.',
+    title: 'Deposit successful',
+    variant: 'success',
+  },
+  argTypes: {
+    autoCloseMs: { control: 'number' },
+    description: { control: 'text' },
+    goTo: { control: false },
+    title: { control: 'text' },
+    tx: { control: false },
+    variant: {
+      control: 'inline-radio',
+      mapping: { none: undefined },
+      options: ['none', 'success', 'error'],
+    },
+  },
+  component: Toast,
+  title: 'Components/Toast',
+} satisfies Meta<typeof Toast>
+
+export default meta
+
+type Story = StoryObj<typeof Toast>
+
+export const Default: Story = {}
+
+export const WithTransaction: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <Toast
+      autoCloseMs={0}
+      description="Here's your transaction:"
+      title="Deposit successful"
+      tx={{
+        href: 'https://explorer.hemi.xyz/tx/0x1234abcd5678ef90',
+        label: '0x1234…ef90',
+      }}
+    />
+  ),
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds a Storybook story for the `Toast` component (`components/toast`).

The `Default` story renders the toast with editable Controls (`title`, `description`, `variant`,
`autoCloseMs`), with `autoCloseMs` set to `0` so it stays visible in the canvas. Two extra stories
cover the variants that use link props, mirroring real app usage: `WithTransaction` shows the `tx`
external link (as in the deposit/withdraw toasts), and `WithGoTo` shows the `goTo` internal link
alongside `tx` (as in `StakeToast`, which links to the staking dashboard). The component is not
modified.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->


<img  alt="components-toast--default--ui" src="https://github.com/user-attachments/assets/498b35ce-ebc7-401f-9be5-0a083bf7b229" />


<img  alt="components-toast--default--ui" src="https://github.com/user-attachments/assets/498b35ce-ebc7-401f-9be5-0a083bf7b229" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1993

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
