### PR TITLE
Keep the earn pool form visible while scrolling

### DIFF
--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolPageContent.tsx
@@ -91,7 +91,7 @@ export const PoolPageContent = function ({ shareAddress }: Props) {
               shareAddress={pool.shareAddress}
             />
           </div>
-          <div className="order-1 lg:order-2 lg:basis-1/3">
+          <div className="order-1 lg:sticky lg:top-4 lg:order-2 lg:basis-1/3 lg:self-start">
             <PoolForm />
           </div>
         </div>

--- a/portal/app/[locale]/staking-dashboard/page.tsx
+++ b/portal/app/[locale]/staking-dashboard/page.tsx
@@ -45,7 +45,7 @@ function StakingContent() {
           </div>
           <StakeTable data={filteredData} filter={filter} loading={isLoading} />
         </div>
-        <div className="w-full shrink-0 lg:w-1/2 lg:shrink xl:flex-1">
+        <div className="w-full shrink-0 lg:sticky lg:top-4 lg:w-1/2 lg:shrink lg:self-start xl:flex-1">
           <StakeForm />
         </div>
       </div>


### PR DESCRIPTION
### Description

This PR fixes the Hemi Earn pool page so the deposit/withdraw form stays visible while scrolling. The content column (info cards, historical metrics, composition) is much taller than the form, so the form used to scroll out of view almost immediately.

The form column is now sticky on desktop viewports, sitting 16px below the top of the scroll area while the rest of the page scrolls, and the pending operation status rendered below the form sticks along with it. On mobile nothing changes — the new classes only kick in at the `lg` breakpoint, the same one where the layout switches to two columns.

Following the review suggestion, the staking governance dashboard gets the same treatment — its positions table outgrows the stake form in exactly the same way.

### Screenshots

https://github.com/user-attachments/assets/4d48c4d4-0a9b-43fd-9b4c-4fdbabd5d481

### Related issue(s)

Closes #2010

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.