### PR TITLE
Skip cooldown reads for terminal earn rows

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -326,16 +326,13 @@ export const HistoricalWithdrawReview = function ({
     spender: getHemiEarnRouterAddress(),
   })
 
-  const needsCooldownReads = !isEarnRowTerminal(transaction)
-
   const { data: isCooldownEligible } = useIsCooldownEligible({
     account: address,
-    enabled: needsCooldownReads,
     stakingVault: pool.stakingVault,
   })
 
   const { data: cooldownDurationSec } = useCooldownDuration({
-    enabled: needsCooldownReads,
+    enabled: !isEarnRowTerminal(transaction),
     stakingVault: pool.stakingVault,
   })
 

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -22,6 +22,7 @@ import { useIsCooldownEligible } from '../../../_hooks/useIsCooldownEligible'
 import {
   claimRecoverSettlement,
   getTerminalDeliveryTxHash,
+  isEarnRowTerminal,
   isLocalEarnTransactionRow,
   isRecoverPath,
   isUserCancel,
@@ -325,12 +326,16 @@ export const HistoricalWithdrawReview = function ({
     spender: getHemiEarnRouterAddress(),
   })
 
+  const needsCooldownReads = !isEarnRowTerminal(transaction)
+
   const { data: isCooldownEligible } = useIsCooldownEligible({
     account: address,
+    enabled: needsCooldownReads,
     stakingVault: pool.stakingVault,
   })
 
   const { data: cooldownDurationSec } = useCooldownDuration({
+    enabled: needsCooldownReads,
     stakingVault: pool.stakingVault,
   })
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
@@ -15,11 +15,14 @@ const STALE_TIME_MS = 4 * 60 * 60 * 1000
 // seconds to tick at minute resolution. Takes the Ethereum-side staking vault
 // (`pool.stakingVault`) directly — callers already hold it.
 export const useCooldownDuration = ({
+  enabled = true,
   stakingVault,
 }: {
+  enabled?: boolean
   stakingVault: Address
 }) =>
   useQuery({
+    enabled,
     async queryFn() {
       const seconds = await getCooldownDuration(
         getEvmL1PublicClient(mainnet.id),

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactions.ts
@@ -3,7 +3,7 @@
 import { useMemo } from 'react'
 import { type Hash } from 'viem'
 
-import { hashesMatch } from '../_utils'
+import { hashesMatch, isEarnRowTerminal } from '../_utils'
 import {
   DepositStatus,
   WithdrawStatus,
@@ -141,7 +141,7 @@ export const useEarnTransactions = function () {
         // local settlement — a pending marker mid-indexing-lag or a stale
         // reverted one. A FINALIZED/RECOVERED row must never re-expose the
         // claim/recover CTA or a "Tx Failed" overlay.
-        const isTerminal = t.status === 'FINALIZED' || t.status === 'RECOVERED'
+        const isTerminal = isEarnRowTerminal(t)
         return {
           ...t,
           ...(local.approvalTxHash

--- a/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
@@ -16,15 +16,13 @@ const STALE_TIME_MS = 4 * 60 * 60 * 1000
 // vault (`pool.stakingVault`) directly — callers already hold it.
 export const useIsCooldownEligible = ({
   account,
-  enabled = true,
   stakingVault,
 }: {
   account: Address | undefined
-  enabled?: boolean
   stakingVault: Address
 }) =>
   useQuery({
-    enabled: enabled && !!account,
+    enabled: !!account,
     async queryFn() {
       const isInstant = await resolveIsInstant({
         caller: account!,

--- a/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
@@ -16,13 +16,15 @@ const STALE_TIME_MS = 4 * 60 * 60 * 1000
 // vault (`pool.stakingVault`) directly — callers already hold it.
 export const useIsCooldownEligible = ({
   account,
+  enabled = true,
   stakingVault,
 }: {
   account: Address | undefined
+  enabled?: boolean
   stakingVault: Address
 }) =>
   useQuery({
-    enabled: !!account,
+    enabled: enabled && !!account,
     async queryFn() {
       const isInstant = await resolveIsInstant({
         caller: account!,

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -209,13 +209,14 @@ export const isEarnRowTerminal = (tx: EarnTransaction) =>
   tx.status === 'FINALIZED' || tx.status === 'RECOVERED'
 
 // A row the table is still actively tracking — drives both the polling loop and
-// the row spinner. Terminal: FINALIZED, RECOVERED, and a *local* FAILED (the Hemi
-// `request*` tx reverted — it's never indexed and never transitions on its own;
-// the user retries from home). A *subgraph* FAILED is the Agent failing
-// cross-chain, which still walks to CANCELLED→RECOVERED (auto-recover or the
-// keeper cancel), so it stays in flight — otherwise the table stops polling at the
-// transient FAILED and never catches the RECOVERED. A CANCELLED request (any kind)
-// likewise stays in flight, mirroring how a FULFILLED request walks to FINALIZED.
+// the row spinner. Out of flight: the subgraph-terminal statuses (see
+// `isEarnRowTerminal`) plus a *local* FAILED (the Hemi `request*` tx reverted —
+// it's never indexed and never transitions on its own; the user retries from
+// home). A *subgraph* FAILED is the Agent failing cross-chain, which still walks
+// to CANCELLED→RECOVERED (auto-recover or the keeper cancel), so it stays in
+// flight — otherwise the table stops polling at the transient FAILED and never
+// catches the RECOVERED. A CANCELLED request (any kind) likewise stays in
+// flight, mirroring how a FULFILLED request walks to FINALIZED.
 export const isEarnRowInFlight = (tx: EarnTransaction) =>
   !isEarnRowTerminal(tx) &&
   !(tx.status === 'FAILED' && isLocalEarnTransactionRow(tx))

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -205,6 +205,9 @@ export const enrichWithSettlement = (
 ): EarnTransaction | undefined =>
   row && settlement ? { ...row, settlement } : row
 
+export const isEarnRowTerminal = (tx: EarnTransaction) =>
+  tx.status === 'FINALIZED' || tx.status === 'RECOVERED'
+
 // A row the table is still actively tracking — drives both the polling loop and
 // the row spinner. Terminal: FINALIZED, RECOVERED, and a *local* FAILED (the Hemi
 // `request*` tx reverted — it's never indexed and never transitions on its own;
@@ -214,8 +217,7 @@ export const enrichWithSettlement = (
 // transient FAILED and never catches the RECOVERED. A CANCELLED request (any kind)
 // likewise stays in flight, mirroring how a FULFILLED request walks to FINALIZED.
 export const isEarnRowInFlight = (tx: EarnTransaction) =>
-  tx.status !== 'FINALIZED' &&
-  tx.status !== 'RECOVERED' &&
+  !isEarnRowTerminal(tx) &&
   !(tx.status === 'FAILED' && isLocalEarnTransactionRow(tx))
 
 // The progress ladder shared by a withdraw's terminal step — the receive step on

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -538,7 +538,7 @@ describe('utils', function () {
       expect(isEarnRowTerminal({ ...baseTx, status })).toBe(false)
     })
 
-    it('is false for a local FAILED row, unlike isEarnRowInFlight', function () {
+    it('is false for a local FAILED row even though it is also out of flight', function () {
       const localFailed = {
         ...baseTx,
         requestId: 'local-1700000000',

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -16,6 +16,7 @@ import {
   hashesMatch,
   isDeliberateCancel,
   isEarnRowInFlight,
+  isEarnRowTerminal,
   isLocalEarnTransactionRow,
   isRecoverPath,
   isUserCancel,
@@ -517,6 +518,35 @@ describe('utils', function () {
         ).toBe(true)
       },
     )
+  })
+
+  describe('isEarnRowTerminal', function () {
+    it.each<EarnTransactionStatusType>(['FINALIZED', 'RECOVERED'])(
+      'is true for the terminal status %s',
+      function (status) {
+        expect(isEarnRowTerminal({ ...baseTx, status })).toBe(true)
+      },
+    )
+
+    it.each<EarnTransactionStatusType>([
+      'CANCELLED',
+      'FAILED',
+      'FULFILLED',
+      'PENDING',
+      'TX_PENDING',
+    ])('is false for the non-terminal status %s', function (status) {
+      expect(isEarnRowTerminal({ ...baseTx, status })).toBe(false)
+    })
+
+    it('is false for a local FAILED row, unlike isEarnRowInFlight', function () {
+      const localFailed = {
+        ...baseTx,
+        requestId: 'local-1700000000',
+        status: 'FAILED',
+      } as EarnTransaction
+      expect(isEarnRowTerminal(localFailed)).toBe(false)
+      expect(isEarnRowInFlight(localFailed)).toBe(false)
+    })
   })
 
   describe('pickEarnRowAmount', function () {

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction.test.ts
@@ -1,0 +1,49 @@
+import {
+  type CooldownInputs,
+  deriveCooldownPostAction,
+} from 'app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction'
+import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import { describe, expect, it } from 'vitest'
+
+const t = ((key: string) => key) as unknown as CooldownInputs['t']
+
+const gatedInputs = {
+  cooldownDurationSec: undefined,
+  cooldownRemainingSec: undefined,
+  isCooldownEligible: undefined,
+  t,
+  unstakeMined: true,
+}
+
+describe('deriveCooldownPostAction', function () {
+  it('returns a completed milestone for FINALIZED rows without consuming the cooldown reads', function () {
+    expect(
+      deriveCooldownPostAction({ ...gatedInputs, subgraphStatus: 'FINALIZED' }),
+    ).toEqual({
+      description: 'cooldown-ended',
+      status: ProgressStatus.COMPLETED,
+    })
+  })
+
+  it('returns undefined for RECOVERED rows without consuming the cooldown reads', function () {
+    expect(
+      deriveCooldownPostAction({ ...gatedInputs, subgraphStatus: 'RECOVERED' }),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for CANCELLED rows without consuming the cooldown reads', function () {
+    expect(
+      deriveCooldownPostAction({ ...gatedInputs, subgraphStatus: 'CANCELLED' }),
+    ).toBeUndefined()
+  })
+
+  it('hides the milestone when the account is not cooldown eligible', function () {
+    expect(
+      deriveCooldownPostAction({
+        ...gatedInputs,
+        isCooldownEligible: false,
+        subgraphStatus: 'FINALIZED',
+      }),
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Description

This PR gates the cooldown duration read in the historical withdraw drawer so it no longer fires for terminal rows. Opening the drawer on a FINALIZED or RECOVERED row triggered the on-chain read even though `deriveCooldownPostAction` short-circuits on the subgraph status before consuming it.

`useCooldownDuration` now accepts an optional `enabled` flag (default `true`), and the drawer disables it when the row is terminal. The eligibility read stays live — it is actually consumed on FINALIZED rows, to hide the cooldown milestone for whitelisted accounts. The other call sites keep their current behavior. While at it, the FINALIZED/RECOVERED check got extracted into a shared `isEarnRowTerminal` util, now reused by `isEarnRowInFlight` and the settlement fold in `useEarnTransactions`, which carried the same pair inline.

Added tests locking the invariant the gate relies on (`deriveCooldownPostAction` with all cooldown inputs undefined) plus coverage for the new util.

### Screenshots

No UI changes.

### Related issue(s)

Closes #2012

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.