### PR TITLE
Add story for table

### DIFF
--- a/portal/.storybook/preview.ts
+++ b/portal/.storybook/preview.ts
@@ -2,8 +2,12 @@ import type { Preview } from '@storybook/nextjs'
 import { createElement } from 'react'
 import { SkeletonTheme } from 'react-loading-skeleton'
 
-import 'styles/globals.css'
+// Import skeleton.css before globals.css so Tailwind utilities (e.g. w-16) win
+// over `.react-loading-skeleton { width: 100% }`. layout.tsx imports them the
+// other way, but Next reorders the compiled bundle to this effective order;
+// Storybook keeps the literal order, so we replicate the app's cascade here.
 import 'react-loading-skeleton/dist/skeleton.css'
+import 'styles/globals.css'
 
 const preview: Preview = {
   // Mirror the SkeletonTheme set on the app root layout so skeleton-based

--- a/portal/components/button/button.css
+++ b/portal/components/button/button.css
@@ -31,6 +31,18 @@ Because of that, we can add all the styles here, and then use plain buttons in t
 }
 
 /* Button Sizes */
+.button-xx-small {
+  @apply h-6 rounded-md text-xs;
+}
+
+.button-xx-small.button-regular {
+  @apply gap-x-1 px-2.5;
+}
+
+.button-xx-small.button-icon {
+  @apply min-w-6;
+}
+
 .button-x-small {
   @apply h-7 rounded-md text-xs;
 }

--- a/portal/components/button/index.tsx
+++ b/portal/components/button/index.tsx
@@ -9,10 +9,14 @@ const variants = {
   tertiary: 'button-tertiary',
 } as const
 
-export type ButtonSize = 'xSmall' | 'small' | 'xLarge'
+export type ButtonSize = 'xxSmall' | 'xSmall' | 'small' | 'xLarge'
 
 /* eslint-disable sort-keys */
 const buttonSizePresets = {
+  xxSmall: {
+    icon: 'button-xx-small button-icon',
+    regular: 'button-xx-small button-regular',
+  },
   xSmall: {
     icon: 'button-x-small button-icon',
     regular: 'button-x-small button-regular',

--- a/portal/components/table/_components/header.tsx
+++ b/portal/components/table/_components/header.tsx
@@ -6,7 +6,7 @@ export const Header = ({
   text: string
 }) => (
   <span
-    className={`block py-3 text-left font-semibold text-neutral-600 ${className}`}
+    className={`block py-3 text-left font-medium text-neutral-600 ${className}`}
   >
     {text}
   </span>

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { type ColumnDef } from '@tanstack/react-table'
+import { ButtonIcon } from 'components/button'
 import { Table, type TableProps } from 'components/table'
 import { Header } from 'components/table/_components/header'
 
@@ -39,6 +40,20 @@ const RewardStack = () => (
   </div>
 )
 
+const EllipsisIcon = () => (
+  <svg
+    className="text-neutral-500"
+    fill="currentColor"
+    height={16}
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <circle cx={4} cy={8} r={1.25} />
+    <circle cx={8} cy={8} r={1.25} />
+    <circle cx={12} cy={8} r={1.25} />
+  </svg>
+)
+
 const ActionCell = ({ timeRemaining }: { timeRemaining: string }) => (
   <div className="flex w-full items-center justify-end gap-x-2">
     <div className="flex h-6 items-center gap-x-1 rounded-md bg-orange-600 px-2.5">
@@ -47,9 +62,9 @@ const ActionCell = ({ timeRemaining }: { timeRemaining: string }) => (
         {timeRemaining}
       </span>
     </div>
-    <div className="flex size-6 items-center justify-center rounded-md bg-neutral-100 text-neutral-500">
-      ···
-    </div>
+    <ButtonIcon size="xSmall" variant="secondary">
+      <EllipsisIcon />
+    </ButtonIcon>
   </div>
 )
 
@@ -59,9 +74,7 @@ const columns: ColumnDef<Row>[] = [
       <div className="flex items-center gap-x-3">
         <TokenIcon />
         <div className="flex flex-col">
-          <span className="text-sm text-neutral-950">
-            {row.original.lockedAmount}
-          </span>
+          <span className="text-neutral-950">{row.original.lockedAmount}</span>
           <span className="text-xxs text-neutral-500">
             {row.original.address}
           </span>
@@ -75,7 +88,7 @@ const columns: ColumnDef<Row>[] = [
   {
     cell: ({ row }) => (
       <div className="flex flex-col">
-        <span className="text-sm text-neutral-950">{row.original.lockup}</span>
+        <span className="text-neutral-950">{row.original.lockup}</span>
         <span className="text-xxs text-emerald-600">{row.original.apy}</span>
       </div>
     ),
@@ -86,9 +99,7 @@ const columns: ColumnDef<Row>[] = [
   {
     cell: ({ row }) => (
       <div className="flex flex-col">
-        <span className="text-sm text-neutral-950">
-          {row.original.votingPower}
-        </span>
+        <span className="text-neutral-950">{row.original.votingPower}</span>
         <span className="text-xxs text-neutral-500">
           {row.original.votingShare}
         </span>
@@ -181,7 +192,7 @@ const meta = {
   component: Table,
   decorators: [
     Story => (
-      <div className="h-96 w-full max-w-3xl">
+      <div className="h-96 w-full max-w-3xl text-sm font-medium">
         <Story />
       </div>
     ),

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
-import { ColumnDef } from '@tanstack/react-table'
+import { type ColumnDef } from '@tanstack/react-table'
 import { Table, type TableProps } from 'components/table'
 import { Header } from 'components/table/_components/header'
 

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -2,120 +2,165 @@ import type { Meta, StoryObj } from '@storybook/nextjs'
 import { ColumnDef } from '@tanstack/react-table'
 import { Table, type TableProps } from 'components/table'
 import { Header } from 'components/table/_components/header'
-import { type ReactNode } from 'react'
 
 type Row = {
-  amount: string
-  apr: string
+  address: string
+  apy: string
+  lockedAmount: string
   lockup: string
-  rewards: string
+  rewardsCount: string
   timeRemaining: string
   votingPower: string
+  votingShare: string
 }
 
-const Centered = ({ children }: { children: ReactNode }) => (
-  <div className="flex items-center justify-center">{children}</div>
+const HemiToken = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 20 20">
+    <rect fill="#FF6C15" height={20} rx={10} width={20} />
+    <path
+      d="M11.2016 3.7519C11.1372 3.74034 11.0767 3.78272 11.0653 3.84823L10.2895 8.3296H9.71049L8.93468 3.84823C8.92333 3.78272 8.86277 3.74034 8.79844 3.7519C6.04337 4.29521 3.93165 6.68425 3.75757 9.60504C3.75757 9.60889 3.75 9.7322 3.75 9.79385C3.75 9.80156 3.75 9.80926 3.75 9.81312C3.75 9.83624 3.75 9.85935 3.75 9.88247C3.75 9.89018 3.75 9.89789 3.75 9.90945C3.75 9.94027 3.75 9.96725 3.75 9.99807C3.75 13.0961 5.92227 15.674 8.80222 16.2442C8.86656 16.2558 8.92711 16.2134 8.93846 16.1479L9.71427 11.6665H10.2933L11.0653 16.1518C11.0767 16.2173 11.1372 16.2597 11.2016 16.2481C13.9566 15.7009 16.0646 13.3119 16.2424 10.3911C16.2424 10.3873 16.25 10.2639 16.25 10.2023C16.25 10.1946 16.25 10.1869 16.25 10.183C16.25 10.1599 16.25 10.1368 16.25 10.1137C16.25 10.106 16.25 10.0983 16.25 10.0867C16.25 10.0559 16.25 10.0289 16.25 9.99807C16.2538 6.90003 14.0815 4.32218 11.2016 3.7519Z"
+      fill="white"
+    />
+  </svg>
+)
+
+const TokenIcon = () => (
+  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-neutral-50 p-2">
+    <HemiToken className="size-5" />
+  </div>
+)
+
+const RewardStack = () => (
+  <div className="flex items-center">
+    <HemiToken className="size-4" />
+    <div className="-ml-1.5 flex rounded-full border border-white">
+      <HemiToken className="size-4" />
+    </div>
+  </div>
+)
+
+const ActionCell = ({ timeRemaining }: { timeRemaining: string }) => (
+  <div className="flex w-full items-center justify-end gap-x-2">
+    <div className="flex h-6 items-center gap-x-1 rounded-md bg-orange-600 px-2.5">
+      <span className="text-xs font-semibold text-white">Unlock</span>
+      <span className="flex h-4 items-center rounded-md bg-orange-100 px-1.5 text-xxs font-medium text-orange-600">
+        {timeRemaining}
+      </span>
+    </div>
+    <div className="flex size-6 items-center justify-center rounded-md bg-neutral-100 text-neutral-500">
+      ···
+    </div>
+  </div>
 )
 
 const columns: ColumnDef<Row>[] = [
   {
     cell: ({ row }) => (
-      <Centered>
-        <span className="text-sm text-neutral-950">{row.original.amount}</span>
-      </Centered>
+      <div className="flex items-center gap-x-3">
+        <TokenIcon />
+        <div className="flex flex-col">
+          <span className="text-sm text-neutral-950">
+            {row.original.lockedAmount}
+          </span>
+          <span className="text-xxs text-neutral-500">
+            {row.original.address}
+          </span>
+        </div>
+      </div>
     ),
     header: () => <Header text="Locked Amount" />,
     id: 'locked-amount',
-    meta: { width: 170 },
+    meta: { width: 180 },
   },
   {
     cell: ({ row }) => (
       <div className="flex flex-col">
-        <span className="text-xs font-normal text-emerald-600">
-          {row.original.apr}
-        </span>
-        <span className="text-neutral-500">{row.original.lockup}</span>
+        <span className="text-sm text-neutral-950">{row.original.lockup}</span>
+        <span className="text-xxs text-emerald-600">{row.original.apy}</span>
       </div>
     ),
     header: () => <Header text="Lockup" />,
     id: 'lockup',
+    meta: { width: 100 },
+  },
+  {
+    cell: ({ row }) => (
+      <div className="flex flex-col">
+        <span className="text-sm text-neutral-950">
+          {row.original.votingPower}
+        </span>
+        <span className="text-xxs text-neutral-500">
+          {row.original.votingShare}
+        </span>
+      </div>
+    ),
+    header: () => <Header text="Voting Power" />,
+    id: 'voting-power',
+    meta: { width: 130 },
+  },
+  {
+    cell: ({ row }) => (
+      <div className="flex flex-col gap-y-0.5">
+        <RewardStack />
+        <span className="text-xxs text-neutral-500">
+          {row.original.rewardsCount}
+        </span>
+      </div>
+    ),
+    header: () => <Header text="Rewards" />,
+    id: 'rewards',
     meta: { width: 120 },
   },
   {
     cell: ({ row }) => (
-      <Centered>
-        <span className="text-sm text-neutral-950">
-          {row.original.votingPower}
-        </span>
-      </Centered>
+      <ActionCell timeRemaining={row.original.timeRemaining} />
     ),
-    header: () => <Header text="Voting Power" />,
-    id: 'voting-power',
-    meta: { width: 150 },
-  },
-  {
-    cell: ({ row }) => (
-      <Centered>
-        <span className="text-sm text-neutral-950">{row.original.rewards}</span>
-      </Centered>
-    ),
-    header: () => <Header text="Claimable rewards" />,
-    id: 'rewards',
-    meta: { width: 170 },
-  },
-  {
-    cell: ({ row }) => (
-      <span className="text-sm text-neutral-950">
-        {row.original.timeRemaining}
-      </span>
-    ),
-    header: () => <Header text="Time remaining" />,
-    id: 'time-remaining',
-    meta: { className: 'justify-end', width: 140 },
-  },
-  {
-    cell: () => (
-      <Centered>
-        <span className="text-sm text-neutral-500">···</span>
-      </Centered>
-    ),
+    header: () => <Header className="justify-end" text="Action" />,
     id: 'action',
-    meta: { width: 60 },
+    meta: { className: 'justify-end', width: 180 },
   },
 ]
 
 const data: Row[] = [
   {
-    amount: '1,234.56 HEMI',
-    apr: '12.5% APR',
-    lockup: '12 months',
-    rewards: '18.20 HEMI',
-    timeRemaining: '284 days',
-    votingPower: '1,180.3',
+    address: '0xdcfe...b5f9',
+    apy: '2.4% APY',
+    lockedAmount: '500 HEMI',
+    lockup: '4 years',
+    rewardsCount: '2 Available',
+    timeRemaining: 'In 12mo',
+    votingPower: '0.096 veHEMI',
+    votingShare: '50%',
   },
   {
-    amount: '89.50 HEMI',
-    apr: '8.0% APR',
-    lockup: '6 months',
-    rewards: '1.05 HEMI',
-    timeRemaining: '95 days',
-    votingPower: '72.1',
+    address: '0x8a21...4c02',
+    apy: '1.8% APY',
+    lockedAmount: '89.50 HEMI',
+    lockup: '2 years',
+    rewardsCount: '1 Available',
+    timeRemaining: 'In 6mo',
+    votingPower: '0.012 veHEMI',
+    votingShare: '18%',
   },
   {
-    amount: '12,345.00 HEMI',
-    apr: '15.0% APR',
-    lockup: '24 months',
-    rewards: '540.00 HEMI',
-    timeRemaining: '712 days',
-    votingPower: '13,600.0',
+    address: '0x4f90...ab13',
+    apy: '3.1% APY',
+    lockedAmount: '12,345.00 HEMI',
+    lockup: '4 years',
+    rewardsCount: '2 Available',
+    timeRemaining: 'In 24mo',
+    votingPower: '2.360 veHEMI',
+    votingShare: '73%',
   },
   {
-    amount: '5.00 HEMI',
-    apr: '4.5% APR',
+    address: '0x1b7c...e5d8',
+    apy: '0.9% APY',
+    lockedAmount: '5.00 HEMI',
     lockup: '3 months',
-    rewards: '0.02 HEMI',
-    timeRemaining: '12 days',
-    votingPower: '4.8',
+    rewardsCount: '1 Available',
+    timeRemaining: 'In 12d',
+    votingPower: '0.001 veHEMI',
+    votingShare: '4%',
   },
 ]
 

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -2,43 +2,121 @@ import type { Meta, StoryObj } from '@storybook/nextjs'
 import { ColumnDef } from '@tanstack/react-table'
 import { Table, type TableProps } from 'components/table'
 import { Header } from 'components/table/_components/header'
+import { type ReactNode } from 'react'
 
 type Row = {
   amount: string
-  status: string
+  apr: string
+  lockup: string
+  rewards: string
+  timeRemaining: string
   votingPower: string
 }
 
-const Cell = ({ text }: { text: string }) => (
-  <span className="text-sm text-neutral-950">{text}</span>
+const Centered = ({ children }: { children: ReactNode }) => (
+  <div className="flex items-center justify-center">{children}</div>
 )
 
 const columns: ColumnDef<Row>[] = [
   {
-    cell: ({ row }) => <Cell text={row.original.amount} />,
-    header: () => <Header text="Amount" />,
-    id: 'amount',
-    meta: { width: 220 },
+    cell: ({ row }) => (
+      <Centered>
+        <span className="text-sm text-neutral-950">{row.original.amount}</span>
+      </Centered>
+    ),
+    header: () => <Header text="Locked Amount" />,
+    id: 'locked-amount',
+    meta: { width: 170 },
   },
   {
-    cell: ({ row }) => <Cell text={row.original.votingPower} />,
+    cell: ({ row }) => (
+      <div className="flex flex-col">
+        <span className="text-xs font-normal text-emerald-600">
+          {row.original.apr}
+        </span>
+        <span className="text-neutral-500">{row.original.lockup}</span>
+      </div>
+    ),
+    header: () => <Header text="Lockup" />,
+    id: 'lockup',
+    meta: { width: 120 },
+  },
+  {
+    cell: ({ row }) => (
+      <Centered>
+        <span className="text-sm text-neutral-950">
+          {row.original.votingPower}
+        </span>
+      </Centered>
+    ),
     header: () => <Header text="Voting Power" />,
-    id: 'votingPower',
-    meta: { width: 220 },
+    id: 'voting-power',
+    meta: { width: 150 },
   },
   {
-    cell: ({ row }) => <Cell text={row.original.status} />,
-    header: () => <Header text="Status" />,
-    id: 'status',
-    meta: { width: 160 },
+    cell: ({ row }) => (
+      <Centered>
+        <span className="text-sm text-neutral-950">{row.original.rewards}</span>
+      </Centered>
+    ),
+    header: () => <Header text="Claimable rewards" />,
+    id: 'rewards',
+    meta: { width: 170 },
+  },
+  {
+    cell: ({ row }) => (
+      <span className="text-sm text-neutral-950">
+        {row.original.timeRemaining}
+      </span>
+    ),
+    header: () => <Header text="Time remaining" />,
+    id: 'time-remaining',
+    meta: { className: 'justify-end', width: 140 },
+  },
+  {
+    cell: () => (
+      <Centered>
+        <span className="text-sm text-neutral-500">···</span>
+      </Centered>
+    ),
+    id: 'action',
+    meta: { width: 60 },
   },
 ]
 
 const data: Row[] = [
-  { amount: '1,234.56 HEMI', status: 'Active', votingPower: '1,180.3' },
-  { amount: '89.50 HEMI', status: 'Active', votingPower: '72.1' },
-  { amount: '12,345.00 HEMI', status: 'Unlocked', votingPower: '0' },
-  { amount: '5.00 HEMI', status: 'Active', votingPower: '4.8' },
+  {
+    amount: '1,234.56 HEMI',
+    apr: '12.5% APR',
+    lockup: '12 months',
+    rewards: '18.20 HEMI',
+    timeRemaining: '284 days',
+    votingPower: '1,180.3',
+  },
+  {
+    amount: '89.50 HEMI',
+    apr: '8.0% APR',
+    lockup: '6 months',
+    rewards: '1.05 HEMI',
+    timeRemaining: '95 days',
+    votingPower: '72.1',
+  },
+  {
+    amount: '12,345.00 HEMI',
+    apr: '15.0% APR',
+    lockup: '24 months',
+    rewards: '540.00 HEMI',
+    timeRemaining: '712 days',
+    votingPower: '13,600.0',
+  },
+  {
+    amount: '5.00 HEMI',
+    apr: '4.5% APR',
+    lockup: '3 months',
+    rewards: '0.02 HEMI',
+    timeRemaining: '12 days',
+    votingPower: '4.8',
+  },
 ]
 
 const meta = {

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { ColumnDef } from '@tanstack/react-table'
+import { Table, type TableProps } from 'components/table'
+import { Header } from 'components/table/_components/header'
+
+type Row = {
+  amount: string
+  status: string
+  votingPower: string
+}
+
+const Cell = ({ text }: { text: string }) => (
+  <span className="text-sm text-neutral-950">{text}</span>
+)
+
+const columns: ColumnDef<Row>[] = [
+  {
+    cell: ({ row }) => <Cell text={row.original.amount} />,
+    header: () => <Header text="Amount" />,
+    id: 'amount',
+    meta: { width: 220 },
+  },
+  {
+    cell: ({ row }) => <Cell text={row.original.votingPower} />,
+    header: () => <Header text="Voting Power" />,
+    id: 'votingPower',
+    meta: { width: 220 },
+  },
+  {
+    cell: ({ row }) => <Cell text={row.original.status} />,
+    header: () => <Header text="Status" />,
+    id: 'status',
+    meta: { width: 160 },
+  },
+]
+
+const data: Row[] = [
+  { amount: '1,234.56 HEMI', status: 'Active', votingPower: '1,180.3' },
+  { amount: '89.50 HEMI', status: 'Active', votingPower: '72.1' },
+  { amount: '12,345.00 HEMI', status: 'Unlocked', votingPower: '0' },
+  { amount: '5.00 HEMI', status: 'Active', votingPower: '4.8' },
+]
+
+const meta = {
+  args: {
+    columns,
+    data,
+    loading: false,
+    mode: 'static',
+  },
+  argTypes: {
+    columns: { control: false },
+    data: { control: false },
+    loading: { control: 'boolean' },
+    mode: { control: 'inline-radio', options: ['static', 'virtual'] },
+    onRowClick: { action: 'onRowClick' },
+    placeholder: { control: false },
+  },
+  component: Table,
+  decorators: [
+    Story => (
+      <div className="h-96 w-full max-w-3xl">
+        <Story />
+      </div>
+    ),
+  ],
+  title: 'Components/Table',
+} satisfies Meta<TableProps<Row>>
+
+export default meta
+
+type Story = StoryObj<TableProps<Row>>
+
+export const Default: Story = {}
+
+export const Empty: Story = {
+  args: {
+    data: [],
+    placeholder: (
+      <div className="flex h-40 items-center justify-center text-sm text-neutral-500">
+        No positions yet.
+      </div>
+    ),
+  },
+  parameters: {
+    controls: { disable: true },
+  },
+}

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -62,7 +62,7 @@ const ActionCell = ({ timeRemaining }: { timeRemaining: string }) => (
         {timeRemaining}
       </span>
     </div>
-    <ButtonIcon size="xSmall" variant="secondary">
+    <ButtonIcon size="xxSmall" variant="secondary">
       <EllipsisIcon />
     </ButtonIcon>
   </div>

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -62,7 +62,12 @@ const ActionCell = ({ timeRemaining }: { timeRemaining: string }) => (
         {timeRemaining}
       </span>
     </div>
-    <ButtonIcon size="xxSmall" variant="secondary">
+    <ButtonIcon
+      aria-label="More actions"
+      size="xxSmall"
+      type="button"
+      variant="secondary"
+    >
       <EllipsisIcon />
     </ButtonIcon>
   </div>

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -124,7 +124,6 @@ const meta = {
     columns,
     data,
     loading: false,
-    mode: 'static',
   },
   argTypes: {
     columns: { control: false },
@@ -150,6 +149,16 @@ export default meta
 type Story = StoryObj<TableProps<Row>>
 
 export const Default: Story = {}
+
+export const Loading: Story = {
+  args: {
+    data: [],
+    loading: true,
+  },
+  parameters: {
+    controls: { disable: true },
+  },
+}
 
 export const Empty: Story = {
   args: {

--- a/portal/stories/table.stories.tsx
+++ b/portal/stories/table.stories.tsx
@@ -16,7 +16,7 @@ type Row = {
 }
 
 const HemiToken = ({ className }: { className?: string }) => (
-  <svg className={className} fill="none" viewBox="0 0 20 20">
+  <svg aria-hidden="true" className={className} fill="none" viewBox="0 0 20 20">
     <rect fill="#FF6C15" height={20} rx={10} width={20} />
     <path
       d="M11.2016 3.7519C11.1372 3.74034 11.0767 3.78272 11.0653 3.84823L10.2895 8.3296H9.71049L8.93468 3.84823C8.92333 3.78272 8.86277 3.74034 8.79844 3.7519C6.04337 4.29521 3.93165 6.68425 3.75757 9.60504C3.75757 9.60889 3.75 9.7322 3.75 9.79385C3.75 9.80156 3.75 9.80926 3.75 9.81312C3.75 9.83624 3.75 9.85935 3.75 9.88247C3.75 9.89018 3.75 9.89789 3.75 9.90945C3.75 9.94027 3.75 9.96725 3.75 9.99807C3.75 13.0961 5.92227 15.674 8.80222 16.2442C8.86656 16.2558 8.92711 16.2134 8.93846 16.1479L9.71427 11.6665H10.2933L11.0653 16.1518C11.0767 16.2173 11.1372 16.2597 11.2016 16.2481C13.9566 15.7009 16.0646 13.3119 16.2424 10.3911C16.2424 10.3873 16.25 10.2639 16.25 10.2023C16.25 10.1946 16.25 10.1869 16.25 10.183C16.25 10.1599 16.25 10.1368 16.25 10.1137C16.25 10.106 16.25 10.0983 16.25 10.0867C16.25 10.0559 16.25 10.0289 16.25 9.99807C16.2538 6.90003 14.0815 4.32218 11.2016 3.7519Z"
@@ -42,8 +42,10 @@ const RewardStack = () => (
 
 const EllipsisIcon = () => (
   <svg
+    aria-hidden="true"
     className="text-neutral-500"
     fill="currentColor"
+    focusable={false}
     height={16}
     viewBox="0 0 16 16"
     width={16}
@@ -56,12 +58,15 @@ const EllipsisIcon = () => (
 
 const ActionCell = ({ timeRemaining }: { timeRemaining: string }) => (
   <div className="flex w-full items-center justify-end gap-x-2">
-    <div className="flex h-6 items-center gap-x-1 rounded-md bg-orange-600 px-2.5">
+    <button
+      className="flex h-6 items-center gap-x-1 rounded-md bg-orange-600 px-2.5"
+      type="button"
+    >
       <span className="text-xs font-semibold text-white">Unlock</span>
       <span className="flex h-4 items-center rounded-md bg-orange-100 px-1.5 text-xxs font-medium text-orange-600">
         {timeRemaining}
       </span>
-    </div>
+    </button>
     <ButtonIcon
       aria-label="More actions"
       size="xxSmall"


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds a Storybook story for the Table component (components/table).
The Default story renders the table with columns built from the component's own Header/cell primitives and a few sample rows, mirroring the Governance Staking positions table (locked amount, lockup + APY, voting power + share, rewards, and an unlock action). Controls expose loading and mode (static/virtual), while columns and data are fixed. A Loading story shows the skeleton state, and an Empty story shows the empty state, passing an empty data array and a custom placeholder.

Alongside the story, this PR includes two small shared-component tweaks that the example relies on: the table `Header` weight is lightened (`font-semibold` → `font-medium`) to match the current design, and a new `xxSmall` size is added to `Button` (used by the row's action icon button). The story is also accessible: the icon button has an `aria-label` and `type="button"`, decorative SVGs are marked `aria-hidden`, and the row action is a semantic button. Exposing `xxSmall` in the Button story's size control (a separate file, not touched here) is tracked as a follow-up in #2090.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img  alt="components-table--default--ui" src="https://github.com/user-attachments/assets/085bda9d-3246-4641-9a4c-ec57546acb47" />

<img  alt="components-table--default" src="https://github.com/user-attachments/assets/4b02f5dd-19db-4389-9f63-f0415bee3270" />

<img  alt="components-table--empty" src="https://github.com/user-attachments/assets/73020a5a-44df-4941-ab5d-6ee77963221f" />

<img  alt="components-table--loading--ui" src="https://github.com/user-attachments/assets/145b66e3-f770-42d5-98be-000674f0dc72" />

<img  alt="components-table--loading" src="https://github.com/user-attachments/assets/418015c3-abde-4c4f-9b13-da2c3edd2b0e" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1993

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
