### PR TITLE
Handle unresolvable earnTxId in earn drawer

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -24,6 +24,8 @@ import { HistoricalWithdrawReview } from './historicalWithdrawReview'
 import { RetryFailedDeposit } from './retryFailedDeposit'
 import { RetryFailedWithdraw } from './retryFailedWithdraw'
 import { AddTokenToWalletCta, SettleCta } from './settleShared'
+import { TransactionDrawerSkeleton } from './transactionDrawerSkeleton'
+import { TransactionNotFound } from './transactionNotFound'
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
 // The drawer is already open, so the CTAs don't redirect on sign. A reverted
@@ -123,38 +125,58 @@ function redeemCallToAction({
 const findTransactionByTxId = (transactions: EarnTransaction[], txId: string) =>
   transactions.find(t => hashesMatch(t.requestTxHash, txId))
 
+const resolveDrawerData = function ({
+  pools,
+  transactions,
+  txId,
+}: {
+  pools: EarnPool[]
+  transactions: EarnTransaction[]
+  txId: string
+}) {
+  const transaction = findTransactionByTxId(transactions, txId)
+  if (!transaction) {
+    return undefined
+  }
+  const pool = findPoolByAsset(pools, transaction.asset)
+  const asset = pool?.assets.find(a =>
+    isAddressEqual(a.address, transaction.asset),
+  )
+  if (!pool || !asset) {
+    return undefined
+  }
+  return { asset, pool, transaction }
+}
+
 const TransactionDrawerContent = function () {
   const [txId, setTxDrawerQueryString] = useTxDrawerQueryString()
-  const { data: transactions } = useEarnTransactions()
-  const { data: pools } = useEarnPools()
+  const { data: transactions, isPending: isTransactionsPending } =
+    useEarnTransactions()
+  const { data: pools, isPending: isPoolsPending } = useEarnPools()
 
   if (!txId) {
     return null
   }
 
   const close = () => setTxDrawerQueryString(null)
-  const transaction = findTransactionByTxId(transactions, txId)
 
-  if (!transaction) {
+  if (isTransactionsPending || isPoolsPending) {
     return (
       <Drawer onClose={close}>
-        <div className="drawer-content" />
+        <TransactionDrawerSkeleton onClose={close} />
       </Drawer>
     )
   }
 
-  const pool = findPoolByAsset(pools, transaction.asset)
-  const asset = pool?.assets.find(a =>
-    isAddressEqual(a.address, transaction.asset),
-  )
-  if (!pool || !asset) {
+  const resolved = resolveDrawerData({ pools, transactions, txId })
+  if (!resolved) {
     return (
       <Drawer onClose={close}>
-        <div className="drawer-content" />
+        <TransactionNotFound onClose={close} />
       </Drawer>
     )
   }
-  const resolved = { asset, pool }
+  const { transaction } = resolved
 
   const callToAction =
     transaction.kind === 'REDEEM'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { Drawer } from 'components/drawer'
-import { Suspense } from 'react'
-import { isAddressEqual } from 'viem'
+import { Suspense, useEffect } from 'react'
+import { isAddressEqual, isHash } from 'viem'
 
 import { useEarnPools } from '../../../_hooks/useEarnPools'
 import { useEarnTransactions } from '../../../_hooks/useEarnTransactions'
@@ -154,7 +154,19 @@ const TransactionDrawerContent = function () {
     useEarnTransactions()
   const { data: pools, isPending: isPoolsPending } = useEarnPools()
 
-  if (!txId) {
+  // A malformed txId (e.g. ?earnTxId=0x123) isn't a transaction at all, so
+  // there's nothing to look up — drop it from the URL and show no drawer.
+  const hasInvalidTxId = txId !== null && !isHash(txId)
+  useEffect(
+    function clearInvalidTxId() {
+      if (hasInvalidTxId) {
+        setTxDrawerQueryString(null)
+      }
+    },
+    [hasInvalidTxId, setTxDrawerQueryString],
+  )
+
+  if (!txId || hasInvalidTxId) {
     return null
   }
 

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/transactionDrawerSkeleton.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/transactionDrawerSkeleton.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { DrawerSection, DrawerTopSection } from 'components/drawer'
+import Skeleton from 'react-loading-skeleton'
+
+const StepSkeleton = () => (
+  <div className="flex items-start gap-x-3 py-3">
+    <Skeleton circle className="size-5" />
+    <div className="flex-1">
+      <Skeleton className="h-16 rounded-lg" />
+    </div>
+  </div>
+)
+
+export const TransactionDrawerSkeleton = ({
+  onClose,
+}: {
+  onClose: VoidFunction
+}) => (
+  <div className="drawer-content h-[80dvh] md:h-full">
+    <div className="mb-3 flex min-h-21 flex-col gap-y-3">
+      <DrawerTopSection
+        heading={<Skeleton className="h-6 w-40" />}
+        onClose={onClose}
+      />
+      <Skeleton className="h-4 w-56" />
+    </div>
+    <div className="skip-parent-padding-x mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <DrawerSection>
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+        <div className="mt-4 flex flex-col gap-y-6">
+          <StepSkeleton />
+          <StepSkeleton />
+          <StepSkeleton />
+        </div>
+      </DrawerSection>
+    </div>
+    <div className="mt-auto flex w-full justify-center border-t border-solid border-neutral-300/55 bg-neutral-50 p-6">
+      <Skeleton className="h-5 w-44" />
+    </div>
+  </div>
+)

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/transactionNotFound.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/transactionNotFound.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { Button } from 'components/button'
+import { useDrawerAnimatedClose } from 'components/drawer'
+import { InboxIcon } from 'components/icons/inboxIcon'
+import { TableEmptyState } from 'components/tableEmptyState'
+import { useTranslations } from 'next-intl'
+
+export const TransactionNotFound = function ({
+  onClose,
+}: {
+  onClose: VoidFunction
+}) {
+  const t = useTranslations('hemi-earn.transactions')
+  const tCommon = useTranslations('common')
+  const requestClose = useDrawerAnimatedClose() ?? onClose
+  return (
+    <div className="drawer-content h-[80dvh] md:h-full">
+      <TableEmptyState
+        action={
+          <Button onClick={requestClose} size="xSmall" type="button">
+            {tCommon('close')}
+          </Button>
+        }
+        icon={<InboxIcon />}
+        subtitle={t('transaction-not-found-subtitle')}
+        title={t('transaction-not-found')}
+      />
+    </div>
+  )
+}

--- a/portal/components/drawer/index.tsx
+++ b/portal/components/drawer/index.tsx
@@ -23,6 +23,9 @@ const DrawerAnimatedCloseContext = createContext<VoidFunction | undefined>(
   undefined,
 )
 
+export const useDrawerAnimatedClose = () =>
+  useContext(DrawerAnimatedCloseContext)
+
 function drawerBackdropClassName(isOpen: boolean, isClosing: boolean) {
   const openClass = isOpen ? 'drawer-backdrop--open' : ''
   const pointerClass =
@@ -182,8 +185,8 @@ export function DrawerTopSection({
   heading,
   onClose,
 }: {
-  heading: string
-  onClose?: () => void
+  heading: ReactNode
+  onClose?: VoidFunction
 }) {
   const requestAnimatedClose = useContext(DrawerAnimatedCloseContext)
 

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -446,6 +446,8 @@
       },
       "subtitle": "Track the status of your deposits and withdrawals.",
       "title": "My earn transactions",
+      "transaction-not-found": "Transaction not found",
+      "transaction-not-found-subtitle": "We couldn't find this transaction. It may no longer be available.",
       "view": "View",
       "withdrawal": "Withdrawal"
     }

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -446,6 +446,8 @@
       },
       "subtitle": "Realice un seguimiento del estado de sus depósitos y retiros.",
       "title": "Mis transacciones de earn",
+      "transaction-not-found": "Transacción no encontrada",
+      "transaction-not-found-subtitle": "No pudimos encontrar esta transacción. Es posible que ya no esté disponible.",
       "view": "Ver",
       "withdrawal": "Retiro"
     }

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -446,6 +446,8 @@
       },
       "subtitle": "Acompanhe o status de seus depósitos e saques.",
       "title": "Minhas transações de earn",
+      "transaction-not-found": "Transação não encontrada",
+      "transaction-not-found-subtitle": "Não foi possível encontrar esta transação. Ela pode não estar mais disponível.",
       "view": "Ver",
       "withdrawal": "Saque"
     }


### PR DESCRIPTION
### Description

This PR fixes the Hemi Earn transactions drawer opening as an empty container when a shared `?earnTxId=` link can't be resolved — previously the user got no heading, no message and no close button, only a backdrop click to escape, and there was no way to tell "still loading" apart from "the deposit's asset was delisted so it'll never resolve".

Now the drawer differentiates the two using `isPending` from `useEarnTransactions` and `useEarnPools`. While it's still loading it shows a skeleton that mirrors the review layout and keeps the URL query string intact, so opening a shared link doesn't flicker. Once loading is done and the transaction/pool/asset still can't be resolved, it shows a "Transaction not found" empty state (same `TableEmptyState` + inbox icon used elsewhere in the feature) with an explicit Close button.

Along the way I exposed a small `useDrawerAnimatedClose` hook so the not-found Close button plays the drawer's exit animation instead of unmounting abruptly, and widened `DrawerTopSection`'s `heading` to `ReactNode` (backward-compatible — every caller still passes a string) so the skeleton can reuse it for a title placeholder.

### Screenshots

https://github.com/user-attachments/assets/827500ff-36d5-446a-8204-282790316c56

### Related issue(s)

Closes #1954 
Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
