### PR TITLE
Expose earn processedAt and processTxHash fields

### DIFF
--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "scripts": {
     "build": "tsc",
     "start": "node --import=./src/instrument.ts server.ts"

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -723,6 +723,7 @@ const toEarnRequestRow = (row: SubgraphRequest): EarnRequestRow => ({
   asset: row.asset as Address,
   automatic: row.automatic ?? true,
   claimTxHash: row.claimTxHash as Hash | null,
+  processTxHash: row.processTxHash as Hash | null,
   receiver: toChecksum(row.receiver as `0x${string}`),
   recoverTxHash: row.recoverTxHash as Hash | null,
   requestTxHash: row.requestTxHash as Hash,
@@ -820,6 +821,8 @@ export const getEarnRequests = async function ({
             failed
             failureReason
             kind
+            processedAt
+            processTxHash
             receiver
             recoverTxHash
             requestedAt

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -28,6 +28,7 @@ type EarnRequestCommonFields = {
   failed: boolean
   failureReason: string | null
   kind: 'DEPOSIT' | 'REDEEM'
+  processedAt: string | null
   requestedAt: string
   requestId: string
 }
@@ -40,6 +41,7 @@ export type SubgraphRequest = EarnRequestCommonFields & {
   asset: string
   automatic: boolean | null
   claimTxHash: string | null
+  processTxHash: string | null
   receiver: string
   recoverTxHash: string | null
   requestTxHash: string
@@ -58,6 +60,7 @@ export type EarnRequestRow = EarnRequestCommonFields & {
   asset: Address
   automatic: boolean
   claimTxHash: Hash | null
+  processTxHash: Hash | null
   receiver: Address
   recoverTxHash: Hash | null
   requestTxHash: Hash


### PR DESCRIPTION
### Description

This PR exposes two fields from the hemi-earn-requests subgraph that the earn requests API was already indexing but never returned: `processedAt` and `processTxHash`. They're wired through the GetEarnRequests query, the earn request types, and the toEarnRequestRow mapper.

The motivation is the upcoming "Claim from vault" work for matured cooldown redeems. processedAt is the return-flight signal: for a cooldown redeem the RedeemRequestProcessed event that populates it only fires inside Agent.claimUnstake, so a non-null value means the matured unstake is being finalized back to the Router. The frontend will use that to hide the finalize CTA once anyone (a keeper or the user) has kicked it off. processTxHash carries the remote Ethereum tx hash for a diagnostic link.

Bumped portal-backend to 2.5.2.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #2028 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
