### PR TITLE
Add Hemi Earn Claim from vault CTA

### DIFF
--- a/packages/hemi-earn-actions/index.ts
+++ b/packages/hemi-earn-actions/index.ts
@@ -7,6 +7,7 @@ export type {
   CancelRedeemEvents,
   ClaimDepositEvents,
   ClaimRedeemEvents,
+  ClaimUnstakeEvents,
   RecoverDepositEvents,
   RecoverRedeemEvents,
   RequestDepositEvents,

--- a/packages/hemi-earn-actions/src/actions/index.ts
+++ b/packages/hemi-earn-actions/src/actions/index.ts
@@ -1,9 +1,11 @@
 export {
   type AssetData,
   type Request,
+  type UnstakeRequest,
   getAgentAddress,
   getAssetData,
   getRequest,
+  getUnstakeRequest,
   quoteDeposit,
   quoteDepositFulfillment,
   quoteRedeem,
@@ -13,6 +15,7 @@ export {
 export { cancelRedeem } from './wallet/cancelRedeem'
 export { claimDeposit } from './wallet/claimDeposit'
 export { claimRedeem } from './wallet/claimRedeem'
+export { claimUnstake } from './wallet/claimUnstake'
 export {
   encodeClaimDeposit,
   encodeClaimRedeem,

--- a/packages/hemi-earn-actions/src/actions/public/getUnstakeRequest.ts
+++ b/packages/hemi-earn-actions/src/actions/public/getUnstakeRequest.ts
@@ -1,0 +1,50 @@
+import {
+  type Address,
+  type Client,
+  isAddress,
+  isAddressEqual,
+  zeroAddress,
+} from 'viem'
+import { readContract } from 'viem/actions'
+
+import { agentAbi } from '../../agentAbi'
+
+export type UnstakeRequest = {
+  amountOutMin: bigint
+  asset: Address
+  claimableAt: bigint
+  nativeFee: bigint
+  operator: Address
+  share: Address
+  shares: bigint
+  unstakingRequestId: bigint
+}
+
+export const getUnstakeRequest = async function ({
+  agentAddress,
+  client,
+  requestId,
+}: {
+  agentAddress: Address
+  client: Client
+  requestId: bigint
+}): Promise<UnstakeRequest> {
+  if (!isAddress(agentAddress, { strict: false })) {
+    throw new Error('getUnstakeRequest: `agentAddress` is not a valid address')
+  }
+  if (isAddressEqual(agentAddress, zeroAddress)) {
+    throw new Error(
+      'getUnstakeRequest: `agentAddress` cannot be the zero address',
+    )
+  }
+  if (requestId <= BigInt(0)) {
+    throw new Error('getUnstakeRequest: `requestId` must be greater than zero')
+  }
+
+  return readContract(client, {
+    abi: agentAbi,
+    address: agentAddress,
+    args: [requestId],
+    functionName: 'unstakeRequests',
+  })
+}

--- a/packages/hemi-earn-actions/src/actions/public/index.ts
+++ b/packages/hemi-earn-actions/src/actions/public/index.ts
@@ -1,6 +1,7 @@
 export { getAgentAddress } from './getAgentAddress'
 export { type AssetData, getAssetData } from './getAssetData'
 export { type Request, getRequest } from './getRequest'
+export { type UnstakeRequest, getUnstakeRequest } from './getUnstakeRequest'
 export { quoteDeposit } from './quoteDeposit'
 export { quoteDepositFulfillment } from './quoteDepositFulfillment'
 export { quoteRedeem } from './quoteRedeem'

--- a/packages/hemi-earn-actions/src/actions/wallet/claimUnstake.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/claimUnstake.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'events'
+import { toPromiseEvent } from 'to-promise-event'
+import type { Address, TransactionReceipt, WalletClient } from 'viem'
+import { waitForTransactionReceipt, writeContract } from 'viem/actions'
+
+import { agentAbi } from '../../agentAbi'
+import type { ClaimUnstakeEvents } from '../../types'
+
+const runClaimUnstake = ({
+  account,
+  agentAddress,
+  nativeFee = BigInt(0),
+  requestId,
+  walletClient,
+}: {
+  account: Address
+  agentAddress: Address
+  nativeFee?: bigint
+  requestId: bigint
+  walletClient: WalletClient
+}) =>
+  async function (emitter: EventEmitter<ClaimUnstakeEvents>) {
+    try {
+      if (!walletClient.chain) {
+        throw new Error('Chain is not defined on wallet')
+      }
+
+      if (requestId <= BigInt(0)) {
+        emitter.emit('tx-failed-validation', 'invalid requestId')
+        return
+      }
+
+      emitter.emit('pre-tx')
+
+      const txHash = await writeContract(walletClient, {
+        abi: agentAbi,
+        account,
+        address: agentAddress,
+        args: [requestId],
+        chain: walletClient.chain,
+        functionName: 'claimUnstake',
+        value: nativeFee,
+      }).catch(function (error) {
+        emitter.emit('user-signing-tx-error', error)
+      })
+
+      if (!txHash) {
+        return
+      }
+
+      emitter.emit('user-signed-tx', txHash)
+
+      const receipt = await waitForTransactionReceipt(walletClient, {
+        hash: txHash,
+      }).catch(function (error) {
+        emitter.emit('tx-failed', error)
+      })
+
+      if (!receipt) {
+        return
+      }
+
+      const eventMap: Record<
+        TransactionReceipt['status'],
+        keyof ClaimUnstakeEvents
+      > = {
+        reverted: 'tx-transaction-reverted',
+        success: 'tx-transaction-succeeded',
+      }
+
+      emitter.emit(eventMap[receipt.status], receipt)
+    } catch (error) {
+      emitter.emit('unexpected-error', error as Error)
+    } finally {
+      emitter.emit('tx-settled')
+    }
+  }
+
+export const claimUnstake = (...args: Parameters<typeof runClaimUnstake>) =>
+  toPromiseEvent<ClaimUnstakeEvents>(runClaimUnstake(...args))

--- a/packages/hemi-earn-actions/src/actions/wallet/claimUnstake.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/claimUnstake.ts
@@ -1,7 +1,11 @@
 import { EventEmitter } from 'events'
 import { toPromiseEvent } from 'to-promise-event'
 import type { Address, TransactionReceipt, WalletClient } from 'viem'
-import { waitForTransactionReceipt, writeContract } from 'viem/actions'
+import {
+  getBalance,
+  waitForTransactionReceipt,
+  writeContract,
+} from 'viem/actions'
 
 import { agentAbi } from '../../agentAbi'
 import type { ClaimUnstakeEvents } from '../../types'
@@ -28,6 +32,14 @@ const runClaimUnstake = ({
       if (requestId <= BigInt(0)) {
         emitter.emit('tx-failed-validation', 'invalid requestId')
         return
+      }
+
+      if (nativeFee > BigInt(0)) {
+        const balance = await getBalance(walletClient, { address: account })
+        if (balance < nativeFee) {
+          emitter.emit('tx-failed-validation', 'insufficient balance for fee')
+          return
+        }
       }
 
       emitter.emit('pre-tx')

--- a/packages/hemi-earn-actions/src/agentAbi.ts
+++ b/packages/hemi-earn-actions/src/agentAbi.ts
@@ -1,9 +1,11 @@
-// ABI subset for the Hemi Earn Agent (Ethereum-side). Only the read functions
-// the portal needs to call directly are bound here; write paths
-// (handleDepositRequest, handleRedeemRequest, retry, cancel, claimUnstake)
-// are triggered by LayerZero composes (or keepers) and never invoked from the
-// client.
 export const agentAbi = [
+  {
+    inputs: [{ internalType: 'uint256', name: 'requestId_', type: 'uint256' }],
+    name: 'claimUnstake',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
   {
     // Quotes the LZ native fee for the fulfillment OFT back to Hemi. The
     // param is the **Ethereum-side staking vault (sVetToken)** address —
@@ -19,6 +21,33 @@ export const agentAbi = [
     inputs: [{ internalType: 'address', name: 'asset_', type: 'address' }],
     name: 'quoteRedeemFulfillment',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    name: 'unstakeRequests',
+    outputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'share', type: 'address' },
+          { internalType: 'uint256', name: 'shares', type: 'uint256' },
+          { internalType: 'address', name: 'asset', type: 'address' },
+          { internalType: 'address', name: 'operator', type: 'address' },
+          { internalType: 'uint256', name: 'amountOutMin', type: 'uint256' },
+          { internalType: 'uint256', name: 'nativeFee', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'unstakingRequestId',
+            type: 'uint256',
+          },
+          { internalType: 'uint256', name: 'claimableAt', type: 'uint256' },
+        ],
+        internalType: 'struct Agent.UnstakeRequest',
+        name: '',
+        type: 'tuple',
+      },
+    ],
     stateMutability: 'view',
     type: 'function',
   },

--- a/packages/hemi-earn-actions/src/types.ts
+++ b/packages/hemi-earn-actions/src/types.ts
@@ -62,6 +62,7 @@ type SettlementEvents = {
 
 export type ClaimDepositEvents = CommonEvents & SettlementEvents
 export type ClaimRedeemEvents = CommonEvents & SettlementEvents
+export type ClaimUnstakeEvents = CommonEvents & SettlementEvents
 export type RecoverDepositEvents = CommonEvents & SettlementEvents
 export type RecoverRedeemEvents = CommonEvents & SettlementEvents
 // `Router.cancel(id)` only emits `CancellationRequested` and never moves the

--- a/packages/hemi-earn-actions/test/actions/public/getUnstakeRequest.test.ts
+++ b/packages/hemi-earn-actions/test/actions/public/getUnstakeRequest.test.ts
@@ -1,0 +1,63 @@
+import { type Address, type Client, zeroAddress } from 'viem'
+import { readContract } from 'viem/actions'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getUnstakeRequest } from '../../../src/actions/public/getUnstakeRequest'
+
+vi.mock('viem/actions', () => ({
+  readContract: vi.fn(),
+}))
+
+const client = {} as Client
+
+const agentAddress = '0x000000000000000000000000000000000000dEaD' as Address
+const someAddress = '0x000000000000000000000000000000000000bEEF' as Address
+
+const unstakeRequest = {
+  amountOutMin: BigInt(10),
+  asset: someAddress,
+  claimableAt: BigInt(1_700_000_000),
+  nativeFee: BigInt(5),
+  operator: someAddress,
+  share: someAddress,
+  shares: BigInt(50),
+  unstakingRequestId: BigInt(3),
+}
+
+describe('getUnstakeRequest', function () {
+  it('returns the on-chain unstake struct', async function () {
+    vi.mocked(readContract).mockResolvedValue(unstakeRequest)
+
+    const result = await getUnstakeRequest({
+      agentAddress,
+      client,
+      requestId: BigInt(1),
+    })
+
+    expect(result).toEqual(unstakeRequest)
+    expect(readContract).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        address: agentAddress,
+        args: [BigInt(1)],
+        functionName: 'unstakeRequests',
+      }),
+    )
+  })
+
+  it('rejects a non-positive requestId', async function () {
+    await expect(
+      getUnstakeRequest({ agentAddress, client, requestId: BigInt(0) }),
+    ).rejects.toThrow(/`requestId` must be greater than zero/)
+  })
+
+  it('rejects a zero agent address', async function () {
+    await expect(
+      getUnstakeRequest({
+        agentAddress: zeroAddress,
+        client,
+        requestId: BigInt(1),
+      }),
+    ).rejects.toThrow(/`agentAddress` cannot be the zero address/)
+  })
+})

--- a/packages/hemi-earn-actions/test/actions/wallet/claimUnstake.test.ts
+++ b/packages/hemi-earn-actions/test/actions/wallet/claimUnstake.test.ts
@@ -1,0 +1,123 @@
+import {
+  type Address,
+  type TransactionReceipt,
+  type WalletClient,
+  zeroAddress,
+  zeroHash,
+} from 'viem'
+import { waitForTransactionReceipt, writeContract } from 'viem/actions'
+import { mainnet } from 'viem/chains'
+import { describe, expect, it, vi } from 'vitest'
+
+import { claimUnstake } from '../../../src/actions/wallet/claimUnstake'
+
+vi.mock('viem/actions', () => ({
+  waitForTransactionReceipt: vi.fn(),
+  writeContract: vi.fn(),
+}))
+
+const mockWalletClient = {
+  chain: mainnet,
+} as unknown as WalletClient
+
+const agentAddress = '0x000000000000000000000000000000000000dEaD' as Address
+
+const validParameters = {
+  account: zeroAddress,
+  agentAddress,
+  nativeFee: BigInt(7),
+  requestId: BigInt(1),
+  walletClient: mockWalletClient,
+}
+
+describe('claimUnstake', function () {
+  it('emits "unexpected-error" when wallet client chain is not defined', async function () {
+    const { emitter, promise } = claimUnstake({
+      ...validParameters,
+      walletClient: {} as WalletClient,
+    })
+
+    const onUnexpectedError = vi.fn()
+    const onSettled = vi.fn()
+    emitter.on('unexpected-error', onUnexpectedError)
+    emitter.on('tx-settled', onSettled)
+
+    await promise
+
+    expect(onUnexpectedError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('emits "tx-failed-validation" when requestId is zero', async function () {
+    const { emitter, promise } = claimUnstake({
+      ...validParameters,
+      requestId: BigInt(0),
+    })
+
+    const onFailedValidation = vi.fn()
+    emitter.on('tx-failed-validation', onFailedValidation)
+
+    await promise
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      'invalid requestId',
+    )
+  })
+
+  it('happy path: signs with the native-fee top-up and emits succeeded', async function () {
+    const receipt = { status: 'success' } as TransactionReceipt
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt)
+
+    const { emitter, promise } = claimUnstake(validParameters)
+
+    const onUserSigned = vi.fn()
+    const onSucceeded = vi.fn()
+    emitter.on('user-signed-tx', onUserSigned)
+    emitter.on('tx-transaction-succeeded', onSucceeded)
+
+    await promise
+
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash)
+    expect(onSucceeded).toHaveBeenCalledExactlyOnceWith(receipt)
+    expect(writeContract).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({
+        address: agentAddress,
+        args: [validParameters.requestId],
+        functionName: 'claimUnstake',
+        value: validParameters.nativeFee,
+      }),
+    )
+  })
+
+  it('emits "tx-transaction-reverted" when receipt is reverted', async function () {
+    const receipt = { status: 'reverted' } as TransactionReceipt
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt)
+
+    const { emitter, promise } = claimUnstake(validParameters)
+
+    const onReverted = vi.fn()
+    emitter.on('tx-transaction-reverted', onReverted)
+
+    await promise
+
+    expect(onReverted).toHaveBeenCalledExactlyOnceWith(receipt)
+  })
+
+  it('emits "user-signing-tx-error" when signing fails', async function () {
+    vi.mocked(writeContract).mockRejectedValue(new Error('user rejected'))
+
+    const { emitter, promise } = claimUnstake(validParameters)
+
+    const onSigningError = vi.fn()
+    emitter.on('user-signing-tx-error', onSigningError)
+
+    await promise
+
+    expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+  })
+})

--- a/packages/hemi-earn-actions/test/actions/wallet/claimUnstake.test.ts
+++ b/packages/hemi-earn-actions/test/actions/wallet/claimUnstake.test.ts
@@ -5,13 +5,18 @@ import {
   zeroAddress,
   zeroHash,
 } from 'viem'
-import { waitForTransactionReceipt, writeContract } from 'viem/actions'
+import {
+  getBalance,
+  waitForTransactionReceipt,
+  writeContract,
+} from 'viem/actions'
 import { mainnet } from 'viem/chains'
 import { describe, expect, it, vi } from 'vitest'
 
 import { claimUnstake } from '../../../src/actions/wallet/claimUnstake'
 
 vi.mock('viem/actions', () => ({
+  getBalance: vi.fn(),
   waitForTransactionReceipt: vi.fn(),
   writeContract: vi.fn(),
 }))
@@ -67,6 +72,7 @@ describe('claimUnstake', function () {
   it('happy path: signs with the native-fee top-up and emits succeeded', async function () {
     const receipt = { status: 'success' } as TransactionReceipt
 
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
     vi.mocked(writeContract).mockResolvedValue(zeroHash)
     vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt)
 
@@ -95,6 +101,7 @@ describe('claimUnstake', function () {
   it('emits "tx-transaction-reverted" when receipt is reverted', async function () {
     const receipt = { status: 'reverted' } as TransactionReceipt
 
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
     vi.mocked(writeContract).mockResolvedValue(zeroHash)
     vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt)
 
@@ -109,6 +116,7 @@ describe('claimUnstake', function () {
   })
 
   it('emits "user-signing-tx-error" when signing fails', async function () {
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
     vi.mocked(writeContract).mockRejectedValue(new Error('user rejected'))
 
     const { emitter, promise } = claimUnstake(validParameters)
@@ -119,5 +127,21 @@ describe('claimUnstake', function () {
     await promise
 
     expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+  })
+
+  it('emits "tx-failed-validation" when the balance is below the fee', async function () {
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1))
+
+    const { emitter, promise } = claimUnstake(validParameters)
+
+    const onFailedValidation = vi.fn()
+    emitter.on('tx-failed-validation', onFailedValidation)
+
+    await promise
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      'insufficient balance for fee',
+    )
+    expect(writeContract).not.toHaveBeenCalled()
   })
 })

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
@@ -7,8 +7,9 @@ import { type MouseEvent, useState } from 'react'
 
 import {
   claimRecoverSettlement,
+  isAwaitingFinalize,
   isEarnRowInFlight,
-  isUserCancel,
+  isFinalizeInFlight,
   needsManualClaim,
   needsRecover,
 } from '../../_utils'
@@ -17,6 +18,7 @@ import { LoaderIcon } from '../icons/loaderIcon'
 import { TrashIcon } from '../icons/trashIcon'
 
 import { CancelRedeemModal } from './cancelRedeemModal'
+import { ClaimFromVaultCta } from './transactionDrawer/claimFromVault'
 import { SettleRowCta } from './transactionDrawer/settleShared'
 import { useTxDrawerQueryString } from './transactionDrawer/useTxDrawerQueryString'
 
@@ -36,6 +38,7 @@ function resolveActionState(transaction: EarnTransaction) {
   // staying a marker-driven in-flight row.
   const settleMarker = claimRecoverSettlement(transaction.settlement)
   return {
+    showClaimFromVault: isAwaitingFinalize(transaction),
     showLoaderIcon: isEarnRowInFlight(transaction) && !settleMarker?.failed,
     showManualCta:
       !settleMarker &&
@@ -47,18 +50,12 @@ export const RowActions = function ({ transaction }: Props) {
   const t = useTranslations('hemi-earn.transactions')
   const [, setTxDrawerQueryString] = useTxDrawerQueryString()
 
-  const { showLoaderIcon, showManualCta } = resolveActionState(transaction)
+  const { showClaimFromVault, showLoaderIcon, showManualCta } =
+    resolveActionState(transaction)
   const [cancelModalOpen, setCancelModalOpen] = useState(false)
 
-  // Only a PENDING *cooldown* redeem is cancellable: `Router.cancel` reverts
-  // unless the request is still PENDING and its vault unstake exists
-  // (`claimableAt` set — instant redeems and the pre-unstake window aren't
-  // cancellable). Hide once a cancel is in flight so it can't be double-signed.
   const showCancelButton =
-    transaction.kind === 'REDEEM' &&
-    transaction.status === 'PENDING' &&
-    transaction.claimableAt != null &&
-    !isUserCancel(transaction)
+    isAwaitingFinalize(transaction) && !isFinalizeInFlight(transaction)
 
   const onViewClick = function (e: MouseEvent) {
     e.stopPropagation()
@@ -94,6 +91,13 @@ export const RowActions = function ({ transaction }: Props) {
       <div className="flex items-center gap-x-2 pr-4">
         {showManualCta ? (
           <SettleRowCta fallback={viewButton} transaction={transaction} />
+        ) : showClaimFromVault ? (
+          <ClaimFromVaultCta
+            fallback={viewButton}
+            fullWidth={false}
+            redirectOnSign
+            transaction={transaction}
+          />
         ) : (
           viewButton
         )}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/claimFromVault.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/claimFromVault.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { Button } from 'components/button'
+import { SubmitWhenConnected } from 'components/submitWhenConnected'
+import { WarningBox } from 'components/warningBox'
+import { useTranslations } from 'next-intl'
+import { type FormEvent, type ReactNode } from 'react'
+
+import { useClaimUnstake } from '../../../_hooks/useClaimUnstake'
+import {
+  isCooldownMature,
+  isFinalizeInFlight,
+  unstakeSettlement,
+} from '../../../_utils'
+import { useEarnCooldownRemaining } from '../../../pool/[shareAddress]/_hooks/useEarnCooldownRemaining'
+import { type EarnTransaction } from '../../../types'
+
+import { useTxDrawerQueryString } from './useTxDrawerQueryString'
+
+const useMatureRemaining = (transaction: EarnTransaction | undefined) =>
+  useEarnCooldownRemaining(
+    transaction?.claimableAt != null
+      ? BigInt(transaction.claimableAt)
+      : undefined,
+  )
+
+export const ClaimFromVaultCta = function ({
+  fallback = null,
+  fullWidth = true,
+  redirectOnSign = false,
+  transaction,
+}: {
+  fallback?: ReactNode
+  fullWidth?: boolean
+  redirectOnSign?: boolean
+  transaction: EarnTransaction
+}) {
+  const t = useTranslations('hemi-earn.transactions')
+  const tCommon = useTranslations('common')
+  const [, setTxDrawerQueryString] = useTxDrawerQueryString()
+  const remainingSec = useMatureRemaining(transaction)
+
+  const { isPending, mutate } = useClaimUnstake({
+    on: redirectOnSign
+      ? emitter =>
+          emitter.on('user-signed-tx', () =>
+            setTxDrawerQueryString(transaction.requestTxHash),
+          )
+      : undefined,
+    transaction,
+  })
+
+  const own = unstakeSettlement(transaction.settlement)
+  const pending = isPending || (!!own && !own.failed)
+  const failed = own?.failed ?? false
+
+  if (!isCooldownMature(transaction, remainingSec)) {
+    return <>{fallback}</>
+  }
+
+  const onSubmit = function (e: FormEvent) {
+    e.preventDefault()
+    if (pending) return
+    mutate()
+  }
+
+  return (
+    <form
+      className={fullWidth ? 'flex w-full [&>button]:w-full' : 'flex'}
+      onSubmit={onSubmit}
+    >
+      <SubmitWhenConnected
+        submitButton={
+          <Button disabled={pending} size="small">
+            {pending
+              ? t('claiming')
+              : failed
+                ? tCommon('try-again')
+                : t('claim-from-vault')}
+          </Button>
+        }
+        submitButtonSize="small"
+      />
+    </form>
+  )
+}
+
+export const ClaimFromVaultBanner = function ({
+  transaction,
+}: {
+  transaction: EarnTransaction | undefined
+}) {
+  const t = useTranslations('hemi-earn.transactions.banner')
+  const remainingSec = useMatureRemaining(transaction)
+
+  if (
+    !transaction ||
+    !isCooldownMature(transaction, remainingSec) ||
+    isFinalizeInFlight(transaction)
+  ) {
+    return null
+  }
+  return (
+    <div className="px-4 py-6 md:px-6">
+      <WarningBox
+        heading={t('claim-from-vault.heading')}
+        subheading={t('claim-from-vault.subheading')}
+      />
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/claimFromVault.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/claimFromVault.tsx
@@ -17,12 +17,12 @@ import { type EarnTransaction } from '../../../types'
 
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
-const useMatureRemaining = (transaction: EarnTransaction | undefined) =>
-  useEarnCooldownRemaining(
-    transaction?.claimableAt != null
-      ? BigInt(transaction.claimableAt)
-      : undefined,
+const useMatureRemaining = function (transaction: EarnTransaction | undefined) {
+  const claimableAt = transaction?.claimableAt ?? null
+  return useEarnCooldownRemaining(
+    claimableAt !== null ? BigInt(claimableAt) : undefined,
   )
+}
 
 export const ClaimFromVaultCta = function ({
   fallback = null,

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/claimFromVault.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/claimFromVault.tsx
@@ -76,7 +76,7 @@ export const ClaimFromVaultCta = function ({
               ? t('claiming')
               : failed
                 ? tCommon('try-again')
-                : t('claim-from-vault')}
+                : t('withdraw')}
           </Button>
         }
         submitButtonSize="small"
@@ -103,8 +103,8 @@ export const ClaimFromVaultBanner = function ({
   return (
     <div className="px-4 py-6 md:px-6">
       <WarningBox
-        heading={t('claim-from-vault.heading')}
-        subheading={t('claim-from-vault.subheading')}
+        heading={t('withdraw.heading')}
+        subheading={t('withdraw.subheading')}
       />
     </div>
   )

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -23,6 +23,7 @@ import {
   claimRecoverSettlement,
   getTerminalDeliveryTxHash,
   isEarnRowTerminal,
+  isFinalizeInFlight,
   isLocalEarnTransactionRow,
   isRecoverPath,
   isUserCancel,
@@ -38,6 +39,7 @@ import {
   type EarnTransactionStatusType,
 } from '../../../types'
 
+import { ClaimFromVaultBanner } from './claimFromVault'
 import { SettleBanner } from './settleShared'
 
 type Props = {
@@ -184,7 +186,7 @@ function buildRecoverStep(
       awaitingAction: needsRecover(tx),
       fallback: ProgressStatus.PROGRESS,
       isComplete: tx.status === 'RECOVERED',
-      settlementFailed: tx.settlement?.failed ?? false,
+      settlementFailed: claimRecoverSettlement(tx.settlement)?.failed ?? false,
       settlementTxHash,
     }),
     txHash,
@@ -209,22 +211,23 @@ const buildApprovalStep = (
 
 function deriveReceiveStatus({
   cooldownRemainingSec,
+  finalizeInFlight,
   isCooldownEligible,
   receiveFromStatus,
   unstakeMined,
 }: {
   cooldownRemainingSec: number | undefined
+  finalizeInFlight: boolean
   isCooldownEligible: boolean | undefined
   receiveFromStatus: ProgressStatusType
   unstakeMined: boolean
 }): ProgressStatusType {
   if (receiveFromStatus !== ProgressStatus.NOT_READY) return receiveFromStatus
   if (!unstakeMined) return receiveFromStatus
-  const needsCooldown = isCooldownEligible !== false
-  const cooldownElapsed = cooldownRemainingSec === 0
-  return !needsCooldown || cooldownElapsed
-    ? ProgressStatus.PROGRESS
-    : receiveFromStatus
+  if (isCooldownEligible === false) return ProgressStatus.PROGRESS
+  if (cooldownRemainingSec !== 0) return receiveFromStatus
+
+  return finalizeInFlight ? ProgressStatus.PROGRESS : ProgressStatus.READY
 }
 
 function buildSteps({
@@ -347,8 +350,11 @@ export const HistoricalWithdrawReview = function ({
   const settleMarker = claimRecoverSettlement(transaction.settlement)
   const settlementTxHash =
     settleMarker && !settleMarker.failed ? settleMarker.txHash : undefined
+
+  const finalizeInFlight = isFinalizeInFlight(transaction)
   const cooldownDerived = deriveReceiveStatus({
     cooldownRemainingSec,
+    finalizeInFlight,
     isCooldownEligible,
     receiveFromStatus,
     unstakeMined,
@@ -393,7 +399,12 @@ export const HistoricalWithdrawReview = function ({
 
   return (
     <Operation
-      aboveCallToAction={<SettleBanner transaction={transaction} />}
+      aboveCallToAction={
+        <>
+          <SettleBanner transaction={transaction} />
+          <ClaimFromVaultBanner transaction={transaction} />
+        </>
+      }
       amount={displayAmount}
       callToAction={callToAction}
       heading={t('withdraw-heading')}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -10,6 +10,7 @@ import {
   canRetryRow,
   findPoolByAsset,
   hashesMatch,
+  isAwaitingFinalize,
   needsManualClaim,
   needsRecover,
 } from '../../../_utils'
@@ -19,6 +20,7 @@ import {
   type EarnTransaction,
 } from '../../../types'
 
+import { ClaimFromVaultCta } from './claimFromVault'
 import { HistoricalDepositReview } from './historicalDepositReview'
 import { HistoricalWithdrawReview } from './historicalWithdrawReview'
 import { RetryFailedDeposit } from './retryFailedDeposit'
@@ -93,6 +95,9 @@ function redeemCallToAction({
         transaction={transaction}
       />
     )
+  }
+  if (isAwaitingFinalize(transaction)) {
+    return <ClaimFromVaultCta transaction={transaction} />
   }
   if (needsManualClaim(transaction)) {
     return (

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
@@ -41,10 +41,38 @@ function formatCooldownText(
 const isCooldownPhase = (status: EarnTransaction['status']) =>
   status === 'PENDING' || status === 'FULFILLED'
 
+function postCooldownText({
+  hasClaimableAt,
+  processedAt,
+  remainingSec,
+  status,
+  t,
+}: {
+  hasClaimableAt: boolean
+  processedAt: string | null | undefined
+  remainingSec: number | undefined
+  status: EarnTransaction['status']
+  t: ReturnType<typeof useTranslations<'hemi-earn.transactions'>>
+}) {
+  if (status === 'PENDING' && processedAt != null) {
+    return t('status.bridging-back')
+  }
+
+  if (status === 'FULFILLED') {
+    return t('status.ready-to-claim')
+  }
+
+  if (hasClaimableAt && remainingSec === 0) {
+    return t('status.ready-to-finalize')
+  }
+  return undefined
+}
+
 function deriveCooldownText({
   cooldownDurationSec,
   hasClaimableAt,
   isCooldownEligible,
+  processedAt,
   remainingSec,
   status,
   t,
@@ -52,18 +80,21 @@ function deriveCooldownText({
   cooldownDurationSec: number | undefined
   hasClaimableAt: boolean
   isCooldownEligible: boolean | undefined
+  processedAt: string | null | undefined
   remainingSec: number | undefined
   status: EarnTransaction['status']
   t: ReturnType<typeof useTranslations<'hemi-earn.transactions'>>
 }): string | undefined {
   if (isCooldownEligible !== true) return undefined
   if (!isCooldownPhase(status)) return undefined
-  // FULFILLED means the Agent fulfilled the redeem (only after the cooldown
-  // matured), so the cooldown is authoritatively done regardless of a stale
-  // `claimableAt` — surface "ready to claim", not a lingering countdown.
-  if (status === 'FULFILLED' || (hasClaimableAt && remainingSec === 0)) {
-    return t('status.ready-to-claim')
-  }
+  const postCooldown = postCooldownText({
+    hasClaimableAt,
+    processedAt,
+    remainingSec,
+    status,
+    t,
+  })
+  if (postCooldown !== undefined) return postCooldown
   const displaySec = hasClaimableAt ? (remainingSec ?? 0) : cooldownDurationSec
   if (displaySec === undefined || displaySec <= 0) return undefined
   return formatCooldownText(displaySec, t)
@@ -97,6 +128,7 @@ const WithdrawStatusCellResolved = function ({
     cooldownDurationSec,
     hasClaimableAt: claimableAt !== null,
     isCooldownEligible,
+    processedAt: transaction.processedAt,
     remainingSec,
     status: transaction.status,
     t,

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
@@ -63,7 +63,7 @@ function postCooldownText({
   }
 
   if (hasClaimableAt && remainingSec === 0) {
-    return t('status.ready-to-finalize')
+    return t('status.ready-to-withdraw')
   }
   return undefined
 }

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
@@ -54,7 +54,7 @@ function postCooldownText({
   status: EarnTransaction['status']
   t: ReturnType<typeof useTranslations<'hemi-earn.transactions'>>
 }) {
-  if (status === 'PENDING' && processedAt != null) {
+  if (status === 'PENDING' && (processedAt ?? null) !== null) {
     return t('status.bridging-back')
   }
 

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
@@ -54,7 +54,7 @@ function postCooldownText({
   status: EarnTransaction['status']
   t: ReturnType<typeof useTranslations<'hemi-earn.transactions'>>
 }) {
-  if (status === 'PENDING' && (processedAt ?? null) !== null) {
+  if (status === 'PENDING' && processedAt) {
     return t('status.bridging-back')
   }
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useClaimUnstake.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useClaimUnstake.ts
@@ -1,7 +1,7 @@
 import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo'
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { type EventEmitter } from 'events'
 import { type ClaimUnstakeEvents } from 'hemi-earn-actions'
 import {
@@ -10,6 +10,7 @@ import {
   quoteRedeemFulfillment,
 } from 'hemi-earn-actions/actions'
 import { mainnet } from 'networks/mainnet'
+import { maxBigInt } from 'utils/bigint'
 import { getEvmL1PublicClient } from 'utils/chainClients'
 import { isAddressEqual, zeroAddress } from 'viem'
 import { useAccount, useWalletClient } from 'wagmi'
@@ -30,7 +31,6 @@ export const useClaimUnstake = function ({ on, transaction }: UseClaimUnstake) {
   const ensureConnectedTo = useEnsureConnectedTo()
   const queryClient = useQueryClient()
   const { setSettlement } = useLocalEarnOperations()
-  const { data: agentAddress } = useQuery(agentAddressQueryOptions())
   const { data: l1WalletClient } = useWalletClient({ chainId: mainnet.id })
   const updateNativeBalanceAfterFees = useUpdateNativeBalanceAfterReceipt(
     mainnet.id,
@@ -44,10 +44,10 @@ export const useClaimUnstake = function ({ on, transaction }: UseClaimUnstake) {
       if (!address) {
         throw new Error('No account connected')
       }
-      if (!agentAddress) {
-        throw new Error('Agent address not resolved')
-      }
 
+      const agentAddress = await queryClient.ensureQueryData(
+        agentAddressQueryOptions(),
+      )
       const client = getEvmL1PublicClient(mainnet.id)
       const id = BigInt(requestId)
 
@@ -57,8 +57,9 @@ export const useClaimUnstake = function ({ on, transaction }: UseClaimUnstake) {
         requestId: id,
       })
       if (isAddressEqual(unstakeRequest.share, zeroAddress)) {
-        queryClient.invalidateQueries({ queryKey: earnTransactionsKeyPrefix })
-        return
+        return queryClient.invalidateQueries({
+          queryKey: earnTransactionsKeyPrefix,
+        })
       }
 
       const quote = await quoteRedeemFulfillment({
@@ -66,10 +67,7 @@ export const useClaimUnstake = function ({ on, transaction }: UseClaimUnstake) {
         asset: unstakeRequest.asset,
         client,
       })
-      const nativeFee =
-        quote > unstakeRequest.nativeFee
-          ? quote - unstakeRequest.nativeFee
-          : BigInt(0)
+      const nativeFee = maxBigInt(BigInt(0), quote - unstakeRequest.nativeFee)
 
       await ensureConnectedTo(mainnet.id)
 
@@ -109,7 +107,7 @@ export const useClaimUnstake = function ({ on, transaction }: UseClaimUnstake) {
 
       on?.(emitter)
 
-      await promise
+      return promise
     },
     onSettled() {
       queryClient.invalidateQueries({ queryKey: earnTransactionsKeyPrefix })

--- a/portal/app/[locale]/hemi-earn/_hooks/useClaimUnstake.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useClaimUnstake.ts
@@ -1,0 +1,119 @@
+import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo'
+import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
+import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { type EventEmitter } from 'events'
+import { type ClaimUnstakeEvents } from 'hemi-earn-actions'
+import {
+  claimUnstake,
+  getUnstakeRequest,
+  quoteRedeemFulfillment,
+} from 'hemi-earn-actions/actions'
+import { mainnet } from 'networks/mainnet'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { isAddressEqual, zeroAddress } from 'viem'
+import { useAccount, useWalletClient } from 'wagmi'
+
+import { earnTransactionsKeyPrefix } from '../_fetchers/fetchEarnTransactions'
+import { type EarnTransaction } from '../types'
+
+import { agentAddressQueryOptions } from './useHemiEarnAgentAddress'
+import { useLocalEarnOperations } from './useLocalEarnOperations'
+
+type UseClaimUnstake = {
+  on?: (emitter: EventEmitter<ClaimUnstakeEvents>) => void
+  transaction: EarnTransaction
+}
+
+export const useClaimUnstake = function ({ on, transaction }: UseClaimUnstake) {
+  const { address } = useAccount()
+  const ensureConnectedTo = useEnsureConnectedTo()
+  const queryClient = useQueryClient()
+  const { setSettlement } = useLocalEarnOperations()
+  const { data: agentAddress } = useQuery(agentAddressQueryOptions())
+  const { data: l1WalletClient } = useWalletClient({ chainId: mainnet.id })
+  const updateNativeBalanceAfterFees = useUpdateNativeBalanceAfterReceipt(
+    mainnet.id,
+  )
+  const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(mainnet.id)
+
+  const { requestId, requestTxHash } = transaction
+
+  return useMutation({
+    async mutationFn() {
+      if (!address) {
+        throw new Error('No account connected')
+      }
+      if (!agentAddress) {
+        throw new Error('Agent address not resolved')
+      }
+
+      const client = getEvmL1PublicClient(mainnet.id)
+      const id = BigInt(requestId)
+
+      const unstakeRequest = await getUnstakeRequest({
+        agentAddress,
+        client,
+        requestId: id,
+      })
+      if (isAddressEqual(unstakeRequest.share, zeroAddress)) {
+        queryClient.invalidateQueries({ queryKey: earnTransactionsKeyPrefix })
+        return
+      }
+
+      const quote = await quoteRedeemFulfillment({
+        agentAddress,
+        asset: unstakeRequest.asset,
+        client,
+      })
+      const nativeFee =
+        quote > unstakeRequest.nativeFee
+          ? quote - unstakeRequest.nativeFee
+          : BigInt(0)
+
+      await ensureConnectedTo(mainnet.id)
+
+      const { emitter, promise } = claimUnstake({
+        account: address,
+        agentAddress,
+        nativeFee,
+        requestId: id,
+        walletClient: l1WalletClient!,
+      })
+
+      const fail = () =>
+        setSettlement(requestTxHash, { failed: true, kind: 'UNSTAKE' })
+
+      emitter.on('user-signed-tx', function (txHash) {
+        setSettlement(requestTxHash, { failed: false, kind: 'UNSTAKE', txHash })
+      })
+      emitter.on('tx-transaction-succeeded', function (receipt) {
+        updateNativeBalanceAfterFees(receipt)
+      })
+      emitter.on('tx-transaction-reverted', async function (receipt) {
+        updateNativeBalanceAfterFees(receipt)
+
+        const current = await getUnstakeRequest({
+          agentAddress,
+          client,
+          requestId: id,
+        }).catch(() => undefined)
+        if (!current || !isAddressEqual(current.share, zeroAddress)) {
+          fail()
+        }
+      })
+      emitter.on('tx-failed', fail)
+      emitter.on('tx-failed-validation', fail)
+      emitter.on('user-signing-tx-error', fail)
+      emitter.on('unexpected-error', fail)
+
+      on?.(emitter)
+
+      await promise
+    },
+    onSettled() {
+      queryClient.invalidateQueries({ queryKey: earnTransactionsKeyPrefix })
+      queryClient.invalidateQueries({ queryKey: nativeTokenBalanceQueryKey })
+    },
+  })
+}

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -230,12 +230,13 @@ export const isEarnRowInFlight = (tx: EarnTransaction) =>
 export const isAwaitingFinalize = (tx: EarnTransaction) =>
   tx.kind === 'REDEEM' &&
   tx.status === 'PENDING' &&
-  tx.claimableAt != null &&
-  tx.processedAt == null &&
+  (tx.claimableAt ?? null) !== null &&
+  (tx.processedAt ?? null) === null &&
   !isUserCancel(tx)
 
 export const isFinalizeInFlight = (tx: EarnTransaction | undefined) =>
-  tx?.processedAt != null || unstakeSettlement(tx?.settlement)?.failed === false
+  (tx?.processedAt ?? null) !== null ||
+  unstakeSettlement(tx?.settlement)?.failed === false
 
 export const isCooldownMature = (
   tx: EarnTransaction,

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -93,14 +93,20 @@ export const isRecoverPath = (tx: EarnTransaction) =>
 export const canRetryRow = (tx: EarnTransaction) =>
   tx.status === 'FAILED' && isLocalEarnTransactionRow(tx)
 
-// A CANCEL marker shares the `settlement` field with CLAIM/RECOVER markers but
-// isn't a claim/recover settlement tx — it's the deliberate-cancel signal. Strip
-// it so the claim/recover machinery (failed badge, recover-step tx, manual CTA
-// gating) never mistakes the cancel for one of its own; a reverted cancel's
-// retry lives in the cancel modal, not these surfaces.
+// CANCEL and UNSTAKE markers share the `settlement` field with CLAIM/RECOVER
+// but aren't claim/recover settlement txs (CANCEL is the deliberate-cancel
+// signal; UNSTAKE is the Ethereum finalize). Strip them so the claim/recover
+// machinery (failed badge, recover-step tx, manual CTA gating) never mistakes
+// them for one of its own.
 export const claimRecoverSettlement = (
   settlement: EarnSettlement | undefined,
-) => (settlement?.kind === 'CANCEL' ? undefined : settlement)
+) =>
+  settlement?.kind === 'CANCEL' || settlement?.kind === 'UNSTAKE'
+    ? undefined
+    : settlement
+
+export const unstakeSettlement = (settlement: EarnSettlement | undefined) =>
+  settlement?.kind === 'UNSTAKE' ? settlement : undefined
 
 // A manual claim/recover the user signed reverted on Hemi. The on-chain status
 // is unchanged (still FULFILLED/CANCELLED), so we surface the revert as a
@@ -220,6 +226,21 @@ export const isEarnRowTerminal = (tx: EarnTransaction) =>
 export const isEarnRowInFlight = (tx: EarnTransaction) =>
   !isEarnRowTerminal(tx) &&
   !(tx.status === 'FAILED' && isLocalEarnTransactionRow(tx))
+
+export const isAwaitingFinalize = (tx: EarnTransaction) =>
+  tx.kind === 'REDEEM' &&
+  tx.status === 'PENDING' &&
+  tx.claimableAt != null &&
+  tx.processedAt == null &&
+  !isUserCancel(tx)
+
+export const isFinalizeInFlight = (tx: EarnTransaction | undefined) =>
+  tx?.processedAt != null || unstakeSettlement(tx?.settlement)?.failed === false
+
+export const isCooldownMature = (
+  tx: EarnTransaction,
+  remainingSec: number | undefined,
+) => isAwaitingFinalize(tx) && remainingSec === 0
 
 // The progress ladder shared by a withdraw's terminal step — the receive step on
 // the claim path, the recover step on the cancel path — across both the live and

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -21,6 +21,10 @@ import { type Address, type Hash, formatUnits } from 'viem'
 import { useAccount, useEstimateGas } from 'wagmi'
 
 import {
+  ClaimFromVaultBanner,
+  ClaimFromVaultCta,
+} from '../../../../_components/transactionsSection/transactionDrawer/claimFromVault'
+import {
   AddTokenToWalletCta,
   SettleBanner,
   SettleCta,
@@ -39,6 +43,8 @@ import {
   findLocalSettlement,
   getTerminalDeliveryTxHash,
   hashesMatch,
+  isAwaitingFinalize,
+  isFinalizeInFlight,
   isRecoverPath,
   isUserCancel,
   needsManualClaim,
@@ -88,6 +94,38 @@ const resolveReceiveStatus = ({
     settlementTxHash,
   })
 
+function resolveReceiveProgress({
+  cooldownElapsed,
+  isFinalized,
+  needsCooldown,
+  row,
+  settlement,
+  settlementTxHash,
+  unstakeMined,
+}: {
+  cooldownElapsed: boolean
+  isFinalized: boolean
+  needsCooldown: boolean
+  row: EarnTransaction | undefined
+  settlement: EarnSettlement | undefined
+  settlementTxHash: Hash | undefined
+  unstakeMined: boolean
+}): ProgressStatusType {
+  const finalizeInFlight = isFinalizeInFlight(row)
+  const matureAwaitingFinalize =
+    row?.status === 'PENDING' &&
+    row?.claimableAt != null &&
+    cooldownElapsed &&
+    !finalizeInFlight
+  return resolveReceiveStatus({
+    awaitingClaim: (!!row && needsManualClaim(row)) || matureAwaitingFinalize,
+    crossChainInFlight: unstakeMined && (!needsCooldown || finalizeInFlight),
+    isFinalized,
+    settlement,
+    settlementTxHash,
+  })
+}
+
 // Maps the settlement-enriched row, local withdraw status, and cooldown state to
 // the receive step's progress + terminal hash. Module-level so the component
 // stays under the complexity threshold.
@@ -131,12 +169,14 @@ function buildReceiveStep({
       </div>
     ),
     explorerChainId: chainId,
-    status: resolveReceiveStatus({
-      awaitingClaim: !!row && needsManualClaim(row),
-      crossChainInFlight: unstakeMined && (!needsCooldown || cooldownElapsed),
+    status: resolveReceiveProgress({
+      cooldownElapsed,
       isFinalized,
+      needsCooldown,
+      row,
       settlement,
       settlementTxHash,
+      unstakeMined,
     }),
     txHash: deliveryHash,
   }
@@ -442,6 +482,9 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
     if (FAILED_STATUSES.includes(withdrawStatus)) {
       return <RetryWithdraw />
     }
+    if (settledRow && isAwaitingFinalize(settledRow)) {
+      return <ClaimFromVaultCta transaction={settledRow} />
+    }
     // Auto-claim off: the user signs the claim here once the Agent delivers the
     // asset back to the Router (FULFILLED).
     if (settledRow && needsManualClaim(settledRow)) {
@@ -497,7 +540,12 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
 
   return (
     <Operation
-      aboveCallToAction={<SettleBanner transaction={settledRow} />}
+      aboveCallToAction={
+        <>
+          <SettleBanner transaction={settledRow} />
+          <ClaimFromVaultBanner transaction={settledRow} />
+        </>
+      }
       amount={withdrawOperation?.amountIn ?? shares.toString()}
       callToAction={getCallToAction()}
       heading={t('withdraw.heading')}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -114,7 +114,7 @@ function resolveReceiveProgress({
   const finalizeInFlight = isFinalizeInFlight(row)
   const matureAwaitingFinalize =
     row?.status === 'PENDING' &&
-    row?.claimableAt != null &&
+    (row?.claimableAt ?? null) !== null &&
     cooldownElapsed &&
     !finalizeInFlight
   return resolveReceiveStatus({

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -28,12 +28,13 @@ export type EarnTransactionKindType = 'DEPOSIT' | 'REDEEM'
 // (`InRelativeTime`). `'TX_PENDING'` and `'FAILED'` are portal-synthetic
 // statuses (derived in `useEarnTransactions` and at the fetcher boundary
 // respectively) — they don't exist in the subgraph schema.
-// A manual claim/recover the user signed on Hemi, tracked locally (the
-// reverted tx isn't a subgraph event). `failed` lets the drawer offer a Retry
-// to re-call the same step — same idea as the request-deposit retry.
+// A settlement the user signed for a request, tracked locally (the reverted tx
+// isn't a subgraph event). `CLAIM`/`RECOVER`/`CANCEL` are Hemi Router txs;
+// `UNSTAKE` is the Ethereum-side `Agent.claimUnstake` that finalizes a matured
+// cooldown redeem. `failed` lets the UI offer a Retry to re-call the step.
 export type EarnSettlement = {
   failed: boolean
-  kind: 'CLAIM' | 'RECOVER' | 'CANCEL'
+  kind: 'CLAIM' | 'RECOVER' | 'CANCEL' | 'UNSTAKE'
   txHash?: Hash
 }
 
@@ -59,6 +60,7 @@ export type EarnTransaction = {
   // with `failed: false` is a deliberate cancel, not a failure.
   failed: boolean
   kind: EarnTransactionKindType
+  processedAt?: string | null
   receiver: Address
   recoverTxHash: Hash | null
   requestedAt: string

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -364,6 +364,10 @@
           "heading": "Withdrawal cancelled",
           "subheading": "We're returning your share tokens to your wallet."
         },
+        "claim-from-vault": {
+          "heading": "Ready to finalize your withdrawal",
+          "subheading": "This usually happens automatically, but you can finalize it yourself. This transaction runs on Ethereum."
+        },
         "claim-funds": {
           "heading": "We couldn't claim your funds automatically",
           "subheading": "Click on 'Claim funds' to get your funds."
@@ -389,6 +393,7 @@
         "title": "Cancel withdrawal"
       },
       "cancel-withdraw": "Cancel withdrawal",
+      "claim-from-vault": "Claim from vault",
       "claim-funds": "Claim funds",
       "claim-share-tokens": "Claim share tokens",
       "claiming": "Claiming...",
@@ -425,6 +430,7 @@
       "recover-shares": "Recover shares",
       "recovering": "Recovering...",
       "status": {
+        "bridging-back": "Bridging back to Hemi",
         "cancelling": "Cancelling withdrawal",
         "cooldown-ready-in-days": "Cooldown · ready in {value}d",
         "cooldown-ready-in-hours": "Cooldown · ready in {value}h",
@@ -435,6 +441,7 @@
         "in-progress": "In progress",
         "manual-claim-needed": "In progress - Manual claim needed",
         "ready-to-claim": "Ready to claim",
+        "ready-to-finalize": "Ready to finalize",
         "recover-funds-needed": "Something went wrong - Recover funds",
         "recover-shares-cancelled": "Withdrawal cancelled - Recover shares",
         "recover-shares-needed": "Something went wrong - Recover shares",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -364,10 +364,6 @@
           "heading": "Withdrawal cancelled",
           "subheading": "We're returning your share tokens to your wallet."
         },
-        "claim-from-vault": {
-          "heading": "Ready to finalize your withdrawal",
-          "subheading": "This usually happens automatically, but you can finalize it yourself. This transaction runs on Ethereum."
-        },
         "claim-funds": {
           "heading": "We couldn't claim your funds automatically",
           "subheading": "Click on 'Claim funds' to get your funds."
@@ -383,6 +379,10 @@
         "recover-shares": {
           "heading": "Transaction failed",
           "subheading": "Something went wrong. Use the button below to return your share tokens to your wallet."
+        },
+        "withdraw": {
+          "heading": "Your withdrawal is ready",
+          "subheading": "This usually happens automatically, but you can do it yourself. This transaction runs on Ethereum."
         }
       },
       "cancel-modal": {
@@ -393,7 +393,6 @@
         "title": "Cancel withdrawal"
       },
       "cancel-withdraw": "Cancel withdrawal",
-      "claim-from-vault": "Claim from vault",
       "claim-funds": "Claim funds",
       "claim-share-tokens": "Claim share tokens",
       "claiming": "Claiming...",
@@ -441,7 +440,7 @@
         "in-progress": "In progress",
         "manual-claim-needed": "In progress - Manual claim needed",
         "ready-to-claim": "Ready to claim",
-        "ready-to-finalize": "Ready to finalize",
+        "ready-to-withdraw": "Ready to withdraw",
         "recover-funds-needed": "Something went wrong - Recover funds",
         "recover-shares-cancelled": "Withdrawal cancelled - Recover shares",
         "recover-shares-needed": "Something went wrong - Recover shares",
@@ -456,6 +455,7 @@
       "transaction-not-found": "Transaction not found",
       "transaction-not-found-subtitle": "We couldn't find this transaction. It may no longer be available.",
       "view": "View",
+      "withdraw": "Withdraw",
       "withdrawal": "Withdrawal"
     }
   },

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -364,6 +364,10 @@
           "heading": "Retiro cancelado",
           "subheading": "Estamos devolviendo sus share tokens a su billetera."
         },
+        "claim-from-vault": {
+          "heading": "Listo para finalizar su retiro",
+          "subheading": "Esto normalmente ocurre de forma automática, pero puede finalizarlo usted mismo. Esta transacción se ejecuta en Ethereum."
+        },
         "claim-funds": {
           "heading": "No pudimos recibir sus fondos automáticamente",
           "subheading": "Haga clic en 'Recibir fondos' para recibir sus fondos."
@@ -389,6 +393,7 @@
         "title": "Cancelar retiro"
       },
       "cancel-withdraw": "Cancelar retiro",
+      "claim-from-vault": "Recibir de la bóveda",
       "claim-funds": "Recibir fondos",
       "claim-share-tokens": "Recibir share tokens",
       "claiming": "Recibiendo...",
@@ -425,6 +430,7 @@
       "recover-shares": "Recuperar shares",
       "recovering": "Recuperando...",
       "status": {
+        "bridging-back": "Regresando a Hemi",
         "cancelling": "Cancelando retiro",
         "cooldown-ready-in-days": "Cooldown · listo en {value}d",
         "cooldown-ready-in-hours": "Cooldown · listo en {value}h",
@@ -435,6 +441,7 @@
         "in-progress": "En progreso",
         "manual-claim-needed": "En progreso - Reclamo manual necesario",
         "ready-to-claim": "Listo para recibir",
+        "ready-to-finalize": "Listo para finalizar",
         "recover-funds-needed": "Algo salió mal - Recuperar fondos",
         "recover-shares-cancelled": "Retiro cancelado - Recuperar shares",
         "recover-shares-needed": "Algo salió mal - Recuperar shares",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -364,10 +364,6 @@
           "heading": "Retiro cancelado",
           "subheading": "Estamos devolviendo sus share tokens a su billetera."
         },
-        "claim-from-vault": {
-          "heading": "Listo para finalizar su retiro",
-          "subheading": "Esto normalmente ocurre de forma automática, pero puede finalizarlo usted mismo. Esta transacción se ejecuta en Ethereum."
-        },
         "claim-funds": {
           "heading": "No pudimos recibir sus fondos automáticamente",
           "subheading": "Haga clic en 'Recibir fondos' para recibir sus fondos."
@@ -383,6 +379,10 @@
         "recover-shares": {
           "heading": "La transacción falló",
           "subheading": "Algo salió mal. Use el botón de abajo para devolver sus share tokens a su billetera."
+        },
+        "withdraw": {
+          "heading": "Su retiro está listo",
+          "subheading": "Esto normalmente ocurre de forma automática, pero puede hacerlo usted mismo. Esta transacción se ejecuta en Ethereum."
         }
       },
       "cancel-modal": {
@@ -393,7 +393,6 @@
         "title": "Cancelar retiro"
       },
       "cancel-withdraw": "Cancelar retiro",
-      "claim-from-vault": "Recibir de la bóveda",
       "claim-funds": "Recibir fondos",
       "claim-share-tokens": "Recibir share tokens",
       "claiming": "Recibiendo...",
@@ -441,7 +440,7 @@
         "in-progress": "En progreso",
         "manual-claim-needed": "En progreso - Reclamo manual necesario",
         "ready-to-claim": "Listo para recibir",
-        "ready-to-finalize": "Listo para finalizar",
+        "ready-to-withdraw": "Listo para retirar",
         "recover-funds-needed": "Algo salió mal - Recuperar fondos",
         "recover-shares-cancelled": "Retiro cancelado - Recuperar shares",
         "recover-shares-needed": "Algo salió mal - Recuperar shares",
@@ -456,6 +455,7 @@
       "transaction-not-found": "Transacción no encontrada",
       "transaction-not-found-subtitle": "No pudimos encontrar esta transacción. Es posible que ya no esté disponible.",
       "view": "Ver",
+      "withdraw": "Retirar",
       "withdrawal": "Retiro"
     }
   },

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -364,10 +364,6 @@
           "heading": "Saque cancelado",
           "subheading": "Estamos devolvendo seus share tokens à sua carteira."
         },
-        "claim-from-vault": {
-          "heading": "Pronto para finalizar seu saque",
-          "subheading": "Isso normalmente acontece automaticamente, mas você pode finalizá-lo. Esta transação é executada na Ethereum."
-        },
         "claim-funds": {
           "heading": "Não foi possível receber seus fundos automaticamente",
           "subheading": "Clique em 'Receber fundos' para receber seus fundos."
@@ -383,6 +379,10 @@
         "recover-shares": {
           "heading": "Transação falhou",
           "subheading": "Algo deu errado. Use o botão abaixo para devolver seus share tokens à sua carteira."
+        },
+        "withdraw": {
+          "heading": "Seu saque está pronto",
+          "subheading": "Isso normalmente acontece automaticamente, mas você mesmo pode fazer o saque. Esta transação é executada na Ethereum."
         }
       },
       "cancel-modal": {
@@ -393,7 +393,6 @@
         "title": "Cancelar saque"
       },
       "cancel-withdraw": "Cancelar saque",
-      "claim-from-vault": "Receber do cofre",
       "claim-funds": "Receber fundos",
       "claim-share-tokens": "Receber share tokens",
       "claiming": "Recebendo...",
@@ -441,7 +440,7 @@
         "in-progress": "Em andamento",
         "manual-claim-needed": "Em andamento - Resgate manual necessário",
         "ready-to-claim": "Pronto para receber",
-        "ready-to-finalize": "Pronto para finalizar",
+        "ready-to-withdraw": "Pronto para sacar",
         "recover-funds-needed": "Algo deu errado - Recuperar fundos",
         "recover-shares-cancelled": "Saque cancelado - Recuperar shares",
         "recover-shares-needed": "Algo deu errado - Recuperar shares",
@@ -456,6 +455,7 @@
       "transaction-not-found": "Transação não encontrada",
       "transaction-not-found-subtitle": "Não foi possível encontrar esta transação. Ela pode não estar mais disponível.",
       "view": "Ver",
+      "withdraw": "Sacar",
       "withdrawal": "Saque"
     }
   },

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -364,6 +364,10 @@
           "heading": "Saque cancelado",
           "subheading": "Estamos devolvendo seus share tokens à sua carteira."
         },
+        "claim-from-vault": {
+          "heading": "Pronto para finalizar seu saque",
+          "subheading": "Isso normalmente acontece automaticamente, mas você pode finalizá-lo. Esta transação é executada na Ethereum."
+        },
         "claim-funds": {
           "heading": "Não foi possível receber seus fundos automaticamente",
           "subheading": "Clique em 'Receber fundos' para receber seus fundos."
@@ -389,6 +393,7 @@
         "title": "Cancelar saque"
       },
       "cancel-withdraw": "Cancelar saque",
+      "claim-from-vault": "Receber do cofre",
       "claim-funds": "Receber fundos",
       "claim-share-tokens": "Receber share tokens",
       "claiming": "Recebendo...",
@@ -425,6 +430,7 @@
       "recover-shares": "Recuperar shares",
       "recovering": "Recuperando...",
       "status": {
+        "bridging-back": "Retornando para a Hemi",
         "cancelling": "Cancelando saque",
         "cooldown-ready-in-days": "Cooldown · pronto em {value}d",
         "cooldown-ready-in-hours": "Cooldown · pronto em {value}h",
@@ -435,6 +441,7 @@
         "in-progress": "Em andamento",
         "manual-claim-needed": "Em andamento - Resgate manual necessário",
         "ready-to-claim": "Pronto para receber",
+        "ready-to-finalize": "Pronto para finalizar",
         "recover-funds-needed": "Algo deu errado - Recuperar fundos",
         "recover-shares-cancelled": "Saque cancelado - Recuperar shares",
         "recover-shares-needed": "Algo deu errado - Recuperar shares",

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -14,9 +14,12 @@ import {
   getTerminalDeliveryTxHash,
   hasFailedSettlement,
   hashesMatch,
+  isAwaitingFinalize,
+  isCooldownMature,
   isDeliberateCancel,
   isEarnRowInFlight,
   isEarnRowTerminal,
+  isFinalizeInFlight,
   isLocalEarnTransactionRow,
   isRecoverPath,
   isUserCancel,
@@ -25,6 +28,7 @@ import {
   pickEarnRowAmount,
   pickSettleBannerKey,
   resolveSettleStepStatus,
+  unstakeSettlement,
 } from '../../../../../app/[locale]/hemi-earn/_utils'
 import {
   type EarnPool,
@@ -348,6 +352,15 @@ describe('utils', function () {
     it('strips a reverted CANCEL marker too', function () {
       expect(
         claimRecoverSettlement({ failed: true, kind: 'CANCEL' }),
+      ).toBeUndefined()
+    })
+
+    it('strips an UNSTAKE marker (the Ethereum finalize, not a settlement)', function () {
+      expect(
+        claimRecoverSettlement({ failed: false, kind: 'UNSTAKE' }),
+      ).toBeUndefined()
+      expect(
+        claimRecoverSettlement({ failed: true, kind: 'UNSTAKE' }),
       ).toBeUndefined()
     })
 
@@ -899,6 +912,157 @@ describe('utils', function () {
 
     it('is false without a cancel request', function () {
       expect(isDeliberateCancel(baseTx)).toBe(false)
+    })
+  })
+
+  describe('unstakeSettlement', function () {
+    it('returns an UNSTAKE marker unchanged', function () {
+      const settlement: EarnSettlement = { failed: false, kind: 'UNSTAKE' }
+      expect(unstakeSettlement(settlement)).toBe(settlement)
+    })
+
+    it.each<EarnSettlement['kind']>(['CLAIM', 'RECOVER', 'CANCEL'])(
+      'returns undefined for a %s marker',
+      function (kind) {
+        expect(unstakeSettlement({ failed: false, kind })).toBeUndefined()
+      },
+    )
+
+    it('returns undefined for no settlement', function () {
+      expect(unstakeSettlement(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('isCooldownMature', function () {
+    const matureRedeem: EarnTransaction = {
+      ...baseTx,
+      claimableAt: '1700000000',
+      kind: 'REDEEM',
+      status: 'PENDING',
+    }
+
+    it('is true for a PENDING cooldown redeem once remaining hits 0', function () {
+      expect(isCooldownMature(matureRedeem, 0)).toBe(true)
+    })
+
+    it('is false while the cooldown is still counting down', function () {
+      expect(isCooldownMature(matureRedeem, 120)).toBe(false)
+    })
+
+    it('is false when remaining is undefined (no claimableAt yet)', function () {
+      expect(
+        isCooldownMature({ ...matureRedeem, claimableAt: null }, undefined),
+      ).toBe(false)
+    })
+
+    it('is false once the Agent processed it (return flight)', function () {
+      expect(
+        isCooldownMature({ ...matureRedeem, processedAt: '1700000100' }, 0),
+      ).toBe(false)
+    })
+
+    it.each<EarnTransactionStatusType>(['FULFILLED', 'CANCELLED', 'FINALIZED'])(
+      'is false for the non-PENDING status %s',
+      function (status) {
+        expect(isCooldownMature({ ...matureRedeem, status }, 0)).toBe(false)
+      },
+    )
+
+    it('is false for a deposit', function () {
+      expect(isCooldownMature({ ...matureRedeem, kind: 'DEPOSIT' }, 0)).toBe(
+        false,
+      )
+    })
+
+    it('is false while the user is cancelling (cancellationRequested)', function () {
+      expect(
+        isCooldownMature({ ...matureRedeem, cancellationRequested: true }, 0),
+      ).toBe(false)
+    })
+
+    it('is false while a CANCEL marker is pending', function () {
+      expect(
+        isCooldownMature(
+          { ...matureRedeem, settlement: { failed: false, kind: 'CANCEL' } },
+          0,
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('isAwaitingFinalize', function () {
+    const awaiting: EarnTransaction = {
+      ...baseTx,
+      claimableAt: '1700000000',
+      kind: 'REDEEM',
+      status: 'PENDING',
+    }
+
+    it('is true for a PENDING cooldown redeem not yet finalized', function () {
+      expect(isAwaitingFinalize(awaiting)).toBe(true)
+    })
+
+    it('is false once the Agent processed it (bridging back)', function () {
+      expect(
+        isAwaitingFinalize({ ...awaiting, processedAt: '1700000100' }),
+      ).toBe(false)
+    })
+
+    it('is false while the user is cancelling', function () {
+      expect(
+        isAwaitingFinalize({ ...awaiting, cancellationRequested: true }),
+      ).toBe(false)
+    })
+
+    it('is false for an instant redeem (no claimableAt)', function () {
+      expect(isAwaitingFinalize({ ...awaiting, claimableAt: null })).toBe(false)
+    })
+
+    it('is false for a deposit', function () {
+      expect(isAwaitingFinalize({ ...awaiting, kind: 'DEPOSIT' })).toBe(false)
+    })
+  })
+
+  describe('isFinalizeInFlight', function () {
+    it('is true when the Agent processed it (processedAt set)', function () {
+      expect(isFinalizeInFlight({ ...baseTx, processedAt: '1700000100' })).toBe(
+        true,
+      )
+    })
+
+    it('is true while a non-failed UNSTAKE marker is mining', function () {
+      expect(
+        isFinalizeInFlight({
+          ...baseTx,
+          settlement: { failed: false, kind: 'UNSTAKE' },
+        }),
+      ).toBe(true)
+    })
+
+    it('is false for a failed UNSTAKE marker (real revert)', function () {
+      expect(
+        isFinalizeInFlight({
+          ...baseTx,
+          settlement: { failed: true, kind: 'UNSTAKE' },
+        }),
+      ).toBe(false)
+    })
+
+    it('ignores a CLAIM marker', function () {
+      expect(
+        isFinalizeInFlight({
+          ...baseTx,
+          settlement: { failed: false, kind: 'CLAIM' },
+        }),
+      ).toBe(false)
+    })
+
+    it('is false with no processedAt and no marker', function () {
+      expect(isFinalizeInFlight(baseTx)).toBe(false)
+    })
+
+    it('is false for undefined', function () {
+      expect(isFinalizeInFlight(undefined)).toBe(false)
     })
   })
 })


### PR DESCRIPTION
### Description

This PR implements the "Claim from vault" CTA for Hemi Earn, letting a user finalize a matured cooldown redeem themselves instead of waiting on a keeper.

A redeem with a vault cooldown stays at Router status PENDING for the whole wait and only becomes claimable once someone calls Agent.claimUnstake on Ethereum to finalize it — normally that's a keeper, but when none acts the matured redeem just sits showing "pending" with nothing the user can do. The CTA runs that finalize on the user's behalf.

On the package side (hemi-earn-actions) it binds claimUnstake / unstakeRequests on the Agent ABI and adds a getUnstakeRequest read plus a claimUnstake wallet action — an Ethereum tx carrying a native-fee top-up for the return leg. On the portal side, a useClaimUnstake mutation switches to Ethereum, reads the Agent to skip the tx entirely if a keeper already finalized, and only tops up the fee shortfall. A small derived state machine (isAwaitingFinalize / isCooldownMature / isFinalizeInFlight, built over the indexed processedAt and a local UNSTAKE marker) drives the CTA, the "Ready to finalize" / "Bridging back to Hemi" status copy, and the receive step — consistently across the live pool drawer, the historical transactions drawer, and the table row.

It's race-safe against the keeper: the on-chain pre-read skips a tx that already ran, and Cancel is hidden once a finalize is in flight so the two cross-chain actions can't be signed against each other. Includes es/pt translations (formal register) and unit tests for the new pure utils and package actions.

### Screenshots

<img width="465" height="856" alt="Captura de Tela 2026-07-07 às 09 34 46" src="https://github.com/user-attachments/assets/1f48349e-c053-4a8d-b817-32e5ec24a957" />
<img width="1148" height="718" alt="Captura de Tela 2026-07-07 às 09 39 13" src="https://github.com/user-attachments/assets/2f3940ac-9a66-43ef-ae03-8287ab06f127" />

**Cancel:**

https://github.com/user-attachments/assets/9a2b7f83-afec-4eb0-9c98-39a4050ac6b3

### Related issue(s)

Related to #2028 
Related to #1943  
Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
