### PR TITLE
Add caption type into the typesetting

### DIFF
--- a/portal/styles/globals.css
+++ b/portal/styles/globals.css
@@ -66,7 +66,7 @@ p {
 }
 
 .body-text-caption {
-  @apply text-xxs font-medium;
+  @apply text-caption font-medium;
 }
 .body-text-normal {
   @apply text-sm font-normal;

--- a/portal/tailwind.config.ts
+++ b/portal/tailwind.config.ts
@@ -111,6 +111,13 @@ const config: Config = {
             lineHeight: '16px',
           },
         ],
+        'caption': [
+          '0.688rem', // 11px
+          {
+            letterSpacing: '0.11px', // 1%
+            lineHeight: '16px',
+          },
+        ],
         'xs': [
           '0.75rem', // 12px,
           {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds the **C1 (Caption)** type as a formal entry in the typesetting system,
matching the Figma spec (Inter Variable · 500 · 11/16 · 1% letter spacing).

A `.body-text-caption` class already existed but relied on the shared `text-xxs`
token, which uses a `0.2px` letter spacing instead of the `0.11px` (1%) the
design requires. Since `text-xxs` is used by other components, a dedicated
`caption` font-size token was added (11px / 16px / 0.11px) and `.body-text-caption`
now points to it. This makes C1 faithful to the design without affecting the
other `text-xxs` usages.


### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img  alt="typography--all" src="https://github.com/user-attachments/assets/8d861472-cf13-45ff-9368-a883566ea2c0" />



### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #2069 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
