### PR TITLE
Trim comments in hemi-earn-actions package

### DIFF
--- a/packages/hemi-earn-actions/src/actions/public/getAgentAddress.ts
+++ b/packages/hemi-earn-actions/src/actions/public/getAgentAddress.ts
@@ -12,9 +12,7 @@ import { readContract } from 'viem/actions'
 import { getHemiEarnRouterAddress } from '../../constants'
 import { routerAbi } from '../../routerAbi'
 
-// Reads the LayerZero peer stored on the Router (Hemi-side) and decodes it into
-// the Agent's address on Ethereum. The peer is stored as a left-padded bytes32,
-// so the address is the trailing 20 bytes.
+// The LayerZero peer is a left-padded bytes32; the Agent address is its trailing 20 bytes.
 export const getAgentAddress = async function (
   client: Client,
   {

--- a/packages/hemi-earn-actions/src/actions/public/getAssetData.ts
+++ b/packages/hemi-earn-actions/src/actions/public/getAssetData.ts
@@ -11,25 +11,14 @@ import { getHemiEarnRouterAddress } from '../../constants'
 import { routerAbi } from '../../routerAbi'
 
 export type AssetData = {
-  // Whether the asset accepts new deposit/redeem requests. The Router reverts
-  // `requestDeposit`/`requestRedeem` for disabled assets. Pool enumeration in
-  // the portal is still static (see `fetchHemiEarnShares`); when that path is
-  // moved to read `getAssetData` on-chain, filter on `enabled !== false`.
   enabled: boolean
-  // Ethereum-side asset address used by the Agent on the fulfillment leg —
-  // the OFT's remote counterpart that the Vetro Gateway accepts as input.
+  // Ethereum-side counterpart the Agent uses on the fulfillment leg.
   remoteAsset: Address
-  // Ethereum-side staking vault (sVetToken) the Agent stakes pegged tokens
-  // into. Carried in the compose message on deposit so the stateless Agent
-  // knows which vault to use without an on-chain registry lookup.
+  // Ethereum staking vault (sVetToken), despite the name — carried in the deposit compose message.
   remoteShare: Address
-  // Hemi-side share OFT this deposit asset settles into (e.g. svetBTC).
   share: Address
 }
 
-// Per-key lookup of the Router's asset registry: given a Hemi-side deposit
-// asset (e.g. the hemiBTC OFT), returns the share OFT it settles into plus
-// the Ethereum-side asset the Agent uses on fulfillment.
 export const getAssetData = async function (
   client: Client,
   {

--- a/packages/hemi-earn-actions/src/actions/public/getRequest.ts
+++ b/packages/hemi-earn-actions/src/actions/public/getRequest.ts
@@ -11,8 +11,7 @@ export type Request = {
   assets: bigint
   automatic: boolean
   kind: RequestKind
-  // Address authorized to call `Router.cancel(id)` for cooldown redeems.
-  // Set at request time; the UI gates the Cancel CTA on `operator === account`.
+  // Authorized to call Router.cancel for cooldown redeems.
   operator: Address
   receiver: Address
   share: Address
@@ -29,8 +28,7 @@ export const getRequest = async function ({
   requestId: bigint
   routerAddress?: Address
 }): Promise<Request> {
-  // Router IDs start at 1 (see `Router.initialize`), so `0n` is never a valid
-  // request and would otherwise return a zero-initialized struct silently.
+  // Router IDs start at 1; reject 0n so we don't read a zero-initialized struct.
   if (requestId <= BigInt(0)) {
     throw new Error('getRequest: `requestId` must be greater than zero')
   }

--- a/packages/hemi-earn-actions/src/actions/public/quoteDepositFulfillment.ts
+++ b/packages/hemi-earn-actions/src/actions/public/quoteDepositFulfillment.ts
@@ -9,17 +9,8 @@ import { readContract } from 'viem/actions'
 
 import { agentAbi } from '../../agentAbi'
 
-// Reads the LayerZero native fee the Agent on Ethereum needs to send the
-// fulfillment response (sVetToken OFT) back to the Router on Hemi. The
-// caller passes this value as `callbackFee` into `quoteDeposit`
-// (Hemi-side), which folds it into the total `msg.value` of `requestDeposit`.
-//
-// `share` is the **Ethereum-side staking vault (sVetToken) address** — the
-// token being OFT-bridged back on the fulfillment leg. Since the
-// `b071540 Stateless Agent` refactor the Agent no longer holds an
-// `assetsData(asset)` mapping; the share has to be supplied directly.
-// Resolve via `Router.assetsData(asset).remoteShare` on the portal (see the
-// `shareConfigQueryOptions` helper).
+// Native fee the Agent needs to send its fulfillment OFT back to Hemi; the caller
+// folds it into requestDeposit's msg.value via quoteDeposit.
 export const quoteDepositFulfillment = async function ({
   agentAddress,
   client,

--- a/packages/hemi-earn-actions/src/actions/public/quoteRedeem.ts
+++ b/packages/hemi-earn-actions/src/actions/public/quoteRedeem.ts
@@ -15,10 +15,7 @@ export const quoteRedeem = async function ({
   asset: Address
   client: Client
   callbackFee: bigint
-  // Declares the redeem path the Router should reserve remote gas for. Must
-  // match what `Agent.handleRedeemRequest` will compute on Ethereum — see
-  // `resolveIsInstant`. If this disagrees with the vault's actual state for
-  // the caller, the Agent sends an immediate cancel back instead of executing.
+  // Must match what the Agent computes (see resolveIsInstant), else it cancels instead of executing.
   isInstant: boolean
   routerAddress?: Address
   shares: bigint

--- a/packages/hemi-earn-actions/src/actions/public/quoteRedeemFulfillment.ts
+++ b/packages/hemi-earn-actions/src/actions/public/quoteRedeemFulfillment.ts
@@ -9,11 +9,8 @@ import { readContract } from 'viem/actions'
 
 import { agentAbi } from '../../agentAbi'
 
-// Reads the LayerZero native fee the Agent on Ethereum needs to send the
-// fulfillment response back to the Router on Hemi for a redeem. Caller passes
-// this into `quoteRedeem` (Hemi-side) and ultimately as `msg.value` to
-// `requestRedeem`. The Agent looks up the share OFT internally from the asset
-// address — the portal only needs to supply the asset.
+// Native fee the Agent needs to send its redeem fulfillment back to Hemi; the caller
+// folds it into requestRedeem's msg.value via quoteRedeem.
 export const quoteRedeemFulfillment = async function ({
   agentAddress,
   asset,

--- a/packages/hemi-earn-actions/src/actions/public/resolveIsInstant.ts
+++ b/packages/hemi-earn-actions/src/actions/public/resolveIsInstant.ts
@@ -4,13 +4,7 @@ import {
 } from '@vetro-protocol/earn/actions'
 import { type Address, type Client } from 'viem'
 
-// Mirrors `Agent.handleRedeemRequest` (Agent.sol:235):
-//   _instantAllowed = !staking.cooldownEnabled() || staking.instantWithdrawWhitelist(caller)
-// The Router needs `isInstant` declared up-front so it can reserve the right
-// remote gas budget at quote/request time. If the value disagrees with the
-// vault's actual state for `caller` when the Agent processes the message, the
-// Agent sends an immediate cancel and the user pays gas for nothing — so this
-// helper must match the Agent's check exactly.
+// Mirrors Agent.handleRedeemRequest exactly; any drift makes the Agent cancel and the user eats gas.
 export const resolveIsInstant = async function ({
   caller,
   client,

--- a/packages/hemi-earn-actions/src/actions/wallet/cancelRedeem.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/cancelRedeem.ts
@@ -13,13 +13,8 @@ import { getHemiEarnRouterAddress } from '../../constants'
 import { routerAbi } from '../../routerAbi'
 import type { CancelRedeemEvents } from '../../types'
 
-// Wraps `Router.cancel(requestId)` on Hemi. Caller must be the request's
-// `operator` (see `getRequest(id).operator`); the contract reverts otherwise.
-// This call ONLY emits `CancellationRequested(requestId)` — it does not move
-// the request out of PENDING. A keeper observes the event off-chain and calls
-// `Agent.cancel(id)` on Ethereum to return the shares, which produces the
-// `MSG_REQUEST_CANCEL` callback that finally sets the Router status to
-// CANCELLED. The user then calls `recoverRedeem(id)` to pull shares back.
+// Caller must be the request operator. Router.cancel only emits CancellationRequested;
+// a keeper's Agent.cancel returns the shares (→ CANCELLED), then the user calls recoverRedeem.
 const runCancelRedeem = ({
   account,
   requestId,

--- a/packages/hemi-earn-actions/src/actions/wallet/claimDeposit.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/claimDeposit.ts
@@ -24,9 +24,7 @@ const runClaimDeposit = ({
         throw new Error('Chain is not defined on wallet')
       }
 
-      // Router IDs start at 1 (see `Router.initialize`), so `0n` is never
-      // a valid request and the contract would otherwise revert with an
-      // opaque `RequestNotFound`. Fail loudly here instead.
+      // Router IDs start at 1; reject 0n instead of an opaque contract revert.
       if (requestId <= BigInt(0)) {
         emitter.emit('tx-failed-validation', 'invalid requestId')
         return

--- a/packages/hemi-earn-actions/src/actions/wallet/encoders.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/encoders.ts
@@ -36,14 +36,10 @@ export const encodeRequestDeposit = ({
   asset: Address
   automatic?: boolean
   callbackFee: bigint
-  // Address authorized to call `Agent.cancel(id)` on the remote chain.
-  // Contract reverts with `ZeroAddress` if `0x0` is passed.
+  // Authorized to call Agent.cancel on the remote chain; reverts if 0x0.
   operator: Address
   receiver: Address
-  // Minimum shares accepted on fulfillment (slippage protection enforced
-  // on the remote chain). Defaults to `0n` when omitted; portal callers
-  // compute this via `applySlippage` against the UX_SPEC defaults (see
-  // `portal/.../hemi-earn/_constants/slippage.ts`).
+  // Min shares accepted on fulfillment (slippage, enforced remotely); 0n disables it.
   sharesOutMin?: bigint
 }) =>
   encodeFunctionData({
@@ -71,19 +67,13 @@ export const encodeRequestRedeem = ({
   shares,
 }: {
   asset: Address
-  // Minimum underlying assets accepted on fulfillment (slippage protection
-  // enforced on the remote chain). Defaults to `0n` when omitted; portal
-  // callers compute this via `applySlippage` against the UX_SPEC defaults
-  // (see `portal/.../hemi-earn/_constants/slippage.ts`).
+  // Min assets accepted on fulfillment (slippage, enforced remotely); 0n disables it.
   assetsOutMin?: bigint
   automatic?: boolean
   callbackFee: bigint
-  // Declares the redeem path (instant vs cooldown). Must match the vault's
-  // actual state for the caller — resolve via `resolveIsInstant` before
-  // calling. A mismatch causes the Agent to send an immediate cancel.
+  // Instant vs cooldown path; must match the vault state (resolveIsInstant) or the Agent cancels.
   isInstant: boolean
-  // Address authorized to call `Router.cancel(id)` for cooldown redeems.
-  // Contract reverts with `ZeroAddress` if `0x0` is passed.
+  // Authorized to call Router.cancel for cooldown redeems; reverts if 0x0.
   operator: Address
   receiver: Address
   shares: bigint

--- a/packages/hemi-earn-actions/src/actions/wallet/requestDeposit.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/requestDeposit.ts
@@ -51,15 +51,11 @@ const runRequestDeposit = ({
   amount: bigint
   asset: Address
   callbackFee: bigint
-  // Address authorized to call `Agent.cancel(id)` on the remote chain.
-  // Contract reverts with `ZeroAddress` if `0x0` is passed.
+  // Authorized to call Agent.cancel on the remote chain; reverts if 0x0.
   operator: Address
   receiver: Address
   routerAddress?: Address
-  // Minimum shares accepted on fulfillment (slippage protection enforced
-  // on the remote chain). Defaults to `0n` when omitted; portal callers
-  // compute this via `applySlippage` against the UX_SPEC defaults (see
-  // `portal/.../hemi-earn/_constants/slippage.ts`).
+  // Min shares accepted on fulfillment (slippage, enforced remotely); 0n disables it.
   sharesOutMin?: bigint
   walletClient: WalletClient
 }) =>

--- a/packages/hemi-earn-actions/src/actions/wallet/requestRedeem.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/requestRedeem.ts
@@ -34,11 +34,8 @@ const calculateAdjustedShares = function ({
   requestedShares: bigint
   userShares: bigint
 }) {
-  // During withdraw operations, the requested shares may be very close to
-  // (but not exactly) the user's balance due to rounding. If above 99.9% of
-  // the balance, withdraw the full balance to avoid leaving dust behind.
-  // Invariant: `requestedShares <= userShares` is guaranteed by the upstream
-  // `canRequestRedeem` validation in `runRequestRedeem` before this is called.
+  // Snap to the full balance when within 0.1% to avoid leaving dust
+  // (upstream canRequestRedeem already guarantees requestedShares <= userShares).
   const threshold = (userShares * BigInt(999)) / BigInt(1000)
   if (requestedShares >= threshold) {
     return userShares
@@ -61,26 +58,16 @@ const runRequestRedeem = ({
 }: {
   account: Address
   asset: Address
-  // Minimum underlying assets accepted on fulfillment (slippage protection
-  // enforced on the remote chain). Defaults to `0n` when omitted; portal
-  // callers compute this via `applySlippage` against the UX_SPEC defaults
-  // (see `portal/.../hemi-earn/_constants/slippage.ts`).
+  // Min assets accepted on fulfillment (slippage, enforced remotely); 0n disables it.
   assetsOutMin?: bigint
   callbackFee: bigint
-  // Declares the redeem path (instant vs cooldown). Must match the vault's
-  // actual state for `account` — resolve via `resolveIsInstant`. Mismatch
-  // causes the Agent to send an immediate cancel; user pays gas for nothing.
+  // Instant vs cooldown path; must match the vault state (resolveIsInstant) or the Agent cancels and the user eats gas.
   isInstant: boolean
-  // Address authorized to call `Router.cancel(id)` for cooldown redeems.
-  // Contract reverts with `ZeroAddress` if `0x0` is passed.
+  // Authorized to call Router.cancel for cooldown redeems; reverts if 0x0.
   operator: Address
   receiver: Address
   routerAddress?: Address
   shares: bigint
-  // Share OFT registered for `asset` on the Router. Required — the asset
-  // registry is loaded dynamically by the portal (via `getAssetRegistry`),
-  // so callers always have this value available and the action no longer
-  // tries to resolve it from a static map.
   shareToken: Address
   walletClient: WalletClient
 }) =>

--- a/packages/hemi-earn-actions/src/agentAbi.ts
+++ b/packages/hemi-earn-actions/src/agentAbi.ts
@@ -7,10 +7,7 @@ export const agentAbi = [
     type: 'function',
   },
   {
-    // Quotes the LZ native fee for the fulfillment OFT back to Hemi. The
-    // param is the **Ethereum-side staking vault (sVetToken)** address —
-    // since the `Stateless Agent` refactor the Agent no longer resolves
-    // share-from-asset internally, so the caller must supply it.
+    // share_ is the Ethereum staking vault (sVetToken), not the Hemi share OFT.
     inputs: [{ internalType: 'address', name: 'share_', type: 'address' }],
     name: 'quoteDepositFulfillment',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],

--- a/packages/hemi-earn-actions/src/types.ts
+++ b/packages/hemi-earn-actions/src/types.ts
@@ -45,10 +45,7 @@ export type RequestRedeemEvents = CommonEvents &
     'withdraw-transaction-succeeded': [TransactionReceipt]
   }
 
-// Single-tx Router writes with no approval / no quote leg (claim & recover).
-// The 4 settlement actions share the same shape — `getRequest` already lets
-// the UI read the current `Status` to know which one to surface, so the
-// event vocabulary is intentionally generic and reused via type aliases.
+// One generic vocabulary reused by the single-tx settlement writes (claim & recover).
 type SettlementEvents = {
   'pre-tx': []
   'tx-failed': [Error]
@@ -65,11 +62,8 @@ export type ClaimRedeemEvents = CommonEvents & SettlementEvents
 export type ClaimUnstakeEvents = CommonEvents & SettlementEvents
 export type RecoverDepositEvents = CommonEvents & SettlementEvents
 export type RecoverRedeemEvents = CommonEvents & SettlementEvents
-// `Router.cancel(id)` only emits `CancellationRequested` and never moves the
-// request out of PENDING — the user still needs to wait for the keeper-driven
-// Agent cancel + `recoverRedeem` follow-ups. The event vocabulary still maps
-// onto `SettlementEvents` because the tx flow here is identical: one Hemi
-// write with no allowance / no quote.
+// Router.cancel only emits CancellationRequested; the keeper's Agent.cancel then
+// sets CANCELLED and the user calls recoverRedeem to pull shares back.
 export type CancelRedeemEvents = CommonEvents & SettlementEvents
 
 // Mirrors the on-chain `Kind` enum from Router.sol (DEPOSIT = 0, REDEEM = 1).


### PR DESCRIPTION
### Description

Same comment-cleanup pass over the Hemi Earn portal UI — comment-only, no behaviour change.

Drops what-comments and caller/PR citations, and compresses the load-bearing *why* to one line each: the cache-invalidation strategy (`resetQueries` vs `invalidate`), the cooldown / finalize state machine, the delivered-token inversion, and the nuqs redirect race. Fixes two stale notes the claim-from-vault epic invalidated ("out of scope for phase 2", "REDEEM rows aren't surfaced yet"). `eslint` directives and real placeholder TODOs are kept.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
