### PR TITLE
Trim comments across the hemi-earn portal UI

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/earnFiatBalance.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnFiatBalance.tsx
@@ -3,12 +3,8 @@ import { type ComponentProps } from 'react'
 
 import { useEarnTokenPrices } from '../_hooks/useEarnTokenPrices'
 
-// Hemi Earn's counterpart to `components/fiatBalance`'s `RenderFiatBalance`: the
-// same component priced through `useEarnTokenPrices` (portal feed + gateway
-// oracle prices) instead of the plain portal feed, so pegged tokens (vetBTC,
-// VUSD) resolve via their whitelisted-proxy `priceSymbol`. A thin wrapper so the
-// shared `RenderFiatBalance` (and its ErrorBoundary) stays the single source of
-// the rendering, defaulting the rest of the app to the portal feed.
+// RenderFiatBalance priced through useEarnTokenPrices so pegged tokens (vetBTC, VUSD)
+// resolve via their priceSymbol; the rest of the app keeps the plain portal feed.
 export const RenderEarnFiatBalance = (
   props: Omit<ComponentProps<typeof RenderFiatBalance>, 'usePrices'>,
 ) => <RenderFiatBalance {...props} usePrices={useEarnTokenPrices} />

--- a/portal/app/[locale]/hemi-earn/_components/earnStatusUpdaters.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnStatusUpdaters.tsx
@@ -6,13 +6,7 @@ import { useEarnDeliveryWatcher } from '../_hooks/useEarnDeliveryWatcher'
 
 import { EarnSuccessToast } from './earnSuccessToast'
 
-// Mounted in the hemi-earn layout. Drives cross-route polling and Vetro-
-// side cache invalidation off a single subscription — `useEarnDeliveryWatcher`
-// soft-settles local entries once the subgraph indexes them and invalidates
-// pool TVL, user pool position, and the staked-balance card when a request
-// transitions to CLAIMED/RECOVERED. The same layout slot renders one
-// success toast per kind so they survive navigation between the pool page
-// and home.
+// Layout-mounted so polling, soft-settle/cache invalidation, and the success toasts persist across route changes (one subscription for all).
 export const EarnStatusUpdaters = function () {
   const t = useTranslations('hemi-earn.pool')
   useEarnDeliveryWatcher()

--- a/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
@@ -9,43 +9,24 @@ import { useEarnTransactionsQuery } from '../_hooks/useEarnTransactionsQuery'
 import { PoolToast } from '../pool/[shareAddress]/_components/poolToast'
 import { type EarnTransactionKindType } from '../types'
 
-// Visible window before the toast unmounts. Matches the `<Toast>` primitive's
-// own auto-close (10s) so the inner close-animation isn't cut short.
+// Match the <Toast> primitive's 10s auto-close so its close animation isn't cut short.
 const TOAST_MS = 10_000
 
 type Props = {
-  // Subgraph kind to watch — `DEPOSIT` for the shares-landing toast,
-  // `REDEEM` for the underlying-received toast. Each consumer mounts its
-  // own instance with the matching kind + title.
   kind: EarnTransactionKindType
   title: string
 }
 
-// Fires when a request reaches the subgraph `FINALIZED` state — the moment
-// the full cross-chain flow completes (share OFTs landing on the user's
-// Hemi wallet for deposits, underlying tokens landing on the user's Hemi
-// wallet for redeems). Mounted once per kind at the hemi-earn layout
-// level so it survives navigation between the pool page and the home
-// page.
-//
-// To avoid noise on first mount (a session with historical FINALIZED rows),
-// the component snapshots the already-finalized hashes on the first non-
-// empty render and only latches the toast for rows that become FINALIZED
-// after that.
+// Toasts when a request reaches FINALIZED (cross-chain complete). Snapshots the
+// already-finalized hashes on first render so a session with historical rows doesn't fire a burst.
 export const EarnSuccessToast = function ({ kind, title }: Props) {
   const { address } = useAccount()
   const { data } = useEarnTransactionsQuery()
 
   const seenFinalizedOnMountRef = useRef<Set<string> | null>(null)
-  // Hashes already surfaced this session. Without this ref the toast would
-  // re-open after the `TOAST_MS` window because `newClaim` keeps returning
-  // the same FINALIZED row from the subgraph poll.
+  // Hashes already shown; without this the toast would re-open each poll (newClaim keeps returning the same FINALIZED row).
   const shownRef = useRef<Set<string>>(new Set())
-  // Both refs are session-scoped state but the data they guard is account-
-  // scoped. Wipe them when the connected wallet changes so account A's
-  // hashes don't leak into account B's polling loop (otherwise every
-  // historical FINALIZED on account B fires a false toast right after the
-  // wallet swap).
+  // Session-scoped refs guarding account-scoped data — wipe on wallet change so A's hashes don't fire false toasts for B.
   const snapshotAccountRef = useRef<Address | undefined>(undefined)
   if (snapshotAccountRef.current !== address) {
     seenFinalizedOnMountRef.current = null

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/cancelRedeemModal.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/cancelRedeemModal.tsx
@@ -14,12 +14,8 @@ type Props = {
   transaction: EarnTransaction
 }
 
-// Confirmation modal for cancelling a cooldown redeem. Confirming signs
-// `Router.cancel`; the button spins until the tx settles. On success `onSuccess`
-// fires (the caller closes the modal and opens the drawer so the user can watch
-// the recover flow); on a revert/reject it stays open with the button back to
-// idle so the user can try again. `onClose` is the plain dismiss ("Keep
-// withdrawal" / overlay), which must NOT open the drawer.
+// Cancel-redeem confirmation (signs Router.cancel). onSuccess opens the drawer to
+// follow the recover flow; onClose is a plain dismiss that must NOT.
 export const CancelRedeemModal = function ({
   onClose,
   onSuccess,

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
@@ -99,17 +99,13 @@ export const buildColumns = ({
       ),
     header: () => <Header text={t('column.status')} />,
     id: 'status',
-    // Wide enough to keep the longest status ("Something went wrong - Recover
-    // funds" / the manual-claim copy) on a single line across locales.
+    // Wide enough for the longest status on one line across locales.
     meta: { className: 'justify-start flex-grow-0', width: 340 },
   },
   {
     cell: ({ row }) => <RowActions transaction={row.original} />,
     id: 'actions',
-    // On mobile this column is reordered to the front, so it hugs the left
-    // edge (the table's first-cell pl-4 gives the 16px lead). From 'md' up it
-    // returns to the trailing edge and right-aligns. Wide enough to fit the
-    // "Claim share tokens" / "Recover funds" CTA without overflowing the cell.
+    // Reordered to the front on mobile (hugs the left edge); md+ right-aligns. Wide enough for the CTA labels.
     meta: { className: 'justify-start md:justify-end', width: 180 },
   },
 ]

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
@@ -26,16 +26,10 @@ type Props = {
   transaction: EarnTransaction
 }
 
-// Spinner while the row is in flight (auto-progressing, including an auto-recover
-// CANCELLED deposit or redeem, or a claim/recover settlement tx mining), but never on a
-// reverted settlement — that's "Tx Failed" with a Retry. The inline
-// Claim/Recover CTA is only for the untouched manual state; once a settlement
-// exists (mining or reverted) the row hands back to View and the drawer carries
-// the spinner/Retry.
+// Spinner while in flight, but never on a reverted settlement (that's Tx Failed + Retry). The
+// inline CTA is only the untouched manual state; once a settlement exists the row hands back to View.
 function resolveActionState(transaction: EarnTransaction) {
-  // Drop the CANCEL marker so a user cancel resting at CANCELLED surfaces the
-  // Recover CTA (and drops the row spinner) like any other recover, instead of
-  // staying a marker-driven in-flight row.
+  // Drop the CANCEL marker so a user cancel at CANCELLED surfaces the Recover CTA (and drops the spinner) like any recover.
   const settleMarker = claimRecoverSettlement(transaction.settlement)
   return {
     showClaimFromVault: isAwaitingFinalize(transaction),
@@ -67,8 +61,7 @@ export const RowActions = function ({ transaction }: Props) {
     setCancelModalOpen(true)
   }
 
-  // Cancel tx confirmed: close the modal and open the drawer so the user can
-  // follow the recover flow the cancel just kicked off.
+  // Cancel confirmed — close the modal and open the drawer to follow the recover flow it kicked off.
   const onCancelSuccess = function () {
     setCancelModalOpen(false)
     setTxDrawerQueryString(transaction.requestTxHash)

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
@@ -68,12 +68,10 @@ function resolveStatusBadge(transaction: EarnTransaction, t: Translator) {
   if (status === 'FAILED') {
     return failedBadge(t)
   }
-  // A cancelled request (deposit or redeem) is mid-recover: the original tokens
-  // are coming back (auto-recover) or await the Recover CTA — never terminal.
+  // CANCELLED is mid-recover (auto-recover or awaiting the Recover CTA), never terminal.
   if (status === 'CANCELLED') {
     return inProgress(t('status.returned'))
   }
-  // The return icon separates a recovered/cancelled row from a completed one.
   if (status === 'RECOVERED') {
     return {
       icon: <ReturnCircleIcon className="text-neutral-400" />,
@@ -93,9 +91,7 @@ function resolveBadge(
   // A reverted claim/recover wins over the (now stale) manual-needed state.
   if (hasFailedSettlement(transaction)) return failedBadge(t)
   const userCancel = isUserCancel(transaction)
-  // Once it rests at CANCELLED it's the recover stage — neutral for a user
-  // cancel, amber for an Agent failure. Only the still-processing PENDING cancel
-  // reads as the passive "Cancelling withdrawal".
+  // At CANCELLED it's the recover stage — neutral for a user cancel, amber for an Agent failure; the PENDING cancel reads as "Cancelling".
   if (needsRecover(transaction)) return recoverBadge(userCancel, kind, t)
   if (userCancel) return inProgress(t('status.cancelling'))
   const byStatus = resolveStatusBadge(transaction, t)

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -48,8 +48,7 @@ type StepStates = {
 
 const stepStatesByStatus: Record<EarnTransactionStatusType, StepStates> = {
   CANCELLED: {
-    // The request tx landed (stake done); the cancel/return shows in the
-    // recover-path terminal step, not a failed stake.
+    // Request landed (stake done); the cancel/return shows in the terminal step, not a failed stake.
     stake: ProgressStatus.COMPLETED,
     waitingForShares: ProgressStatus.NOT_READY,
   },
@@ -79,10 +78,8 @@ const stepStatesByStatus: Record<EarnTransactionStatusType, StepStates> = {
   },
 }
 
-// FAILED splits by source: local rows mean the Hemi tx itself reverted (stake
-// step is FAILED), subgraph rows mean the Vetro Agent failed after a
-// successful Hemi tx (stake step completed, failure is in the cross-chain
-// step instead).
+// FAILED splits by source: local = Hemi tx reverted (stake FAILED); subgraph =
+// Agent failed after a good Hemi tx (failure in the cross-chain step).
 const resolveStepStates = (tx: EarnTransaction): StepStates =>
   tx.status === 'FAILED' && !isLocalEarnTransactionRow(tx)
     ? {
@@ -106,9 +103,6 @@ function buildStakeStep(tx: EarnTransaction, token: EvmToken, t: Translator) {
   }
 }
 
-// COMPLETED wins over everything; a reverted settlement → FAILED; a mining tx →
-// PROGRESS; a pending manual action → READY (active, not a spinner); else the
-// natural status.
 function resolveTerminalStatus(
   tx: EarnTransaction,
   baseStatus: ProgressStatusType,
@@ -126,8 +120,7 @@ function resolveTerminalStatus(
   return natural
 }
 
-// Happy path → "Get share tokens"; recover path → "Funds returned" (the asset
-// comes back, so it's labeled with the asset token).
+// Recover path returns the asset, so its terminal step is labeled with the asset token.
 function buildTerminalStep({
   baseStatus,
   settlementTxHash,
@@ -143,8 +136,7 @@ function buildTerminalStep({
 }): StepPropsWithoutPosition {
   const status = resolveTerminalStatus(tx, baseStatus, settlementTxHash)
   const txHash = settlementTxHash ?? getTerminalDeliveryTxHash(tx)
-  // Link whenever a delivery hash is available — an auto-finalized claim/recover
-  // has one too, even though the user didn't sign it.
+  // Link whenever a delivery hash exists — an auto-finalized claim/recover has one the user never signed.
   const explorerChainId = txHash ? hemi.id : undefined
   if (isRecoverPath(tx)) {
     // "Funds returned" only once RECOVERED; CANCELLED still awaits the recover.
@@ -209,8 +201,7 @@ export const HistoricalDepositReview = function ({
   })
 
   const { waitingForShares } = resolveStepStates(transaction)
-  // Only a still-mining settlement drives the step to PROGRESS; a failed one
-  // leaves the natural (FAILED) status and surfaces a Retry CTA instead.
+  // Only a still-mining settlement drives PROGRESS; a failed one keeps the natural (FAILED) status + Retry CTA.
   const { settlement } = transaction
   const settlementTxHash =
     settlement && !settlement.failed ? settlement.txHash : undefined
@@ -232,9 +223,7 @@ export const HistoricalDepositReview = function ({
       status: ProgressStatus.NOT_READY,
     })
   }
-  // Only the locally-mirrored entries carry `approvalTxHash` (see merge in
-  // `useEarnTransactions`). Rows opened from another browser/device won't
-  // have this step — the indexer doesn't link an approval tx to a request.
+  // Only local-mirror entries carry approvalTxHash; rows from another browser skip this step (the indexer can't link it).
   if (transaction.approvalTxHash) {
     steps.push(buildApprovalStep(transaction.approvalTxHash, token, t))
   }

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -60,8 +60,7 @@ type StepStates = {
 
 const stepStatesByStatus: Record<EarnTransactionStatusType, StepStates> = {
   CANCELLED: {
-    // A cancelled redeem isn't a failed unstake — the request landed and the
-    // shares are coming back via the recover path.
+    // A cancelled redeem isn't a failed unstake — the request landed; shares come back via the recover path.
     receive: ProgressStatus.NOT_READY,
     unstake: ProgressStatus.COMPLETED,
   },
@@ -91,9 +90,8 @@ const stepStatesByStatus: Record<EarnTransactionStatusType, StepStates> = {
   },
 }
 
-// FAILED splits by source: local rows mean the Hemi tx itself reverted
-// (unstake step is FAILED), subgraph rows mean the Vetro Agent failed after a
-// successful Hemi tx (unstake completed, failure is in the cross-chain step).
+// FAILED splits by source: local = Hemi tx reverted (unstake FAILED); subgraph =
+// Agent failed after a good Hemi tx (failure in the cross-chain step).
 const resolveStepStates = (tx: EarnTransaction): StepStates =>
   tx.status === 'FAILED' && !isLocalEarnTransactionRow(tx)
     ? {
@@ -140,8 +138,7 @@ function buildReceiveStep({
   t: Translator
   tx: EarnTransaction
 }) {
-  // Link the mining claim while still FULFILLED (the terminal `claimTxHash` only
-  // lands once FINALIZED), matching the deposit drawer.
+  // Link the mining claim while still FULFILLED — the terminal claimTxHash only lands at FINALIZED.
   const txHash = settlementTxHash ?? getTerminalDeliveryTxHash(tx)
   return {
     description: (
@@ -156,17 +153,14 @@ function buildReceiveStep({
   }
 }
 
-// On the recover path the user gets the SHARES back (not the asset), so the
-// terminal step is labeled with the share token: "Shares to recover" while
-// CANCELLED, "Shares returned" once RECOVERED.
+// Recover returns the SHARES (not the asset), so the terminal step is labeled with the share token.
 function buildRecoverStep(
   tx: EarnTransaction,
   shareToken: EvmToken,
   t: Translator,
   settlementTxHash: Hash | undefined,
 ) {
-  // Link the mining manual-recover tx while CANCELLED (its terminal
-  // `recoverTxHash` only lands once RECOVERED), matching the deposit drawer.
+  // Link the mining recover tx while CANCELLED — the terminal recoverTxHash only lands at RECOVERED.
   const txHash = settlementTxHash ?? getTerminalDeliveryTxHash(tx)
   return {
     description: (
@@ -271,11 +265,8 @@ function buildSteps({
     )
   }
   const unstakeStep = buildUnstakeStep(transaction, pool.shareToken, t)
-  // Recover path: the unstake landed and the shares come back (not the asset),
-  // so the cooldown/receive machinery doesn't apply. A deliberate cancel still
-  // PENDING (the keeper hasn't driven it to CANCELLED yet) joins this branch so
-  // the drawer drops the now-moot cooldown countdown + "Receive" step and reads
-  // as the recover it's becoming — matching the neutral "cancelling" banner.
+  // Recover path: shares come back, so the cooldown/receive machinery doesn't apply. A
+  // still-PENDING deliberate cancel joins here too, dropping the now-moot countdown + Receive step.
   if (isRecoverPath(transaction) || isUserCancel(transaction)) {
     steps.push(unstakeStep)
     steps.push(
@@ -309,13 +300,11 @@ export const HistoricalWithdrawReview = function ({
   transaction,
 }: Props) {
   const t = useTranslations('hemi-earn.transactions.drawer')
-  // The cooldown sub-step copy is shared with the live pool review; keep
-  // it under `pool.drawer` instead of duplicating the keys here.
+  // Cooldown copy is shared with the live pool review — reuse the pool.drawer namespace instead of duplicating keys.
   const tCooldown = useTranslations('hemi-earn.pool.drawer')
   const { address } = useAccount()
 
-  // `useToken` returns `Token | undefined` (BtcToken | EvmToken); for the
-  // Hemi-side asset address this is always an EvmToken.
+  // useToken returns Token | undefined; for the Hemi-side asset it's always an EvmToken.
   const { data: rawReceiveToken } = useToken({
     address: transaction.asset,
     chainId: hemi.id,

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -30,10 +30,8 @@ import { TransactionDrawerSkeleton } from './transactionDrawerSkeleton'
 import { TransactionNotFound } from './transactionNotFound'
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
-// The drawer is already open, so the CTAs don't redirect on sign. A reverted
-// claim/recover keeps the row at FULFILLED/CANCELLED, so the same
-// `needsManualClaim`/`needsRecover` branch re-surfaces the CTA (which shows
-// "try again" off the failed settlement marker).
+// Drawer's already open, so no redirect on sign. A reverted claim/recover stays at
+// FULFILLED/CANCELLED, re-surfacing the same CTA (as "try again").
 function depositCallToAction({
   asset,
   pool,
@@ -68,16 +66,14 @@ function depositCallToAction({
       />
     )
   }
-  // Shares have landed (claim done) — offer to add the share token to the
-  // wallet, matching the live drawer and the tunnel history.
+  // Claim done — offer to add the share token to the wallet.
   if (transaction.status === 'FINALIZED') {
     return <AddTokenToWalletCta token={pool.shareToken} />
   }
   return null
 }
 
-// Mirror of `depositCallToAction` for redeem: claim delivers the underlying
-// asset, recover returns the shares.
+// Redeem mirror: claim delivers the asset, recover returns the shares.
 function redeemCallToAction({
   asset,
   pool,
@@ -119,8 +115,7 @@ function redeemCallToAction({
       />
     )
   }
-  // The underlying asset has landed (claim done) — offer to add it to the wallet,
-  // matching the live drawer and the tunnel history.
+  // Claim done — offer to add the asset to the wallet.
   if (transaction.status === 'FINALIZED') {
     return <AddTokenToWalletCta token={asset.token} />
   }
@@ -159,8 +154,7 @@ const TransactionDrawerContent = function () {
     useEarnTransactions()
   const { data: pools, isPending: isPoolsPending } = useEarnPools()
 
-  // A malformed txId (e.g. ?earnTxId=0x123) isn't a transaction at all, so
-  // there's nothing to look up — drop it from the URL and show no drawer.
+  // A malformed txId (e.g. 0x123) isn't a real tx — drop it from the URL and show no drawer.
   const hasInvalidTxId = txId !== null && !isHash(txId)
   useEffect(
     function clearInvalidTxId() {

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedDeposit.tsx
@@ -28,12 +28,8 @@ type Props = {
   transaction: EarnTransaction
 }
 
-// "Try again" CTA shown inside `<HistoricalDepositReview>` when a deposit
-// failed. Reuses `useDeposit` directly — the hook is decoupled from the pool
-// drawer (`setDrawerQueryString` is wired by the pool components, not here).
-// On `user-signed-deposit`, redirects the drawer's `earnTxId` to the new tx
-// hash so the drawer transitions in place from the FAILED view to the new
-// in-flight view (instead of closing or going blank).
+// Retry CTA in the historical deposit drawer; on user-signed-deposit it redirects
+// earnTxId to the new tx so the drawer transitions in place from FAILED to in-flight.
 export const RetryFailedDeposit = function ({
   asset,
   pool,

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedWithdraw.tsx
@@ -27,10 +27,7 @@ type Props = {
   transaction: EarnTransaction
 }
 
-// "Try again" CTA shown inside `<HistoricalWithdrawReview>` when a redeem
-// failed. Mirrors `<RetryFailedDeposit>`: reuses `useWithdraw` and on
-// `user-signed-withdraw` redirects the drawer's `earnTxId` so the FAILED
-// view transitions in place into the new in-flight view.
+// Retry CTA in the historical withdraw drawer; mirrors RetryFailedDeposit, redirecting earnTxId on user-signed-withdraw.
 export const RetryFailedWithdraw = function ({
   asset,
   pool,
@@ -41,8 +38,7 @@ export const RetryFailedWithdraw = function ({
     useState<WithdrawOperationRunning>('idle')
   const t = useTranslations()
 
-  // `amountIn` on a REDEEM row is in share-token units — exactly what the
-  // Router burns again on retry.
+  // A REDEEM row's amountIn is in share units — exactly what the Router re-burns on retry.
   const shares = BigInt(transaction.amountIn)
 
   const {

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
@@ -31,8 +31,7 @@ import {
 
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
-// The compact settle button shared by every claim/recover CTA (deposit + redeem).
-// Drawer CTAs stretch full-width; the table cell renders a compact button.
+// Shared settle button for every claim/recover CTA; full-width in drawers, compact in the table cell.
 const SettleForm = ({
   disabled,
   fullWidth,
@@ -61,8 +60,7 @@ const SettleForm = ({
 
 type SettleOperation = 'CLAIM' | 'RECOVER'
 
-// One table for the whole (kind, operation) matrix so the Router action and the
-// idle label stay in lockstep and can't get mismatched across call sites.
+// (kind, operation) matrix so the Router action and its label stay in lockstep across call sites.
 const SETTLE_CONFIG = {
   DEPOSIT: {
     CLAIM: { action: claimDeposit, label: 'claim-share-tokens' },
@@ -76,21 +74,16 @@ const SETTLE_CONFIG = {
 
 type SettleCtaProps = {
   asset: EarnAsset
-  // Drawer CTAs stretch full-width; the table cell renders a compact button.
   fullWidth?: boolean
   operation: SettleOperation
   pool: EarnPool
-  // When rendered in the table the drawer isn't open yet, so opening it on
-  // signing lets the user watch the settlement mine. In the drawer it's already
-  // open, so the redirect is skipped.
+  // In the table the drawer isn't open yet, so sign opens it to watch the settlement mine; skipped in the drawer.
   redirectOnSign?: boolean
   transaction: EarnTransaction
 }
 
-// The claim/recover CTA for one request — a single component covering both kinds
-// and both operations. The delivered-token inversion lives here in one place: a
-// deposit claim / redeem recover deliver shares; a deposit recover / redeem claim
-// deliver the underlying asset (same rule as `useEarnDeliveryWatcher`).
+// Claim/recover CTA covering both kinds/operations. Delivered-token inversion lives here:
+// deposit claim / redeem recover deliver shares; the other two deliver the asset.
 export const SettleCta = function ({
   asset,
   fullWidth = true,
@@ -147,16 +140,12 @@ export const SettleCta = function ({
   )
 }
 
-// The table-row variant: resolves the pool/asset and renders the compact
-// Claim/Recover CTA (or nothing). Retry stays a View→drawer flow, so it isn't
-// handled here.
+// Table-row variant: resolves the pool/asset and renders the compact Claim/Recover CTA (retry stays a View→drawer flow).
 export const SettleRowCta = function ({
   fallback,
   transaction,
 }: {
-  // Rendered when the pool/asset can't be resolved yet (pools still loading) or
-  // for a delisted asset — keeps the row's View affordance instead of an empty
-  // cell.
+  // Shown when the pool/asset can't resolve (still loading or delisted) — keeps the View affordance.
   fallback?: ReactNode
   transaction: EarnTransaction
 }) {
@@ -196,11 +185,8 @@ export const SettleRowCta = function ({
   return null
 }
 
-// Explains the manual Claim/Recover CTA — shown above the CTA inside the drawers.
-// Self-gates via `pickSettleBannerKey`, so nothing renders for the retry-original
-// / add-to-wallet / in-flight states. Uses its own translation namespace so it's
-// reusable across drawers that translate under different roots (`pool.drawer` vs
-// `transactions.drawer`).
+// Explains the manual Claim/Recover CTA (self-gates via pickSettleBannerKey).
+// Own translation namespace so it's reusable across drawers under different roots.
 export const SettleBanner = function ({
   transaction,
 }: {
@@ -209,9 +195,7 @@ export const SettleBanner = function ({
   const t = useTranslations('hemi-earn.transactions.banner')
   const key = pickSettleBannerKey(transaction)
   if (!key) return null
-  // Rendered in the drawer's `aboveCallToAction` slot (outside the scroll area)
-  // so it stays pinned above the CTA regardless of step count. The padding
-  // matches the drawer's 24px gutter (16px on mobile).
+  // Padding matches the drawer's 24px gutter (16px on mobile).
   return (
     <div className="px-4 py-6 md:px-6">
       <WarningBox
@@ -222,10 +206,7 @@ export const SettleBanner = function ({
   )
 }
 
-// "Add {token} to wallet" CTA surfaced once a request is FINALIZED (the delivered
-// token has landed): the share OFT for a deposit, the underlying asset for a
-// redeem. Shared by the live and historical drawers so both match the tunnel
-// history affordance.
+// "Add to wallet" CTA offered once FINALIZED, when the delivered token has landed.
 export const AddTokenToWalletCta = function ({ token }: { token: EvmToken }) {
   const tCommon = useTranslations('common')
   return (

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionsTable.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionsTable.tsx
@@ -52,10 +52,8 @@ export const TransactionsTable = function () {
         columns={columns}
         data={transactions}
         loading={isPending}
-        // Virtual mode (default) gives sticky header + body scroll out of the
-        // box, so a long list of past deposits doesn't push the page height.
-        // Mobile column order per designer: Action, Status, Type, Amount,
-        // Date (so the most-used cells stay reachable when narrow).
+        // Virtual mode: sticky header + body scroll so a long list doesn't grow the page.
+        // Mobile column order (designer): Actions, Status, Type, Amount, Date.
         priorityColumnIdsOnSmall={[
           'actions',
           'status',
@@ -65,8 +63,7 @@ export const TransactionsTable = function () {
         ]}
         rowSize={48}
         skeletonRows={5}
-        // Keep the desktop column layout from 'md' (768px) up; the compact,
-        // reordered layout only applies on narrow mobile viewports.
+        // Desktop layout from md up; the compact reordered layout is mobile-only.
         smallBreakpoint={screenBreakpoints.md}
       />
     )

--- a/portal/app/[locale]/hemi-earn/_constants/slippage.ts
+++ b/portal/app/[locale]/hemi-earn/_constants/slippage.ts
@@ -1,15 +1,12 @@
-// Redeem is wider than deposit because `amountOutMin` is frozen across the
-// ~7d cooldown — yield drift or fee changes in that window would otherwise
-// revert `claimUnstake`. User-selectable slippage tracked in #1981.
+// Redeem is wider than deposit: amountOutMin is frozen across the ~7d cooldown,
+// so yield or fee drift in that window could otherwise revert claimUnstake.
 export const DEPOSIT_SLIPPAGE_BPS = BigInt(50)
 export const REDEEM_SLIPPAGE_BPS = BigInt(100)
 
 const BPS_DENOMINATOR = BigInt(10000)
 
-// Clamps to `1n` when floor-division would round the result to `0n` —
-// otherwise the on-chain `*OutMin` would silently accept a zero-out
-// fulfillment. Rejects `bps` outside `[0, BPS_DENOMINATOR]` so a
-// misconfigured value can't slip past the clamp into the same failure mode.
+// Clamp to 1n so a floor-divided 0n can't become an on-chain "accept zero out";
+// reject out-of-range bps so a misconfigured value can't slip into the same failure mode.
 export function applySlippage(amount: bigint, bps: bigint): bigint {
   if (bps < BigInt(0) || bps > BPS_DENOMINATOR) {
     throw new RangeError(

--- a/portal/app/[locale]/hemi-earn/_context/localEarnOperationsContext.tsx
+++ b/portal/app/[locale]/hemi-earn/_context/localEarnOperationsContext.tsx
@@ -29,17 +29,10 @@ type UpsertPayload = Partial<LocalEarnOperation> & {
 type LocalEarnOperationsContextValue = {
   clearForAccount: (account: Address) => void
   localOperations: LocalEarnOperation[]
-  // Soft-deletes the entry whose `initiateTxHash` matches by flipping
-  // `settled: true`. Scoped to the connected wallet so a hash-match can't
-  // accidentally touch another account's entries on a shared device. Used
-  // by retry flows (to supersede a specific prior attempt) and by the
-  // reconcile loop (once the subgraph has indexed the request, the row
-  // hides from the merge but the entry stays around so the drawer can
-  // still read locally-captured metadata like `approvalTxHash`).
+  // Soft-delete (settled:true) the entry matching initiateTxHash, scoped to the
+  // connected wallet; the entry stays so the drawer can still read its local metadata.
   markSettledByInitiateTxHash: (initiateTxHash: Hash) => void
-  // Records (or clears, with `undefined`) the manual claim/recover state on the
-  // local entry whose `initiateTxHash` matches the request tx. No-op when the
-  // request has no local entry (e.g. the deposit was made in another browser).
+  // Records/clears the claim/recover marker on the matching entry; no-op if the request has no local entry.
   setSettlement: (
     initiateTxHash: Hash,
     settlement: EarnSettlement | undefined,
@@ -62,9 +55,7 @@ const garbageCollect = function (entries: LocalEarnOperation[]) {
     .slice(0, MAX_ENTRIES_PER_ACCOUNT)
 }
 
-// Match an existing entry to update. Once we have an initiateTxHash, that's
-// the canonical key; before that, the (account, startedAt) tuple identifies
-// the user's signing session.
+// Key by initiateTxHash once known; before that, the (account, startedAt) tuple identifies the signing session.
 const matchesExisting = function (
   entry: LocalEarnOperation,
   payload: UpsertPayload,

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchComposition.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchComposition.ts
@@ -9,12 +9,8 @@ import { type Address, formatUnits, isAddressEqual } from 'viem'
 
 import { gatewayForShareQueryOptions } from '../_hooks/gatewayForShare'
 
-// Shape of each entry returned by `GET /analytics/treasury/:gatewayAddress`.
-// Token amounts (`totalDebt`, `withdrawable`, a strategy's `totalDebt`) are
-// denominated in the token's erc20 minimal units. `latestPrice` is the token's
-// oracle price denominated in the gateway's peg unit (e.g. BTC for the vetBTC
-// gateway), so converting to USD only needs the peg's USD price on top — see
-// `toCompositionData`.
+// Amounts are in erc20 minimal units; latestPrice is in the gateway's peg unit
+// (e.g. BTC for the vetBTC gateway), so USD = latestPrice × pegPrice.
 type TreasuryToken = {
   activeStrategies: { name: string; totalDebt: string }[]
   latestPrice: string
@@ -24,10 +20,7 @@ type TreasuryToken = {
   withdrawable: string
 }
 
-// Raw, locale-free and grouping-agnostic data cached by the composition query:
-// per whitelisted token, the USD value of each active strategy plus the
-// token's deployed (`totalDebt`) and total (`withdrawable`, deployed + idle)
-// USD values. Grouping into display items happens in `toCompositionItems`.
+// Cached raw data (locale-free, ungrouped); grouping into display items happens in toCompositionItems.
 export type CompositionData = {
   strategies: { amount: number; name: string }[]
   symbol: string
@@ -35,10 +28,6 @@ export type CompositionData = {
   withdrawable: number
 }[]
 
-// Turns the treasury response into the composition data. Each token's oracle
-// `latestPrice` is denominated in the gateway's peg unit, so its USD price is
-// `latestPrice × pegPrice` (the peg's USD price). `tokens` holds the resolved
-// metadata (symbol, decimals) to scale the token amounts.
 const toCompositionData = function (
   treasury: TreasuryToken[],
   tokens: Token[],
@@ -79,12 +68,8 @@ const toCompositionData = function (
   return data
 }
 
-// Groups the cached composition data into display items. 'protocol' lists the
-// individual strategies and appends the idle funds (`withdrawable` minus
-// `totalDebt`, across tokens) as a reserve-buffer entry. 'token' lists each
-// whitelisted token by its `withdrawable` value, which already contains the
-// token's idle share — so no separate buffer entry. Shares are percentages of
-// the grouped total.
+// 'protocol' groups by strategy and appends idle funds (withdrawable − totalDebt)
+// as a reserve buffer; 'token' groups by token (idle already included).
 export const toCompositionItems = function ({
   data,
   reserveBufferLabel,
@@ -123,7 +108,6 @@ export const toCompositionItems = function ({
   const total = visible.reduce((sum, item) => sum + item.amount, 0)
   return visible.map(item => ({
     amount: item.amount,
-    // Lets consumers exclude the buffer row from e.g. position counts
     isReserveBuffer: item.isReserveBuffer === true,
     name: item.name,
     share: total > 0 ? (item.amount / total) * 100 : 0,
@@ -142,9 +126,7 @@ export const fetchComposition = async function ({
   const gatewayAddress = await queryClient.ensureQueryData(
     gatewayForShareQueryOptions(shareAddress),
   )
-  // Whitelisted-token oracles are denominated in the gateway's peg unit, so a
-  // single feed lookup for the peg symbol prices every token. "USD" pegs are
-  // the identity (no conversion needed).
+  // Oracles are in the gateway's peg unit, so one peg-symbol price covers every token (USD peg = identity).
   const pegBaseSymbol = gateways.find(gateway =>
     isAddressEqual(gateway.address, gatewayAddress),
   )?.pegBaseSymbol
@@ -156,10 +138,7 @@ export const fetchComposition = async function ({
     `${apiUrl}/analytics/treasury/${gatewayAddress}`,
   )) as TreasuryToken[]
 
-  // The endpoint returns the token addresses but not their metadata, so
-  // resolve each one through the shared token query (token list + erc20
-  // fallback). Both lookups are cached and shared across reloads and other
-  // consumers.
+  // The endpoint returns addresses but no metadata; resolve each via the shared (cached) token query.
   const uniqueAddresses = [
     ...new Set(treasury.map(token => token.tokenAddress)),
   ]

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnPositions.ts
@@ -45,15 +45,8 @@ export const fetchEarnPositions = async function ({
 }): Promise<EarnPosition[]> {
   const shares = await queryClient.ensureQueryData(hemiEarnSharesQueryOptions())
 
-  // Use `allSettled` so a single failing share-balance read doesn't take down
-  // the whole composition: matches the previous `useQueries` behavior where
-  // the hook only escalated to an error state if *every* read failed.
-  //
-  // `ensureQueryData` reads cached results when present. Freshness after a
-  // deposit/withdraw is the mutation's responsibility — `useDeposit` and
-  // `useWithdraw` call `removeQueries({ queryKey: earnPositionsKeyPrefix })`
-  // on `onSettled`, which evicts both the outer aggregated query and these
-  // nested share-balance entries so the next read hits the network.
+  // allSettled so one failing balance read doesn't sink the whole set (escalate only if all fail).
+  // ensureQueryData serves cache; the mutations evict earnPositionsKeyPrefix on settle for freshness.
   const settled = await Promise.allSettled(
     shares.map(share =>
       queryClient

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnPositions.ts
@@ -46,7 +46,7 @@ export const fetchEarnPositions = async function ({
   const shares = await queryClient.ensureQueryData(hemiEarnSharesQueryOptions())
 
   // allSettled so one failing balance read doesn't sink the whole set (escalate only if all fail).
-  // ensureQueryData serves cache; the mutations evict earnPositionsKeyPrefix on settle for freshness.
+  // ensureQueryData serves cache; withdraw/settle and the delivery watcher reset earnPositionsKeyPrefix for freshness.
   const settled = await Promise.allSettled(
     shares.map(share =>
       queryClient

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTokenPrices.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTokenPrices.ts
@@ -10,21 +10,13 @@ import { oraclePricesQueryOptions } from './fetchOraclePrices'
 
 type Prices = Record<string, string>
 
-// "USD" pegs are the identity; any other peg unit (BTC, ETH) is converted to
-// USD with its portal price. A missing peg price degrades that gateway's
-// tokens to $0 rather than crashing.
+// USD peg = identity; other pegs convert via portal price, degrading to $0 (not a crash) if missing.
 const pegToUsdRate = (pegBaseSymbol: string, portal: Prices) =>
   pegBaseSymbol === 'USD' ? 1 : Number(portal[pegBaseSymbol] ?? 0)
 
-// The Hemi Earn price feed: the app-wide portal `/prices` feed (`useTokenPrices`)
-// extended with each gateway's on-chain oracle prices. Oracle entries are
-// denominated in the gateway's peg unit, converted to USD (× the peg's USD
-// price) and override the portal entry on symbol collision, since the oracle is
-// the source the protocol itself uses. A pegged token (vetBTC, VUSD) has no
-// oracle of its own; it is priced by aliasing to a whitelisted proxy in its
-// gateway via `extensions.priceSymbol` (vetBTC→WBTC, VUSD→USDT), resolved
-// downstream by `getTokenPrice`. Kept earn-scoped so the rest of the app keeps
-// using the plain portal feed.
+// Portal /prices feed extended with each gateway's oracle prices (converted to USD;
+// oracle wins on symbol collision). Pegged tokens (vetBTC, VUSD) have no oracle —
+// priced via an extensions.priceSymbol alias. Earn-scoped.
 export const fetchEarnTokenPrices = async function (
   queryClient: QueryClient,
 ): Promise<Prices> {
@@ -65,7 +57,6 @@ export const earnTokenPricesQueryOptions = (
   queryOptions({
     queryFn: ({ client }) => fetchEarnTokenPrices(client),
     queryKey: ['hemi-earn', 'token-prices'],
-    // refetch every 5 min
     refetchInterval: 5 * 60 * 1000,
     staleTime: 30 * 1000,
     ...options,

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.ts
@@ -21,12 +21,8 @@ export type ShareSkeleton = Pick<
   'assets' | 'peggedToken' | 'shareAddress' | 'shareToken' | 'stakingVault'
 >
 
-// Pegged tokens (vetBTC, VUSD) aren't in the curated token list, so they
-// resolve via the erc20 fallback with no `priceSymbol`. They have no oracle of
-// their own either, so — like vetro-4 — price them by aliasing to a
-// whitelisted proxy token in their gateway. `useEarnTokenPrices` exposes those
-// proxies' oracle-adjusted USD prices, and `getTokenPrice` reads the alias
-// from `extensions.priceSymbol`.
+// Pegged tokens have no oracle; price them by aliasing to a whitelisted proxy
+// (BTC→WBTC, USD→USDT) via priceSymbol.
 const pegBaseToPriceSymbol: Record<string, string> = {
   BTC: 'WBTC',
   USD: 'USDT',
@@ -39,12 +35,7 @@ export const fetchHemiEarnShares = async function (
     hemiEarnAssetConfigsQueryOptions(),
   )
 
-  // Resolve token metadata (symbol, decimals, logo, priceSymbol) through the
-  // shared token query — the curated token list with an on-chain erc20
-  // fallback. The pegged token lives on Ethereum mainnet (the staking vault's
-  // `asset()`), while share/deposit tokens are Hemi-side, so each is looked up
-  // on its own chain. Returns `undefined` so the share/asset is skipped when
-  // neither source resolves the token.
+  // Resolve via the shared token query; the pegged token is on Ethereum, share/deposit tokens on Hemi (each on its own chain).
   const resolveToken = async function (
     address: Address,
     chainId: RemoteChain['id'],
@@ -58,9 +49,7 @@ export const fetchHemiEarnShares = async function (
     }
   }
 
-  // A share can accept several deposit assets, so the asset-config list repeats
-  // `share`/`remoteShare`; build one skeleton per unique share to avoid
-  // duplicate pools (and double-counted positions/TVL).
+  // A share accepts several deposit assets, so configs repeat it — one skeleton per unique share to avoid duplicate pools.
   const skeletons = await Promise.all(
     uniqueShareConfigs(configs).map(async function ({
       remoteShare,
@@ -76,10 +65,7 @@ export const fetchHemiEarnShares = async function (
       if (!shareToken || !peggedToken) {
         return null
       }
-      // The pegged token's USD price comes from its gateway's peg base (e.g.
-      // BTC for the vetBTC gateway, USD for VUSD). Resolve the gateway from the
-      // staking vault (same path `fetchComposition` uses; the `asset()` leg is
-      // already cached) and tag the pegged token with the matching feed symbol.
+      // Price the pegged token via its gateway's peg base; resolve the gateway from the staking vault and tag it with the feed symbol.
       const gatewayAddress = await queryClient.ensureQueryData(
         gatewayForRemoteShareQueryOptions(remoteShare),
       )
@@ -89,8 +75,7 @@ export const fetchHemiEarnShares = async function (
       const priceSymbol = pegBaseSymbol
         ? pegBaseToPriceSymbol[pegBaseSymbol]
         : undefined
-      // Build a new token rather than mutate — the resolved token is a shared
-      // cached reference. Fall back to the unpriced token for unmapped pegs.
+      // Build a new token, don't mutate — the resolved token is a shared cached reference.
       const pricedPeggedToken = priceSymbol
         ? {
             ...peggedToken,

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.ts
@@ -10,9 +10,7 @@ import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address, formatUnits } from 'viem'
 import { readContract } from 'viem/actions'
 
-// Minimal Chainlink aggregator interface. A whitelisted token's oracle reports
-// the token's price denominated in the gateway's peg unit (e.g. WBTC/BTC for
-// the vetBTC gateway), not USD.
+// Chainlink aggregator; reports the token's price in the gateway's peg unit, not USD.
 const aggregatorV3Abi = [
   {
     inputs: [],
@@ -36,12 +34,8 @@ const aggregatorV3Abi = [
   },
 ] as const
 
-// Reads every whitelisted-token oracle for a gateway and returns a
-// `{ SYMBOL: price }` dict where each price is denominated in the gateway's peg
-// unit (BTC for the vetBTC gateway, USD for VUSD). `fetchEarnTokenPrices`
-// converts these to USD. The dict is keyed by the token's uppercased symbol so
-// each entry is unique within the gateway — `priceSymbol` is only a downstream
-// lookup alias and would collide here when several tokens share one alias.
+// Returns { SYMBOL: pegUnitPrice } keyed by the uppercased symbol — not priceSymbol,
+// which would collide when several tokens share one alias. fetchEarnTokenPrices converts to USD.
 export const fetchOraclePrices = async function (
   queryClient: QueryClient,
   gatewayAddress: Address,
@@ -86,7 +80,6 @@ export const oraclePricesQueryOptions = (gatewayAddress: Address) =>
   queryOptions({
     queryFn: ({ client }) => fetchOraclePrices(client, gatewayAddress),
     queryKey: ['hemi-earn', 'oracle-prices', gatewayAddress],
-    // refetch every 5 min
     refetchInterval: 5 * 60 * 1000,
     staleTime: 30 * 1000,
   })

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchSharesToPegged.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchSharesToPegged.ts
@@ -15,11 +15,8 @@ export type SharesToPeggedParams = {
   shares: bigint
 }
 
-// Pure share→pegged conversion via `StakingVault.convertToAssets`. Takes the
-// resolved Ethereum-side staking vault (`remoteShare`) so it stays a leaf —
-// `sharesToPeggedOptions` resolves the vault from the share. Cached separately
-// from the asset-specific leg so switching the withdraw asset (which only
-// changes the gateway `previewRedeem` step) doesn't re-run this RPC.
+// share→pegged via StakingVault.convertToAssets. Cached separately from the asset
+// leg so switching the withdraw asset doesn't re-run this RPC.
 export async function fetchSharesToPegged({
   shares,
   stakingVault,

--- a/portal/app/[locale]/hemi-earn/_hooks/gatewayForRemoteShare.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/gatewayForRemoteShare.ts
@@ -6,10 +6,8 @@ import { type Address } from 'viem'
 
 import { vaultAssetQueryOptions } from './vaultAsset'
 
-// Resolves the Ethereum-side Vetro Gateway from the Ethereum-side StakingVault
-// (the Router's `remoteShare`), following the chain the Agent walks:
-// `StakingVault.asset()` → pegged token, then `PeggedToken.gateway()` → gateway.
-// The `asset()` leg is shared with `vaultAssetQueryOptions` so it runs once.
+// Gateway from the staking vault, following the Agent's walk: asset() → pegged token
+// → gateway(); the asset() leg is shared so it runs once.
 export const gatewayForRemoteShareQueryOptions = (remoteShare: Address) =>
   queryOptions({
     async queryFn({ client }) {

--- a/portal/app/[locale]/hemi-earn/_hooks/gatewayForShare.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/gatewayForShare.ts
@@ -5,9 +5,7 @@ import { shareConfigQueryOptions } from '../_fetchers/fetchHemiEarnAssetConfigs'
 
 import { gatewayForRemoteShareQueryOptions } from './gatewayForRemoteShare'
 
-// The gateway is identical across all of a share's deposit assets, so callers
-// that only have a share OFT (e.g. composition) resolve it from the share's
-// staking vault (`remoteShare`) via the cached asset-config list.
+// The gateway is the same for all of a share's assets, so share-only callers resolve it from the share's staking vault.
 export const gatewayForShareQueryOptions = (shareAddress: Address) =>
   queryOptions({
     async queryFn({ client }) {

--- a/portal/app/[locale]/hemi-earn/_hooks/useAssetData.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useAssetData.ts
@@ -3,11 +3,8 @@ import { type Address, isAddressEqual } from 'viem'
 
 import { hemiEarnAssetConfigsQueryOptions } from '../_fetchers/fetchHemiEarnAssetConfigs'
 
-// `Router.assetsData(asset)` on Hemi — resolves a Hemi-side asset to its
-// Ethereum-side counterparts (`remoteShare` = staking vault, `remoteAsset`).
-// Served from the cached on-chain asset-config list (which already read
-// `assetsData` for every registered asset) so the deposit/withdraw flows don't
-// re-issue the same per-asset RPC.
+// Hemi asset → its Ethereum counterparts (remoteShare = staking vault, remoteAsset),
+// served from the cached config list so the flows don't re-issue the per-asset RPC.
 export const assetDataQueryOptions = (asset: Address) =>
   queryOptions({
     async queryFn({ client }) {

--- a/portal/app/[locale]/hemi-earn/_hooks/useCancelRedeem.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useCancelRedeem.ts
@@ -46,9 +46,7 @@ export const useCancelRedeem = function ({ on, transaction }: UseCancelRedeem) {
         walletClient: hemiWalletClient!,
       })
 
-      // Flag the marker failed on any revert/error so the modal returns to its
-      // idle state for another try; left pending on success so the row reads as
-      // cancelling and the merge drops it once terminal (RECOVERED).
+      // Flag failed on revert so the modal resets for a retry; left pending on success so the row reads as cancelling until terminal.
       const fail = () =>
         setSettlement(transaction.requestTxHash, {
           failed: true,
@@ -74,8 +72,7 @@ export const useCancelRedeem = function ({ on, transaction }: UseCancelRedeem) {
       emitter.on('user-signing-tx-error', fail)
       emitter.on('unexpected-error', fail)
 
-      // Caller listens for `tx-transaction-succeeded` to close the modal — only
-      // once the cancel is mined, so a revert keeps it open for another try.
+      // Caller closes the modal on tx-transaction-succeeded — only when mined, so a revert keeps it open.
       on?.(emitter)
 
       return promise

--- a/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
@@ -4,16 +4,10 @@ import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 
-// `cooldownDuration` is governance-controlled and rarely changes. Caching
-// for a few hours avoids refetching on every window focus / wallet
-// reconnect.
+// Governance-controlled and rarely changes; cache for hours to avoid refetch on every focus/reconnect.
 const STALE_TIME_MS = 4 * 60 * 60 * 1000
 
-// Returns the raw on-chain cooldown duration in seconds. Callers that just
-// need the day count (e.g. the warning banner) convert with
-// `secondsToDays`; the withdraw drawer's live countdown needs the raw
-// seconds to tick at minute resolution. Takes the Ethereum-side staking vault
-// (`pool.stakingVault`) directly — callers already hold it.
+// Raw cooldown duration in seconds (callers convert to days as needed).
 export const useCooldownDuration = ({
   enabled = true,
   stakingVault,

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
@@ -10,23 +10,17 @@ export const isApyApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
 
 type ApyByVault = Partial<Record<Address, { apy: number }>>
 
-// Shared queryOptions: a single network call serves every share via the
-// per-vault map returned by the API. Pair with `selectApyValue` below to
-// resolve the per-share tri-state from a parent query subscription.
+// One network call serves every share (per-vault map); pair with selectApyValue for the per-share value.
 export const earnApyQueryOptions = () =>
   queryOptions({
     enabled: isApyApiConfigured,
     queryFn: () => fetch(`${apiUrl}/variable-stake/apy`) as Promise<ApyByVault>,
     queryKey: ['hemi-earn', 'apy'],
-    refetchInterval: 5 * 60 * 1000, // refetch every 5 min
+    refetchInterval: 5 * 60 * 1000,
     retry: 2,
   })
 
-// Resolve the apy for a single share against an already-fetched response.
-// The API keys its per-vault map by the share's Ethereum-side staking vault,
-// so callers pass that (`pool.stakingVault`). Returns `undefined` while the
-// query is pending, `null` once settled but missing for that vault (errored
-// response or vault not in the payload), and the apy number otherwise.
+// Resolve one share's apy from the fetched map (keyed by staking vault): undefined while pending, null if settled-but-missing.
 export const selectApyValue = (
   data: ApyByVault | undefined,
   isPending: boolean,

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
@@ -33,12 +33,7 @@ type ReconcileArgs = {
   subgraphHashes: Set<string>
 }
 
-// Soft-settles any local entry whose `initiateTxHash` has appeared in the
-// subgraph — the subgraph row supersedes the local mirror in the merged
-// table, but the local entry stays in storage so drawers can still read
-// locally-captured metadata (e.g. `approvalTxHash`) that the indexer
-// doesn't expose. Idempotent: re-flagging an already-settled entry is a
-// no-op.
+// Soft-settle local entries once the subgraph indexes them; the entry stays for drawer metadata. Idempotent.
 function reconcileLocals({
   localOperations,
   markSettledByInitiateTxHash,
@@ -64,15 +59,9 @@ type DeliveredEvent = {
   status: DeliveredStatus
 }
 
-// Walks the subgraph rows and reports every request that transitioned from
-// an in-flight state into a terminal delivery state (FINALIZED / RECOVERED)
-// since the previous poll. Returns the delivered events with enough metadata
-// (kind, asset, receiver) for the caller to build the exact cache keys
-// that actually moved — deposits make the share OFT land on the user's
-// Hemi wallet, redeems make the underlying land on the user's Hemi wallet.
-// First-time observations of already-terminal hashes (page reload after
-// FINALIZED) do NOT count — those rows are historical and don't move
-// balances.
+// Requests that transitioned in-flight → terminal (FINALIZED/RECOVERED) since the last
+// poll, with the metadata to build the moved cache keys. First-time-terminal rows (page
+// reload) are historical and skipped — they don't move balances.
 function detectCrossChainDeliveries(
   previous: Map<string, EarnTransactionStatusType>,
   rows: EarnTransaction[],
@@ -95,13 +84,7 @@ function detectCrossChainDeliveries(
 const findShareForAsset = (configs: HemiEarnAssetConfig[], asset: Address) =>
   configs.find(config => isAddressEqual(config.asset, asset))?.share
 
-// Maps a terminal event to the token whose balance actually moved:
-//   DEPOSIT + FINALIZED → share OFT lands on the user's Hemi wallet
-//   DEPOSIT + RECOVERED → the deposited asset is refunded
-//   REDEEM  + FINALIZED → the underlying asset is delivered
-//   REDEEM  + RECOVERED → shares are returned to the user
-// RECOVERED inverts the delivery vs FINALIZED in both directions, so we
-// need (kind, status) to pick the right cache key.
+// Which token's balance moved. RECOVERED inverts the delivery vs FINALIZED, so both kind and status are needed.
 const movesShareBalance = (event: DeliveredEvent) =>
   (event.kind === 'DEPOSIT' && event.status === 'FINALIZED') ||
   (event.kind === 'REDEEM' && event.status === 'RECOVERED')
@@ -120,10 +103,7 @@ function invalidateOnDelivery(
 ) {
   queryClient.invalidateQueries({ queryKey: vetroPoolsPrefix })
   queryClient.invalidateQueries({ queryKey: vetroUserShareValuePrefix })
-  // Synchronous read of the already-loaded on-chain asset config list (the
-  // earn pages fetch it via `useHemiEarnShares`). If it isn't cached yet the
-  // share-balance key is skipped; the pools/positions invalidation below
-  // still runs.
+  // Sync read of the already-loaded config list; if not cached, skip the share-balance key (pools/positions still invalidate).
   const configs =
     queryClient.getQueryData(hemiEarnAssetConfigsQueryOptions().queryKey) ?? []
   for (const event of events) {
@@ -137,22 +117,12 @@ function invalidateOnDelivery(
       }),
     })
   }
-  // `resetQueries` is the only single-call primitive that does both halves
-  // of what we need: it removes every matching cache entry (so the inner
-  // `ensureQueryData` reads inside `fetchEarnPositions` go to the network
-  // instead of returning stale data) AND it triggers a refetch on the
-  // active observer (`useEarnPositions`, which stays mounted on the home
-  // page while the user waits for the deposit to settle). The intuitive
-  // pair `removeQueries` + `invalidateQueries` does not work in v5 — the
-  // first call evicts the cache entry, leaving `invalidateQueries` with
-  // nothing to match.
+  // resetQueries both evicts the cache (so fetchEarnPositions' ensureQueryData refetches)
+  // and refetches the mounted observer; removeQueries + invalidateQueries doesn't do both in v5.
   queryClient.resetQueries({ queryKey: earnPositionsKeyPrefix })
 }
 
-// Mount this exactly once per route group (today, inside the layout-level
-// `<EarnStatusUpdaters>`). Mounting from multiple consumers would multiply
-// the side-effect work without changing behavior — react-query dedupes the
-// underlying fetch, but every observer runs its own useEffect.
+// Mount exactly once per route group; extra mounts duplicate the side-effect work (RQ dedupes the fetch, not the effect).
 export const useEarnDeliveryWatcher = function () {
   const { address } = useAccount()
   const queryClient = useQueryClient()
@@ -164,9 +134,7 @@ export const useEarnDeliveryWatcher = function () {
     Map<string, EarnTransactionStatusType>
   >(new Map())
 
-  // The previous-status snapshot is account-scoped — wipe it on wallet
-  // change so account A's hashes don't leak into account B's transition
-  // detection.
+  // Account-scoped snapshot; wipe on wallet change so A's hashes don't leak into B's transition detection.
   useEffect(
     function resetSnapshotOnAccountChange() {
       previousSubgraphStatusRef.current = new Map()

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -13,12 +13,7 @@ import {
 import { earnTvlQueryOptions } from './useEarnTvl'
 import { useHemiEarnShares } from './useHemiEarnShares'
 
-// Composes the per-pool view out of the registry of shares plus two
-// independent side queries: TVL (one read per share, on-chain) and APY
-// (a single shared HTTP call whose response is keyed by vault address).
-// Each piece keeps its own freshness lifecycle — TVL is invalidated by
-// deposit/withdraw, APY refetches on a 5-minute interval — and we just
-// pick the resolved values up here at render time.
+// Combines the shares registry with independent TVL (per-share) and APY (one shared call) queries, each with its own freshness.
 export const useEarnPools = function () {
   const [networkType] = useNetworkType()
   const {
@@ -27,10 +22,7 @@ export const useEarnPools = function () {
     isPending: isSharesPending,
   } = useHemiEarnShares()
 
-  // TVL queries are intentionally NOT part of `isPending`: the page renders
-  // immediately while the cross-chain read is in flight, and each pool's
-  // total-deposits cell shows its own skeleton (driven by `totalDepositsStatus`
-  // below) rather than blocking the whole page.
+  // TVL is deliberately out of isPending: the page renders immediately and each cell shows its own skeleton via totalDepositsStatus.
   const tvlQueries = useQueries({
     queries: shares.map(share => ({
       ...earnTvlQueryOptions({

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTokenPrices.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTokenPrices.ts
@@ -4,11 +4,8 @@ import { earnTokenPricesQueryOptions } from '../_fetchers/fetchEarnTokenPrices'
 
 type Prices = Record<string, string>
 
-// USD prices for Hemi Earn: `useTokenPrices` (the portal `/prices` feed)
-// extended with each gateway's on-chain oracle prices (see
-// `fetchEarnTokenPrices`). Use this — rather than `useTokenPrices` — anywhere
-// Hemi Earn prices a pegged token (vetBTC, VUSD), which resolves through its
-// `extensions.priceSymbol` whitelisted-proxy alias.
+// Use this (not useTokenPrices) for Hemi Earn prices — it adds gateway oracle prices
+// so pegged tokens (vetBTC, VUSD) resolve via their priceSymbol alias.
 export const useEarnTokenPrices = (
   options: Omit<UseQueryOptions<Prices, Error>, 'queryKey' | 'queryFn'> = {},
 ) => useQuery(earnTokenPricesQueryOptions(options))

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactions.ts
@@ -24,15 +24,8 @@ import {
 import { useEarnTransactionsQuery } from './useEarnTransactionsQuery'
 import { useLocalEarnOperations } from './useLocalEarnOperations'
 
-// Maps the granular local `DepositStatus` enum to the table-level
-// `EarnTransactionStatusType`. Declared as a `Record` so any new
-// `DepositStatus` member added later becomes a compile error instead of
-// silently falling through to "in progress".
-//
-// `TX_PENDING` covers everything before the request-deposit tx is mined.
-// `PENDING` covers the post-mine window before the subgraph indexes the
-// row — semantically equivalent to subgraph `PENDING` (on-chain piece
-// done, cross-chain in flight).
+// Record (not a function) so a new DepositStatus becomes a compile error. TX_PENDING =
+// before the tx mines; PENDING = mined but not yet indexed (= subgraph PENDING).
 const localStatusByDepositStatus: Record<
   DepositStatusType,
   EarnTransactionStatusType
@@ -65,9 +58,7 @@ const localWithdrawStatus = (
   operation: WithdrawOperation,
 ): EarnTransactionStatusType => localStatusByWithdrawStatus[operation.status]
 
-// Convert a not-yet-indexed local entry into a row the table can render.
-// Callers must filter out approve-only entries (no `initiateTxHash` yet)
-// before passing to these — the casts trust that.
+// Local entry → table row. Callers must filter out approve-only entries (no initiateTxHash) first — the cast trusts that.
 const localToEarnDepositTransaction = (
   local: LocalEarnDepositOperation,
 ): EarnTransaction => ({
@@ -108,15 +99,8 @@ const localToEarnWithdrawTransaction = (
   status: localWithdrawStatus(local.operation),
 })
 
-// Public data hook for the transactions table and drawer. Returns the
-// subgraph rows merged with not-yet-indexed local entries, sorted by
-// requested-at descending.
-//
-// Side effects (removing local entries once the subgraph indexes them,
-// invalidating Vetro-side balance caches on FINALIZED/RECOVERED
-// transitions) live in the separate `useEarnDeliveryWatcher` so they fire
-// exactly once per polling cycle instead of N times — once per active
-// consumer of this hook.
+// Merges subgraph rows with not-yet-indexed local entries (sorted desc). Side effects
+// live in useEarnDeliveryWatcher so they fire once per poll, not once per consumer.
 export const useEarnTransactions = function () {
   const { data, isError, isLoading } = useEarnTransactionsQuery()
   const { localOperations } = useLocalEarnOperations()
@@ -125,10 +109,7 @@ export const useEarnTransactions = function () {
     function () {
       const localDeposits = localOperations.filter(isLocalEarnDeposit)
       const localWithdraws = localOperations.filter(isLocalEarnWithdraw)
-      // Locally-captured metadata keyed by request tx hash. Survives the
-      // soft-settle flag because the entry stays in storage — that's the
-      // whole point of soft-delete: enrich subgraph rows with bits the
-      // indexer doesn't expose (`approvalTxHash`).
+      // Local metadata keyed by request hash; survives soft-settle to enrich subgraph rows with indexer-missing bits (approvalTxHash).
       const localByRequestHash = new Map(
         [...localDeposits, ...localWithdraws]
           .filter(op => op.initiateTxHash !== undefined)
@@ -137,10 +118,8 @@ export const useEarnTransactions = function () {
       const subgraph = (data ?? []).map(function (t) {
         const local = localByRequestHash.get(t.requestTxHash.toLowerCase())
         if (!local) return t
-        // The authoritative terminal Router status wins over a lingering
-        // local settlement — a pending marker mid-indexing-lag or a stale
-        // reverted one. A FINALIZED/RECOVERED row must never re-expose the
-        // claim/recover CTA or a "Tx Failed" overlay.
+        // Terminal Router status wins over a lingering local settlement — a
+        // FINALIZED/RECOVERED row must never re-expose the CTA or a Tx Failed overlay.
         const isTerminal = isEarnRowTerminal(t)
         return {
           ...t,
@@ -156,13 +135,9 @@ export const useEarnTransactions = function () {
         subgraph.map(t => t.requestTxHash.toLowerCase()),
       )
       const inFlightDeposits = localDeposits
-        // Only show in the table once the user has signed the request tx —
-        // an approve-only entry isn't a committed action (the user can still
-        // back out of the wallet prompt). The entry stays in localStorage so
-        // the row reappears once the request hash is captured.
+        // Show only once the request tx is signed — an approve-only entry isn't committed yet (the entry stays for when it is).
         .filter(op => op.initiateTxHash !== undefined)
-        // Skip soft-settled entries — the subgraph row supersedes them
-        // (we still kept the entry above to enrich with `approvalTxHash`).
+        // Skip soft-settled entries; the subgraph row supersedes them (kept above only to enrich).
         .filter(op => !op.settled)
         .filter(op => !subgraphHashes.has(op.initiateTxHash!.toLowerCase()))
         .filter(

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
@@ -13,16 +13,9 @@ import { type EarnTransaction } from '../types'
 
 import { useLocalEarnOperations } from './useLocalEarnOperations'
 
-// Raw subgraph query. Internal building block shared by `useEarnTransactions`
-// (which merges with local entries for the table) and `useEarnDeliveryWatcher`
-// (which runs the reconcile + invalidation side effects against the raw
-// subgraph view). React Query dedupes the underlying fetch across both
-// consumers — a single network call per interval drives every subscriber.
-//
-// Polling: every 10s while a row is in flight (`isEarnRowInFlight`: cross-chain
-// pending, auto-claim/auto-recover progressing, a deposit or redeem awaiting
-// recovery, cooldown maturing) or a local entry hasn't shown up in the subgraph
-// yet. Stops on the terminals (FINALIZED/RECOVERED/FAILED).
+// Raw subgraph query shared by useEarnTransactions (merge) and useEarnDeliveryWatcher
+// (side effects); RQ dedupes to one fetch per interval. Polls every 10s while any row
+// is in flight or a local entry isn't indexed yet; stops on the terminals.
 export const useEarnTransactionsQuery = function () {
   const [networkType] = useNetworkType()
   const { address } = useAccount()

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTvl.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTvl.ts
@@ -6,9 +6,7 @@ import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 import { totalAssets } from 'viem-erc4626/actions'
 
-// Exported so deposit/withdraw mutations can invalidate this entry after
-// settling on-chain. Keyed by the staking vault (the address actually read)
-// rather than the share OFT.
+// Exported so mutations can invalidate after settling. Keyed by the staking vault (the address actually read), not the share OFT.
 export const earnTvlQueryKey = ({
   networkType,
   stakingVault,

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnAgentAddress.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnAgentAddress.ts
@@ -8,7 +8,6 @@ export const agentAddressQueryOptions = () =>
     gcTime: Infinity,
     queryFn: () => getAgentAddress(getPublicClient(hemi.id)),
     queryKey: ['hemi-earn', 'agent-address'],
-    // `Router.peerAddress()` on Hemi, decoded to the Agent address on Ethereum.
     // Immutable once the peer is set, so cache it indefinitely.
     staleTime: Infinity,
   })

--- a/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
@@ -4,16 +4,10 @@ import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 
-// Underlying reads (`cooldownEnabled`, `instantWithdrawWhitelist`) are
-// governance/admin-controlled and change infrequently. Caching for a few
-// hours avoids refetching on every window focus / wallet reconnect.
+// Governance-controlled and rarely changes; cache for hours to avoid refetch on every focus/reconnect.
 const STALE_TIME_MS = 4 * 60 * 60 * 1000
 
-// Resolves whether the caller is subject to the vault's 7-day withdraw cooldown
-// (i.e. cooldown is enabled AND the caller is not on the instant-withdraw
-// whitelist). Mirrors `resolveIsInstant` and inverts it so the consumer can
-// gate UI like "withdraw takes 7 days" on a single boolean. Takes the staking
-// vault (`pool.stakingVault`) directly — callers already hold it.
+// True when the caller is subject to the withdraw cooldown — the inverse of resolveIsInstant, for gating UI on one boolean.
 export const useIsCooldownEligible = ({
   account,
   stakingVault,

--- a/portal/app/[locale]/hemi-earn/_hooks/useSettle.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useSettle.ts
@@ -16,31 +16,23 @@ import { type EarnTransaction } from '../types'
 
 import { useLocalEarnOperations } from './useLocalEarnOperations'
 
-// `claimDeposit`/`recoverDeposit`/`claimRedeem`/`recoverRedeem` all share this
-// signature — a single Hemi Router tx with no approval or quote leg.
+// The four settlement actions share this signature (one Hemi Router tx, no approval/quote leg).
 type SettleAction = (typeof import('hemi-earn-actions/actions'))['claimDeposit']
 
 type UseSettle = {
   action: SettleAction
-  // The token that lands in the wallet on success — caller-supplied because the
-  // direction inverts by flow: a deposit claim delivers shares / recover returns
-  // the asset; a redeem claim delivers the asset / recover returns the shares.
+  // Token that lands on success; caller-supplied because the direction inverts by flow
+  // (deposit claim → shares, redeem claim → asset; recover flips each).
   deliveredTokenAddress: Address
-  // Drives the settlement marker: `CLAIM` (FULFILLED→FINALIZED) vs `RECOVER`
-  // (CANCELLED→RECOVERED).
+  // Settlement marker: CLAIM (FULFILLED→FINALIZED) vs RECOVER (CANCELLED→RECOVERED).
   kind: 'CLAIM' | 'RECOVER'
-  // All four settlement actions emit the same shape; `ClaimDepositEvents` is the
-  // canonical alias.
+  // All four actions emit the same shape; ClaimDepositEvents is the canonical alias.
   on?: (emitter: EventEmitter<ClaimDepositEvents>) => void
   transaction: EarnTransaction
 }
 
-// Shared mutation core for the single-tx claim/recover settlements (deposit and
-// redeem). Mirrors the `useWithdraw` scaffolding (wallet client + invalidations)
-// without the approval/quote machinery. The settlement state is persisted on the
-// local entry (`setSettlement`): flagged failed on revert so the CTA returns as a
-// Retry, left pending on success and dropped by the merge once the row is terminal
-// (so the CTA doesn't flicker back during the indexing lag).
+// Shared core for the single-tx claim/recover settlements. Marker on the local entry:
+// failed on revert (CTA becomes Retry), pending on success then dropped once terminal (no flicker during indexing lag).
 export const useSettle = function ({
   action,
   deliveredTokenAddress,
@@ -80,12 +72,7 @@ export const useSettle = function ({
         walletClient: hemiWalletClient!,
       })
 
-      // Any failure flags the settlement so the drawer offers a Retry. On
-      // success the marker is left pending — the merge drops it once the row is
-      // FINALIZED/RECOVERED, so the CTA stays suppressed through the indexing
-      // lag instead of re-appearing while the status is still FULFILLED/
-      // CANCELLED. Keyed by the request tx (`requestTxHash` = the local entry's
-      // `initiateTxHash`).
+      // Keyed by the request tx (requestTxHash = the local entry's initiateTxHash).
       const fail = () =>
         setSettlement(transaction.requestTxHash, { failed: true, kind })
 
@@ -108,24 +95,18 @@ export const useSettle = function ({
       emitter.on('user-signing-tx-error', fail)
       emitter.on('unexpected-error', fail)
 
-      // Caller hook (e.g. the table CTA) listens for `user-signed-tx` to
-      // redirect the drawer.
+      // Caller listens for user-signed-tx to redirect the drawer.
       on?.(emitter)
 
       return promise
     },
     onSettled() {
       queryClient.invalidateQueries({ queryKey: earnTransactionsKeyPrefix })
-      // `resetQueries` (not `invalidate`) so the manage page shows a fresh value
-      // instead of flashing the stale balance: the form usually mounts *after*
-      // the mutation (the user clicks "manage" post-settlement), and an
-      // invalidated-but-cached entry would render the old number until the
-      // background refetch lands.
+      // resetQueries (not invalidate): the manage form usually mounts after the mutation,
+      // so an invalidated-but-cached entry would flash the stale balance.
       queryClient.resetQueries({ queryKey: deliveredBalanceQueryKey })
       queryClient.invalidateQueries({ queryKey: nativeTokenBalanceQueryKey })
-      // `resetQueries` (not `removeQueries`) so the `useEarnPositions` observer
-      // refetches and the staked-balance card updates — same rationale as
-      // `useWithdraw`.
+      // resetQueries (not removeQueries) so the useEarnPositions observer refetches the staked-balance card.
       queryClient.resetQueries({ queryKey: earnPositionsKeyPrefix })
     },
   })

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
@@ -18,9 +18,7 @@ const positionUsd = (
   price: string,
 ) => Big(formatUnits(peggedAmount, peggedTokenDecimals)).times(price)
 
-// Sums the USD value of every share position the user holds. Each entry is
-// `convertToAssets(stakingVault, shares)` (shares → pegged token) priced via
-// `getTokenPrice(peggedToken)` against the oracle-merged earn price feed.
+// Sums each position's USD: shares → pegged (convertToAssets) → priced via the oracle-merged earn feed.
 export const useTotalDeposits = function () {
   const {
     data: positions = [],

--- a/portal/app/[locale]/hemi-earn/_hooks/vaultAsset.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/vaultAsset.ts
@@ -4,10 +4,8 @@ import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 import { asset as getVaultAsset } from 'viem-erc4626/actions'
 
-// Ethereum-side ERC-4626 staking vault's `asset()` — the pegged token (vBTC,
-// vUSD) backing the vault. Immutable per deployment, so cache forever. Shared
-// by pegged-token resolution (`fetchHemiEarnShares`) and gateway resolution
-// (`gatewayForRemoteShare`) so the `asset()` read happens once per vault.
+// The vault's asset() — the pegged token backing it. Immutable per deployment
+// (cache forever); shared across consumers so the read runs once per vault.
 export const vaultAssetQueryOptions = (vault: Address) =>
   queryOptions({
     queryFn: () =>

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -13,13 +13,6 @@ import {
   type LocalEarnOperation,
 } from '../types'
 
-// Case-insensitive equality for tx hashes. `viem` ships `isAddressEqual`
-// for 20-byte addresses but no equivalent for 32-byte tx hashes — the
-// canonical form is just lowercase hex, so a direct compare after
-// lowercasing is sufficient. Accepts plain strings so callers reading
-// from URL query params or local-store payloads don't need to cast.
-// Returns false if either side is undefined so callers don't have to
-// null-check separately.
 export const hashesMatch = (a: string | undefined, b: string | undefined) =>
   !!a && !!b && a.toLowerCase() === b.toLowerCase()
 
@@ -30,9 +23,6 @@ export const formatApyDisplay = function (apy: number) {
   return formatPercentage(apy)
 }
 
-// The terminal on-chain hash for a delivery — claim for FINALIZED,
-// recover for RECOVERED. Used by the drawer's waiting-for-shares step to
-// render the "Confirmed" bottom row.
 export const getTerminalDeliveryTxHash = function (
   tx: EarnTransaction | undefined,
 ) {
@@ -41,63 +31,40 @@ export const getTerminalDeliveryTxHash = function (
   return undefined
 }
 
-// Resolves an `EarnPool` keyed by a Hemi-side asset address (a share can
-// accept multiple deposit assets, so we match on `pool.assets`). Returns
-// `undefined` when the asset isn't registered against any pool.
 export const findPoolByAsset = (
   pools: EarnPool[],
   asset: Address,
 ): EarnPool | undefined =>
   pools.find(p => p.assets.some(a => isAddressEqual(a.address, asset)))
 
-// Resolves an `EarnPool` keyed by its share OFT address.
 export const findPoolByShare = (
   pools: EarnPool[],
   shareAddress: Address,
 ): EarnPool | undefined =>
   pools.find(p => isAddressEqual(p.shareAddress, shareAddress))
 
-// Local rows mean the Hemi `request*` tx reverted; subgraph rows mean the
-// Agent failed after a successful Hemi tx (recover, not retry).
+// Local rows = the Hemi request tx reverted (retryable); subgraph FAILED = the Agent failed after a successful Hemi tx.
 export const isLocalEarnTransactionRow = (tx: EarnTransaction) =>
   tx.requestId.startsWith('local-')
 
-// A FULFILLED request awaiting a manual claim — the user signs
-// `claim{Deposit,Redeem}(id)` to receive the tokens (shares for a deposit, the
-// underlying asset for a redeem). Auto-finalize runs in the same tx as the
-// fulfillment (`Router._handleRequestFulfillment`), so a request only *rests* at
-// FULFILLED when it was manual (`automatic === false`) OR auto-finalize reverted
-// (caught, `AutoFinalizationFailed`) — both leave the manual claim as the escape,
-// so the `automatic` flag isn't checked here.
+// Auto-finalize runs inline, so a request rests at FULFILLED only when manual or
+// auto-finalize reverted — manual claim is the escape either way (automatic not checked).
 export const needsManualClaim = (tx: EarnTransaction) =>
   tx.status === 'FULFILLED'
 
-// A CANCELLED request awaiting a manual recover — the user signs
-// `recover{Deposit,Redeem}(id)` to pull the original tokens to their wallet (the
-// asset for a deposit, the shares for a redeem). Like `needsManualClaim`, a
-// request only rests at CANCELLED when it was manual or auto-recover reverted —
-// both need the manual recover, so `automatic` isn't checked. `recover*` reverts
-// unless the request is CANCELLED, so this is the only valid state.
+// Recover-path mirror of needsManualClaim; recover* reverts unless CANCELLED, so it's the only valid state.
 export const needsRecover = (tx: EarnTransaction) => tx.status === 'CANCELLED'
 
-// Broader than `needsRecover`: any request on the recover branch (awaiting or
-// past recovery), regardless of `automatic`. Drives the display — the terminal
-// step shows the returned tokens (asset for a deposit, shares for a redeem), not
-// the claimed ones — even when auto-recover means no CTA is shown.
+// Any request on the recover branch (awaiting or past), regardless of automatic — drives the returned-token display.
 export const isRecoverPath = (tx: EarnTransaction) =>
   tx.status === 'CANCELLED' || tx.status === 'RECOVERED'
 
-// The Hemi `request*` tx reverted before it ever landed on-chain, so the user
-// can re-run the original request. Subgraph FAILED rows are a different beast
-// (handled elsewhere), hence the local-only gate.
+// Local FAILED = the request reverted before landing, so the user can re-run it (subgraph FAILED is handled elsewhere).
 export const canRetryRow = (tx: EarnTransaction) =>
   tx.status === 'FAILED' && isLocalEarnTransactionRow(tx)
 
-// CANCEL and UNSTAKE markers share the `settlement` field with CLAIM/RECOVER
-// but aren't claim/recover settlement txs (CANCEL is the deliberate-cancel
-// signal; UNSTAKE is the Ethereum finalize). Strip them so the claim/recover
-// machinery (failed badge, recover-step tx, manual CTA gating) never mistakes
-// them for one of its own.
+// CANCEL/UNSTAKE reuse the settlement field but aren't claim/recover txs — strip
+// them so the claim/recover UI never treats them as its own.
 export const claimRecoverSettlement = (
   settlement: EarnSettlement | undefined,
 ) =>
@@ -108,37 +75,24 @@ export const claimRecoverSettlement = (
 export const unstakeSettlement = (settlement: EarnSettlement | undefined) =>
   settlement?.kind === 'UNSTAKE' ? settlement : undefined
 
-// A manual claim/recover the user signed reverted on Hemi. The on-chain status
-// is unchanged (still FULFILLED/CANCELLED), so we surface the revert as a
-// failure in the badge/step and offer a retry, rather than trusting the now
-// misleading "needed" state.
+// A signed claim/recover reverted while the on-chain status stayed FULFILLED/CANCELLED — surface it as failed, not "needed".
 export const hasFailedSettlement = (tx: EarnTransaction) =>
   claimRecoverSettlement(tx.settlement)?.failed === true
 
-// A deliberate user cancel still in flight, vs an Agent failure — both reach
-// CANCELLED→recover, but only this reads neutrally. Detected by the indexed
-// `cancellationRequested`, bridged by the local `CANCEL` marker during indexing
-// lag. `!tx.failed` gates both signals: an Agent failure reads as a failure even
-// with a lingering cancel marker (and a reverted cancel — failed marker — is out
-// too; the modal owns that retry). Scoped to PENDING/CANCELLED — a cancel can
-// lose the race to the redeem, so a terminal row reads as what happened.
+// A deliberate cancel still in flight (reads neutrally) vs an Agent failure. !failed gates
+// both the indexed flag and the local CANCEL marker; scoped to PENDING/CANCELLED so a terminal row reads as what happened.
 export const isUserCancel = (tx: EarnTransaction) =>
   (tx.status === 'PENDING' || tx.status === 'CANCELLED') &&
   !tx.failed &&
   (tx.cancellationRequested === true ||
     (tx.settlement?.kind === 'CANCEL' && tx.settlement.failed !== true))
 
-// A deliberate user cancel vs a keeper/Agent-failure recovery. Nature-only (no
-// status scope), so it also answers a terminal RECOVERED row where
-// `isUserCancel` no longer applies.
+// Like isUserCancel but nature-only (no status scope), so it also answers a terminal RECOVERED row.
 export const isDeliberateCancel = (tx: EarnTransaction) =>
   tx.cancellationRequested === true && !tx.failed
 
-// Which explanatory banner (if any) a drawer should show above the settle CTA —
-// undefined unless the row is awaiting an *untouched* manual claim (FULFILLED) or
-// recover (CANCELLED). The shares/funds split follows the same delivered-token
-// inversion as `SettleCta`: a deposit claim / redeem recover act on shares; a
-// deposit recover / redeem claim act on the underlying asset (funds).
+// Banner above the settle CTA; undefined unless awaiting an untouched claim/recover.
+// shares/funds follow the same delivered-token inversion as SettleCta.
 export const pickSettleBannerKey = function (
   tx: EarnTransaction | undefined,
 ):
@@ -149,14 +103,9 @@ export const pickSettleBannerKey = function (
   | 'recover-shares'
   | undefined {
   if (!tx) return undefined
-  // A deliberate cancel reads neutrally, not as a recover failure — even while
-  // its CANCEL marker is still pending before the subgraph indexes the cancel.
-  // `isUserCancel` already drops at RECOVERED, so the terminal step (not this
-  // "returning your shares" banner) tells that story.
+  // A deliberate cancel reads neutrally, not as a recover failure (isUserCancel drops at RECOVERED).
   if (isUserCancel(tx)) return 'cancelled'
-  // A claim/recover marker means the user already engaged with that CTA
-  // (Claiming…/Try again); the banner would contradict it. A CANCEL marker isn't
-  // one, so it must not hide an Agent-failure recover banner.
+  // A claim/recover marker means the user already engaged that CTA; don't also show the banner.
   if (claimRecoverSettlement(tx.settlement)) return undefined
   const operation = needsManualClaim(tx)
     ? 'CLAIM'
@@ -171,12 +120,8 @@ export const pickSettleBannerKey = function (
   return deliversShares ? 'recover-shares' : 'recover-funds'
 }
 
-// Picks the amount + token to render for an earn transaction row. A DEPOSIT
-// always shows the deposited asset (`amountIn`, asset units) — its `amountOut`
-// is the minted share amount (sVetToken, 18 decimals) and must never be rendered
-// against the 8-decimal asset token. A REDEEM shows shares (`amountIn` +
-// shareToken) while `amountOut` is unset, then the returned asset (`amountOut` +
-// assetToken) once it's populated at fulfillment.
+// DEPOSIT renders amountIn (asset units) — never amountOut, which is 18-dec shares.
+// REDEEM renders shares until amountOut (the returned asset) lands at fulfillment.
 export const pickEarnRowAmount = (
   transaction: EarnTransaction,
   { assetToken, shareToken }: { assetToken?: Token; shareToken?: Token },
@@ -188,9 +133,7 @@ export const pickEarnRowAmount = (
       }
     : { rawAmount: transaction.amountIn, token: assetToken }
 
-// Reads the manual claim/recover settlement marker straight from the local
-// store, keyed by the request tx — for callers holding a raw (not
-// merge-enriched) subgraph row, like the live pool drawers.
+// Reads the settlement marker straight from the local store for callers holding a raw (un-enriched) subgraph row.
 export const findLocalSettlement = (
   localOperations: LocalEarnOperation[],
   requestTxHash: Hash | undefined,
@@ -202,9 +145,7 @@ export const findLocalSettlement = (
       )?.settlement
     : undefined
 
-// Folds the local settlement into a raw subgraph row before handing it to the
-// CTA — otherwise the button can't reflect the pending/reverted claim/recover
-// (it'd stay on the idle label after a revert).
+// Fold the local settlement into a raw row so the CTA can reflect a pending/reverted claim/recover.
 export const enrichWithSettlement = (
   row: EarnTransaction | undefined,
   settlement: EarnSettlement | undefined,
@@ -214,15 +155,8 @@ export const enrichWithSettlement = (
 export const isEarnRowTerminal = (tx: EarnTransaction) =>
   tx.status === 'FINALIZED' || tx.status === 'RECOVERED'
 
-// A row the table is still actively tracking — drives both the polling loop and
-// the row spinner. Out of flight: the subgraph-terminal statuses (see
-// `isEarnRowTerminal`) plus a *local* FAILED (the Hemi `request*` tx reverted —
-// it's never indexed and never transitions on its own; the user retries from
-// home). A *subgraph* FAILED is the Agent failing cross-chain, which still walks
-// to CANCELLED→RECOVERED (auto-recover or the keeper cancel), so it stays in
-// flight — otherwise the table stops polling at the transient FAILED and never
-// catches the RECOVERED. A CANCELLED request (any kind) likewise stays in
-// flight, mirroring how a FULFILLED request walks to FINALIZED.
+// Drives polling + the row spinner. Out of flight = subgraph-terminal or a local FAILED
+// (never indexed); a subgraph FAILED stays in flight so polling catches the eventual RECOVERED.
 export const isEarnRowInFlight = (tx: EarnTransaction) =>
   !isEarnRowTerminal(tx) &&
   !(tx.status === 'FAILED' && isLocalEarnTransactionRow(tx))
@@ -243,12 +177,8 @@ export const isCooldownMature = (
   remainingSec: number | undefined,
 ) => isAwaitingFinalize(tx) && remainingSec === 0
 
-// The progress ladder shared by a withdraw's terminal step — the receive step on
-// the claim path, the recover step on the cancel path — across both the live and
-// historical drawers. Same precedence in every case: done → COMPLETED; a reverted
-// settlement → FAILED; a mining one → PROGRESS; an untouched manual settlement →
-// READY (the user must sign, nothing is spinning yet); otherwise the caller's
-// in-flight `fallback` (cooldown-derived for receive, PROGRESS for recover).
+// Shared terminal-step ladder for both drawers' receive (claim) and recover steps;
+// untouched manual settlements resolve to READY (nothing spinning yet), else the caller's fallback.
 export const resolveSettleStepStatus = function ({
   awaitingAction,
   fallback,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/assetSelector.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/assetSelector.tsx
@@ -15,10 +15,7 @@ type Props = {
   pool: EarnPool
 }
 
-// Selects which deposit asset (e.g. USDC vs USDT) the user wants to send into
-// the share vault. Local state only — the route stays on the share, no
-// navigation. When a pool only has one asset (degenerate case), the chip is
-// read-only.
+// Local state only — picking a deposit asset doesn't navigate; a single-asset pool renders read-only.
 export const AssetSelector = function ({ disabled, pool }: Props) {
   const { selectedAsset, setSelectedAsset } = usePoolForm()
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionChart.tsx
@@ -6,13 +6,11 @@ import { VictoryPie } from 'victory'
 
 import { type CompositionItemWithColor } from './compositionColumns'
 
-// Constants for the composition chart
 const chartSize = 216
 const innerRadius = 78
 const padAngle = 3
 const cornerRadius = 4
 
-// Lighter versions of the composition colors for the default (no hover) state
 const defaultOpacity = 0.3
 const activeOpacity = 1
 

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/index.tsx
@@ -16,7 +16,7 @@ import { SegmentedControlItem } from '../segmentedControlItem'
 import { CompositionChart } from './compositionChart'
 import { CompositionTable } from './compositionTable'
 
-// Orange palette (dark to light); items beyond the palette wrap around
+// Orange palette; colors cycle for items beyond the 8.
 const compositionColors = [
   '#CC2F02', // orange-700
   '#FF4600', // orange-600

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -82,17 +82,12 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
     token: selectedAsset.token,
   })
 
-  // Fail safe: when the eligibility read on Ethereum is in-flight or errors,
-  // assume the cooldown applies so the warning shows. Silently hiding it
-  // would let the user sign a deposit thinking instant withdraw is available.
+  // Fail-safe: assume the cooldown applies while eligibility loads/errors, so we don't imply an instant withdraw.
   const { data: isCooldownEligible = true } = useIsCooldownEligible({
     account: address,
     stakingVault: pool.stakingVault,
   })
 
-  // Single composed query owns shares preview, quote, and allowance reads.
-  // `deposit.tsx` only consumes the derived outputs here — no separate
-  // subscriptions for those upstream queries.
   const {
     approvalGasFees,
     canDeposit,
@@ -124,10 +119,7 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
     callbackFee: quote?.callbackFee ?? BigInt(0),
     input,
     on(emitter) {
-      // Open the pool drawer as soon as the user signs anything — wired
-      // here (rather than inside `useDeposit`) so the hook stays reusable
-      // outside the pool page (the home retry calls it without a drawer
-      // to open).
+      // Open the drawer on first signature — wired here, not in useDeposit, so the hook stays reusable off the pool page (home retry has no drawer).
       emitter.on('user-signed-approval', () =>
         setDrawerQueryString('depositing'),
       )

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
@@ -28,9 +28,8 @@ import {
 
 const getChartPadding = (metricType: MetricType) => ({
   bottom: 24,
-  // APY labels are short ("4%"), but deposits labels carry the token symbol
-  // ("400M vetBTC") and locales like es/pt add a space in compact notation
-  // ("400 M" instead of the en "400M"), so we reserve extra room for them.
+  // deposits labels carry the token symbol (and es/pt add a space in compact
+  // notation), so reserve more left room than the short APY "4%".
   left: metricType === 'apy' ? 28 : 80,
   right: 0,
   top: 4,
@@ -86,10 +85,7 @@ const formatShortTimestamp = (timestampMs: number, locale: string) =>
 const formatFullTimestamp = (timestampMs: number, locale: string) =>
   formatDate(new Date(timestampMs), locale, 'UTC')
 
-// 'compact' is meant for the axis ticks, where APY is rendered as a rounded
-// integer ("4%") to keep the axis readable. 'full' keeps the full precision
-// via formatPercentage ("4.53%") and is used in the tooltip, where the user
-// is explicitly asking for detail.
+// compact = rounded axis ticks ("4%"); full = precise tooltip value ("4.53%").
 type FormatPrecision = 'compact' | 'full'
 
 const formatYAxis = function ({
@@ -160,14 +156,8 @@ function ChartTooltipLabel({
 
 const chartHeight = 130
 
-// Victory renders the chart as an SVG with a viewBox, and the SVG scales to
-// fill its container width. This means the chosen width defines the baseline
-// coordinate system used by the labels — a smaller viewBox width makes the
-// labels appear larger on screen (they get scaled up), and a larger viewBox
-// width makes them smaller. We pick different widths per breakpoint so the
-// axis tick labels end up roughly the same visual size on every layout.
-// Entries are checked from largest to smallest breakpoint and the first
-// match wins; the fallback is used below the smallest breakpoint.
+// The SVG scales to fill its container, so a smaller viewBox width makes labels appear
+// larger. Pick widths per breakpoint (largest first) so tick labels stay a consistent visual size.
 const chartWidthByBreakpoint: ReadonlyArray<[number, number]> = [
   [screenBreakpoints.xl, 680],
   [screenBreakpoints.lg, 520],

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/index.tsx
@@ -69,7 +69,6 @@ export const HistoricalMetrics = function ({
           <h2 className="shrink-0 text-2xl font-semibold leading-8 -tracking-[0.48px] text-neutral-950">
             {renderHeadline()}
           </h2>
-          {/* Desktop: period + metric type toggles inline */}
           <div className="hidden items-center gap-3 lg:flex">
             <div className="flex items-center gap-2">
               <SegmentedControlItem
@@ -113,7 +112,6 @@ export const HistoricalMetrics = function ({
               </SegmentedControlItem>
             </div>
           </div>
-          {/* Mobile: only metric type toggle inline */}
           <div className="flex items-center gap-2 lg:hidden">
             <SegmentedControlItem
               onClick={() => setMetricType('deposits')}
@@ -139,7 +137,6 @@ export const HistoricalMetrics = function ({
             period={period}
           />
         </div>
-        {/* Mobile: period buttons below chart */}
         <div className="mt-6 flex items-center gap-2 lg:hidden">
           <SegmentedControlItem
             className="flex-1"

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolPageContent.tsx
@@ -38,12 +38,8 @@ export const PoolPageContent = function ({ shareAddress }: Props) {
     function redirectOnNetworkChange() {
       if (networkTypeRef.current === networkType) return
       networkTypeRef.current = networkType
-      // nuqs defers its URL flush via setTimeout(~50ms). Calling router.push
-      // here fires immediately but nuqs's flush overwrites it 50ms later with
-      // the pool URL + ?networkType. Instead, we pre-set location.pathname to
-      // /hemi-earn via history.pushState *before* nuqs flushes. nuqs then reads
-      // the updated pathname and applies ?networkType to the earn page URL,
-      // and its own router.replace finishes the navigation — no hard reload needed.
+      // nuqs defers its URL flush ~50ms, so a router.push here would be overwritten. Pre-set
+      // location.pathname to /hemi-earn via pushState first; nuqs then applies ?networkType to the earn URL.
       history.pushState(null, '', `/${locale}/hemi-earn`)
     },
     [locale, networkType],

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction.ts
@@ -20,20 +20,14 @@ export type CooldownInputs = {
   unstakeMined: boolean
 }
 
-// Statuses on the recover branch — the cooldown milestone doesn't apply there.
 const RECOVER_PATH_STATUSES = new Set<string | undefined>([
   'CANCELLED',
   'RECOVERED',
 ])
 
-// Decides what (if anything) to render under the Unstake step as a clock
-// sub-step. Pure function so the component's complexity stays low.
-//
-// Mirrors the tunnel's wait-step pattern (e.g. `reviewEvmWithdrawal`):
-// the sub-step stays mounted across its whole lifecycle (NOT_READY →
-// PROGRESS → COMPLETED) so the user keeps a visible milestone even
-// after the wait period elapses. The only case we hide it entirely is
-// when the user simply doesn't have a cooldown (whitelist / disabled).
+// The cooldown clock sub-step under Unstake. Like the tunnel's wait-step, it stays mounted
+// across its whole lifecycle so the milestone stays visible after the wait elapses; hidden only
+// when there's no cooldown (whitelist / disabled).
 export function deriveCooldownPostAction({
   cooldownDurationSec,
   cooldownRemainingSec,
@@ -43,24 +37,13 @@ export function deriveCooldownPostAction({
   unstakeMined,
 }: CooldownInputs): CooldownPostAction | undefined {
   if (isCooldownEligible === false) return undefined
-  // Recover path (CANCELLED/RECOVERED): the cooldown was aborted/bypassed and the
-  // shares come straight back, so there's no cooldown milestone to show — the
-  // recover terminal step carries the state instead.
+  // Recover path: cooldown was bypassed, shares come straight back — no milestone here (the recover step carries the state).
   if (RECOVER_PATH_STATUSES.has(subgraphStatus)) {
     return undefined
   }
-  // The cooldown is effectively over once any of:
-  //   - the local timer elapsed
-  //   - the subgraph row reached FULFILLED (the Agent only fulfills a redeem
-  //     after the cooldown matured and `claimUnstake` ran, so a FULFILLED row
-  //     awaiting a manual claim implies the cooldown is done — the status is
-  //     authoritative over a stale `claimableAt`)
-  //   - the subgraph row reached FINALIZED (auto-claim fired the moment
-  //     the cooldown matured)
-  // Keep the sub-step visible as a COMPLETED milestone — without this,
-  // an auto-claim landing seconds after the timer hits zero would make
-  // the sub-step disappear right when the user expects to see it tick
-  // over to "done".
+  // Cooldown is over once the timer elapses or the row reaches FULFILLED/FINALIZED (both imply
+  // it matured — authoritative over a stale claimableAt). Keep it as a COMPLETED milestone so an
+  // auto-claim landing right after zero doesn't make the sub-step vanish.
   const cooldownOver =
     cooldownRemainingSec === 0 ||
     subgraphStatus === 'FULFILLED' ||
@@ -71,8 +54,6 @@ export function deriveCooldownPostAction({
       status: ProgressStatus.COMPLETED,
     }
   }
-  // Duration still loading — render nothing for now; the postAction
-  // shows up once the on-chain read settles.
   if (cooldownDurationSec === undefined) return undefined
 
   const days = secondsToWholeDays(cooldownDurationSec)
@@ -91,10 +72,7 @@ export function deriveCooldownPostAction({
     }
   }
 
-  // Sub-hour remaining: avoid the misleading "0h" by collapsing to a
-  // generic "less than an hour" copy. Tick interval is at minute
-  // resolution, so showing a precise minute countdown would lie about
-  // freshness; the shorter copy is honest about where we are.
+  // Under an hour: show "less than an hour" — a precise countdown would lie given the minute-resolution tick.
   if (cooldownRemainingSec < 3600) {
     return {
       description: t('wait-cooldown-countdown-soon'),

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/retryDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/retryDeposit.tsx
@@ -80,9 +80,7 @@ export const RetryDeposit = function () {
     priorApprovalTxHash: depositOperation?.approvalTxHash,
     selectedAsset,
     sharesOutMin,
-    // Hide the specific failed row from the table when the user commits to
-    // this retry. `depositOperation.transactionHash` is the failed deposit's
-    // hash (set on `user-signed-deposit` and not cleared by the revert).
+    // Hide the specific failed row once this retry is signed (transactionHash is the failed deposit's hash).
     supersedesInitiateTxHash: depositOperation?.transactionHash,
     updateDepositOperation,
   })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/retryWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/retryWithdraw.tsx
@@ -28,8 +28,7 @@ export const RetryWithdraw = function () {
   } = usePoolForm()
 
   const t = useTranslations()
-  // Input is in share-token units (svetBTC); the Router burns shares
-  // directly. `assetsOutMin` is derived from the asset preview below.
+  // Input is in share units — the Router burns shares directly; assetsOutMin comes from the asset preview below.
   const shares = parseTokenUnits(input, pool.shareToken)
 
   const {
@@ -82,9 +81,7 @@ export const RetryWithdraw = function () {
     priorApprovalTxHash: withdrawOperation?.approvalTxHash,
     selectedAsset,
     shares,
-    // Hide the specific failed row from the table when the user commits to
-    // this retry. `withdrawOperation.transactionHash` is the failed redeem's
-    // hash (set on `user-signed-withdraw` and not cleared by the revert).
+    // Hide the specific failed row once this retry is signed (transactionHash is the failed redeem's hash).
     supersedesInitiateTxHash: withdrawOperation?.transactionHash,
     updateWithdrawOperation,
   })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -51,9 +51,6 @@ type Props = {
   onClose: VoidFunction
 }
 
-// COMPLETED wins; a remote failure or reverted settlement → FAILED; a mining tx
-// → PROGRESS; a pending manual action → READY; else PROGRESS (recover/auto or
-// confirmed) or NOT_READY.
 function resolveGetSharesStatus({
   awaitingUserAction,
   hasSettlementTx,
@@ -83,8 +80,7 @@ function getSharesStepMeta(
   subgraphRow: EarnTransaction | undefined,
   marker: { failed: boolean; txHash?: Hash } | undefined,
 ) {
-  // A failed marker leaves the natural status (so a Retry shows); only a
-  // still-mining one drives PROGRESS.
+  // A failed marker keeps the natural status (Retry shows); only a still-mining one drives PROGRESS.
   const settlementTxHash = marker && !marker.failed ? marker.txHash : undefined
   const settlementFailed = marker?.failed ?? false
   if (!subgraphRow) {
@@ -104,8 +100,7 @@ function getSharesStepMeta(
     isComplete: isRecover
       ? subgraphRow.status === 'RECOVERED'
       : subgraphRow.status === 'FINALIZED',
-    // Remote (Gateway/Agent) failure: the subgraph derives `failed → FAILED`
-    // while the Router stays PENDING. Reflect it instead of spinning forever.
+    // Remote (Agent) failure: subgraph marks FAILED while the Router stays PENDING — reflect it instead of spinning forever.
     isFailed: subgraphRow.status === 'FAILED',
     isRecover,
     settlementFailed,
@@ -113,8 +108,6 @@ function getSharesStepMeta(
   }
 }
 
-// Drawer opens after the user signs the first wallet prompt (approval if
-// needed, otherwise the deposit).
 export const ReviewDeposit = function ({ onClose }: Props) {
   const { depositOperation, input, pool, selectedAsset } = usePoolForm()
   const { localOperations } = useLocalEarnOperations()
@@ -123,8 +116,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
   const chain = useChain(chainId)
   const { address } = useAccount()
 
-  // Shared subscription with the layout-mounted watcher; lets the new
-  // get-share-tokens step flip to COMPLETED off the subgraph status.
+  // Shared subscription with the layout watcher; lets the get-share-tokens step sync to the subgraph status.
   const { data: subgraphRows = [] } = useEarnTransactionsQuery()
   const subgraphRow = subgraphRows.find(
     r =>
@@ -269,10 +261,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       DepositStatus.DEPOSIT_TX_FAILED,
     ].includes(depositStatus)
 
-    // Roll the LayerZero fee into the deposit step's gas line. Splitting it
-    // into its own step would imply a separate signature/transaction, which
-    // isn't the case — `msg.value = nativeFee` is paid as part of the same
-    // `requestDeposit` tx.
+    // Roll the LayerZero fee into the deposit gas line — it's msg.value on the same requestDeposit tx, not a separate signature.
     const depositLineTotal = depositGasFees + layerZeroFee
 
     const status = statusMap[depositStatus] ?? ProgressStatus.NOT_READY
@@ -309,9 +298,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
     const deliveryHash = settlementTxHash ?? terminalHash
 
     return {
-      // Recover path → the asset comes back, labeled with the asset token.
-      // "Funds returned" only once RECOVERED; while still awaiting it reads as
-      // the pending "Funds to recover".
+      // Recover path returns the asset (labeled with the asset token); "Funds returned" only at RECOVERED.
       description: isRecover ? (
         <div className="flex items-center gap-x-2">
           <TokenLogo size="small" token={selectedAsset.token} />
@@ -347,8 +334,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
     ) {
       return <RetryDeposit />
     }
-    // Auto-claim off: the user signs the claim here once the Agent has
-    // delivered the shares back to the Router (FULFILLED).
+    // Auto-claim off: the user signs the claim once the Agent delivers shares back (FULFILLED).
     if (settledRow && needsManualClaim(settledRow)) {
       return (
         <SettleCta
@@ -359,8 +345,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
         />
       )
     }
-    // The request was cancelled and the original asset is back on the Router;
-    // the user signs the recover to pull it to their wallet.
+    // Cancelled: the original asset is back on the Router; the user signs recover to pull it to their wallet.
     if (settledRow && needsRecover(settledRow)) {
       return (
         <SettleCta
@@ -371,10 +356,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
         />
       )
     }
-    // Shares only land in the user's wallet once cross-chain delivery
-    // completes (subgraph FINALIZED). Showing the "Add token" CTA before
-    // that points the wallet at a token with no balance and confuses
-    // wallets that gate metadata reads on a non-zero balance.
+    // Only offer "Add token" at FINALIZED — earlier the wallet has no balance, and some wallets gate metadata reads on a non-zero balance.
     if (subgraphRow?.status === 'FINALIZED') {
       return <AddTokenToWalletCta token={pool.shareToken} />
     }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -68,9 +68,6 @@ type Props = {
   onClose: VoidFunction
 }
 
-// Adapts the receive step's local state to the shared `resolveSettleStepStatus`
-// ladder. A thin wrapper (not inlined) so `buildReceiveStep` stays under the
-// complexity threshold.
 const resolveReceiveStatus = ({
   awaitingClaim,
   crossChainInFlight,
@@ -126,9 +123,6 @@ function resolveReceiveProgress({
   })
 }
 
-// Maps the settlement-enriched row, local withdraw status, and cooldown state to
-// the receive step's progress + terminal hash. Module-level so the component
-// stays under the complexity threshold.
 function buildReceiveStep({
   chainId,
   cooldownRemainingSec,
@@ -146,18 +140,15 @@ function buildReceiveStep({
   t: ReturnType<typeof useTranslations<'hemi-earn.pool.drawer'>>
   withdrawStatus: WithdrawStatusType
 }): StepPropsWithoutPosition {
-  // Only FINALIZED actually delivers the underlying asset (the recover path —
-  // RECOVERED — returns shares instead and is rendered by `addRecoverStep`).
+  // Only FINALIZED delivers the asset; RECOVERED returns shares (rendered by addRecoverStep).
   const isFinalized = row?.status === 'FINALIZED'
   const claimTxHash = isFinalized ? (row?.claimTxHash ?? undefined) : undefined
-  // A reverted CANCEL marker must not fail this step — strip it (the receive
-  // step only tracks claim/recover settlements).
+  // Strip a CANCEL marker so it can't fail this step (receive only tracks claim/recover).
   const settlement = claimRecoverSettlement(row?.settlement)
   const settlementTxHash =
     settlement && !settlement.failed ? settlement.txHash : undefined
   const unstakeMined = withdrawStatus === WithdrawStatus.WITHDRAW_TX_CONFIRMED
-  // `needsCooldown` defaults to true while `useIsCooldownEligible` loads (the
-  // common case); `cooldownElapsed` asks whether the timer has finished.
+  // Default to cooldown while eligibility loads; cooldownElapsed checks whether the timer finished.
   const needsCooldown = isCooldownEligible !== false
   const cooldownElapsed = cooldownRemainingSec === 0
   const deliveryHash = settlementTxHash ?? claimTxHash
@@ -187,8 +178,7 @@ const FAILED_STATUSES: WithdrawStatusType[] = [
   WithdrawStatus.WITHDRAW_TX_FAILED,
 ]
 
-// Adapts the recover step's local state to the shared ladder, mirroring
-// `resolveReceiveStatus`; auto-recover (no manual action) rests at PROGRESS.
+// Recover-step adapter to the shared ladder; auto-recover (no manual action) rests at PROGRESS.
 const resolveRecoverStepStatus = ({
   isComplete,
   needsRecoverAction,
@@ -208,8 +198,6 @@ const resolveRecoverStepStatus = ({
     settlementTxHash,
   })
 
-// Builds the `data:` argument for `useEstimateGas`. Module-level so the
-// component doesn't pay the branching tax for this conditional encode.
 function encodeRedeemForGasEstimate({
   account,
   assetAddress,
@@ -237,8 +225,6 @@ function encodeRedeemForGasEstimate({
   })
 }
 
-// Drawer opens after the user signs the first wallet prompt (approval if
-// needed, otherwise the redeem).
 export const ReviewWithdraw = function ({ onClose }: Props) {
   const { input, pool, selectedAsset, withdrawOperation } = usePoolForm()
   const t = useTranslations('hemi-earn.pool.drawer')
@@ -246,8 +232,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
   const chain = useChain(chainId)
   const { address } = useAccount()
 
-  // Shared subscription with the layout-mounted watcher; lets the new
-  // receive step flip to COMPLETED off the subgraph status.
+  // Shared subscription with the layout watcher; lets the receive step sync to the subgraph status.
   const { data: subgraphRows = [] } = useEarnTransactionsQuery()
   const subgraphRow = subgraphRows.find(
     r =>
@@ -261,17 +246,14 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
     subgraphRow?.requestTxHash,
   )
   const settledRow = enrichWithSettlement(subgraphRow, settlement)
-  // A deliberate cancel still PENDING reads as the recover it's becoming: drop
-  // the moot cooldown countdown and render the recover (not receive) step.
+  // A still-PENDING deliberate cancel reads as the recover it's becoming: drop the countdown, render the recover step.
   const cancelling = !!settledRow && isUserCancel(settledRow)
 
   const { data: isCooldownEligible } = useIsCooldownEligible({
     account: address,
     stakingVault: pool.stakingVault,
   })
-  // Pool-level cooldown duration drives the static "Wait for the N-day
-  // cooldown period" copy while we don't yet have a request to query
-  // (pre-sign / pre-indexed).
+  // Pool-level cooldown duration drives the static "wait N days" copy before there's a request to query.
   const { data: cooldownDurationSec } = useCooldownDuration({
     stakingVault: pool.stakingVault,
   })
@@ -284,8 +266,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
   const withdrawStatus =
     withdrawOperation?.status ?? WithdrawStatus.APPROVAL_TX_COMPLETED
 
-  // Input is in share-token units (svetBTC); the Router burns shares
-  // directly. `assetsOutMin` is derived from the asset preview below.
+  // Input is in share units — the Router burns shares directly; assetsOutMin comes from the asset preview below.
   const shares = parseTokenUnits(input, pool.shareToken)
   const routerAddress = getHemiEarnRouterAddress()
 
@@ -418,9 +399,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
       WithdrawStatus.WITHDRAW_TX_FAILED,
     ].includes(withdrawStatus)
 
-    // Mirror the deposit review: the LayerZero fee is paid as msg.value on the
-    // same `requestRedeem` tx, so we sum it into the withdraw line rather than
-    // showing a fictitious separate transaction.
+    // LayerZero fee is msg.value on the same requestRedeem tx, so fold it into the withdraw line (mirrors the deposit review).
     const withdrawLineTotal = withdrawGasFees + layerZeroFee
 
     return {
@@ -485,8 +464,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
     if (settledRow && isAwaitingFinalize(settledRow)) {
       return <ClaimFromVaultCta transaction={settledRow} />
     }
-    // Auto-claim off: the user signs the claim here once the Agent delivers the
-    // asset back to the Router (FULFILLED).
+    // Auto-claim off: the user signs the claim once the Agent delivers the asset back (FULFILLED).
     if (settledRow && needsManualClaim(settledRow)) {
       return (
         <SettleCta
@@ -497,8 +475,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
         />
       )
     }
-    // The redeem was cancelled and the shares are back on the Router; the user
-    // signs the recover to pull them to their wallet.
+    // Cancelled: the shares are back on the Router; the user signs recover to pull them to their wallet.
     if (settledRow && needsRecover(settledRow)) {
       return (
         <SettleCta

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/withdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/withdraw.tsx
@@ -169,9 +169,7 @@ export const Withdraw = function ({
     shareToken: pool.shareToken,
   })
 
-  // Fail safe: when the eligibility read on Ethereum is in-flight or errors,
-  // assume the cooldown applies so the warning shows. Silently hiding it
-  // would let the user start a withdraw thinking the funds land instantly.
+  // Fail-safe: assume the cooldown applies while eligibility loads/errors, so we don't imply an instant withdraw.
   const { data: isCooldownEligible = true } = useIsCooldownEligible({
     account: address,
     stakingVault: pool.stakingVault,
@@ -277,9 +275,7 @@ export const Withdraw = function ({
             disabled={isRunningOperation}
             errorKey={sharesErrorKey}
             fiatBalance={{
-              // When `shares` is 0n the preview query stays disabled and
-              // `peggedAmountRaw` is `undefined` — force 0n here so the fiat
-              // row reads "$0" for an empty input instead of a stuck skeleton.
+              // shares 0n keeps the preview disabled (peggedAmountRaw undefined) — force 0n so the fiat row reads "$0", not a stuck skeleton.
               balance: shares > BigInt(0) ? peggedAmountRaw : BigInt(0),
               token: pool.peggedToken,
             }}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_context/poolFormContext.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_context/poolFormContext.tsx
@@ -36,7 +36,6 @@ export function PoolFormProvider({
     () => pool.assets[0].address,
   )
 
-  // When the pool changes (route swap), reset the selection to the first asset.
   useEffect(
     function resetSelectionOnPoolChange() {
       setSelectedAssetAddress(pool.assets[0].address)

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchDepositPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchDepositPreview.ts
@@ -33,10 +33,7 @@ const getDepositPreviewQueryKey = ({
     amount.toString(),
   ] as const
 
-// Mirror of `withdrawPreviewOptions` on the deposit side. Composes
-// quote-deposit + deposit-shares via `ensureQueryData`. Allowance lives
-// in `useNeedsApproval` at the hook layer so an allowance error is
-// surfaced independently from a quote/shares error.
+// Composes quote + deposit-shares. Allowance stays in useNeedsApproval so its error surfaces independently.
 export const depositPreviewOptions = ({
   account,
   amount,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchDepositShares.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchDepositShares.ts
@@ -14,10 +14,7 @@ export type DepositSharesParams = {
   shareAddress: Address
 }
 
-// `fetchQuery` (not `ensureQueryData`) so a stale cached `peggedAmount`
-// can't slip into `sharesOutMin` — gateway drift between mounts would
-// otherwise produce a `requestDeposit` whose min is derived from an
-// older quote than the one the user sees in the form.
+// fetchQuery (not ensureQueryData) so a stale cached peggedAmount can't slip into sharesOutMin from an older quote.
 export async function fetchDepositShares(
   queryClient: QueryClient,
   { amount, asset, shareAddress }: DepositSharesParams,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteDeposit.ts
@@ -28,10 +28,7 @@ export type QuoteDepositParams = {
   shareAddress: Address
 }
 
-// Plain async fetcher — react-query agnostic, so it can be called from any
-// chained queryFn (via `queryClient.ensureQueryData(quoteDepositOptions(...))`),
-// from server-side scripts, or unit-tested directly without mocking the
-// react-query observer.
+// Plain async (react-query agnostic) so it's callable from chained queryFns, server scripts, or unit tests.
 export async function fetchQuoteDeposit({
   amount,
   asset,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchQuoteRedeem.ts
@@ -28,10 +28,8 @@ export type QuoteRedeemParams = {
   shares: bigint
 }
 
-// Mirror of `fetchQuoteDeposit`: resolves the redeem path (instant vs
-// cooldown) on Ethereum, then `Agent.quoteRedeemFulfillment` on Ethereum,
-// then `Router.quoteRedeem` on Hemi with the resolved `isInstant`. Plain
-// async so it stays callable outside of react-query.
+// Resolves isInstant (Ethereum) → quoteRedeemFulfillment (Ethereum) → quoteRedeem (Hemi).
+// Plain async so it stays callable outside react-query.
 export async function fetchQuoteRedeem({
   account,
   asset,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchSharesToAssets.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchSharesToAssets.ts
@@ -20,18 +20,10 @@ export type SharesToAssetsParams = {
   shares: bigint
 }
 
-// Converts a share amount to the asset units the user will receive on
-// redeem. Composes the share→pegged query (`fetchSharesToPegged`,
-// asset-agnostic) with the asset-specific gateway leg (`previewRedeem`),
-// so switching the withdraw asset dropdown only re-runs the gateway step.
-// `peggedAmount` is exposed because the redeem burns this many vault
-// assets, letting `useWithdraw` optimistically subtract it from
-// `totalAssets()` in the right unit.
-// `fetchQuery` (not `ensureQueryData`) on the shares→pegged leg so a
-// stale cached `peggedAmount` can't slip into `assetsOutMin` — vault
-// price drift between mounts would otherwise produce a `requestRedeem`
-// whose min is derived from an older `convertToAssets` than the one the
-// user sees in the form. Mirrors `fetchDepositShares`.
+// share→asset for redeem. Composes the asset-agnostic share→pegged leg with the gateway
+// previewRedeem, so switching the asset only re-runs the gateway step. peggedAmount is exposed
+// so useWithdraw can optimistically debit totalAssets(). fetchQuery (not ensureQueryData) on the
+// share→pegged leg keeps a stale peggedAmount out of assetsOutMin.
 export async function fetchSharesToAssets({
   assetAddress,
   queryClient,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchSharesToAssets.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchSharesToAssets.ts
@@ -22,7 +22,7 @@ export type SharesToAssetsParams = {
 
 // share→asset for redeem. Composes the asset-agnostic share→pegged leg with the gateway
 // previewRedeem, so switching the asset only re-runs the gateway step. peggedAmount is exposed
-// so useWithdraw can optimistically debit totalAssets(). fetchQuery (not ensureQueryData) on the
+// so useWithdraw can optimistically debit the user's share value. fetchQuery (not ensureQueryData) on the
 // share→pegged leg keeps a stale peggedAmount out of assetsOutMin.
 export async function fetchSharesToAssets({
   assetAddress,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchUserShareValue.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchUserShareValue.ts
@@ -17,10 +17,7 @@ export type UserShareValueParams = {
   shareAddress: Address
 }
 
-// Reads the user's share OFT balance on Hemi and converts it to vault
-// pegged-token units via `sharesToPeggedOptions`. Independent of the
-// withdraw asset selection; `peggedAmount` follows `pricePerShare`, so
-// accumulated yield is reflected naturally in the fiat preview.
+// Share balance → pegged units; peggedAmount tracks pricePerShare, so accrued yield shows in the fiat preview.
 export async function fetchUserShareValue({
   account,
   queryClient,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchWithdrawPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_fetchers/fetchWithdrawPreview.ts
@@ -33,14 +33,8 @@ const getWithdrawPreviewQueryKey = ({
     shares.toString(),
   ] as const
 
-// Composes the two preview reads the withdraw form needs (shares → asset
-// preview + redeem quote) into a single query so the call site only deals
-// with one subscription. Allowance/needsApproval are intentionally NOT in
-// this composition — they live in `useNeedsApproval` so the form can
-// surface a real allowance failure independently from a preview/quote
-// failure. Freshness of the on-chain slippage min (`assetsOutMin`) is
-// guaranteed inside `fetchSharesToAssets`, which uses `fetchQuery` on the
-// shares→pegged sub-leg so a stale cached `peggedAmount` cannot slip in.
+// Composes sharesToAssets + redeem quote into one subscription. Allowance stays in useNeedsApproval
+// so its error surfaces independently; assetsOutMin freshness is handled by fetchSharesToAssets' fetchQuery.
 export const withdrawPreviewOptions = ({
   account,
   asset,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useComposition.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useComposition.ts
@@ -34,8 +34,7 @@ type CompositionQueryOptions = {
   shareAddress: Address
 }
 
-// The cached data is grouping-agnostic, so both view modes share one entry —
-// `viewMode` only drives the `select` below and is kept out of the query key.
+// Cache is grouping-agnostic; viewMode only drives the select below, so it's out of the query key.
 const compositionQueryOptions = ({
   chainId,
   queryClient,
@@ -71,9 +70,7 @@ export const useComposition = function ({
       queryClient,
       shareAddress,
     }),
-    // The cached data is locale-free and ungrouped — the translated
-    // reserve-buffer label, the per-mode grouping and the derived share
-    // percentages are applied at render time.
+    // Cache is locale-free and ungrouped; translation + grouping + share % happen here at render time.
     select: (data: CompositionData): CompositionItem[] =>
       toCompositionItems({
         data,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDeposit.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDeposit.ts
@@ -27,20 +27,13 @@ type UseDeposit = {
   input: string
   on?: (emitter: EventEmitter<RequestDepositEvents>) => void
   pool: EarnPool
-  // Set by retry callers when the prior attempt had a successful approval
-  // (allowance is still on-chain, so `requestDeposit` won't emit
-  // `user-signed-approval` again). Carried forward into the new local-store
-  // entry so the historical drawer keeps surfacing the approval step.
+  // Retry callers pass the prior approval hash (allowance still on-chain, so no new
+  // user-signed-approval); carried into the new entry so the drawer keeps the approval step.
   priorApprovalTxHash?: Hash
   selectedAsset: EarnAsset
-  // Slippage-protected minimum shares the caller expects to receive on
-  // fulfillment. Enforced on the remote chain when the Agent stakes into
-  // the vault.
   sharesOutMin: bigint
-  // Set by retry callers: the `initiateTxHash` of the specific prior FAILED
-  // attempt being replaced. Once the new deposit is signed, that entry is
-  // flagged `settled` so the table doesn't show the old failure alongside
-  // the new attempt. Only the exact hash is touched — no broader filtering.
+  // Retry callers pass the FAILED attempt's initiateTxHash; once the new deposit is signed,
+  // that exact entry is flagged settled so the old failure doesn't show beside the new attempt.
   supersedesInitiateTxHash?: Hash
   updateDepositOperation?: (payload?: DepositOperation) => void
 }
@@ -64,8 +57,6 @@ export const useDeposit = function ({
   const config = useConfig()
   const ensureConnectedTo = useEnsureConnectedTo()
   const queryClient = useQueryClient()
-  // Requires <LocalEarnOperationsProvider> upstream (mounted in the
-  // hemi-earn layout). Hook throws at runtime if used outside it.
   const { markSettledByInitiateTxHash, upsertLocalOperation } =
     useLocalEarnOperations()
 
@@ -97,13 +88,8 @@ export const useDeposit = function ({
 
       const walletClient = await getWalletClient(config, { chainId })
 
-      // Local-store entries are created at two points:
-      //   1. `user-signed-approval` — captures `approvalTxHash` so the
-      //      historical drawer can later render the approval step (the
-      //      indexer has no way to link an approval tx to a request).
-      //   2. `user-signed-deposit` — adds `initiateTxHash`, which is the
-      //      key the merge in `useEarnTransactions` uses to dedupe against
-      //      the subgraph row.
+      // Local entries are created at two points: user-signed-approval (captures approvalTxHash,
+      // which the indexer can't link) and user-signed-deposit (adds initiateTxHash, the merge dedupe key).
       const startedAt = Number(unixNowTimestamp())
       const baseLocalPayload = {
         account: address,
@@ -116,11 +102,7 @@ export const useDeposit = function ({
         startedAt,
       }
 
-      // Tracks the approval hash for this specific attempt. Seeded from
-      // `priorApprovalTxHash` so retries (where allowance is still on-chain
-      // and `user-signed-approval` won't fire) keep showing the original
-      // approval step in the historical drawer. Overwritten when a fresh
-      // approval is signed in this attempt.
+      // Approval hash for this attempt; seeded from priorApprovalTxHash for retries, overwritten if a fresh approval is signed.
       let observedApprovalTxHash: Hash | undefined = priorApprovalTxHash
 
       const { emitter, promise } = requestDeposit({
@@ -143,9 +125,7 @@ export const useDeposit = function ({
           status: DepositStatus.APPROVAL_TX_PENDING,
           transactionHash: undefined,
         })
-        // Persist the approval hash to the local store so the historical
-        // drawer can later surface the approval step even on a different
-        // route — the indexer never sees this association.
+        // Persist so the drawer can show the approval step across routes (the indexer never links it).
         upsertLocalOperation({
           ...baseLocalPayload,
           approvalTxHash,
@@ -191,9 +171,7 @@ export const useDeposit = function ({
             transactionHash,
           },
         })
-        // Hide the specific prior FAILED entry the user is replacing.
-        // Done here (and not on retry click) so the row only disappears
-        // once the user actually commits to the new attempt by signing.
+        // Hide the prior FAILED entry — here, not on retry click, so it only disappears once the user actually signs.
         if (supersedesInitiateTxHash) {
           markSettledByInitiateTxHash(supersedesInitiateTxHash)
         }
@@ -210,11 +188,8 @@ export const useDeposit = function ({
         })
         updateNativeBalanceAfterFees(receipt)
 
-        // Decrement wallet ERC-20 immediately — Router pulled the tokens in
-        // this same tx. Pool TVL and user position aren't touched here: those
-        // only move after the cross-chain delivery (1–3 min). The CLAIMED /
-        // RECOVERED reconcile in `useEarnTransactions` invalidates them when
-        // the subgraph reports the terminal state.
+        // Decrement the wallet balance now — the Router pulled tokens in this tx. Pool TVL/position
+        // wait for the cross-chain delivery (reconciled by useEarnTransactions at the terminal status).
         queryClient.setQueryData<bigint>(tokenBalanceQueryKey, old =>
           old === undefined ? old : maxBigInt(old - amount, BigInt(0)),
         )
@@ -236,8 +211,7 @@ export const useDeposit = function ({
         updateDepositOperation?.({
           status: DepositStatus.DEPOSIT_TX_FAILED,
         })
-        // No local upsert — no `initiateTxHash` was produced, so this never
-        // had a table row to update.
+        // No initiateTxHash was produced, so there's no row to upsert.
       })
 
       emitter.on('deposit-failed-validation', function () {
@@ -273,11 +247,8 @@ export const useDeposit = function ({
       return promise
     },
     onSettled() {
-      // Only invalidate queries that reflect Hemi-side state right now. The
-      // Vetro-side queries (pool TVL, user pool balance, staked-balance card)
-      // are invalidated by `useEarnTransactions` when the subgraph reports
-      // CLAIMED / RECOVERED, since cross-chain delivery hasn't happened yet
-      // at this point in the mutation lifecycle.
+      // Only invalidate Hemi-side state here; the Vetro-side queries move later, when
+      // useEarnTransactions sees the terminal status (cross-chain delivery hasn't happened yet).
       queryClient.invalidateQueries({ queryKey: tokenBalanceQueryKey })
       queryClient.invalidateQueries({ queryKey: allowanceQueryKey })
       queryClient.invalidateQueries({ queryKey: nativeTokenBalanceQueryKey })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositPreview.ts
@@ -64,10 +64,7 @@ const computeIsFeesError = ({
   isPreviewError ||
   (needsApproval && isApprovalGasFeesError)
 
-// Mirror of `useWithdrawPreview`: subscribes to the composed
-// `depositPreviewOptions` (shares + quote) and pairs it with the
-// canonical `useNeedsApproval` for allowance reads. Adds wagmi-side gas
-// estimation on top.
+// Composed depositPreviewOptions (shares + quote) + useNeedsApproval for allowance, plus gas estimation.
 export const useDepositPreview = function ({
   account,
   amount,
@@ -115,12 +112,8 @@ export const useDepositPreview = function ({
   const sharesOutMin = composed?.sharesOutMin ?? BigInt(0)
   const layerZeroFee = quote?.nativeFee ?? BigInt(0)
 
-  // Gate submit on a positive shares preview. Without this, a fast submit
-  // before the preview resolves would land `sharesOutMin=0n` on-chain —
-  // zero slippage protection.
-  // Also gate on `!isAllowanceLoading` so the fees summary can't render with
-  // `needsApproval=false` while allowance is still pending (the total would
-  // jump up once allowance settles).
+  // Gate on a positive shares preview (else a fast submit lands sharesOutMin=0n — no slippage
+  // protection) and on !isAllowanceLoading (else the fee total jumps once allowance settles).
   const canDeposit =
     validInput &&
     shares !== undefined &&

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
@@ -3,18 +3,9 @@
 import { useEffect, useState } from 'react'
 import { unixNowTimestamp } from 'utils/time'
 
-// Local-only countdown driven by `claimableAt` from the Envio subgraph.
-// Ticks every 60s so the drawer's cooldown sub-step copy (and any future
-// table column) updates without round-tripping through react-query.
-//
-// `claimableAt` is the unix-seconds timestamp at which the Vetro Agent
-// will allow the claim to fire (set on Ethereum at observation time —
-// the authoritative source for cooldown maturity, free of the
-// LayerZero-delay drift a local `requestedAt + duration` calculation
-// would carry).
-//
-// Returns `undefined` while the input is missing, otherwise the
-// remaining seconds (clamped at 0).
+// Local countdown from the subgraph's claimableAt (unix seconds, set on Ethereum — authoritative
+// for maturity, free of the LayerZero drift a local requestedAt + duration would carry). Ticks
+// every 60s; returns undefined until the input exists.
 const TICK_MS = 60_000
 
 const nowInSeconds = () => Number(unixNowTimestamp())

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdraw.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdraw.ts
@@ -27,36 +27,23 @@ import { type WithdrawOperation, WithdrawStatus } from '../_types/operations'
 import { useDrawerQueryString } from './useDrawerQueryString'
 
 type UseWithdraw = {
-  // Slippage-protected minimum the caller expects to receive on
-  // fulfillment, in `selectedAsset` units. Enforced on the remote chain;
-  // locked at request time and frozen across the ~7d cooldown.
+  // Slippage min in asset units; enforced remotely and frozen across the ~7d cooldown.
   assetsOutMin: bigint
   callbackFee: bigint
-  // Resolved by the caller via `useQuoteRedeem`, which mirrors what the
-  // Agent computes on Ethereum (`!cooldownEnabled || whitelisted`). The
-  // request body and the Router's gas reservation must agree on this; a
-  // mismatch causes the Agent to bounce the request as cancel.
+  // Must match what the Agent computes (via useQuoteRedeem) — a mismatch makes the Agent bounce the request as cancel.
   isInstant: boolean
   on?: (emitter: EventEmitter<RequestRedeemEvents>) => void
-  // Pegged-token amount that will leave `totalAssets()` when these shares
-  // are redeemed. Computed by the caller (the withdraw drawer) alongside
-  // the shares→asset conversion in `useSharesToAssets`. Pass `0n` while
-  // the preview is pending; `onSettled` invalidation reconciles.
+  // Pegged amount leaving totalAssets() on redeem (from useSharesToAssets); 0n while the preview is pending, reconciled by onSettled.
   peggedAmount: bigint
   pool: EarnPool
-  // Set by retry callers when the prior attempt had a successful approval
-  // (allowance is still on-chain, so `requestRedeem` won't emit
-  // `user-signed-approval` again). Carried forward into the new local-store
-  // entry so the historical drawer keeps surfacing the approval step.
+  // Retry callers pass the prior approval hash (allowance still on-chain, so no new
+  // user-signed-approval); carried into the new entry so the drawer keeps the approval step.
   priorApprovalTxHash?: Hash
   selectedAsset: EarnAsset
-  // Share amount in shareToken units — the user-entered withdraw amount.
-  // The Router's `requestRedeem` burns this many shares on Hemi.
+  // Withdraw amount in shareToken units; the Router's requestRedeem burns this many shares on Hemi.
   shares: bigint
-  // Set by retry callers: the `initiateTxHash` of the specific prior FAILED
-  // attempt being replaced. Once the new withdraw is signed, that entry is
-  // flagged `settled` so the table doesn't show the old failure alongside
-  // the new attempt.
+  // Retry callers pass the FAILED attempt's initiateTxHash; once the new withdraw is signed,
+  // that entry is flagged settled so the old failure doesn't show beside the new attempt.
   supersedesInitiateTxHash?: Hash
   updateWithdrawOperation?: (payload?: WithdrawOperation) => void
 }
@@ -82,8 +69,6 @@ export const useWithdraw = function ({
   const queryClient = useQueryClient()
   const [networkType] = useNetworkType()
   const routerAddress = getHemiEarnRouterAddress()
-  // Requires <LocalEarnOperationsProvider> upstream (mounted in the
-  // hemi-earn layout). Hook throws at runtime if used outside it.
   const { markSettledByInitiateTxHash, upsertLocalOperation } =
     useLocalEarnOperations()
 
@@ -131,21 +116,11 @@ export const useWithdraw = function ({
 
       const walletClient = await getWalletClient(config, { chainId })
 
-      // Local-store entries are created at two points:
-      //   1. `user-signed-approval` — captures `approvalTxHash` so a future
-      //      historical drawer can later render the approval step (the
-      //      indexer has no way to link an approval tx to a request).
-      //   2. `user-signed-withdraw` — adds `initiateTxHash`, which is the
-      //      key the merge would use to dedupe against the subgraph row.
-      // REDEEM rows aren't surfaced in the table yet, but the local entries
-      // still drive `useEarnTransactionsQuery` polling and the cooldown
-      // sub-step's reactivity.
+      // Local entries are created at two points: user-signed-approval (captures approvalTxHash,
+      // unlinkable by the indexer) and user-signed-withdraw (adds initiateTxHash, the merge dedupe key).
       const startedAt = Number(unixNowTimestamp())
-      // `amountIn` for REDEEM stores the share amount being burned (raw
-      // share-token units). The drawer displays this directly as "X
-      // {shareSymbol}" — survives `resetStateAfterOperation()` clearing
-      // the form input. DEPOSIT stores the asset amount instead; the
-      // difference reflects what each kind actually puts in on-chain.
+      // REDEEM stores the share amount being burned (share-token units), not the asset —
+      // that's what the drawer shows and what goes on-chain.
       const baseLocalPayload = {
         account: address,
         amountIn: shares.toString(),
@@ -157,10 +132,7 @@ export const useWithdraw = function ({
         startedAt,
       }
 
-      // Tracks the approval hash for this specific attempt. Seeded from
-      // `priorApprovalTxHash` so retries (where allowance is still on-chain
-      // and `user-signed-approval` won't fire) keep showing the original
-      // approval step. Overwritten when a fresh approval is signed.
+      // Approval hash for this attempt; seeded from priorApprovalTxHash for retries, overwritten if a fresh approval is signed.
       let observedApprovalTxHash: Hash | undefined = priorApprovalTxHash
 
       const { emitter, promise } = requestRedeem({
@@ -185,9 +157,7 @@ export const useWithdraw = function ({
           status: WithdrawStatus.APPROVAL_TX_PENDING,
           transactionHash: undefined,
         })
-        // Persist the approval hash to the local store so the drawer can
-        // surface the approval step across route changes — the indexer
-        // never sees this association.
+        // Persist so the drawer can show the approval step across routes (the indexer never links it).
         upsertLocalOperation({
           ...baseLocalPayload,
           approvalTxHash,
@@ -234,9 +204,7 @@ export const useWithdraw = function ({
             transactionHash,
           },
         })
-        // Hide the specific prior FAILED entry the user is replacing. Done
-        // here (and not on retry click) so the row only disappears once the
-        // user actually commits to the new attempt by signing.
+        // Hide the prior FAILED entry — here, not on retry click, so it only disappears once the user actually signs.
         if (supersedesInitiateTxHash) {
           markSettledByInitiateTxHash(supersedesInitiateTxHash)
         }
@@ -262,14 +230,9 @@ export const useWithdraw = function ({
           operation: { status: WithdrawStatus.WITHDRAW_TX_CONFIRMED },
         })
         updateNativeBalanceAfterFees(receipt)
-        // Optimistic bumps for user-side caches only. The Hemi tx burns the
-        // user's shares so wallet/share-value caches can be decremented
-        // right away. `poolTotalAssets` is intentionally left to the
-        // `onSettled` invalidation + the cross-chain delivery watcher: the
-        // vault on Ethereum still holds the assets until the LayerZero
-        // relay lands, so optimistically subtracting here would under-
-        // report TVL across the UI for the cross-chain window (and a
-        // refetch before delivery would bounce the number back up).
+        // Optimistic bumps for user-side caches only — the Hemi tx burns the user's shares now.
+        // Pool TVL waits for onSettled + the delivery watcher: the Ethereum vault still holds the
+        // assets until the relay lands, so debiting here would under-report TVL.
         queryClient.setQueryData<{ peggedAmount: bigint; shares: bigint }>(
           userShareValueQueryKey,
           old =>
@@ -338,13 +301,9 @@ export const useWithdraw = function ({
         queryKey: poolTotalAssetsQueryKey,
       })
       queryClient.invalidateQueries({ queryKey: userShareValueQueryKey })
-      // `resetQueries` (not `removeQueries`) so the outer
-      // `useEarnPositions` observer actually refetches: `removeQueries`
-      // evicts the cache but leaves active observers unnotified, so the
-      // staked-balance card kept showing the pre-withdraw value until a
-      // hard reload. `resetQueries` evicts AND triggers the queryFn —
-      // which lets `fetchEarnPositions`' inner `ensureQueryData` reads
-      // go to the network instead of returning stale share balances.
+      // resetQueries (not removeQueries) so the useEarnPositions observer refetches — removeQueries
+      // evicts but leaves observers unnotified, and reset also lets fetchEarnPositions' inner
+      // ensureQueryData reads hit the network instead of returning stale balances.
       queryClient.resetQueries({ queryKey: earnPositionsKeyPrefix })
     },
   })

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
@@ -76,7 +76,7 @@ const computeIsFeesError = ({
   (needsApproval && isApprovalGasFeesError)
 
 // Composed withdrawPreviewOptions (sharesToAssets + quoteRedeem) + useNeedsApproval so an
-// allowance failure reads apart from a preview failure, plus gas estimation.
+// allowance failure is distinguishable from a preview failure, plus gas estimation.
 export const useWithdrawPreview = function ({
   account,
   asset,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
@@ -75,11 +75,8 @@ const computeIsFeesError = ({
   isPreviewError ||
   (needsApproval && isApprovalGasFeesError)
 
-// Subscribes to a single composed query (`withdrawPreviewOptions`) that
-// fans out `sharesToAssets` + `quoteRedeem` via `ensureQueryData`, and
-// pairs it with the canonical `useNeedsApproval` for allowance reads so
-// the form can tell an allowance failure apart from a preview failure.
-// Adds the wagmi-side gas estimation on top.
+// Composed withdrawPreviewOptions (sharesToAssets + quoteRedeem) + useNeedsApproval so an
+// allowance failure reads apart from a preview failure, plus gas estimation.
 export const useWithdrawPreview = function ({
   account,
   asset,
@@ -128,9 +125,7 @@ export const useWithdrawPreview = function ({
   const quote = composed?.quote
   const layerZeroFee = quote?.nativeFee ?? BigInt(0)
 
-  // Gate on `!isAllowanceLoading` so the fees summary (driven by canWithdraw)
-  // can't render with `needsApproval=false` while allowance is still pending —
-  // otherwise the user sees a wrong total that jumps up once allowance settles.
+  // Gate on !isAllowanceLoading so the fee total doesn't render (and then jump) while allowance is still pending.
   const canWithdraw =
     validInput &&
     shares > BigInt(0) &&
@@ -167,10 +162,7 @@ export const useWithdrawPreview = function ({
       isGasUnitsError: isWithdrawGasUnitsError,
     })
 
-  // `*Raw` fields preserve `undefined` while the composed query is loading
-  // so the summary can render a skeleton; the bigint aliases default to 0n
-  // for hooks that don't tolerate undefined (e.g. `useWithdraw`'s
-  // optimistic decrements).
+  // *Raw fields keep undefined (for skeletons) while loading; the bigint aliases default to 0n for hooks that can't take undefined.
   return {
     assetOut,
     assetOutRaw: composed?.assetOut,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_types/operations.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_types/operations.ts
@@ -3,17 +3,11 @@ import type { Hash } from 'viem'
 // Prefer ordering these by value rather than by key
 /* eslint-disable sort-keys */
 export const DepositStatus = {
-  // The Approval TX is sent but not confirmed.
   APPROVAL_TX_PENDING: 0,
-  // The Approval TX failed to be confirmed.
   APPROVAL_TX_FAILED: 1,
-  // Once the Approval TX is confirmed, but the user hasn't sent the deposit Transaction
   APPROVAL_TX_COMPLETED: 2,
-  // The user has confirmed the TX in their wallet, but it hasn't been included in a block
   DEPOSIT_TX_PENDING: 3,
-  // Deposit tx reverted
   DEPOSIT_TX_FAILED: 4,
-  // Transaction deposit confirmed
   DEPOSIT_TX_CONFIRMED: 5,
 } as const
 /* eslint-enable sort-keys */
@@ -37,18 +31,12 @@ export type DepositOperationRunning =
 // Prefer ordering these by value rather than by key
 /* eslint-disable sort-keys */
 export const WithdrawStatus = {
-  // The user has signed the share approval but it's not yet mined.
   APPROVAL_TX_PENDING: 0,
-  // The share approval transaction reverted or was rejected.
   APPROVAL_TX_FAILED: 1,
-  // The share approval is confirmed; the redeem transaction can be sent.
   APPROVAL_TX_COMPLETED: 2,
-  // The user has confirmed the redeem TX but it hasn't been included in a block.
   WITHDRAW_TX_PENDING: 3,
-  // The redeem TX reverted.
   WITHDRAW_TX_FAILED: 4,
-  // The redeem TX is confirmed (request is now in flight cross-chain — UI stops
-  // tracking here; LayerZero fulfillment / claim are out of scope for phase 2).
+  // Local enum stops here; the cross-chain leg (fulfillment/claim) is tracked via the subgraph.
   WITHDRAW_TX_CONFIRMED: 5,
 } as const
 /* eslint-enable sort-keys */

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/formState.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/formState.ts
@@ -1,18 +1,10 @@
-// Shared form-state helpers for the deposit and withdraw forms. Both forms
-// derive their submit-button state from the same pieces (wallet connected,
-// balance loaded, allowance loaded, preview loading) and surface the same
-// kinds of preview issues (floor-rounded dust, asset unavailable, network
-// error). Keeping the logic here prevents drift between the two forms.
-
+// Shared form-state helpers so the deposit and withdraw forms don't drift.
 export type PreviewIssue =
   | 'amount-too-small'
   | 'asset-unavailable'
   | 'network-error'
 
-// Discriminates the three distinct "no shares" causes the form can hit after
-// the preview resolves. Ordered most-actionable first: a network error means
-// "retry"; an unavailable asset means "wait / pick another"; only the
-// remaining shares-rounded-to-zero case is a genuine "amount too small".
+// The three "no shares" causes, ordered most-actionable first: network error, unavailable asset, then amount-too-small.
 export function resolvePreviewIssue({
   hasShares,
   isPreviewError,
@@ -23,10 +15,7 @@ export function resolvePreviewIssue({
   hasShares: boolean
   isPreviewError: boolean
   isPreviewLoading: boolean
-  // Intermediate pegged-token value from the on-chain preview. `undefined`
-  // when the upstream quote/preview hasn't produced one yet. `0n` is the
-  // signal that the Gateway returned nothing — the asset is paused or
-  // blocked, not that the requested amount was too small.
+  // undefined = preview not ready; 0n = the Gateway returned nothing (asset paused/blocked, not amount too small).
   peggedAmount: bigint | undefined
   validInput: boolean
 }): PreviewIssue | undefined {
@@ -56,9 +45,7 @@ export const computeIsLoading = ({
   validInput: boolean
 }) => isAllowanceLoading || !balanceLoaded || (validInput && isPreviewLoading)
 
-// `previewIssueMessage` takes precedence when set — the preview issue is
-// always more specific than the upstream validation error, and the two are
-// mutually exclusive in practice (`resolvePreviewIssue` gates on `validInput`).
+// Preview issue takes precedence — it's more specific and mutually exclusive with the validation error.
 export const resolveValidationError = (
   previewIssueMessage: string | undefined,
   validationError: string | undefined,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/page.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/page.tsx
@@ -9,13 +9,8 @@ type Props = {
   params: Promise<{ shareAddress: string }>
 }
 
-// One static page per Vetro share OFT registered on the Router. Each page
-// renders the share's deposit assets (e.g. USDC + USDT for sVUSD) and the
-// share-level metrics (TVL, APY) — see `useEarnPools`. The share list is
-// derived on-chain (gateways → treasuries → whitelisted tokens → Router) by
-// `fetchHemiEarnAssetConfigs`; one config per asset, so dedupe by share to
-// avoid generating the same page twice. A failed read at build time throws on
-// purpose — a broken registry should fail the build, not ship empty pages.
+// One static page per share OFT (dedupe configs by share). A failed registry read
+// at build time throws on purpose — a broken registry should fail the build, not ship empty pages.
 export async function generateStaticParams() {
   const configs = await fetchHemiEarnAssetConfigs()
   return uniqueShareConfigs(configs).map(config => ({

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -22,42 +22,29 @@ export type EarnTransactionStatusType =
 
 export type EarnTransactionKindType = 'DEPOSIT' | 'REDEEM'
 
-// Mirror of the `Request` entity exposed by the `hemi-earn-requests-subgraph`
-// Envio indexer. BigInt values arrive as JSON strings; consumers parse with
-// `BigInt(...)` for arithmetic (`formatUnits`) and `Number(...)` for display
-// (`InRelativeTime`). `'TX_PENDING'` and `'FAILED'` are portal-synthetic
-// statuses (derived in `useEarnTransactions` and at the fetcher boundary
-// respectively) — they don't exist in the subgraph schema.
-// A settlement the user signed for a request, tracked locally (the reverted tx
-// isn't a subgraph event). `CLAIM`/`RECOVER`/`CANCEL` are Hemi Router txs;
-// `UNSTAKE` is the Ethereum-side `Agent.claimUnstake` that finalizes a matured
-// cooldown redeem. `failed` lets the UI offer a Retry to re-call the step.
+// A locally-tracked settlement tx the user signed (not a subgraph event). UNSTAKE
+// is the Ethereum Agent.claimUnstake; failed lets the UI offer a Retry.
 export type EarnSettlement = {
   failed: boolean
   kind: 'CLAIM' | 'RECOVER' | 'CANCEL' | 'UNSTAKE'
   txHash?: Hash
 }
 
+// Subgraph Request row; bigints arrive as JSON strings. TX_PENDING/FAILED are
+// portal-synthetic statuses (not in the subgraph schema).
 export type EarnTransaction = {
   amountIn: string
   amountOut: string | null
-  // Approval tx hash, only available for entries surfaced from this
-  // browser's local store (where `useDeposit` captures it on
-  // `user-signed-approval`). Subgraph-only rows don't expose it — the
-  // indexer has no way to tie an approval tx to a specific request.
+  // Only present on local-store rows; the indexer can't tie an approval tx to a request.
   approvalTxHash?: Hash
   asset: Address
   automatic: boolean
-  // True once the user signed `Router.cancel` for this request. With `failed`
-  // it tells a deliberate cancel (`cancellationRequested && !failed`) apart from
-  // an Agent failure on a CANCELLED/RECOVERED redeem.
+  // True once the user signed Router.cancel; with failed, tells a deliberate cancel from an Agent failure.
   cancellationRequested: boolean
-  // Unix-seconds the Vetro Agent set on Ethereum at LayerZero-observation
-  // time. Null until the Agent emits `UnstakeRequested`; immutable after.
+  // Unix seconds set by the Agent on UnstakeRequested; null before, immutable after.
   claimableAt?: string | null
   claimTxHash: Hash | null
-  // Agent-side failure flag (lingers through CANCELLED/RECOVERED). A recover
-  // with `failed: false` is a deliberate cancel, not a failure.
+  // Agent-side failure flag; lingers through CANCELLED/RECOVERED (failed:false recover = deliberate cancel).
   failed: boolean
   kind: EarnTransactionKindType
   processedAt?: string | null
@@ -66,86 +53,56 @@ export type EarnTransaction = {
   requestedAt: string
   requestId: string
   requestTxHash: Hash
-  // Locally-tracked manual claim/recover attempt for this request (enriched
-  // from the local store by `useEarnTransactions`, like `approvalTxHash`).
   settlement?: EarnSettlement
   status: EarnTransactionStatusType
 }
 
-// One deposit option that settles into a share OFT.
 export type EarnAsset = {
   address: Address
   token: EvmToken
 }
 
-// A pool, in this codebase, is one Vetro share vault on the Ethereum side
-// (e.g. sVUSD) plus every deposit asset registered on the Hemi Router that
-// settles into it. APY and TVL live at the share level — the per-asset rows
-// of the old ERC-4626 model are now collapsed into `assets`.
-//
-// `totalDeposits` is `StakingVault.totalAssets()`, expressed in the pegged
-// token's units (vBTC, vUSD — that's what the vault's `asset()` returns).
-// Pair it with `peggedToken` for formatting and pricing; never with
-// `shareToken`, since the share OFT has no public price feed. It is
-// `undefined` while the TVL read is in flight — pair with `totalDepositsStatus`
-// so consumers can show a skeleton (pending) or '-' (error) instead of `$0`.
-// `apy` is tri-state:
-//   `undefined` — APY query still pending (show skeleton)
-//   `null`      — APY query settled but no value for this share (error or
-//                 missing in response → show '-')
-//   `number`    — APY available
+// A pool = one Vetro share vault (Ethereum) plus every Hemi deposit asset that settles into it.
 export type EarnPool = {
+  // null = settled with no value (show '-'); undefined = still pending.
   apy: number | null | undefined
   assets: EarnAsset[]
   exposureTokens: { address: Address; chainId: EvmToken['chainId'] }[]
   peggedToken: EvmToken
   shareAddress: Address
   shareToken: EvmToken
-  // Ethereum-side ERC-4626 staking vault (`Router.assetsData(asset).remoteShare`)
+  // Ethereum ERC-4626 staking vault (assetsData(asset).remoteShare).
   stakingVault: Address
+  // StakingVault.totalAssets() in peggedToken units — price via peggedToken, never shareToken (no feed); undefined while loading.
   totalDeposits: bigint | undefined
   totalDepositsStatus: QueryStatus
 }
 
-// `yourDeposit` is the raw share OFT balance (denominated in
-// `shareToken.decimals`); fiat conversion goes through `peggedToken` via
-// `convertToAssets`.
 export type EarnPosition = {
   peggedToken: EvmToken
   shareAddress: Address
   shareToken: EvmToken
+  // Raw share OFT balance (shareToken.decimals); fiat goes through peggedToken via convertToAssets.
   yourDeposit: bigint
 }
 
-// Local mirror of an earn operation initiated from this browser. Survives the
-// route change between /hemi-earn and /hemi-earn/pool/[shareAddress] and is
-// soft-deleted (flag `settled: true`) once the subgraph indexes the matching
-// request — `useEarnDeliveryWatcher`'s reconcile loop flips the flag. The
-// entry stays in storage so the drawer can keep enriching the subgraph row
-// with locally-captured metadata that the indexer doesn't expose (e.g.
-// `approvalTxHash`). TTL + per-account cap keep storage bounded.
-//
-// `amountIn` is a string because bigint can't be serialized to JSON (and
-// therefore can't be persisted to localStorage). Same convention as
-// `CommonOperation.amount` in `portal/types/tunnel.ts`. Convert with
-// `BigInt(...)` only when arithmetic is needed (e.g. formatUnits).
+// Local mirror of an earn op from this browser; survives route changes and is
+// soft-deleted (settled:true) once indexed, but kept so the drawer can still read
+// local-only metadata (e.g. approvalTxHash) the indexer never exposes.
 type LocalEarnOperationBase = {
   account: Address
+  // String because bigint isn't JSON-serializable for localStorage.
   amountIn: string
   approvalTxHash?: Hash
   asset: Address
   chainId: Chain['id']
   initiateTxHash?: Hash
   operator?: Address
-  // Manual claim/recover the user signed on this request (keyed by the same
-  // `initiateTxHash` = the request tx). Survives the soft-settle so the drawer
-  // keeps offering the Retry after the subgraph indexes the request.
+  // Manual claim/recover the user signed; survives the soft-settle so the drawer keeps offering Retry.
   settlement?: EarnSettlement
   settled?: boolean
   shareAddress: Address
-  // Unix seconds. Matches the unit of `TTL_SECONDS` in
-  // `localEarnOperationsContext.tsx` — if this ever changes to ms, the GC
-  // comparison there must change too.
+  // Unix seconds — must match TTL_SECONDS' unit in localEarnOperationsContext (the GC compares them).
   startedAt: number
 }
 


### PR DESCRIPTION
### Description

Comment-cleanup pass over the `hemi-earn-actions` package source — comment-only, no behaviour change.

Applies the project's minimize-comments bar: removes comments that restate the code, a name/signature/type, or cite the caller/PR/commit, and compresses the genuine *why* to a single line — Router id guards, slippage / native-fee notes, the `isInstant`-must-match-Agent gotcha, and the cancel → keeper → recover flow.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
