### PR TITLE
Add Agent retry/cancel/failedRequests wrappers

### DIFF
--- a/packages/hemi-earn-actions/index.ts
+++ b/packages/hemi-earn-actions/index.ts
@@ -5,6 +5,7 @@ export {
 
 export type {
   CancelRedeemEvents,
+  CancelRequestEvents,
   ClaimDepositEvents,
   ClaimRedeemEvents,
   ClaimUnstakeEvents,
@@ -14,4 +15,5 @@ export type {
   RequestKind,
   RequestRedeemEvents,
   RequestStatus,
+  RetryRequestEvents,
 } from './src/types'

--- a/packages/hemi-earn-actions/src/actions/index.ts
+++ b/packages/hemi-earn-actions/src/actions/index.ts
@@ -1,9 +1,11 @@
 export {
   type AssetData,
+  type FailedRequest,
   type Request,
   type UnstakeRequest,
   getAgentAddress,
   getAssetData,
+  getFailedRequest,
   getRequest,
   getUnstakeRequest,
   quoteDeposit,
@@ -13,6 +15,7 @@ export {
   resolveIsInstant,
 } from './public'
 export { cancelRedeem } from './wallet/cancelRedeem'
+export { cancelRequest } from './wallet/cancelRequest'
 export { claimDeposit } from './wallet/claimDeposit'
 export { claimRedeem } from './wallet/claimRedeem'
 export { claimUnstake } from './wallet/claimUnstake'
@@ -28,3 +31,4 @@ export { recoverDeposit } from './wallet/recoverDeposit'
 export { recoverRedeem } from './wallet/recoverRedeem'
 export { requestDeposit } from './wallet/requestDeposit'
 export { requestRedeem } from './wallet/requestRedeem'
+export { retryRequest } from './wallet/retryRequest'

--- a/packages/hemi-earn-actions/src/actions/public/getFailedRequest.ts
+++ b/packages/hemi-earn-actions/src/actions/public/getFailedRequest.ts
@@ -1,0 +1,47 @@
+import {
+  type Address,
+  type Client,
+  type Hex,
+  isAddress,
+  isAddressEqual,
+  zeroAddress,
+} from 'viem'
+import { readContract } from 'viem/actions'
+
+import { agentAbi } from '../../agentAbi'
+
+export type FailedRequest = {
+  amountIn: bigint
+  msg: Hex
+  nativeFee: bigint
+  tokenIn: Address
+}
+
+export const getFailedRequest = async function ({
+  agentAddress,
+  client,
+  requestId,
+}: {
+  agentAddress: Address
+  client: Client
+  requestId: bigint
+}): Promise<FailedRequest> {
+  if (!isAddress(agentAddress, { strict: false })) {
+    throw new Error('getFailedRequest: `agentAddress` is not a valid address')
+  }
+  if (isAddressEqual(agentAddress, zeroAddress)) {
+    throw new Error(
+      'getFailedRequest: `agentAddress` cannot be the zero address',
+    )
+  }
+  if (requestId <= BigInt(0)) {
+    throw new Error('getFailedRequest: `requestId` must be greater than zero')
+  }
+
+  return readContract(client, {
+    abi: agentAbi,
+    address: agentAddress,
+    args: [requestId],
+    functionName: 'failedRequests',
+  })
+}

--- a/packages/hemi-earn-actions/src/actions/public/index.ts
+++ b/packages/hemi-earn-actions/src/actions/public/index.ts
@@ -1,5 +1,6 @@
 export { getAgentAddress } from './getAgentAddress'
 export { type AssetData, getAssetData } from './getAssetData'
+export { type FailedRequest, getFailedRequest } from './getFailedRequest'
 export { type Request, getRequest } from './getRequest'
 export { type UnstakeRequest, getUnstakeRequest } from './getUnstakeRequest'
 export { quoteDeposit } from './quoteDeposit'

--- a/packages/hemi-earn-actions/src/actions/wallet/cancelRequest.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/cancelRequest.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'events'
+import { toPromiseEvent } from 'to-promise-event'
+import type { Address, TransactionReceipt, WalletClient } from 'viem'
+import {
+  getBalance,
+  waitForTransactionReceipt,
+  writeContract,
+} from 'viem/actions'
+
+import { agentAbi } from '../../agentAbi'
+import type { CancelRequestEvents } from '../../types'
+
+const runCancelRequest = ({
+  account,
+  agentAddress,
+  nativeFee = BigInt(0),
+  requestId,
+  walletClient,
+}: {
+  account: Address
+  agentAddress: Address
+  nativeFee?: bigint
+  requestId: bigint
+  walletClient: WalletClient
+}) =>
+  async function (emitter: EventEmitter<CancelRequestEvents>) {
+    try {
+      if (!walletClient.chain) {
+        throw new Error('Chain is not defined on wallet')
+      }
+
+      if (requestId <= BigInt(0)) {
+        emitter.emit('tx-failed-validation', 'invalid requestId')
+        return
+      }
+
+      if (nativeFee > BigInt(0)) {
+        const balance = await getBalance(walletClient, { address: account })
+        if (balance < nativeFee) {
+          emitter.emit('tx-failed-validation', 'insufficient balance for fee')
+          return
+        }
+      }
+
+      emitter.emit('pre-tx')
+
+      const txHash = await writeContract(walletClient, {
+        abi: agentAbi,
+        account,
+        address: agentAddress,
+        args: [requestId],
+        chain: walletClient.chain,
+        functionName: 'cancel',
+        value: nativeFee,
+      }).catch(function (error) {
+        emitter.emit('user-signing-tx-error', error)
+      })
+
+      if (!txHash) {
+        return
+      }
+
+      emitter.emit('user-signed-tx', txHash)
+
+      const receipt = await waitForTransactionReceipt(walletClient, {
+        hash: txHash,
+      }).catch(function (error) {
+        emitter.emit('tx-failed', error)
+      })
+
+      if (!receipt) {
+        return
+      }
+
+      const eventMap: Record<
+        TransactionReceipt['status'],
+        keyof CancelRequestEvents
+      > = {
+        reverted: 'tx-transaction-reverted',
+        success: 'tx-transaction-succeeded',
+      }
+
+      emitter.emit(eventMap[receipt.status], receipt)
+    } catch (error) {
+      emitter.emit('unexpected-error', error as Error)
+    } finally {
+      emitter.emit('tx-settled')
+    }
+  }
+
+export const cancelRequest = (...args: Parameters<typeof runCancelRequest>) =>
+  toPromiseEvent<CancelRequestEvents>(runCancelRequest(...args))

--- a/packages/hemi-earn-actions/src/actions/wallet/retryRequest.ts
+++ b/packages/hemi-earn-actions/src/actions/wallet/retryRequest.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'events'
+import { toPromiseEvent } from 'to-promise-event'
+import type { Address, TransactionReceipt, WalletClient } from 'viem'
+import {
+  getBalance,
+  waitForTransactionReceipt,
+  writeContract,
+} from 'viem/actions'
+
+import { agentAbi } from '../../agentAbi'
+import type { RetryRequestEvents } from '../../types'
+
+const runRetryRequest = ({
+  account,
+  agentAddress,
+  nativeFee = BigInt(0),
+  requestId,
+  walletClient,
+}: {
+  account: Address
+  agentAddress: Address
+  nativeFee?: bigint
+  requestId: bigint
+  walletClient: WalletClient
+}) =>
+  async function (emitter: EventEmitter<RetryRequestEvents>) {
+    try {
+      if (!walletClient.chain) {
+        throw new Error('Chain is not defined on wallet')
+      }
+
+      if (requestId <= BigInt(0)) {
+        emitter.emit('tx-failed-validation', 'invalid requestId')
+        return
+      }
+
+      if (nativeFee > BigInt(0)) {
+        const balance = await getBalance(walletClient, { address: account })
+        if (balance < nativeFee) {
+          emitter.emit('tx-failed-validation', 'insufficient balance for fee')
+          return
+        }
+      }
+
+      emitter.emit('pre-tx')
+
+      const txHash = await writeContract(walletClient, {
+        abi: agentAbi,
+        account,
+        address: agentAddress,
+        args: [requestId],
+        chain: walletClient.chain,
+        functionName: 'retry',
+        value: nativeFee,
+      }).catch(function (error) {
+        emitter.emit('user-signing-tx-error', error)
+      })
+
+      if (!txHash) {
+        return
+      }
+
+      emitter.emit('user-signed-tx', txHash)
+
+      const receipt = await waitForTransactionReceipt(walletClient, {
+        hash: txHash,
+      }).catch(function (error) {
+        emitter.emit('tx-failed', error)
+      })
+
+      if (!receipt) {
+        return
+      }
+
+      const eventMap: Record<
+        TransactionReceipt['status'],
+        keyof RetryRequestEvents
+      > = {
+        reverted: 'tx-transaction-reverted',
+        success: 'tx-transaction-succeeded',
+      }
+
+      emitter.emit(eventMap[receipt.status], receipt)
+    } catch (error) {
+      emitter.emit('unexpected-error', error as Error)
+    } finally {
+      emitter.emit('tx-settled')
+    }
+  }
+
+export const retryRequest = (...args: Parameters<typeof runRetryRequest>) =>
+  toPromiseEvent<RetryRequestEvents>(runRetryRequest(...args))

--- a/packages/hemi-earn-actions/src/agentAbi.ts
+++ b/packages/hemi-earn-actions/src/agentAbi.ts
@@ -1,7 +1,21 @@
 export const agentAbi = [
   {
     inputs: [{ internalType: 'uint256', name: 'requestId_', type: 'uint256' }],
+    name: 'cancel',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'requestId_', type: 'uint256' }],
     name: 'claimUnstake',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'requestId_', type: 'uint256' }],
+    name: 'retry',
     outputs: [],
     stateMutability: 'payable',
     type: 'function',
@@ -41,6 +55,25 @@ export const agentAbi = [
           { internalType: 'uint256', name: 'claimableAt', type: 'uint256' },
         ],
         internalType: 'struct Agent.UnstakeRequest',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    name: 'failedRequests',
+    outputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'tokenIn', type: 'address' },
+          { internalType: 'uint256', name: 'amountIn', type: 'uint256' },
+          { internalType: 'bytes', name: 'msg', type: 'bytes' },
+          { internalType: 'uint256', name: 'nativeFee', type: 'uint256' },
+        ],
+        internalType: 'struct Agent.FailedRequest',
         name: '',
         type: 'tuple',
       },

--- a/packages/hemi-earn-actions/src/types.ts
+++ b/packages/hemi-earn-actions/src/types.ts
@@ -65,6 +65,9 @@ export type RecoverRedeemEvents = CommonEvents & SettlementEvents
 // Router.cancel only emits CancellationRequested; the keeper's Agent.cancel then
 // sets CANCELLED and the user calls recoverRedeem to pull shares back.
 export type CancelRedeemEvents = CommonEvents & SettlementEvents
+// Agent-side writes for a failed request on Ethereum (cancel ≠ Router-side CancelRedeem).
+export type CancelRequestEvents = CommonEvents & SettlementEvents
+export type RetryRequestEvents = CommonEvents & SettlementEvents
 
 // Mirrors the on-chain `Kind` enum from Router.sol (DEPOSIT = 0, REDEEM = 1).
 export type RequestKind = 0 | 1

--- a/packages/hemi-earn-actions/src/types.ts
+++ b/packages/hemi-earn-actions/src/types.ts
@@ -65,7 +65,8 @@ export type RecoverRedeemEvents = CommonEvents & SettlementEvents
 // Router.cancel only emits CancellationRequested; the keeper's Agent.cancel then
 // sets CANCELLED and the user calls recoverRedeem to pull shares back.
 export type CancelRedeemEvents = CommonEvents & SettlementEvents
-// Agent-side writes for a failed request on Ethereum (cancel ≠ Router-side CancelRedeem).
+// Agent-side writes on Ethereum: retry re-runs a failed request; cancel returns
+// the original tokens for a failed OR in-cooldown one (≠ Router-side cancelRedeem).
 export type CancelRequestEvents = CommonEvents & SettlementEvents
 export type RetryRequestEvents = CommonEvents & SettlementEvents
 

--- a/packages/hemi-earn-actions/test/actions/public/getFailedRequest.test.ts
+++ b/packages/hemi-earn-actions/test/actions/public/getFailedRequest.test.ts
@@ -1,0 +1,59 @@
+import { type Address, type Client, type Hex, zeroAddress } from 'viem'
+import { readContract } from 'viem/actions'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getFailedRequest } from '../../../src/actions/public/getFailedRequest'
+
+vi.mock('viem/actions', () => ({
+  readContract: vi.fn(),
+}))
+
+const client = {} as Client
+
+const agentAddress = '0x000000000000000000000000000000000000dEaD' as Address
+const someAddress = '0x000000000000000000000000000000000000bEEF' as Address
+
+const failedRequest = {
+  amountIn: BigInt(100),
+  msg: '0xabcdef' as Hex,
+  nativeFee: BigInt(5),
+  tokenIn: someAddress,
+}
+
+describe('getFailedRequest', function () {
+  it('returns the on-chain failed-request struct', async function () {
+    vi.mocked(readContract).mockResolvedValue(failedRequest)
+
+    const result = await getFailedRequest({
+      agentAddress,
+      client,
+      requestId: BigInt(1),
+    })
+
+    expect(result).toEqual(failedRequest)
+    expect(readContract).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        address: agentAddress,
+        args: [BigInt(1)],
+        functionName: 'failedRequests',
+      }),
+    )
+  })
+
+  it('rejects a non-positive requestId', async function () {
+    await expect(
+      getFailedRequest({ agentAddress, client, requestId: BigInt(0) }),
+    ).rejects.toThrow(/`requestId` must be greater than zero/)
+  })
+
+  it('rejects a zero agent address', async function () {
+    await expect(
+      getFailedRequest({
+        agentAddress: zeroAddress,
+        client,
+        requestId: BigInt(1),
+      }),
+    ).rejects.toThrow(/`agentAddress` cannot be the zero address/)
+  })
+})

--- a/packages/hemi-earn-actions/test/actions/wallet/cancelRequest.test.ts
+++ b/packages/hemi-earn-actions/test/actions/wallet/cancelRequest.test.ts
@@ -1,0 +1,147 @@
+import {
+  type Address,
+  type TransactionReceipt,
+  type WalletClient,
+  zeroAddress,
+  zeroHash,
+} from 'viem'
+import {
+  getBalance,
+  waitForTransactionReceipt,
+  writeContract,
+} from 'viem/actions'
+import { mainnet } from 'viem/chains'
+import { describe, expect, it, vi } from 'vitest'
+
+import { cancelRequest } from '../../../src/actions/wallet/cancelRequest'
+
+vi.mock('viem/actions', () => ({
+  getBalance: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+  writeContract: vi.fn(),
+}))
+
+const mockWalletClient = {
+  chain: mainnet,
+} as unknown as WalletClient
+
+const agentAddress = '0x000000000000000000000000000000000000dEaD' as Address
+
+const validParameters = {
+  account: zeroAddress,
+  agentAddress,
+  nativeFee: BigInt(7),
+  requestId: BigInt(1),
+  walletClient: mockWalletClient,
+}
+
+describe('cancelRequest', function () {
+  it('emits "unexpected-error" when wallet client chain is not defined', async function () {
+    const { emitter, promise } = cancelRequest({
+      ...validParameters,
+      walletClient: {} as WalletClient,
+    })
+
+    const onUnexpectedError = vi.fn()
+    const onSettled = vi.fn()
+    emitter.on('unexpected-error', onUnexpectedError)
+    emitter.on('tx-settled', onSettled)
+
+    await promise
+
+    expect(onUnexpectedError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('emits "tx-failed-validation" when requestId is zero', async function () {
+    const { emitter, promise } = cancelRequest({
+      ...validParameters,
+      requestId: BigInt(0),
+    })
+
+    const onFailedValidation = vi.fn()
+    emitter.on('tx-failed-validation', onFailedValidation)
+
+    await promise
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      'invalid requestId',
+    )
+  })
+
+  it('happy path: signs with the native-fee top-up and emits succeeded', async function () {
+    const receipt = { status: 'success' } as TransactionReceipt
+
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt)
+
+    const { emitter, promise } = cancelRequest(validParameters)
+
+    const onUserSigned = vi.fn()
+    const onSucceeded = vi.fn()
+    emitter.on('user-signed-tx', onUserSigned)
+    emitter.on('tx-transaction-succeeded', onSucceeded)
+
+    await promise
+
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash)
+    expect(onSucceeded).toHaveBeenCalledExactlyOnceWith(receipt)
+    expect(writeContract).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({
+        address: agentAddress,
+        args: [validParameters.requestId],
+        functionName: 'cancel',
+        value: validParameters.nativeFee,
+      }),
+    )
+  })
+
+  it('emits "tx-transaction-reverted" when receipt is reverted', async function () {
+    const receipt = { status: 'reverted' } as TransactionReceipt
+
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt)
+
+    const { emitter, promise } = cancelRequest(validParameters)
+
+    const onReverted = vi.fn()
+    emitter.on('tx-transaction-reverted', onReverted)
+
+    await promise
+
+    expect(onReverted).toHaveBeenCalledExactlyOnceWith(receipt)
+  })
+
+  it('emits "user-signing-tx-error" when signing fails', async function () {
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
+    vi.mocked(writeContract).mockRejectedValue(new Error('user rejected'))
+
+    const { emitter, promise } = cancelRequest(validParameters)
+
+    const onSigningError = vi.fn()
+    emitter.on('user-signing-tx-error', onSigningError)
+
+    await promise
+
+    expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+  })
+
+  it('emits "tx-failed-validation" when the balance is below the fee', async function () {
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1))
+
+    const { emitter, promise } = cancelRequest(validParameters)
+
+    const onFailedValidation = vi.fn()
+    emitter.on('tx-failed-validation', onFailedValidation)
+
+    await promise
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      'insufficient balance for fee',
+    )
+    expect(writeContract).not.toHaveBeenCalled()
+  })
+})

--- a/packages/hemi-earn-actions/test/actions/wallet/retryRequest.test.ts
+++ b/packages/hemi-earn-actions/test/actions/wallet/retryRequest.test.ts
@@ -1,0 +1,147 @@
+import {
+  type Address,
+  type TransactionReceipt,
+  type WalletClient,
+  zeroAddress,
+  zeroHash,
+} from 'viem'
+import {
+  getBalance,
+  waitForTransactionReceipt,
+  writeContract,
+} from 'viem/actions'
+import { mainnet } from 'viem/chains'
+import { describe, expect, it, vi } from 'vitest'
+
+import { retryRequest } from '../../../src/actions/wallet/retryRequest'
+
+vi.mock('viem/actions', () => ({
+  getBalance: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+  writeContract: vi.fn(),
+}))
+
+const mockWalletClient = {
+  chain: mainnet,
+} as unknown as WalletClient
+
+const agentAddress = '0x000000000000000000000000000000000000dEaD' as Address
+
+const validParameters = {
+  account: zeroAddress,
+  agentAddress,
+  nativeFee: BigInt(7),
+  requestId: BigInt(1),
+  walletClient: mockWalletClient,
+}
+
+describe('retryRequest', function () {
+  it('emits "unexpected-error" when wallet client chain is not defined', async function () {
+    const { emitter, promise } = retryRequest({
+      ...validParameters,
+      walletClient: {} as WalletClient,
+    })
+
+    const onUnexpectedError = vi.fn()
+    const onSettled = vi.fn()
+    emitter.on('unexpected-error', onUnexpectedError)
+    emitter.on('tx-settled', onSettled)
+
+    await promise
+
+    expect(onUnexpectedError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('emits "tx-failed-validation" when requestId is zero', async function () {
+    const { emitter, promise } = retryRequest({
+      ...validParameters,
+      requestId: BigInt(0),
+    })
+
+    const onFailedValidation = vi.fn()
+    emitter.on('tx-failed-validation', onFailedValidation)
+
+    await promise
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      'invalid requestId',
+    )
+  })
+
+  it('happy path: signs with the native-fee top-up and emits succeeded', async function () {
+    const receipt = { status: 'success' } as TransactionReceipt
+
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt)
+
+    const { emitter, promise } = retryRequest(validParameters)
+
+    const onUserSigned = vi.fn()
+    const onSucceeded = vi.fn()
+    emitter.on('user-signed-tx', onUserSigned)
+    emitter.on('tx-transaction-succeeded', onSucceeded)
+
+    await promise
+
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash)
+    expect(onSucceeded).toHaveBeenCalledExactlyOnceWith(receipt)
+    expect(writeContract).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({
+        address: agentAddress,
+        args: [validParameters.requestId],
+        functionName: 'retry',
+        value: validParameters.nativeFee,
+      }),
+    )
+  })
+
+  it('emits "tx-transaction-reverted" when receipt is reverted', async function () {
+    const receipt = { status: 'reverted' } as TransactionReceipt
+
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
+    vi.mocked(writeContract).mockResolvedValue(zeroHash)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt)
+
+    const { emitter, promise } = retryRequest(validParameters)
+
+    const onReverted = vi.fn()
+    emitter.on('tx-transaction-reverted', onReverted)
+
+    await promise
+
+    expect(onReverted).toHaveBeenCalledExactlyOnceWith(receipt)
+  })
+
+  it('emits "user-signing-tx-error" when signing fails', async function () {
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1000))
+    vi.mocked(writeContract).mockRejectedValue(new Error('user rejected'))
+
+    const { emitter, promise } = retryRequest(validParameters)
+
+    const onSigningError = vi.fn()
+    emitter.on('user-signing-tx-error', onSigningError)
+
+    await promise
+
+    expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+  })
+
+  it('emits "tx-failed-validation" when the balance is below the fee', async function () {
+    vi.mocked(getBalance).mockResolvedValue(BigInt(1))
+
+    const { emitter, promise } = retryRequest(validParameters)
+
+    const onFailedValidation = vi.fn()
+    emitter.on('tx-failed-validation', onFailedValidation)
+
+    await promise
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      'insufficient balance for fee',
+    )
+    expect(writeContract).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### Description

This PR adds the Agent-side wrappers the portal needs to handle a REMOTE_FAILED request — the case where the Agent's remote execution reverts (slippage, insufficient native fee, gateway error), the request lands in Agent.failedRequests, and the Router stays stuck on PENDING with no action available in the UI today.

The key piece is getFailedRequest, a read of failedRequests(id): it's the authoritative "is this genuinely stuck or already being auto-recovered?" signal, because the contract deletes the entry the moment a retry or cancel succeeds (so tokenIn != 0x0 means still stuck). On top of that it adds the two payable writes — retryRequest (Agent.retry, re-runs the failed leg with a gas top-up) and cancelRequest (Agent.cancel, returns the original tokens). Note cancelRequest calls Agent.cancel on Ethereum and is deliberately distinct from the existing cancelRedeem, which is Router.cancel on Hemi.

Everything mirrors the existing claimUnstake / getUnstakeRequest siblings — new agentAbi entries (cancel, retry, failedRequests), event types, barrels and tests. It's package-only and purely additive; nothing consumes it yet, the portal wiring comes in a follow-up PR.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #1943
Related to #2028 
Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
