### PR TITLE
Expose receivedAt and retryCount on earn requests

### DIFF
--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "scripts": {
     "build": "tsc",
     "start": "node --import=./src/instrument.ts server.ts"

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -823,11 +823,13 @@ export const getEarnRequests = async function ({
             kind
             processedAt
             processTxHash
+            receivedAt
             receiver
             recoverTxHash
             requestedAt
             requestId
             requestTxHash
+            retryCount
             status
           }
         }`,

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -29,8 +29,10 @@ type EarnRequestCommonFields = {
   failureReason: string | null
   kind: 'DEPOSIT' | 'REDEEM'
   processedAt: string | null
+  receivedAt: string | null
   requestedAt: string
   requestId: string
+  retryCount: number
 }
 
 // Raw `Request` entity from the Envio `hemi-earn-requests-subgraph`. The


### PR DESCRIPTION
### Description

This PR exposes `receivedAt` and `retryCount` on the earn-requests endpoint so the upcoming REMOTE_FAILED UI can tell how long a request has been failing and whether it's already been retried.

That's what lets the UI defer to the keeper for a short grace window before surfacing a Retry/Cancel to the user, instead of prompting the moment a request fails. Both fields are already indexed in the `hemi-earn-requests` subgraph; they just weren't being surfaced by the API. Since the row mapper is a plain passthrough, adding them to the query and the shared `EarnRequestCommonFields` type is all it takes.

One nice property: for a failed request `receivedAt` equals the failure block — the Agent emits `*RequestReceived` in the same `_receive` call as `RequestFailed`, and a retry re-emits it — so it doubles as the failure timestamp the grace window anchors on.

Verified against a local backend: the endpoint now returns `receivedAt` + `retryCount`, and the historically-failed requests carry a decodable `failureReason` alongside them.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #1943
Related to #2028 
Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
