### PR TITLE
Add remote-failure recovery to Hemi Earn redeems

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
@@ -10,6 +10,7 @@ import {
   isAwaitingFinalize,
   isEarnRowInFlight,
   isFinalizeInFlight,
+  isRemoteFailed,
   needsManualClaim,
   needsRecover,
 } from '../../_utils'
@@ -19,6 +20,7 @@ import { TrashIcon } from '../icons/trashIcon'
 
 import { CancelRedeemModal } from './cancelRedeemModal'
 import { ClaimFromVaultCta } from './transactionDrawer/claimFromVault'
+import { RemoteFailedCta } from './transactionDrawer/remoteFailed'
 import { SettleRowCta } from './transactionDrawer/settleShared'
 import { useTxDrawerQueryString } from './transactionDrawer/useTxDrawerQueryString'
 
@@ -37,6 +39,8 @@ function resolveActionState(transaction: EarnTransaction) {
     showManualCta:
       !settleMarker &&
       (needsManualClaim(transaction) || needsRecover(transaction)),
+    // Remote-failed self-gates: the CTA falls back to the View+spinner during the keeper grace.
+    showRemoteFailed: isRemoteFailed(transaction),
   }
 }
 
@@ -44,8 +48,12 @@ export const RowActions = function ({ transaction }: Props) {
   const t = useTranslations('hemi-earn.transactions')
   const [, setTxDrawerQueryString] = useTxDrawerQueryString()
 
-  const { showClaimFromVault, showLoaderIcon, showManualCta } =
-    resolveActionState(transaction)
+  const {
+    showClaimFromVault,
+    showLoaderIcon,
+    showManualCta,
+    showRemoteFailed,
+  } = resolveActionState(transaction)
   const [cancelModalOpen, setCancelModalOpen] = useState(false)
 
   const showCancelButton =
@@ -82,7 +90,14 @@ export const RowActions = function ({ transaction }: Props) {
   return (
     <>
       <div className="flex items-center gap-x-2 pr-4">
-        {showManualCta ? (
+        {showRemoteFailed ? (
+          <RemoteFailedCta
+            fallback={viewButton}
+            fullWidth={false}
+            redirectOnSign
+            transaction={transaction}
+          />
+        ) : showManualCta ? (
           <SettleRowCta fallback={viewButton} transaction={transaction} />
         ) : showClaimFromVault ? (
           <ClaimFromVaultCta

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
@@ -14,6 +14,7 @@ import {
   needsRecover,
   remoteFailedSettlement,
 } from '../../_utils'
+import { decodeFailureReason } from '../../_utils/decodeFailureReason'
 import { type EarnTransaction, type EarnTransactionKindType } from '../../types'
 import { InProgressIcon } from '../icons/inProgressIcon'
 
@@ -43,6 +44,13 @@ const actionNeededBadge = (t: Translator) => ({
   textClassName: 'text-neutral-900',
 })
 
+// Slippage names the cause instead of the generic "Action needed": a retry can't fix it, only Cancel.
+const slippageBadge = (t: Translator) => ({
+  icon: <WarningIcon className="text-amber-500" />,
+  text: t('status.slippage-exceeded'),
+  textClassName: 'text-neutral-900',
+})
+
 // An in-flight retry/cancel reads as progress; a stuck remote failure asks the user to act.
 // Only drives the badge while still FAILED — once the row advances (FULFILLED/CANCELLED after a
 // successful retry/cancel) the lingering marker must hand back to the normal claim/recover badge.
@@ -63,7 +71,10 @@ function remoteBadge(
     )
   }
   // Within the keeper grace the CTA is hidden, so read as in-progress, not "Action needed".
-  return ready ? actionNeededBadge(t) : inProgress(t('status.in-progress'))
+  if (!ready) return inProgress(t('status.in-progress'))
+  return decodeFailureReason(transaction.failureReason) === 'slippage'
+    ? slippageBadge(t)
+    : actionNeededBadge(t)
 }
 
 const recoverBadge = (

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
@@ -4,12 +4,15 @@ import { ReturnCircleIcon } from 'components/icons/returnCircleIcon'
 import { WarningIcon } from 'components/icons/warningIcon'
 import { useTranslations } from 'next-intl'
 
+import { useRemoteFailedState } from '../../_hooks/useRemoteFailedState'
 import {
   hasFailedSettlement,
   isDeliberateCancel,
+  isRemoteFailed,
   isUserCancel,
   needsManualClaim,
   needsRecover,
+  remoteFailedSettlement,
 } from '../../_utils'
 import { type EarnTransaction, type EarnTransactionKindType } from '../../types'
 import { InProgressIcon } from '../icons/inProgressIcon'
@@ -32,6 +35,36 @@ const failedBadge = (t: Translator) => ({
   text: t('status.tx-failed'),
   textClassName: 'text-neutral-900',
 })
+
+// Amber (not the red Tx Failed): the request is recoverable, the user just needs to Retry/Cancel.
+const actionNeededBadge = (t: Translator) => ({
+  icon: <WarningIcon className="text-amber-500" />,
+  text: t('status.action-needed'),
+  textClassName: 'text-neutral-900',
+})
+
+// An in-flight retry/cancel reads as progress; a stuck remote failure asks the user to act.
+// Only drives the badge while still FAILED — once the row advances (FULFILLED/CANCELLED after a
+// successful retry/cancel) the lingering marker must hand back to the normal claim/recover badge.
+function remoteBadge(
+  transaction: EarnTransaction,
+  ready: boolean,
+  t: Translator,
+) {
+  if (!isRemoteFailed(transaction)) return undefined
+  const marker = remoteFailedSettlement(transaction.settlement)
+  if (marker && !marker.failed) {
+    return inProgress(
+      t(
+        marker.kind === 'RETRY'
+          ? 'status.retrying'
+          : 'status.cancelling-request',
+      ),
+    )
+  }
+  // Within the keeper grace the CTA is hidden, so read as in-progress, not "Action needed".
+  return ready ? actionNeededBadge(t) : inProgress(t('status.in-progress'))
+}
 
 const recoverBadge = (
   userCancel: boolean,
@@ -85,11 +118,14 @@ function resolveStatusBadge(transaction: EarnTransaction, t: Translator) {
 function resolveBadge(
   transaction: EarnTransaction,
   cooldownText: string | undefined,
+  remoteFailedReady: boolean,
   t: Translator,
 ) {
   const { kind } = transaction
   // A reverted claim/recover wins over the (now stale) manual-needed state.
   if (hasFailedSettlement(transaction)) return failedBadge(t)
+  const remote = remoteBadge(transaction, remoteFailedReady, t)
+  if (remote) return remote
   const userCancel = isUserCancel(transaction)
   // At CANCELLED it's the recover stage — neutral for a user cancel, amber for an Agent failure; the PENDING cancel reads as "Cancelling".
   if (needsRecover(transaction)) return recoverBadge(userCancel, kind, t)
@@ -108,9 +144,11 @@ function resolveBadge(
 
 export const StatusBadge = function ({ cooldownText, transaction }: Props) {
   const t = useTranslations('hemi-earn.transactions')
+  const { show: remoteFailedReady } = useRemoteFailedState(transaction)
   const { icon, text, textClassName } = resolveBadge(
     transaction,
     cooldownText,
+    remoteFailedReady,
     t,
   )
   return (

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -19,6 +19,7 @@ import { useAccount } from 'wagmi'
 
 import { useCooldownDuration } from '../../../_hooks/useCooldownDuration'
 import { useIsCooldownEligible } from '../../../_hooks/useIsCooldownEligible'
+import { useRemoteFailedState } from '../../../_hooks/useRemoteFailedState'
 import {
   claimRecoverSettlement,
   getTerminalDeliveryTxHash,
@@ -26,9 +27,11 @@ import {
   isFinalizeInFlight,
   isLocalEarnTransactionRow,
   isRecoverPath,
+  isRemoteFailed,
   isUserCancel,
   needsManualClaim,
   needsRecover,
+  remoteFailedStepStatus,
   resolveSettleStepStatus,
 } from '../../../_utils'
 import { deriveCooldownPostAction } from '../../../pool/[shareAddress]/_components/poolReview/cooldownPostAction'
@@ -40,6 +43,7 @@ import {
 } from '../../../types'
 
 import { ClaimFromVaultBanner } from './claimFromVault'
+import { RemoteFailedBanner } from './remoteFailed'
 import { SettleBanner } from './settleShared'
 
 type Props = {
@@ -333,6 +337,8 @@ export const HistoricalWithdrawReview = function ({
     claimableAt !== null ? BigInt(claimableAt) : undefined,
   )
 
+  const { show: remoteFailedReady } = useRemoteFailedState(transaction)
+
   const { receive: receiveFromStatus, unstake } = resolveStepStates(transaction)
   const unstakeMined = unstake === ProgressStatus.COMPLETED
   // Drop the CANCEL marker so it doesn't pose as the recover step's transaction.
@@ -348,13 +354,16 @@ export const HistoricalWithdrawReview = function ({
     receiveFromStatus,
     unstakeMined,
   })
-  const receive = resolveSettleStepStatus({
-    awaitingAction: needsManualClaim(transaction),
-    fallback: cooldownDerived,
-    isComplete: cooldownDerived === ProgressStatus.COMPLETED,
-    settlementFailed: settleMarker?.failed ?? false,
-    settlementTxHash,
-  })
+  // Receive step tracks the remote-failed sub-state (FAILED only when the CTA is surfaced).
+  const receive = isRemoteFailed(transaction)
+    ? remoteFailedStepStatus(remoteFailedReady, transaction.settlement)
+    : resolveSettleStepStatus({
+        awaitingAction: needsManualClaim(transaction),
+        fallback: cooldownDerived,
+        isComplete: cooldownDerived === ProgressStatus.COMPLETED,
+        settlementFailed: settleMarker?.failed ?? false,
+        settlementTxHash,
+      })
 
   const cooldownPostAction = deriveCooldownPostAction({
     cooldownDurationSec,
@@ -392,6 +401,7 @@ export const HistoricalWithdrawReview = function ({
         <>
           <SettleBanner transaction={transaction} />
           <ClaimFromVaultBanner transaction={transaction} />
+          <RemoteFailedBanner transaction={transaction} />
         </>
       }
       amount={displayAmount}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -11,6 +11,7 @@ import {
   findPoolByAsset,
   hashesMatch,
   isAwaitingFinalize,
+  isRemoteFailed,
   needsManualClaim,
   needsRecover,
 } from '../../../_utils'
@@ -23,6 +24,7 @@ import {
 import { ClaimFromVaultCta } from './claimFromVault'
 import { HistoricalDepositReview } from './historicalDepositReview'
 import { HistoricalWithdrawReview } from './historicalWithdrawReview'
+import { RemoteFailedCta } from './remoteFailed'
 import { RetryFailedDeposit } from './retryFailedDeposit'
 import { RetryFailedWithdraw } from './retryFailedWithdraw'
 import { AddTokenToWalletCta, SettleCta } from './settleShared'
@@ -91,6 +93,9 @@ function redeemCallToAction({
         transaction={transaction}
       />
     )
+  }
+  if (isRemoteFailed(transaction)) {
+    return <RemoteFailedCta transaction={transaction} />
   }
   if (isAwaitingFinalize(transaction)) {
     return <ClaimFromVaultCta transaction={transaction} />

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { Button } from 'components/button'
+import { SubmitWhenConnected } from 'components/submitWhenConnected'
+import { WarningBox } from 'components/warningBox'
+import { type EventEmitter } from 'events'
+import { type RetryRequestEvents } from 'hemi-earn-actions'
+import { useTranslations } from 'next-intl'
+import { type MouseEvent, type ReactNode } from 'react'
+
+import {
+  useCancelRequest,
+  useRetryRequest,
+} from '../../../_hooks/useRemoteFailedActions'
+import { useRemoteFailedState } from '../../../_hooks/useRemoteFailedState'
+import { remoteFailedSettlement } from '../../../_utils'
+import { type EarnSettlement, type EarnTransaction } from '../../../types'
+
+import { useTxDrawerQueryString } from './useTxDrawerQueryString'
+
+type RecoveryConfig = {
+  idleKey: 'cancel-request' | 'retry'
+  kind: EarnSettlement['kind']
+  mutation: ReturnType<typeof useRetryRequest>
+  pendingKey: 'status.cancelling-request' | 'status.retrying'
+  primary: boolean
+}
+
+const RecoveryButton = function ({
+  config,
+  disabled,
+  marker,
+}: {
+  config: RecoveryConfig
+  disabled: boolean
+  marker: EarnSettlement | undefined
+}) {
+  const t = useTranslations('hemi-earn.transactions')
+  const own = marker?.kind === config.kind ? marker : undefined
+  const pending = config.mutation.isPending || (!!own && !own.failed)
+
+  const onClick = function (e: MouseEvent) {
+    e.stopPropagation()
+    if (!disabled) config.mutation.mutate()
+  }
+
+  return (
+    <Button
+      disabled={disabled}
+      onClick={onClick}
+      size="small"
+      type="button"
+      variant={config.primary ? 'primary' : 'secondary'}
+    >
+      {pending ? t(config.pendingKey) : t(config.idleKey)}
+    </Button>
+  )
+}
+
+export const RemoteFailedCta = function ({
+  fallback = null,
+  fullWidth = true,
+  redirectOnSign = false,
+  transaction,
+}: {
+  fallback?: ReactNode
+  fullWidth?: boolean
+  redirectOnSign?: boolean
+  transaction: EarnTransaction
+}) {
+  const [, setTxDrawerQueryString] = useTxDrawerQueryString()
+  const { category, show } = useRemoteFailedState(transaction)
+
+  const on = redirectOnSign
+    ? (emitter: EventEmitter<RetryRequestEvents>) =>
+        emitter.on('user-signed-tx', () =>
+          setTxDrawerQueryString(transaction.requestTxHash),
+        )
+    : undefined
+
+  const retry = useRetryRequest({ on, transaction })
+  const cancel = useCancelRequest({ on, transaction })
+
+  const marker = remoteFailedSettlement(transaction.settlement)
+  const retryConfig: RecoveryConfig = {
+    idleKey: 'retry',
+    kind: 'RETRY',
+    mutation: retry,
+    pendingKey: 'status.retrying',
+    primary: true,
+  }
+  const cancelConfig: RecoveryConfig = {
+    idleKey: 'cancel-request',
+    kind: 'CANCEL_REQUEST',
+    mutation: cancel,
+    pendingKey: 'status.cancelling-request',
+    primary: category === 'slippage',
+  }
+  // A slippage retry just slips again against the frozen min-out, so offer only Cancel;
+  // for gas/unknown, Retry leads with Cancel as the escape hatch.
+  const configs =
+    category === 'slippage' ? [cancelConfig] : [retryConfig, cancelConfig]
+  const anyPending = configs.some(
+    c => c.mutation.isPending || (marker?.kind === c.kind && !marker.failed),
+  )
+
+  if (!show) {
+    return <>{fallback}</>
+  }
+
+  return (
+    <SubmitWhenConnected
+      submitButton={
+        <div
+          className={
+            fullWidth ? 'flex w-full gap-x-2 [&>button]:flex-1' : 'flex gap-x-2'
+          }
+        >
+          {configs.map(config => (
+            <RecoveryButton
+              config={config}
+              disabled={anyPending}
+              key={config.kind}
+              marker={marker}
+            />
+          ))}
+        </div>
+      }
+      submitButtonSize="small"
+    />
+  )
+}
+
+export const RemoteFailedBanner = function ({
+  transaction,
+}: {
+  transaction: EarnTransaction | undefined
+}) {
+  const t = useTranslations('hemi-earn.transactions.banner')
+  const { category, show } = useRemoteFailedState(transaction)
+
+  if (!show) {
+    return null
+  }
+  return (
+    <div className="px-4 py-6 md:px-6">
+      <WarningBox
+        heading={t('remote-failed.heading')}
+        subheading={t(
+          category === 'slippage'
+            ? 'remote-failed.subheading-slippage'
+            : 'remote-failed.subheading',
+        )}
+      />
+    </div>
+  )
+}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
@@ -19,7 +19,7 @@ import { type EarnSettlement, type EarnTransaction } from '../../../types'
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
 type RecoveryConfig = {
-  idleKey: 'cancel-request' | 'retry' | 'return-share-tokens'
+  idleKey: 'retry' | 'return-share-tokens'
   kind: EarnSettlement['kind']
   mutation: ReturnType<typeof useRetryRequest>
   pendingKey: 'status.cancelling-request' | 'status.retrying'
@@ -90,7 +90,7 @@ export const RemoteFailedCta = function ({
     primary: true,
   }
   const cancelConfig: RecoveryConfig = {
-    idleKey: category === 'slippage' ? 'return-share-tokens' : 'cancel-request',
+    idleKey: 'return-share-tokens',
     kind: 'CANCEL_REQUEST',
     mutation: cancel,
     pendingKey: 'status.cancelling-request',

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
@@ -19,7 +19,7 @@ import { type EarnSettlement, type EarnTransaction } from '../../../types'
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
 type RecoveryConfig = {
-  idleKey: 'cancel-request' | 'retry'
+  idleKey: 'cancel-request' | 'retry' | 'return-share-tokens'
   kind: EarnSettlement['kind']
   mutation: ReturnType<typeof useRetryRequest>
   pendingKey: 'status.cancelling-request' | 'status.retrying'
@@ -90,7 +90,7 @@ export const RemoteFailedCta = function ({
     primary: true,
   }
   const cancelConfig: RecoveryConfig = {
-    idleKey: 'cancel-request',
+    idleKey: category === 'slippage' ? 'return-share-tokens' : 'cancel-request',
     kind: 'CANCEL_REQUEST',
     mutation: cancel,
     pendingKey: 'status.cancelling-request',
@@ -145,7 +145,11 @@ export const RemoteFailedBanner = function ({
   return (
     <div className="px-4 py-6 md:px-6">
       <WarningBox
-        heading={t('remote-failed.heading')}
+        heading={t(
+          category === 'slippage'
+            ? 'remote-failed.heading-slippage'
+            : 'remote-failed.heading',
+        )}
         subheading={t(
           category === 'slippage'
             ? 'remote-failed.subheading-slippage'

--- a/portal/app/[locale]/hemi-earn/_hooks/useFailedRequest.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useFailedRequest.ts
@@ -30,13 +30,16 @@ export const useFailedRequest = function (
   return useQuery({
     enabled: !!address && isRemoteFailed(transaction),
     async queryFn() {
+      if (requestId === undefined) {
+        throw new Error('useFailedRequest: missing requestId')
+      }
       const agentAddress = await queryClient.ensureQueryData(
         agentAddressQueryOptions(),
       )
       return getFailedRequest({
         agentAddress,
         client: getEvmL1PublicClient(mainnet.id),
-        requestId: BigInt(requestId!),
+        requestId: BigInt(requestId),
       })
     },
     queryKey: getFailedRequestQueryKey(address, requestId),

--- a/portal/app/[locale]/hemi-earn/_hooks/useFailedRequest.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useFailedRequest.ts
@@ -1,0 +1,50 @@
+'use client'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { getFailedRequest } from 'hemi-earn-actions/actions'
+import { mainnet } from 'networks/mainnet'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { type Address, isAddressEqual, zeroAddress } from 'viem'
+import { useAccount } from 'wagmi'
+
+import { isRemoteFailed } from '../_utils'
+import { type EarnTransaction } from '../types'
+
+import { agentAddressQueryOptions } from './useHemiEarnAgentAddress'
+
+export const getFailedRequestQueryKey = (
+  account: Address | undefined,
+  requestId: string | undefined,
+) => ['hemi-earn', 'failed-request', account, requestId]
+
+// Reads the Agent's on-chain failedRequests entry: tokenIn !== zeroAddress means the request is
+// still stuck (the contract deletes the entry on retry/cancel), which the CTA gate keys off.
+export const useFailedRequest = function (
+  transaction: EarnTransaction | undefined,
+) {
+  const { address } = useAccount()
+  const queryClient = useQueryClient()
+
+  const requestId = transaction?.requestId
+
+  return useQuery({
+    enabled: !!address && isRemoteFailed(transaction),
+    async queryFn() {
+      const agentAddress = await queryClient.ensureQueryData(
+        agentAddressQueryOptions(),
+      )
+      return getFailedRequest({
+        agentAddress,
+        client: getEvmL1PublicClient(mainnet.id),
+        requestId: BigInt(requestId!),
+      })
+    },
+    queryKey: getFailedRequestQueryKey(address, requestId),
+    // Poll while stuck; stop once the entry is cleared on-chain (keeper resolved it) so we
+    // don't keep reading an empty struct until the subgraph re-indexes off FAILED.
+    refetchInterval: query =>
+      query.state.data && isAddressEqual(query.state.data.tokenIn, zeroAddress)
+        ? false
+        : 10_000,
+  })
+}

--- a/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo'
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
@@ -10,6 +12,7 @@ import {
 import {
   cancelRequest,
   getFailedRequest,
+  quoteDepositFulfillment,
   quoteRedeemFulfillment,
   retryRequest,
 } from 'hemi-earn-actions/actions'
@@ -83,14 +86,23 @@ const useRemoteFailedAction = function ({
         })
       }
 
-      const { remoteAsset } = await queryClient.ensureQueryData(
+      const { remoteAsset, remoteShare } = await queryClient.ensureQueryData(
         assetDataQueryOptions(asset),
       )
-      const quote = await quoteRedeemFulfillment({
-        agentAddress,
-        asset: remoteAsset,
-        client,
-      })
+      // Retry re-sends the asset fulfillment (asset OFT); cancel returns the shares (share OFT).
+      // Quote each on the OFT it actually uses so the top-up isn't sized against the wrong path.
+      const quote =
+        kind === 'RETRY'
+          ? await quoteRedeemFulfillment({
+              agentAddress,
+              asset: remoteAsset,
+              client,
+            })
+          : await quoteDepositFulfillment({
+              agentAddress,
+              client,
+              share: remoteShare,
+            })
       // retry/cancel run with failedRequest.nativeFee + msg.value on-chain, so only top up the shortfall.
       const nativeFee = maxBigInt(BigInt(0), quote - failedRequest.nativeFee)
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
@@ -1,0 +1,173 @@
+import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo'
+import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
+import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { type EventEmitter } from 'events'
+import {
+  type CancelRequestEvents,
+  type RetryRequestEvents,
+} from 'hemi-earn-actions'
+import {
+  cancelRequest,
+  getFailedRequest,
+  quoteRedeemFulfillment,
+  retryRequest,
+} from 'hemi-earn-actions/actions'
+import { mainnet } from 'networks/mainnet'
+import { maxBigInt } from 'utils/bigint'
+import { getEvmL1PublicClient } from 'utils/chainClients'
+import { isAddressEqual, zeroAddress } from 'viem'
+import { useAccount, useWalletClient } from 'wagmi'
+
+import { earnTransactionsKeyPrefix } from '../_fetchers/fetchEarnTransactions'
+import { type EarnSettlement, type EarnTransaction } from '../types'
+
+import { assetDataQueryOptions } from './useAssetData'
+import { getFailedRequestQueryKey } from './useFailedRequest'
+import { agentAddressQueryOptions } from './useHemiEarnAgentAddress'
+import { useLocalEarnOperations } from './useLocalEarnOperations'
+
+type RemoteFailedKind = Extract<
+  EarnSettlement['kind'],
+  'RETRY' | 'CANCEL_REQUEST'
+>
+
+type UseRemoteFailedAction = {
+  action: typeof retryRequest
+  kind: RemoteFailedKind
+  on?: (emitter: EventEmitter<RetryRequestEvents>) => void
+  transaction: EarnTransaction
+}
+
+const useRemoteFailedAction = function ({
+  action,
+  kind,
+  on,
+  transaction,
+}: UseRemoteFailedAction) {
+  const { address } = useAccount()
+  const ensureConnectedTo = useEnsureConnectedTo()
+  const queryClient = useQueryClient()
+  const { setSettlement } = useLocalEarnOperations()
+  const { data: l1WalletClient } = useWalletClient({
+    chainId: mainnet.id,
+  })
+  const updateNativeBalanceAfterFees = useUpdateNativeBalanceAfterReceipt(
+    mainnet.id,
+  )
+  const { queryKey: nativeTokenBalanceQueryKey } = useNativeBalance(mainnet.id)
+
+  const { asset, requestId, requestTxHash } = transaction
+
+  return useMutation({
+    async mutationFn() {
+      if (!address) {
+        throw new Error('No account connected')
+      }
+
+      const agentAddress = await queryClient.ensureQueryData(
+        agentAddressQueryOptions(),
+      )
+      const client = getEvmL1PublicClient(mainnet.id)
+      const id = BigInt(requestId)
+
+      const failedRequest = await getFailedRequest({
+        agentAddress,
+        client,
+        requestId: id,
+      })
+      // Entry already gone — a keeper retried/cancelled first; nothing to sign, just refresh.
+      if (isAddressEqual(failedRequest.tokenIn, zeroAddress)) {
+        return queryClient.invalidateQueries({
+          queryKey: earnTransactionsKeyPrefix,
+        })
+      }
+
+      const { remoteAsset } = await queryClient.ensureQueryData(
+        assetDataQueryOptions(asset),
+      )
+      const quote = await quoteRedeemFulfillment({
+        agentAddress,
+        asset: remoteAsset,
+        client,
+      })
+      // retry/cancel run with failedRequest.nativeFee + msg.value on-chain, so only top up the shortfall.
+      const nativeFee = maxBigInt(BigInt(0), quote - failedRequest.nativeFee)
+
+      await ensureConnectedTo(mainnet.id)
+
+      const { emitter, promise } = action({
+        account: address,
+        agentAddress,
+        nativeFee,
+        requestId: id,
+        walletClient: l1WalletClient!,
+      })
+
+      const fail = () => setSettlement(requestTxHash, { failed: true, kind })
+
+      emitter.on('user-signed-tx', function (txHash) {
+        setSettlement(requestTxHash, { failed: false, kind, txHash })
+      })
+      emitter.on('tx-transaction-succeeded', function (receipt) {
+        updateNativeBalanceAfterFees(receipt)
+      })
+      emitter.on('tx-transaction-reverted', async function (receipt) {
+        updateNativeBalanceAfterFees(receipt)
+
+        const current = await getFailedRequest({
+          agentAddress,
+          client,
+          requestId: id,
+        }).catch(() => undefined)
+        // Benign revert: the entry is gone, so someone else resolved it — don't flag failed.
+        if (!current || !isAddressEqual(current.tokenIn, zeroAddress)) {
+          fail()
+        }
+      })
+      emitter.on('tx-failed', fail)
+      emitter.on('tx-failed-validation', fail)
+      emitter.on('user-signing-tx-error', fail)
+      emitter.on('unexpected-error', fail)
+
+      on?.(emitter)
+
+      return promise
+    },
+    onSettled() {
+      queryClient.invalidateQueries({ queryKey: earnTransactionsKeyPrefix })
+      queryClient.invalidateQueries({ queryKey: nativeTokenBalanceQueryKey })
+      queryClient.invalidateQueries({
+        queryKey: getFailedRequestQueryKey(address, requestId),
+      })
+    },
+  })
+}
+
+export const useRetryRequest = ({
+  on,
+  transaction,
+}: {
+  on?: (emitter: EventEmitter<RetryRequestEvents>) => void
+  transaction: EarnTransaction
+}) =>
+  useRemoteFailedAction({
+    action: retryRequest,
+    kind: 'RETRY',
+    on,
+    transaction,
+  })
+
+export const useCancelRequest = ({
+  on,
+  transaction,
+}: {
+  on?: (emitter: EventEmitter<CancelRequestEvents>) => void
+  transaction: EarnTransaction
+}) =>
+  useRemoteFailedAction({
+    action: cancelRequest,
+    kind: 'CANCEL_REQUEST',
+    on,
+    transaction,
+  })

--- a/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedState.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedState.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { unixNowTimestamp } from 'utils/time'
+import { isAddressEqual, zeroAddress } from 'viem'
+
+import { shouldShowRemoteFailedCtas } from '../_utils'
+import { decodeFailureReason } from '../_utils/decodeFailureReason'
+import { type EarnTransaction } from '../types'
+
+import { useFailedRequest } from './useFailedRequest'
+
+export const useRemoteFailedState = function (
+  transaction: EarnTransaction | undefined,
+) {
+  const { data: failedRequest } = useFailedRequest(transaction)
+  const category = decodeFailureReason(transaction?.failureReason)
+  const isStuck =
+    !!failedRequest && !isAddressEqual(failedRequest.tokenIn, zeroAddress)
+  return {
+    category,
+    show:
+      !!transaction &&
+      shouldShowRemoteFailedCtas({
+        category,
+        isStuck,
+        nowSec: Number(unixNowTimestamp()),
+        tx: transaction,
+      }),
+  }
+}

--- a/portal/app/[locale]/hemi-earn/_utils/decodeFailureReason.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/decodeFailureReason.ts
@@ -1,0 +1,43 @@
+import { type Hex, decodeErrorResult } from 'viem'
+
+export type FailureCategory = 'gas' | 'slippage' | 'unknown'
+
+// Vetro enforces min-out on the gateway, so a slippage revert surfaces as Error(string)
+// with one of these in its message; a custom Vetro error we can't name falls through to 'unknown'.
+const slippageMessage =
+  /slippage|amount.?out|min.?(amount|out)|insufficient.{0,4}output|too little received/i
+
+// Agent.sol reverts InsufficientFee when the forwarded nativeFee can't cover the return message.
+const agentErrorsAbi = [
+  {
+    inputs: [
+      { name: 'provided', type: 'uint256' },
+      { name: 'required', type: 'uint256' },
+    ],
+    name: 'InsufficientFee',
+    type: 'error',
+  },
+] as const
+
+// Return type pinned so TS keeps the literal union (it widens inferred literal returns to `string`).
+export const decodeFailureReason = function (
+  reason: string | null | undefined,
+): FailureCategory {
+  // Empty returndata is an out-of-gas / bare revert — retrying with more gas is the safe default.
+  if (!reason || reason === '0x' || reason.length < 10) return 'gas'
+
+  let decoded
+  try {
+    decoded = decodeErrorResult({ abi: agentErrorsAbi, data: reason as Hex })
+  } catch {
+    return 'unknown'
+  }
+
+  if (decoded.errorName === 'InsufficientFee') return 'gas'
+  if (decoded.errorName === 'Error') {
+    return slippageMessage.test(String(decoded.args?.[0] ?? ''))
+      ? 'slippage'
+      : 'unknown'
+  }
+  return 'unknown'
+}

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -13,6 +13,8 @@ import {
   type LocalEarnOperation,
 } from '../types'
 
+import { type FailureCategory } from './decodeFailureReason'
+
 export const hashesMatch = (a: string | undefined, b: string | undefined) =>
   !!a && !!b && a.toLowerCase() === b.toLowerCase()
 
@@ -63,17 +65,47 @@ export const isRecoverPath = (tx: EarnTransaction) =>
 export const canRetryRow = (tx: EarnTransaction) =>
   tx.status === 'FAILED' && isLocalEarnTransactionRow(tx)
 
-// CANCEL/UNSTAKE reuse the settlement field but aren't claim/recover txs — strip
-// them so the claim/recover UI never treats them as its own.
+// Subgraph FAILED sibling of canRetryRow: the Agent reverted on Ethereum after a good Hemi
+// tx, so the request is stuck remotely and the user drives Agent.retry / Agent.cancel.
+export const isRemoteFailed = (tx: EarnTransaction | undefined) =>
+  !!tx &&
+  tx.kind === 'REDEEM' &&
+  tx.status === 'FAILED' &&
+  tx.failed &&
+  !isLocalEarnTransactionRow(tx)
+
+// CANCEL/UNSTAKE/RETRY/CANCEL_REQUEST reuse the settlement field but aren't claim/recover
+// txs — strip them so the claim/recover UI never treats them as its own.
 export const claimRecoverSettlement = (
   settlement: EarnSettlement | undefined,
 ) =>
-  settlement?.kind === 'CANCEL' || settlement?.kind === 'UNSTAKE'
+  settlement?.kind === 'CANCEL' ||
+  settlement?.kind === 'UNSTAKE' ||
+  settlement?.kind === 'RETRY' ||
+  settlement?.kind === 'CANCEL_REQUEST'
     ? undefined
     : settlement
 
 export const unstakeSettlement = (settlement: EarnSettlement | undefined) =>
   settlement?.kind === 'UNSTAKE' ? settlement : undefined
+
+export const remoteFailedSettlement = (
+  settlement: EarnSettlement | undefined,
+) =>
+  settlement?.kind === 'RETRY' || settlement?.kind === 'CANCEL_REQUEST'
+    ? settlement
+    : undefined
+
+// Remote-failed receive step: FAILED only once the CTA is surfaced (stuck past the grace, no
+// retry/cancel in flight); in-progress otherwise (grace window or a signed recovery mining).
+export const remoteFailedStepStatus = function (
+  ready: boolean,
+  settlement: EarnSettlement | undefined,
+) {
+  const marker = remoteFailedSettlement(settlement)
+  const inFlight = !!marker && !marker.failed
+  return ready && !inFlight ? ProgressStatus.FAILED : ProgressStatus.PROGRESS
+}
 
 // A signed claim/recover reverted while the on-chain status stayed FULFILLED/CANCELLED — surface it as failed, not "needed".
 export const hasFailedSettlement = (tx: EarnTransaction) =>
@@ -176,6 +208,31 @@ export const isCooldownMature = (
   tx: EarnTransaction,
   remainingSec: number | undefined,
 ) => isAwaitingFinalize(tx) && remainingSec === 0
+
+// Grace before offering Retry/Cancel on a remote failure, so the keeper gets first crack at
+// auto-recovering it. Anchored on the request's receivedAt (== the failure block).
+const REMOTE_FAILED_GRACE_SECONDS = 120
+
+// Grace gate for the remote-failed CTAs: stay quiet right after the failure so the keeper can
+// auto-recover, unless slippage (needs a user call), a keeper retry already failed, or the grace elapsed.
+export const shouldShowRemoteFailedCtas = function ({
+  category,
+  isStuck,
+  nowSec,
+  tx,
+}: {
+  category: FailureCategory
+  isStuck: boolean
+  nowSec: number
+  tx: EarnTransaction
+}) {
+  if (!isStuck) return false
+  if (category === 'slippage') return true
+  if ((tx.retryCount ?? 0) > 0) return true
+  // Guard against a missing / '0' / non-numeric receivedAt so the grace can't be skipped by Number(...) === 0.
+  const receivedAt = Number(tx.receivedAt ?? 0)
+  return receivedAt > 0 && nowSec - receivedAt > REMOTE_FAILED_GRACE_SECONDS
+}
 
 // Shared terminal-step ladder for both drawers' receive (claim) and recover steps;
 // untouched manual settlements resolve to READY (nothing spinning yet), else the caller's fallback.

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -25,6 +25,10 @@ import {
   ClaimFromVaultCta,
 } from '../../../../_components/transactionsSection/transactionDrawer/claimFromVault'
 import {
+  RemoteFailedBanner,
+  RemoteFailedCta,
+} from '../../../../_components/transactionsSection/transactionDrawer/remoteFailed'
+import {
   AddTokenToWalletCta,
   SettleBanner,
   SettleCta,
@@ -37,6 +41,7 @@ import { useCooldownDuration } from '../../../../_hooks/useCooldownDuration'
 import { useEarnTransactionsQuery } from '../../../../_hooks/useEarnTransactionsQuery'
 import { useIsCooldownEligible } from '../../../../_hooks/useIsCooldownEligible'
 import { useLocalEarnOperations } from '../../../../_hooks/useLocalEarnOperations'
+import { useRemoteFailedState } from '../../../../_hooks/useRemoteFailedState'
 import {
   claimRecoverSettlement,
   enrichWithSettlement,
@@ -46,9 +51,11 @@ import {
   isAwaitingFinalize,
   isFinalizeInFlight,
   isRecoverPath,
+  isRemoteFailed,
   isUserCancel,
   needsManualClaim,
   needsRecover,
+  remoteFailedStepStatus,
   resolveSettleStepStatus,
 } from '../../../../_utils'
 import { type EarnSettlement, type EarnTransaction } from '../../../../types'
@@ -248,6 +255,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
   const settledRow = enrichWithSettlement(subgraphRow, settlement)
   // A still-PENDING deliberate cancel reads as the recover it's becoming: drop the countdown, render the recover step.
   const cancelling = !!settledRow && isUserCancel(settledRow)
+  const { show: remoteFailedReady } = useRemoteFailedState(settledRow)
 
   const { data: isCooldownEligible } = useIsCooldownEligible({
     account: address,
@@ -461,6 +469,9 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
     if (FAILED_STATUSES.includes(withdrawStatus)) {
       return <RetryWithdraw />
     }
+    if (isRemoteFailed(settledRow)) {
+      return <RemoteFailedCta transaction={settledRow!} />
+    }
     if (settledRow && isAwaitingFinalize(settledRow)) {
       return <ClaimFromVaultCta transaction={settledRow} />
     }
@@ -499,18 +510,31 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
       steps.push(addApprovalStep())
     }
     steps.push(addUnstakeStep())
+    if ((settledRow && isRecoverPath(settledRow)) || cancelling) {
+      steps.push(addRecoverStep())
+      return steps
+    }
+    const receiveStep = buildReceiveStep({
+      chainId,
+      cooldownRemainingSec,
+      isCooldownEligible,
+      receiveToken: selectedAsset.token,
+      row: settledRow,
+      t,
+      withdrawStatus,
+    })
+    // Remote failure: FAILED only when the CTA is surfaced; in-progress during the grace or
+    // while a retry/cancel is being signed/mined.
     steps.push(
-      (settledRow && isRecoverPath(settledRow)) || cancelling
-        ? addRecoverStep()
-        : buildReceiveStep({
-            chainId,
-            cooldownRemainingSec,
-            isCooldownEligible,
-            receiveToken: selectedAsset.token,
-            row: settledRow,
-            t,
-            withdrawStatus,
-          }),
+      isRemoteFailed(settledRow)
+        ? {
+            ...receiveStep,
+            status: remoteFailedStepStatus(
+              remoteFailedReady,
+              settledRow?.settlement,
+            ),
+          }
+        : receiveStep,
     )
     return steps
   }
@@ -521,6 +545,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
         <>
           <SettleBanner transaction={settledRow} />
           <ClaimFromVaultBanner transaction={settledRow} />
+          <RemoteFailedBanner transaction={settledRow} />
         </>
       }
       amount={withdrawOperation?.amountIn ?? shares.toString()}

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -23,10 +23,11 @@ export type EarnTransactionStatusType =
 export type EarnTransactionKindType = 'DEPOSIT' | 'REDEEM'
 
 // A locally-tracked settlement tx the user signed (not a subgraph event). UNSTAKE
-// is the Ethereum Agent.claimUnstake; failed lets the UI offer a Retry.
+// is Agent.claimUnstake; RETRY/CANCEL_REQUEST are Agent.retry/cancel on a remote
+// failure; failed lets the UI offer a Retry.
 export type EarnSettlement = {
   failed: boolean
-  kind: 'CLAIM' | 'RECOVER' | 'CANCEL' | 'UNSTAKE'
+  kind: 'CLAIM' | 'RECOVER' | 'CANCEL' | 'UNSTAKE' | 'RETRY' | 'CANCEL_REQUEST'
   txHash?: Hash
 }
 
@@ -46,13 +47,19 @@ export type EarnTransaction = {
   claimTxHash: Hash | null
   // Agent-side failure flag; lingers through CANCELLED/RECOVERED (failed:false recover = deliberate cancel).
   failed: boolean
+  // Raw Agent revert reason (bytes) on a remote failure; decoded to pick the recovery CTA.
+  failureReason?: string | null
   kind: EarnTransactionKindType
   processedAt?: string | null
+  // Unix seconds the Agent received the request (== the failure block on a remote failure).
+  receivedAt?: string | null
   receiver: Address
   recoverTxHash: Hash | null
   requestedAt: string
   requestId: string
   requestTxHash: Hash
+  // Keeper retries of a remote-failed request; 0 until the first retry.
+  retryCount?: number
   settlement?: EarnSettlement
   status: EarnTransactionStatusType
 }

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -380,6 +380,11 @@
           "heading": "Transaction failed",
           "subheading": "Something went wrong. Use the button below to return your share tokens to your wallet."
         },
+        "remote-failed": {
+          "heading": "Your withdrawal is stuck on Ethereum",
+          "subheading": "The cross-chain step failed. Retry to add more gas and complete the withdrawal, or cancel to return your share tokens to your wallet.",
+          "subheading-slippage": "The price moved beyond your limit, so your withdrawal couldn't complete. Cancel to return your share tokens to your wallet."
+        },
         "withdraw": {
           "heading": "Your withdrawal is ready",
           "subheading": "This usually happens automatically, but you can do it yourself. This transaction runs on Ethereum."
@@ -392,6 +397,7 @@
         "keep": "Keep withdrawal",
         "title": "Cancel withdrawal"
       },
+      "cancel-request": "Cancel",
       "cancel-withdraw": "Cancel withdrawal",
       "claim-funds": "Claim funds",
       "claim-share-tokens": "Claim share tokens",
@@ -428,9 +434,12 @@
       "recover-funds": "Recover funds",
       "recover-shares": "Recover shares",
       "recovering": "Recovering...",
+      "retry": "Retry",
       "status": {
+        "action-needed": "Action needed",
         "bridging-back": "Bridging back to Hemi",
         "cancelling": "Cancelling withdrawal",
+        "cancelling-request": "Cancelling...",
         "cooldown-ready-in-days": "Cooldown · ready in {value}d",
         "cooldown-ready-in-hours": "Cooldown · ready in {value}h",
         "cooldown-ready-in-minutes": "Cooldown · ready in {value}m",
@@ -444,6 +453,7 @@
         "recover-funds-needed": "Something went wrong - Recover funds",
         "recover-shares-cancelled": "Withdrawal cancelled - Recover shares",
         "recover-shares-needed": "Something went wrong - Recover shares",
+        "retrying": "Retrying...",
         "returned": "Returned",
         "shares-returned": "Shares returned",
         "shares-returned-cancelled": "Withdrawal cancelled - Shares returned",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -382,8 +382,9 @@
         },
         "remote-failed": {
           "heading": "Your withdrawal is stuck on Ethereum",
+          "heading-slippage": "Your withdrawal didn't complete",
           "subheading": "The cross-chain step failed. Retry to add more gas and complete the withdrawal, or cancel to return your share tokens to your wallet.",
-          "subheading-slippage": "The price moved beyond your limit, so your withdrawal couldn't complete. Cancel to return your share tokens to your wallet."
+          "subheading-slippage": "The price moved past your slippage limit before the final step could run, so your share tokens are still held. Return them to your wallet, then try the withdrawal again with a higher slippage tolerance."
         },
         "withdraw": {
           "heading": "Your withdrawal is ready",
@@ -435,6 +436,7 @@
       "recover-shares": "Recover shares",
       "recovering": "Recovering...",
       "retry": "Retry",
+      "return-share-tokens": "Return share tokens",
       "status": {
         "action-needed": "Action needed",
         "bridging-back": "Bridging back to Hemi",
@@ -457,6 +459,7 @@
         "returned": "Returned",
         "shares-returned": "Shares returned",
         "shares-returned-cancelled": "Withdrawal cancelled - Shares returned",
+        "slippage-exceeded": "Slippage limit exceeded",
         "tx-failed": "Tx Failed",
         "withdrawn": "Withdrawn"
       },

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -398,7 +398,6 @@
         "keep": "Keep withdrawal",
         "title": "Cancel withdrawal"
       },
-      "cancel-request": "Cancel",
       "cancel-withdraw": "Cancel withdrawal",
       "claim-funds": "Claim funds",
       "claim-share-tokens": "Claim share tokens",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -380,6 +380,11 @@
           "heading": "La transacción falló",
           "subheading": "Algo salió mal. Use el botón de abajo para devolver sus share tokens a su billetera."
         },
+        "remote-failed": {
+          "heading": "Su retiro quedó atascado en Ethereum",
+          "subheading": "El paso entre cadenas falló. Reintente para agregar gas y completar el retiro, o cancele para devolver sus share tokens a su billetera.",
+          "subheading-slippage": "El precio se movió más allá de su límite, por lo que el retiro no pudo completarse. Cancele para devolver sus share tokens a su billetera."
+        },
         "withdraw": {
           "heading": "Su retiro está listo",
           "subheading": "Esto normalmente ocurre de forma automática, pero puede hacerlo usted mismo. Esta transacción se ejecuta en Ethereum."
@@ -392,6 +397,7 @@
         "keep": "Mantener retiro",
         "title": "Cancelar retiro"
       },
+      "cancel-request": "Cancelar",
       "cancel-withdraw": "Cancelar retiro",
       "claim-funds": "Recibir fondos",
       "claim-share-tokens": "Recibir share tokens",
@@ -428,9 +434,12 @@
       "recover-funds": "Recuperar fondos",
       "recover-shares": "Recuperar shares",
       "recovering": "Recuperando...",
+      "retry": "Reintentar",
       "status": {
+        "action-needed": "Acción requerida",
         "bridging-back": "Regresando a Hemi",
         "cancelling": "Cancelando retiro",
+        "cancelling-request": "Cancelando...",
         "cooldown-ready-in-days": "Cooldown · listo en {value}d",
         "cooldown-ready-in-hours": "Cooldown · listo en {value}h",
         "cooldown-ready-in-minutes": "Cooldown · listo en {value}m",
@@ -444,6 +453,7 @@
         "recover-funds-needed": "Algo salió mal - Recuperar fondos",
         "recover-shares-cancelled": "Retiro cancelado - Recuperar shares",
         "recover-shares-needed": "Algo salió mal - Recuperar shares",
+        "retrying": "Reintentando...",
         "returned": "Devuelto",
         "shares-returned": "Shares devueltas",
         "shares-returned-cancelled": "Retiro cancelado - Shares devueltas",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -398,7 +398,6 @@
         "keep": "Mantener retiro",
         "title": "Cancelar retiro"
       },
-      "cancel-request": "Cancelar",
       "cancel-withdraw": "Cancelar retiro",
       "claim-funds": "Recibir fondos",
       "claim-share-tokens": "Recibir share tokens",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -382,8 +382,9 @@
         },
         "remote-failed": {
           "heading": "Su retiro quedó atascado en Ethereum",
-          "subheading": "El paso entre cadenas falló. Reintente para agregar gas y completar el retiro, o cancele para devolver sus share tokens a su billetera.",
-          "subheading-slippage": "El precio se movió más allá de su límite, por lo que el retiro no pudo completarse. Cancele para devolver sus share tokens a su billetera."
+          "heading-slippage": "Su retiro no se completó",
+          "subheading": "El paso entre redes falló. Reintente para agregar gas y completar el retiro, o cancele para devolver sus share tokens a su billetera.",
+          "subheading-slippage": "El precio superó su límite de slippage antes de que el paso final pudiera ejecutarse, por lo que sus share tokens siguen retenidos. Devuélvalos a su billetera y luego intente el retiro de nuevo con una tolerancia de slippage mayor."
         },
         "withdraw": {
           "heading": "Su retiro está listo",
@@ -435,6 +436,7 @@
       "recover-shares": "Recuperar shares",
       "recovering": "Recuperando...",
       "retry": "Reintentar",
+      "return-share-tokens": "Devolver share tokens",
       "status": {
         "action-needed": "Acción requerida",
         "bridging-back": "Regresando a Hemi",
@@ -457,6 +459,7 @@
         "returned": "Devuelto",
         "shares-returned": "Shares devueltas",
         "shares-returned-cancelled": "Retiro cancelado - Shares devueltas",
+        "slippage-exceeded": "Límite de slippage superado",
         "tx-failed": "Tx fallida",
         "withdrawn": "Retirado"
       },

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -380,6 +380,11 @@
           "heading": "Transação falhou",
           "subheading": "Algo deu errado. Use o botão abaixo para devolver seus share tokens à sua carteira."
         },
+        "remote-failed": {
+          "heading": "Seu saque travou na Ethereum",
+          "subheading": "A etapa entre cadeias falhou. Tente novamente para adicionar gas e concluir o saque, ou cancele para devolver seus share tokens à sua carteira.",
+          "subheading-slippage": "O preço se moveu além do seu limite, então o saque não pôde ser concluído. Cancele para devolver seus share tokens à sua carteira."
+        },
         "withdraw": {
           "heading": "Seu saque está pronto",
           "subheading": "Isso normalmente acontece automaticamente, mas você mesmo pode fazer o saque. Esta transação é executada na Ethereum."
@@ -392,6 +397,7 @@
         "keep": "Manter saque",
         "title": "Cancelar saque"
       },
+      "cancel-request": "Cancelar",
       "cancel-withdraw": "Cancelar saque",
       "claim-funds": "Receber fundos",
       "claim-share-tokens": "Receber share tokens",
@@ -428,9 +434,12 @@
       "recover-funds": "Recuperar fundos",
       "recover-shares": "Recuperar shares",
       "recovering": "Recuperando...",
+      "retry": "Tentar novamente",
       "status": {
+        "action-needed": "Ação necessária",
         "bridging-back": "Retornando para a Hemi",
         "cancelling": "Cancelando saque",
+        "cancelling-request": "Cancelando...",
         "cooldown-ready-in-days": "Cooldown · pronto em {value}d",
         "cooldown-ready-in-hours": "Cooldown · pronto em {value}h",
         "cooldown-ready-in-minutes": "Cooldown · pronto em {value}m",
@@ -444,6 +453,7 @@
         "recover-funds-needed": "Algo deu errado - Recuperar fundos",
         "recover-shares-cancelled": "Saque cancelado - Recuperar shares",
         "recover-shares-needed": "Algo deu errado - Recuperar shares",
+        "retrying": "Tentando novamente...",
         "returned": "Devolvido",
         "shares-returned": "Shares devolvidas",
         "shares-returned-cancelled": "Saque cancelado - Shares devolvidas",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -398,7 +398,6 @@
         "keep": "Manter saque",
         "title": "Cancelar saque"
       },
-      "cancel-request": "Cancelar",
       "cancel-withdraw": "Cancelar saque",
       "claim-funds": "Receber fundos",
       "claim-share-tokens": "Receber share tokens",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -382,8 +382,9 @@
         },
         "remote-failed": {
           "heading": "Seu saque travou na Ethereum",
-          "subheading": "A etapa entre cadeias falhou. Tente novamente para adicionar gas e concluir o saque, ou cancele para devolver seus share tokens à sua carteira.",
-          "subheading-slippage": "O preço se moveu além do seu limite, então o saque não pôde ser concluído. Cancele para devolver seus share tokens à sua carteira."
+          "heading-slippage": "Seu saque não foi concluído",
+          "subheading": "A etapa entre redes falhou. Tente novamente para adicionar gas e concluir o saque, ou cancele para devolver seus share tokens à sua carteira.",
+          "subheading-slippage": "O preço ultrapassou seu limite de slippage antes que a etapa final pudesse ser executada, então seus share tokens continuam retidos. Devolva-os à sua carteira e tente o saque novamente com uma tolerância de slippage maior."
         },
         "withdraw": {
           "heading": "Seu saque está pronto",
@@ -435,6 +436,7 @@
       "recover-shares": "Recuperar shares",
       "recovering": "Recuperando...",
       "retry": "Tentar novamente",
+      "return-share-tokens": "Devolver share tokens",
       "status": {
         "action-needed": "Ação necessária",
         "bridging-back": "Retornando para a Hemi",
@@ -457,6 +459,7 @@
         "returned": "Devolvido",
         "shares-returned": "Shares devolvidas",
         "shares-returned-cancelled": "Saque cancelado - Shares devolvidas",
+        "slippage-exceeded": "Limite de slippage excedido",
         "tx-failed": "Tx falhou",
         "withdrawn": "Sacado"
       },

--- a/portal/test/app/[locale]/hemi-earn/_utils/decodeFailureReason.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/decodeFailureReason.test.ts
@@ -1,0 +1,82 @@
+import { encodeErrorResult } from 'viem'
+import { describe, expect, it } from 'vitest'
+
+import { decodeFailureReason } from '../../../../../app/[locale]/hemi-earn/_utils/decodeFailureReason'
+
+const errorStringAbi = [
+  { inputs: [{ type: 'string' }], name: 'Error', type: 'error' },
+] as const
+
+const panicAbi = [
+  { inputs: [{ type: 'uint256' }], name: 'Panic', type: 'error' },
+] as const
+
+const insufficientFeeAbi = [
+  {
+    inputs: [
+      { name: 'provided', type: 'uint256' },
+      { name: 'required', type: 'uint256' },
+    ],
+    name: 'InsufficientFee',
+    type: 'error',
+  },
+] as const
+
+const boomAbi = [{ inputs: [], name: 'Boom', type: 'error' }] as const
+
+const errorString = (message: string) =>
+  encodeErrorResult({
+    abi: errorStringAbi,
+    args: [message],
+    errorName: 'Error',
+  })
+
+describe('decodeFailureReason', function () {
+  it('treats empty / missing returndata as gas', function () {
+    expect(decodeFailureReason(undefined)).toBe('gas')
+    expect(decodeFailureReason(null)).toBe('gas')
+    expect(decodeFailureReason('')).toBe('gas')
+    expect(decodeFailureReason('0x')).toBe('gas')
+  })
+
+  it('maps InsufficientFee to gas', function () {
+    const data = encodeErrorResult({
+      abi: insufficientFeeAbi,
+      args: [BigInt(1), BigInt(2)],
+      errorName: 'InsufficientFee',
+    })
+    expect(decodeFailureReason(data)).toBe('gas')
+  })
+
+  it('maps a slippage-worded Error(string) to slippage', function () {
+    expect(decodeFailureReason(errorString('slippage exceeded'))).toBe(
+      'slippage',
+    )
+    expect(decodeFailureReason(errorString('Too little received'))).toBe(
+      'slippage',
+    )
+    expect(decodeFailureReason(errorString('insufficient output amount'))).toBe(
+      'slippage',
+    )
+  })
+
+  it('maps an unrelated Error(string) to unknown', function () {
+    expect(
+      decodeFailureReason(errorString('GatewayMock: deposit failed')),
+    ).toBe('unknown')
+  })
+
+  it('maps Panic to unknown', function () {
+    const data = encodeErrorResult({
+      abi: panicAbi,
+      args: [BigInt(0x11)],
+      errorName: 'Panic',
+    })
+    expect(decodeFailureReason(data)).toBe('unknown')
+  })
+
+  it('maps an unrecognized custom error to unknown', function () {
+    const data = encodeErrorResult({ abi: boomAbi, errorName: 'Boom' })
+    expect(decodeFailureReason(data)).toBe('unknown')
+  })
+})

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -22,12 +22,16 @@ import {
   isFinalizeInFlight,
   isLocalEarnTransactionRow,
   isRecoverPath,
+  isRemoteFailed,
   isUserCancel,
   needsManualClaim,
   needsRecover,
   pickEarnRowAmount,
   pickSettleBannerKey,
+  remoteFailedSettlement,
+  remoteFailedStepStatus,
   resolveSettleStepStatus,
+  shouldShowRemoteFailedCtas,
   unstakeSettlement,
 } from '../../../../../app/[locale]/hemi-earn/_utils'
 import {
@@ -328,6 +332,42 @@ describe('utils', function () {
     })
   })
 
+  describe('isRemoteFailed', function () {
+    const remoteFailed: EarnTransaction = {
+      ...baseTx,
+      failed: true,
+      kind: 'REDEEM',
+      requestId: '42',
+      status: 'FAILED',
+    }
+
+    it('is true for a subgraph FAILED redeem flagged failed', function () {
+      expect(isRemoteFailed(remoteFailed)).toBe(true)
+    })
+
+    it('is false for a local FAILED row (retryable from home)', function () {
+      expect(
+        isRemoteFailed({ ...remoteFailed, requestId: 'local-1700000000' }),
+      ).toBe(false)
+    })
+
+    it('is false when the failed flag is not set', function () {
+      expect(isRemoteFailed({ ...remoteFailed, failed: false })).toBe(false)
+    })
+
+    it('is false for a deposit', function () {
+      expect(isRemoteFailed({ ...remoteFailed, kind: 'DEPOSIT' })).toBe(false)
+    })
+
+    it('is false for a non-FAILED status', function () {
+      expect(isRemoteFailed({ ...remoteFailed, status: 'PENDING' })).toBe(false)
+    })
+
+    it('is false for undefined', function () {
+      expect(isRemoteFailed(undefined)).toBe(false)
+    })
+  })
+
   describe('claimRecoverSettlement', function () {
     it('returns a CLAIM settlement unchanged', function () {
       const settlement: EarnSettlement = {
@@ -361,6 +401,15 @@ describe('utils', function () {
       ).toBeUndefined()
       expect(
         claimRecoverSettlement({ failed: true, kind: 'UNSTAKE' }),
+      ).toBeUndefined()
+    })
+
+    it('strips RETRY and CANCEL_REQUEST markers (Agent-side, not a settlement)', function () {
+      expect(
+        claimRecoverSettlement({ failed: false, kind: 'RETRY' }),
+      ).toBeUndefined()
+      expect(
+        claimRecoverSettlement({ failed: true, kind: 'CANCEL_REQUEST' }),
       ).toBeUndefined()
     })
 
@@ -1063,6 +1112,141 @@ describe('utils', function () {
 
     it('is false for undefined', function () {
       expect(isFinalizeInFlight(undefined)).toBe(false)
+    })
+  })
+
+  describe('remoteFailedSettlement', function () {
+    it('returns a RETRY marker unchanged', function () {
+      const settlement: EarnSettlement = { failed: false, kind: 'RETRY' }
+      expect(remoteFailedSettlement(settlement)).toBe(settlement)
+    })
+
+    it('returns a CANCEL_REQUEST marker unchanged', function () {
+      const settlement: EarnSettlement = {
+        failed: true,
+        kind: 'CANCEL_REQUEST',
+      }
+      expect(remoteFailedSettlement(settlement)).toBe(settlement)
+    })
+
+    it('ignores claim/recover/unstake markers', function () {
+      expect(
+        remoteFailedSettlement({ failed: false, kind: 'CLAIM' }),
+      ).toBeUndefined()
+      expect(
+        remoteFailedSettlement({ failed: false, kind: 'UNSTAKE' }),
+      ).toBeUndefined()
+    })
+
+    it('returns undefined for no settlement', function () {
+      expect(remoteFailedSettlement(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('remoteFailedStepStatus', function () {
+    it('is FAILED when ready and nothing in flight', function () {
+      expect(remoteFailedStepStatus(true, undefined)).toBe(
+        ProgressStatus.FAILED,
+      )
+    })
+
+    it('is in progress while a retry/cancel is in flight', function () {
+      expect(
+        remoteFailedStepStatus(true, { failed: false, kind: 'RETRY' }),
+      ).toBe(ProgressStatus.PROGRESS)
+      expect(
+        remoteFailedStepStatus(true, { failed: false, kind: 'CANCEL_REQUEST' }),
+      ).toBe(ProgressStatus.PROGRESS)
+    })
+
+    it('is FAILED again once the retry/cancel reverted', function () {
+      expect(
+        remoteFailedStepStatus(true, { failed: true, kind: 'RETRY' }),
+      ).toBe(ProgressStatus.FAILED)
+    })
+
+    it('is in progress during the grace (not ready yet)', function () {
+      expect(remoteFailedStepStatus(false, undefined)).toBe(
+        ProgressStatus.PROGRESS,
+      )
+    })
+  })
+
+  describe('shouldShowRemoteFailedCtas', function () {
+    const stuckTx: EarnTransaction = {
+      ...baseTx,
+      failed: true,
+      kind: 'REDEEM',
+      receivedAt: '1000',
+      requestId: '42',
+      retryCount: 0,
+      status: 'FAILED',
+    }
+
+    it('is false when not stuck on-chain', function () {
+      expect(
+        shouldShowRemoteFailedCtas({
+          category: 'slippage',
+          isStuck: false,
+          nowSec: 999999,
+          tx: stuckTx,
+        }),
+      ).toBe(false)
+    })
+
+    it('shows immediately for slippage (needs a user call)', function () {
+      expect(
+        shouldShowRemoteFailedCtas({
+          category: 'slippage',
+          isStuck: true,
+          nowSec: 1001,
+          tx: stuckTx,
+        }),
+      ).toBe(true)
+    })
+
+    it('shows once a keeper retry already failed', function () {
+      expect(
+        shouldShowRemoteFailedCtas({
+          category: 'gas',
+          isStuck: true,
+          nowSec: 1001,
+          tx: { ...stuckTx, retryCount: 1 },
+        }),
+      ).toBe(true)
+    })
+
+    it('shows after the grace elapses', function () {
+      expect(
+        shouldShowRemoteFailedCtas({
+          category: 'gas',
+          isStuck: true,
+          nowSec: 1121,
+          tx: stuckTx,
+        }),
+      ).toBe(true)
+    })
+
+    it('stays hidden within the grace window', function () {
+      expect(
+        shouldShowRemoteFailedCtas({
+          category: 'gas',
+          isStuck: true,
+          nowSec: 1060,
+          tx: stuckTx,
+        }),
+      ).toBe(false)
+    })
+
+    it('stays hidden with no receivedAt and no retries', function () {
+      expect(
+        shouldShowRemoteFailedCtas({
+          category: 'unknown',
+          isStuck: true,
+          nowSec: 999999,
+          tx: { ...stuckTx, receivedAt: null },
+        }),
+      ).toBe(false)
     })
   })
 })


### PR DESCRIPTION
### Description

This PR implements a recovery path for Hemi Earn redeems that get stuck on Ethereum. When the Agent's cross-chain execution reverts — slippage, an insufficient LayerZero fee, or a gateway failure — the request lands in `Agent.failedRequests` while the Router stays `PENDING`, and until now the row just showed a spinner with no way forward.

Important context: these are **fallbacks for edge cases the keeper bot couldn't auto-resolve on its own**. In normal operation the keeper retries/cancels these automatically, so the user should never see or use these controls — they only surface after a short grace window (giving the bot first crack) and only while the request is still stuck on-chain.

When it does surface, the user gets a **Retry** (top up the fee and re-run the redeem) and/or **Cancel** (return the share tokens), which call `Agent.retry` / `Agent.cancel` on Ethereum, mirroring the existing Claim-from-vault flow. The failure category decides what's offered: slippage shows only Cancel (a retry would just slip again against the frozen min-out), while gas/unknown lead with Retry and keep Cancel as an escape hatch. It's redeem-only for now; deposit recovery is a follow-up.

Under the hood it consumes the `receivedAt` / `retryCount` / `failureReason` fields from the earn-requests API, and wires the CTA, banner, and a grace-aware status badge + cross-chain step into both the live and historical withdraw drawers.

### Screenshots

slippage
<img width="420" height="877" alt="Captura de Tela 2026-07-10 às 11 45 18" src="https://github.com/user-attachments/assets/69bc2a8b-4d20-4e77-96f9-f2e45252ba19" />



fees/unknown

<img width="463" height="959" alt="Captura de Tela 2026-07-10 às 10 31 29" src="https://github.com/user-attachments/assets/ac481771-35c9-4670-bc27-66c6a7e6772c" />

Table

<img width="1503" height="770" alt="Captura de Tela 2026-07-10 às 13 31 59" src="https://github.com/user-attachments/assets/c5fc3123-0531-4521-9a80-3d95fd06d3e2" />


### Related issue(s)

Related to #1943
Related to #2028 
Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
