### PR TITLE
Add xxSmall size to Button

### DIFF
--- a/portal/.storybook/main.ts
+++ b/portal/.storybook/main.ts
@@ -7,9 +7,11 @@ const config: StorybookConfig = {
     options: {},
   },
   // `next/font/local` registers the @font-face rules but @storybook/nextjs does
-  // not emit the font files, so serve the whole `fonts` directory at the path
-  // the generated rules reference (`/fonts/...`) to keep the app typography.
-  staticDirs: [{ from: '../fonts', to: '/fonts' }],
+  // not emit the font files, so serve the `inter` asset directory at the path
+  // the generated rules reference (`/fonts/inter/...`) to keep the app
+  // typography. Only `inter` is served so source files (e.g. `fonts/index.ts`)
+  // are not published in the Storybook build.
+  staticDirs: [{ from: '../fonts/inter', to: '/fonts/inter' }],
   stories: ['../stories/**/*.stories.@(ts|tsx)'],
 }
 

--- a/portal/.storybook/main.ts
+++ b/portal/.storybook/main.ts
@@ -6,6 +6,10 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs',
     options: {},
   },
+  // `next/font/local` registers the @font-face rules but @storybook/nextjs does
+  // not emit the font files, so serve the whole `fonts` directory at the path
+  // the generated rules reference (`/fonts/...`) to keep the app typography.
+  staticDirs: [{ from: '../fonts', to: '/fonts' }],
   stories: ['../stories/**/*.stories.@(ts|tsx)'],
 }
 

--- a/portal/.storybook/preview.ts
+++ b/portal/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/nextjs'
+import { interDisplay, interVariable } from 'fonts/index'
 import { createElement } from 'react'
 import { SkeletonTheme } from 'react-loading-skeleton'
 
@@ -6,14 +7,20 @@ import 'styles/globals.css'
 import 'react-loading-skeleton/dist/skeleton.css'
 
 const preview: Preview = {
-  // Mirror the SkeletonTheme set on the app root layout so skeleton-based
-  // components (e.g. ButtonLoader) render with the same colors in Storybook.
+  // Mirror the app root layout: expose the Inter font CSS variables (so
+  // `globals.css` resolves `font-inter-variable`/`font-inter-display` instead
+  // of falling back to a system font) and the SkeletonTheme (so skeleton-based
+  // components like ButtonLoader render with the same colors).
   decorators: [
     Story =>
       createElement(
-        SkeletonTheme,
-        { baseColor: '#E5E5E5', highlightColor: '#FAFAFA' },
-        createElement(Story),
+        'div',
+        { className: `${interVariable.variable} ${interDisplay.variable}` },
+        createElement(
+          SkeletonTheme,
+          { baseColor: '#E5E5E5', highlightColor: '#FAFAFA' },
+          createElement(Story),
+        ),
       ),
   ],
   parameters: {

--- a/portal/components/button/button.css
+++ b/portal/components/button/button.css
@@ -31,6 +31,18 @@ Because of that, we can add all the styles here, and then use plain buttons in t
 }
 
 /* Button Sizes */
+.button-xx-small {
+  @apply h-6 rounded-md text-xs;
+}
+
+.button-xx-small.button-regular {
+  @apply gap-x-1 px-2.5;
+}
+
+.button-xx-small.button-icon {
+  @apply min-w-6;
+}
+
 .button-x-small {
   @apply h-7 rounded-md text-xs;
 }

--- a/portal/components/button/button.css
+++ b/portal/components/button/button.css
@@ -15,6 +15,11 @@ Because of that, we can add all the styles here, and then use plain buttons in t
   - Applying a transition effect on opacity (`before:transition-opacity before:duration-200`)
   */
   @apply before:absolute before:inset-0 before:-z-10 before:opacity-0 before:transition-opacity before:duration-200 before:content-[''] hover:before:opacity-100 disabled:hover:before:opacity-0;
+  /*
+  Icons (direct <svg> children) sit at reduced opacity at rest and go to full
+  opacity on hover, matching the Figma spec.
+  */
+  @apply [&:disabled:hover>svg]:opacity-70 [&:hover>svg]:opacity-100 [&>svg]:opacity-70 [&>svg]:transition-opacity [&>svg]:duration-200;
 }
 
 /* Button Variants */

--- a/portal/components/button/index.tsx
+++ b/portal/components/button/index.tsx
@@ -9,10 +9,14 @@ const variants = {
   tertiary: 'button-tertiary',
 } as const
 
-export type ButtonSize = 'xSmall' | 'small' | 'xLarge'
+export type ButtonSize = 'xxSmall' | 'xSmall' | 'small' | 'xLarge'
 
 /* eslint-disable sort-keys */
 const buttonSizePresets = {
+  xxSmall: {
+    icon: 'button-xx-small button-icon',
+    regular: 'button-xx-small button-regular',
+  },
   xSmall: {
     icon: 'button-x-small button-icon',
     regular: 'button-x-small button-regular',

--- a/portal/stories/button.stories.tsx
+++ b/portal/stories/button.stories.tsx
@@ -4,7 +4,8 @@ import { Chevron } from 'components/icons/chevron'
 import { ComponentProps } from 'react'
 
 type StoryProps = ComponentProps<typeof Button> & {
-  iconPosition: 'none' | 'left' | 'right'
+  iconLeft: boolean
+  iconRight: boolean
 }
 
 // Match the Figma icon colors: white on primary, dark on secondary/tertiary.
@@ -19,7 +20,8 @@ const iconColor = (variant: StoryProps['variant']) =>
 const meta = {
   args: {
     children: 'Connect Wallet',
-    iconPosition: 'none',
+    iconLeft: false,
+    iconRight: false,
     size: 'small',
     variant: 'primary',
   },
@@ -30,9 +32,11 @@ const meta = {
     disabled: {
       control: 'boolean',
     },
-    iconPosition: {
-      control: 'inline-radio',
-      options: ['none', 'left', 'right'],
+    iconLeft: {
+      control: 'boolean',
+    },
+    iconRight: {
+      control: 'boolean',
     },
     size: {
       control: 'select',
@@ -44,15 +48,11 @@ const meta = {
     },
   },
   component: Button,
-  render: ({ children, iconPosition, variant, ...args }) => (
+  render: ({ children, iconLeft, iconRight, variant, ...args }) => (
     <Button variant={variant} {...args}>
-      {iconPosition === 'left' && (
-        <Chevron.Left className={iconColor(variant)} />
-      )}
+      {iconLeft && <Chevron.Left className={iconColor(variant)} />}
       {children}
-      {iconPosition === 'right' && (
-        <Chevron.Right className={iconColor(variant)} />
-      )}
+      {iconRight && <Chevron.Right className={iconColor(variant)} />}
     </Button>
   ),
   title: 'Components/Button',
@@ -83,6 +83,13 @@ export const Tertiary: Story = {
 export const Disabled: Story = {
   args: {
     disabled: true,
+  },
+}
+
+export const TwoIcons: Story = {
+  args: {
+    iconLeft: true,
+    iconRight: true,
   },
 }
 

--- a/portal/stories/button.stories.tsx
+++ b/portal/stories/button.stories.tsx
@@ -36,7 +36,7 @@ const meta = {
     },
     size: {
       control: 'select',
-      options: ['xSmall', 'small', 'xLarge'],
+      options: ['xxSmall', 'xSmall', 'small', 'xLarge'],
     },
     variant: {
       control: 'select',


### PR DESCRIPTION
### Description

Adds a new `xxSmall` (24px) size to the shared `Button` component, matching the Figma spec: a new `ButtonSize` value, its size preset, and the `.button-xx-small` styles (`h-6`, tighter padding, `min-w-6` for the icon variant).

The Button Storybook story's `size` control is updated to include `xxSmall`, so the control reflects the full supported surface. This is the size used by the row action button in the upcoming table story (#2061), extracted here so it lands as a standalone Button change first.

### Also included in this PR

Beyond the `xxSmall` size, this PR bundles a few closely related Button/Storybook changes:

- **Icon opacity** (`button.css`): direct `<svg>` children of a button render at reduced opacity at rest (70%, the closest available to Figma's 72%) and go to full opacity on hover, applied on `.button--base` so it stays consistent across all variants.
- **Story icon controls** (`button.stories.tsx`): the `iconPosition` radio is replaced by independent `iconLeft`/`iconRight` boolean controls, so a button can show a leading icon, a trailing icon, or both. Adds a `TwoIcons` story.
- **Inter font in Storybook** (`preview.ts` + `main.ts`): stories were falling back to a system font. The preview decorator now exposes the `next/font` CSS variables and `staticDirs` serves the `fonts/` directory, so stories render with the app's real typography.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img  alt="Captura de pantalla 2026-07-13 a la(s) 6 02 22 p  m" src="https://github.com/user-attachments/assets/f588d64a-6a9b-49dc-9581-8ddce3839da5" />

The `xxSmall` size renders a 24px-tall button; it can be previewed in the Button story via the `size` control.

### Related issue(s)

Closes #2090
Closes #2088
Related to #1993

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.