### PR TITLE
Add remote-failure recovery to Hemi Earn deposits

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/statusBadge.tsx
@@ -62,12 +62,12 @@ function remoteBadge(
   if (!isRemoteFailed(transaction)) return undefined
   const marker = remoteFailedSettlement(transaction.settlement)
   if (marker && !marker.failed) {
+    const returningKey =
+      transaction.kind === 'DEPOSIT'
+        ? 'status.returning-funds'
+        : 'status.returning-share-tokens'
     return inProgress(
-      t(
-        marker.kind === 'RETRY'
-          ? 'status.retrying'
-          : 'status.cancelling-request',
-      ),
+      t(marker.kind === 'RETRY' ? 'status.retrying' : returningKey),
     )
   }
   // Within the keeper grace the CTA is hidden, so read as in-progress, not "Action needed".

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -15,19 +15,24 @@ import { type ReactNode } from 'react'
 import { type EvmToken } from 'types/token'
 import { type Hash } from 'viem'
 
+import { useRemoteFailedState } from '../../../_hooks/useRemoteFailedState'
 import { SparkleIcon } from '../../../_icons/sparkleIcon'
 import {
   getTerminalDeliveryTxHash,
   isLocalEarnTransactionRow,
   isRecoverPath,
+  isRemoteFailed,
+  isRemoteFailedCancel,
   needsManualClaim,
   needsRecover,
+  remoteFailedStepStatus,
 } from '../../../_utils'
 import {
   type EarnTransaction,
   type EarnTransactionStatusType,
 } from '../../../types'
 
+import { RemoteFailedBanner } from './remoteFailed'
 import { SettleBanner } from './settleShared'
 
 type Props = {
@@ -123,23 +128,27 @@ function resolveTerminalStatus(
 // Recover path returns the asset, so its terminal step is labeled with the asset token.
 function buildTerminalStep({
   baseStatus,
+  remoteFailedReady,
   settlementTxHash,
   t,
   token,
   tx,
 }: {
   baseStatus: ProgressStatusType
+  remoteFailedReady: boolean
   settlementTxHash: Hash | undefined
   t: Translator
   token: EvmToken
   tx: EarnTransaction
 }): StepPropsWithoutPosition {
-  const status = resolveTerminalStatus(tx, baseStatus, settlementTxHash)
+  const status = isRemoteFailed(tx)
+    ? remoteFailedStepStatus(remoteFailedReady, tx.settlement)
+    : resolveTerminalStatus(tx, baseStatus, settlementTxHash)
   const txHash = settlementTxHash ?? getTerminalDeliveryTxHash(tx)
   // Link whenever a delivery hash exists — an auto-finalized claim/recover has one the user never signed.
   const explorerChainId = txHash ? hemi.id : undefined
-  if (isRecoverPath(tx)) {
-    // "Funds returned" only once RECOVERED; CANCELLED still awaits the recover.
+  if (isRecoverPath(tx) || isRemoteFailedCancel(tx)) {
+    // "Funds returned" only once RECOVERED; CANCELLED / a signed remote-failed cancel awaits the recover.
     const recoverLabel =
       tx.status === 'RECOVERED'
         ? 'step.funds-returned'
@@ -200,6 +209,8 @@ export const HistoricalDepositReview = function ({
     spender: getHemiEarnRouterAddress(),
   })
 
+  const { show: remoteFailedReady } = useRemoteFailedState(transaction)
+
   const { waitingForShares } = resolveStepStates(transaction)
   // Only a still-mining settlement drives PROGRESS; a failed one keeps the natural (FAILED) status + Retry CTA.
   const { settlement } = transaction
@@ -231,6 +242,7 @@ export const HistoricalDepositReview = function ({
   steps.push(
     buildTerminalStep({
       baseStatus: waitingForShares,
+      remoteFailedReady,
       settlementTxHash,
       t,
       token,
@@ -240,7 +252,12 @@ export const HistoricalDepositReview = function ({
 
   return (
     <Operation
-      aboveCallToAction={<SettleBanner transaction={transaction} />}
+      aboveCallToAction={
+        <>
+          <SettleBanner transaction={transaction} />
+          <RemoteFailedBanner transaction={transaction} />
+        </>
+      }
       amount={transaction.amountIn}
       callToAction={callToAction}
       heading={t('deposit-heading')}

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -10,7 +10,6 @@ import { TokenLogo } from 'components/tokenLogo'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
 import { hemi } from 'hemi-viem'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
-import { mainnet } from 'networks/mainnet'
 import { useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
 import { type EvmToken } from 'types/token'
@@ -26,8 +25,8 @@ import {
   isRemoteFailedCancel,
   needsManualClaim,
   needsRecover,
-  remoteFailedSettlement,
   remoteFailedStepStatus,
+  resolveStepExplorerChainId,
 } from '../../../_utils'
 import {
   type EarnTransaction,
@@ -147,13 +146,11 @@ function buildTerminalStep({
     ? remoteFailedStepStatus(remoteFailedReady, tx.settlement)
     : resolveTerminalStatus(tx, baseStatus, settlementTxHash)
   const txHash = settlementTxHash ?? getTerminalDeliveryTxHash(tx)
-  // A remote-failed retry/cancel is signed on the Agent's L1, so link it to mainnet, not Hemi.
-  const recoveryTxHash = remoteFailedSettlement(tx.settlement)?.txHash
-  const explorerChainId = txHash
-    ? txHash === recoveryTxHash
-      ? mainnet.id
-      : hemi.id
-    : undefined
+  const explorerChainId = resolveStepExplorerChainId({
+    fallbackChainId: hemi.id,
+    settlement: tx.settlement,
+    txHash,
+  })
   if (isRecoverPath(tx) || isRemoteFailedCancel(tx)) {
     // "Funds returned" only once RECOVERED; CANCELLED / a signed remote-failed cancel awaits the recover.
     const recoverLabel =

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -10,6 +10,7 @@ import { TokenLogo } from 'components/tokenLogo'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
 import { hemi } from 'hemi-viem'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
+import { mainnet } from 'networks/mainnet'
 import { useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
 import { type EvmToken } from 'types/token'
@@ -25,6 +26,7 @@ import {
   isRemoteFailedCancel,
   needsManualClaim,
   needsRecover,
+  remoteFailedSettlement,
   remoteFailedStepStatus,
 } from '../../../_utils'
 import {
@@ -145,8 +147,13 @@ function buildTerminalStep({
     ? remoteFailedStepStatus(remoteFailedReady, tx.settlement)
     : resolveTerminalStatus(tx, baseStatus, settlementTxHash)
   const txHash = settlementTxHash ?? getTerminalDeliveryTxHash(tx)
-  // Link whenever a delivery hash exists — an auto-finalized claim/recover has one the user never signed.
-  const explorerChainId = txHash ? hemi.id : undefined
+  // A remote-failed retry/cancel is signed on the Agent's L1, so link it to mainnet, not Hemi.
+  const recoveryTxHash = remoteFailedSettlement(tx.settlement)?.txHash
+  const explorerChainId = txHash
+    ? txHash === recoveryTxHash
+      ? mainnet.id
+      : hemi.id
+    : undefined
   if (isRecoverPath(tx) || isRemoteFailedCancel(tx)) {
     // "Funds returned" only once RECOVERED; CANCELLED / a signed remote-failed cancel awaits the recover.
     const recoverLabel =

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -28,6 +28,7 @@ import {
   isLocalEarnTransactionRow,
   isRecoverPath,
   isRemoteFailed,
+  isRemoteFailedCancel,
   isUserCancel,
   needsManualClaim,
   needsRecover,
@@ -271,7 +272,11 @@ function buildSteps({
   const unstakeStep = buildUnstakeStep(transaction, pool.shareToken, t)
   // Recover path: shares come back, so the cooldown/receive machinery doesn't apply. A
   // still-PENDING deliberate cancel joins here too, dropping the now-moot countdown + Receive step.
-  if (isRecoverPath(transaction) || isUserCancel(transaction)) {
+  if (
+    isRecoverPath(transaction) ||
+    isUserCancel(transaction) ||
+    isRemoteFailedCancel(transaction)
+  ) {
     steps.push(unstakeStep)
     steps.push(
       buildRecoverStep(transaction, pool.shareToken, t, settlementTxHash),

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -48,6 +48,9 @@ function depositCallToAction({
       <RetryFailedDeposit asset={asset} pool={pool} transaction={transaction} />
     )
   }
+  if (isRemoteFailed(transaction)) {
+    return <RemoteFailedCta transaction={transaction} />
+  }
   if (needsManualClaim(transaction)) {
     return (
       <SettleCta

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
@@ -19,10 +19,13 @@ import { type EarnSettlement, type EarnTransaction } from '../../../types'
 import { useTxDrawerQueryString } from './useTxDrawerQueryString'
 
 type RecoveryConfig = {
-  idleKey: 'retry' | 'return-share-tokens'
+  idleKey: 'retry' | 'return-funds' | 'return-share-tokens'
   kind: EarnSettlement['kind']
   mutation: ReturnType<typeof useRetryRequest>
-  pendingKey: 'status.cancelling-request' | 'status.retrying'
+  pendingKey:
+    | 'status.retrying'
+    | 'status.returning-funds'
+    | 'status.returning-share-tokens'
   primary: boolean
 }
 
@@ -90,10 +93,14 @@ export const RemoteFailedCta = function ({
     primary: true,
   }
   const cancelConfig: RecoveryConfig = {
-    idleKey: 'return-share-tokens',
+    idleKey:
+      transaction.kind === 'DEPOSIT' ? 'return-funds' : 'return-share-tokens',
     kind: 'CANCEL_REQUEST',
     mutation: cancel,
-    pendingKey: 'status.cancelling-request',
+    pendingKey:
+      transaction.kind === 'DEPOSIT'
+        ? 'status.returning-funds'
+        : 'status.returning-share-tokens',
     primary: category === 'slippage',
   }
   // A slippage retry just slips again against the frozen min-out, so offer only Cancel;
@@ -142,19 +149,13 @@ export const RemoteFailedBanner = function ({
   if (!show) {
     return null
   }
+  const variant = category === 'slippage' ? '-slippage' : ''
+  const suffix = transaction?.kind === 'DEPOSIT' ? '-deposit' : ''
   return (
     <div className="px-4 py-6 md:px-6">
       <WarningBox
-        heading={t(
-          category === 'slippage'
-            ? 'remote-failed.heading-slippage'
-            : 'remote-failed.heading',
-        )}
-        subheading={t(
-          category === 'slippage'
-            ? 'remote-failed.subheading-slippage'
-            : 'remote-failed.subheading',
-        )}
+        heading={t(`remote-failed.heading${variant}${suffix}`)}
+        subheading={t(`remote-failed.subheading${variant}${suffix}`)}
       />
     </div>
   )

--- a/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
@@ -89,20 +89,22 @@ const useRemoteFailedAction = function ({
       const { remoteAsset, remoteShare } = await queryClient.ensureQueryData(
         assetDataQueryOptions(asset),
       )
-      // Retry re-sends the asset fulfillment (asset OFT); cancel returns the shares (share OFT).
-      // Quote each on the OFT it actually uses so the top-up isn't sized against the wrong path.
-      const quote =
-        kind === 'RETRY'
-          ? await quoteRedeemFulfillment({
-              agentAddress,
-              asset: remoteAsset,
-              client,
-            })
-          : await quoteDepositFulfillment({
-              agentAddress,
-              client,
-              share: remoteShare,
-            })
+      // Quote the OFT the action actually sends: retry sends the fulfillment token
+      // (deposit → share, redeem → asset), cancel returns tokenIn (deposit → asset,
+      // redeem → share). Sizing against the wrong OFT would under/over-fund the top-up.
+      const usesShareOft =
+        (transaction.kind === 'DEPOSIT') === (kind === 'RETRY')
+      const quote = usesShareOft
+        ? await quoteDepositFulfillment({
+            agentAddress,
+            client,
+            share: remoteShare,
+          })
+        : await quoteRedeemFulfillment({
+            agentAddress,
+            asset: remoteAsset,
+            client,
+          })
       // retry/cancel run with failedRequest.nativeFee + msg.value on-chain, so only top up the shortfall.
       const nativeFee = maxBigInt(BigInt(0), quote - failedRequest.nativeFee)
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
@@ -92,8 +92,9 @@ const useRemoteFailedAction = function ({
       // Quote the OFT the action actually sends: retry sends the fulfillment token
       // (deposit → share, redeem → asset), cancel returns tokenIn (deposit → asset,
       // redeem → share). Sizing against the wrong OFT would under/over-fund the top-up.
-      const usesShareOft =
-        (transaction.kind === 'DEPOSIT') === (kind === 'RETRY')
+      const isRetry = kind === 'RETRY'
+      const isDeposit = transaction.kind === 'DEPOSIT'
+      const usesShareOft = (isDeposit && isRetry) || (!isDeposit && !isRetry)
       const quote = usesShareOft
         ? await quoteDepositFulfillment({
             agentAddress,

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -68,11 +68,7 @@ export const canRetryRow = (tx: EarnTransaction) =>
 // Subgraph FAILED sibling of canRetryRow: the Agent reverted on Ethereum after a good Hemi
 // tx, so the request is stuck remotely and the user drives Agent.retry / Agent.cancel.
 export const isRemoteFailed = (tx: EarnTransaction | undefined) =>
-  !!tx &&
-  tx.kind === 'REDEEM' &&
-  tx.status === 'FAILED' &&
-  tx.failed &&
-  !isLocalEarnTransactionRow(tx)
+  !!tx && tx.status === 'FAILED' && tx.failed && !isLocalEarnTransactionRow(tx)
 
 // CANCEL/UNSTAKE/RETRY/CANCEL_REQUEST reuse the settlement field but aren't claim/recover
 // txs — strip them so the claim/recover UI never treats them as its own.
@@ -106,6 +102,13 @@ export const remoteFailedStepStatus = function (
   const inFlight = !!marker && !marker.failed
   return ready && !inFlight ? ProgressStatus.FAILED : ProgressStatus.PROGRESS
 }
+
+// A remote-failed request whose chosen recovery is cancel, which returns tokenIn (funds for a
+// deposit, shares for a redeem) — the terminal step should show that returned token, not the
+// fulfillment. Keys off the signed CANCEL_REQUEST marker, so it flips once the cancel is signed.
+export const isRemoteFailedCancel = (tx: EarnTransaction | undefined) =>
+  isRemoteFailed(tx) &&
+  remoteFailedSettlement(tx?.settlement)?.kind === 'CANCEL_REQUEST'
 
 // A signed claim/recover reverted while the on-chain status stayed FULFILLED/CANCELLED — surface it as failed, not "needed".
 export const hasFailedSettlement = (tx: EarnTransaction) =>

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -2,9 +2,10 @@ import {
   ProgressStatus,
   type ProgressStatusType,
 } from 'components/reviewOperation/progressStatus'
+import { mainnet } from 'networks/mainnet'
 import { type Token } from 'types/token'
 import { formatPercentage } from 'utils/format'
-import { type Address, type Hash, isAddressEqual } from 'viem'
+import { type Address, type Chain, type Hash, isAddressEqual } from 'viem'
 
 import {
   type EarnPool,
@@ -68,7 +69,10 @@ export const canRetryRow = (tx: EarnTransaction) =>
 // Subgraph FAILED sibling of canRetryRow: the Agent reverted on Ethereum after a good Hemi
 // tx, so the request is stuck remotely and the user drives Agent.retry / Agent.cancel.
 export const isRemoteFailed = (tx: EarnTransaction | undefined) =>
-  !!tx && tx.status === 'FAILED' && tx.failed && !isLocalEarnTransactionRow(tx)
+  tx !== undefined &&
+  tx.status === 'FAILED' &&
+  tx.failed &&
+  !isLocalEarnTransactionRow(tx)
 
 // CANCEL/UNSTAKE/RETRY/CANCEL_REQUEST reuse the settlement field but aren't claim/recover
 // txs — strip them so the claim/recover UI never treats them as its own.
@@ -109,6 +113,23 @@ export const remoteFailedStepStatus = function (
 export const isRemoteFailedCancel = (tx: EarnTransaction | undefined) =>
   isRemoteFailed(tx) &&
   remoteFailedSettlement(tx?.settlement)?.kind === 'CANCEL_REQUEST'
+
+// A remote-failed retry/cancel is signed on the Agent's L1, so its step link points to mainnet;
+// any other delivery hash lives on the request's own chain.
+export const resolveStepExplorerChainId = ({
+  fallbackChainId,
+  settlement,
+  txHash,
+}: {
+  fallbackChainId: Chain['id']
+  settlement: EarnSettlement | undefined
+  txHash: Hash | undefined
+}) =>
+  txHash === undefined
+    ? undefined
+    : txHash === remoteFailedSettlement(settlement)?.txHash
+      ? mainnet.id
+      : fallbackChainId
 
 // A signed claim/recover reverted while the on-chain status stayed FULFILLED/CANCELLED — surface it as failed, not "needed".
 export const hasFailedSettlement = (tx: EarnTransaction) =>

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -12,6 +12,7 @@ import { encodeRequestDeposit } from 'hemi-earn-actions/actions'
 import { useChain } from 'hooks/useChain'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useEstimateFees } from 'hooks/useEstimateFees'
+import { mainnet } from 'networks/mainnet'
 import { useTranslations } from 'next-intl'
 import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
@@ -45,6 +46,7 @@ import {
   isRemoteFailedCancel,
   needsManualClaim,
   needsRecover,
+  remoteFailedSettlement,
   remoteFailedStepStatus,
 } from '../../../../_utils'
 import { type EarnTransaction } from '../../../../types'
@@ -305,6 +307,8 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       settlementTxHash,
     } = getSharesStepMeta(subgraphRow, settlement)
     const deliveryHash = settlementTxHash ?? terminalHash
+    // A remote-failed retry/cancel is signed on the Agent's L1, so link it to mainnet, not Hemi.
+    const recoveryTxHash = remoteFailedSettlement(settlement)?.txHash
     // A signed remote-failed cancel returns the funds, so it labels the step like the recover path.
     const isReturningFunds = isRecover || isRemoteFailedCancel(settledRow)
 
@@ -321,7 +325,11 @@ export const ReviewDeposit = function ({ onClose }: Props) {
           <span>{t('get-share-tokens')}</span>
         </div>
       ),
-      explorerChainId: deliveryHash ? chainId : undefined,
+      explorerChainId: deliveryHash
+        ? deliveryHash === recoveryTxHash
+          ? mainnet.id
+          : chainId
+        : undefined,
       status: isRemoteFailed(settledRow)
         ? remoteFailedStepStatus(remoteFailedReady, settledRow?.settlement)
         : resolveGetSharesStatus({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -19,6 +19,10 @@ import { type Hash, formatUnits } from 'viem'
 import { useAccount, useEstimateGas } from 'wagmi'
 
 import {
+  RemoteFailedBanner,
+  RemoteFailedCta,
+} from '../../../../_components/transactionsSection/transactionDrawer/remoteFailed'
+import {
   AddTokenToWalletCta,
   SettleBanner,
   SettleCta,
@@ -29,6 +33,7 @@ import {
 } from '../../../../_constants/slippage'
 import { useEarnTransactionsQuery } from '../../../../_hooks/useEarnTransactionsQuery'
 import { useLocalEarnOperations } from '../../../../_hooks/useLocalEarnOperations'
+import { useRemoteFailedState } from '../../../../_hooks/useRemoteFailedState'
 import { SparkleIcon } from '../../../../_icons/sparkleIcon'
 import {
   enrichWithSettlement,
@@ -36,8 +41,11 @@ import {
   getTerminalDeliveryTxHash,
   hashesMatch,
   isRecoverPath,
+  isRemoteFailed,
+  isRemoteFailedCancel,
   needsManualClaim,
   needsRecover,
+  remoteFailedStepStatus,
 } from '../../../../_utils'
 import { type EarnTransaction } from '../../../../types'
 import { usePoolForm } from '../../_context/poolFormContext'
@@ -129,6 +137,7 @@ export const ReviewDeposit = function ({ onClose }: Props) {
     subgraphRow?.requestTxHash,
   )
   const settledRow = enrichWithSettlement(subgraphRow, settlement)
+  const { show: remoteFailedReady } = useRemoteFailedState(settledRow)
 
   const depositStatus =
     depositOperation?.status ?? DepositStatus.APPROVAL_TX_COMPLETED
@@ -296,10 +305,12 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       settlementTxHash,
     } = getSharesStepMeta(subgraphRow, settlement)
     const deliveryHash = settlementTxHash ?? terminalHash
+    // A signed remote-failed cancel returns the funds, so it labels the step like the recover path.
+    const isReturningFunds = isRecover || isRemoteFailedCancel(settledRow)
 
     return {
       // Recover path returns the asset (labeled with the asset token); "Funds returned" only at RECOVERED.
-      description: isRecover ? (
+      description: isReturningFunds ? (
         <div className="flex items-center gap-x-2">
           <TokenLogo size="small" token={selectedAsset.token} />
           <span>{t(isComplete ? 'funds-returned' : 'funds-to-recover')}</span>
@@ -311,16 +322,18 @@ export const ReviewDeposit = function ({ onClose }: Props) {
         </div>
       ),
       explorerChainId: deliveryHash ? chainId : undefined,
-      status: resolveGetSharesStatus({
-        awaitingUserAction,
-        hasSettlementTx: !!settlementTxHash,
-        isComplete,
-        isDepositConfirmed:
-          depositStatus === DepositStatus.DEPOSIT_TX_CONFIRMED,
-        isFailed,
-        isRecover,
-        settlementFailed,
-      }),
+      status: isRemoteFailed(settledRow)
+        ? remoteFailedStepStatus(remoteFailedReady, settledRow?.settlement)
+        : resolveGetSharesStatus({
+            awaitingUserAction,
+            hasSettlementTx: !!settlementTxHash,
+            isComplete,
+            isDepositConfirmed:
+              depositStatus === DepositStatus.DEPOSIT_TX_CONFIRMED,
+            isFailed,
+            isRecover,
+            settlementFailed,
+          }),
       txHash: deliveryHash,
     }
   }
@@ -333,6 +346,9 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       ].includes(depositStatus)
     ) {
       return <RetryDeposit />
+    }
+    if (settledRow && isRemoteFailed(settledRow)) {
+      return <RemoteFailedCta transaction={settledRow} />
     }
     // Auto-claim off: the user signs the claim once the Agent delivers shares back (FULFILLED).
     if (settledRow && needsManualClaim(settledRow)) {
@@ -375,7 +391,12 @@ export const ReviewDeposit = function ({ onClose }: Props) {
 
   return (
     <Operation
-      aboveCallToAction={<SettleBanner transaction={settledRow} />}
+      aboveCallToAction={
+        <>
+          <SettleBanner transaction={settledRow} />
+          <RemoteFailedBanner transaction={settledRow} />
+        </>
+      }
       amount={depositOperation?.amountIn ?? amount.toString()}
       callToAction={getCallToAction()}
       heading={t('deposit.heading')}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -12,7 +12,6 @@ import { encodeRequestDeposit } from 'hemi-earn-actions/actions'
 import { useChain } from 'hooks/useChain'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useEstimateFees } from 'hooks/useEstimateFees'
-import { mainnet } from 'networks/mainnet'
 import { useTranslations } from 'next-intl'
 import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
@@ -46,8 +45,8 @@ import {
   isRemoteFailedCancel,
   needsManualClaim,
   needsRecover,
-  remoteFailedSettlement,
   remoteFailedStepStatus,
+  resolveStepExplorerChainId,
 } from '../../../../_utils'
 import { type EarnTransaction } from '../../../../types'
 import { usePoolForm } from '../../_context/poolFormContext'
@@ -307,8 +306,6 @@ export const ReviewDeposit = function ({ onClose }: Props) {
       settlementTxHash,
     } = getSharesStepMeta(subgraphRow, settlement)
     const deliveryHash = settlementTxHash ?? terminalHash
-    // A remote-failed retry/cancel is signed on the Agent's L1, so link it to mainnet, not Hemi.
-    const recoveryTxHash = remoteFailedSettlement(settlement)?.txHash
     // A signed remote-failed cancel returns the funds, so it labels the step like the recover path.
     const isReturningFunds = isRecover || isRemoteFailedCancel(settledRow)
 
@@ -325,11 +322,11 @@ export const ReviewDeposit = function ({ onClose }: Props) {
           <span>{t('get-share-tokens')}</span>
         </div>
       ),
-      explorerChainId: deliveryHash
-        ? deliveryHash === recoveryTxHash
-          ? mainnet.id
-          : chainId
-        : undefined,
+      explorerChainId: resolveStepExplorerChainId({
+        fallbackChainId: chainId,
+        settlement,
+        txHash: deliveryHash,
+      }),
       status: isRemoteFailed(settledRow)
         ? remoteFailedStepStatus(remoteFailedReady, settledRow?.settlement)
         : resolveGetSharesStatus({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -52,6 +52,7 @@ import {
   isFinalizeInFlight,
   isRecoverPath,
   isRemoteFailed,
+  isRemoteFailedCancel,
   isUserCancel,
   needsManualClaim,
   needsRecover,
@@ -510,7 +511,11 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
       steps.push(addApprovalStep())
     }
     steps.push(addUnstakeStep())
-    if ((settledRow && isRecoverPath(settledRow)) || cancelling) {
+    if (
+      (settledRow &&
+        (isRecoverPath(settledRow) || isRemoteFailedCancel(settledRow))) ||
+      cancelling
+    ) {
       steps.push(addRecoverStep())
       return steps
     }

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -327,9 +327,13 @@
         },
         "remote-failed": {
           "heading": "Your withdrawal is stuck on Ethereum",
+          "heading-deposit": "Your deposit is stuck on Ethereum",
           "heading-slippage": "Your withdrawal didn't complete",
+          "heading-slippage-deposit": "Your deposit didn't complete",
           "subheading": "The cross-chain step failed. Retry to add more gas and complete the withdrawal, or cancel to return your share tokens to your wallet.",
-          "subheading-slippage": "The price moved past your slippage limit before the final step could run, so your share tokens are still held. Return them to your wallet, then try the withdrawal again with a higher slippage tolerance."
+          "subheading-deposit": "The cross-chain step failed. Retry to add more gas and complete the deposit, or cancel to return your funds to your wallet.",
+          "subheading-slippage": "The price moved past your slippage limit before the final step could run, so your share tokens are still held. Return them to your wallet, then try the withdrawal again with a higher slippage tolerance.",
+          "subheading-slippage-deposit": "The price moved past your slippage limit before the final step could run, so your funds are still held. Return them to your wallet, then try the deposit again with a higher slippage tolerance."
         },
         "withdraw": {
           "heading": "Your withdrawal is ready",
@@ -380,12 +384,12 @@
       "recover-shares": "Recover shares",
       "recovering": "Recovering...",
       "retry": "Retry",
+      "return-funds": "Return funds",
       "return-share-tokens": "Return share tokens",
       "status": {
         "action-needed": "Action needed",
         "bridging-back": "Bridging back to Hemi",
         "cancelling": "Cancelling withdrawal",
-        "cancelling-request": "Cancelling...",
         "cooldown-ready-in-days": "Cooldown · ready in {value}d",
         "cooldown-ready-in-hours": "Cooldown · ready in {value}h",
         "cooldown-ready-in-minutes": "Cooldown · ready in {value}m",
@@ -401,6 +405,8 @@
         "recover-shares-needed": "Something went wrong - Recover shares",
         "retrying": "Retrying...",
         "returned": "Returned",
+        "returning-funds": "Returning funds...",
+        "returning-share-tokens": "Returning share tokens...",
         "shares-returned": "Shares returned",
         "shares-returned-cancelled": "Withdrawal cancelled - Shares returned",
         "slippage-exceeded": "Slippage limit exceeded",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -327,9 +327,13 @@
         },
         "remote-failed": {
           "heading": "Su retiro quedó atascado en Ethereum",
+          "heading-deposit": "Su depósito quedó atascado en Ethereum",
           "heading-slippage": "Su retiro no se completó",
+          "heading-slippage-deposit": "Su depósito no se completó",
           "subheading": "El paso entre redes falló. Reintente para agregar gas y completar el retiro, o cancele para devolver sus share tokens a su billetera.",
-          "subheading-slippage": "El precio superó su límite de slippage antes de que el paso final pudiera ejecutarse, por lo que sus share tokens siguen retenidos. Devuélvalos a su billetera y luego intente el retiro de nuevo con una tolerancia de slippage mayor."
+          "subheading-deposit": "El paso entre redes falló. Reintente para agregar gas y completar el depósito, o cancele para devolver sus fondos a su billetera.",
+          "subheading-slippage": "El precio superó su límite de slippage antes de que el paso final pudiera ejecutarse, por lo que sus share tokens siguen retenidos. Devuélvalos a su billetera y luego intente el retiro de nuevo con una tolerancia de slippage mayor.",
+          "subheading-slippage-deposit": "El precio superó su límite de slippage antes de que el paso final pudiera ejecutarse, por lo que sus fondos siguen retenidos. Devuélvalos a su billetera y luego intente el depósito de nuevo con una tolerancia de slippage mayor."
         },
         "withdraw": {
           "heading": "Su retiro está listo",
@@ -380,12 +384,12 @@
       "recover-shares": "Recuperar shares",
       "recovering": "Recuperando...",
       "retry": "Reintentar",
+      "return-funds": "Devolver fondos",
       "return-share-tokens": "Devolver share tokens",
       "status": {
         "action-needed": "Acción requerida",
         "bridging-back": "Regresando a Hemi",
         "cancelling": "Cancelando retiro",
-        "cancelling-request": "Cancelando...",
         "cooldown-ready-in-days": "Cooldown · listo en {value}d",
         "cooldown-ready-in-hours": "Cooldown · listo en {value}h",
         "cooldown-ready-in-minutes": "Cooldown · listo en {value}m",
@@ -401,6 +405,8 @@
         "recover-shares-needed": "Algo salió mal - Recuperar shares",
         "retrying": "Reintentando...",
         "returned": "Devuelto",
+        "returning-funds": "Devolviendo fondos...",
+        "returning-share-tokens": "Devolviendo share tokens...",
         "shares-returned": "Shares devueltas",
         "shares-returned-cancelled": "Retiro cancelado - Shares devueltas",
         "slippage-exceeded": "Límite de slippage superado",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -327,9 +327,13 @@
         },
         "remote-failed": {
           "heading": "Seu saque travou na Ethereum",
+          "heading-deposit": "Seu depósito travou na Ethereum",
           "heading-slippage": "Seu saque não foi concluído",
+          "heading-slippage-deposit": "Seu depósito não foi concluído",
           "subheading": "A etapa entre redes falhou. Tente novamente para adicionar gas e concluir o saque, ou cancele para devolver seus share tokens à sua carteira.",
-          "subheading-slippage": "O preço ultrapassou seu limite de slippage antes que a etapa final pudesse ser executada, então seus share tokens continuam retidos. Devolva-os à sua carteira e tente o saque novamente com uma tolerância de slippage maior."
+          "subheading-deposit": "A etapa entre redes falhou. Tente novamente para adicionar gas e concluir o depósito, ou cancele para devolver seus fundos à sua carteira.",
+          "subheading-slippage": "O preço ultrapassou seu limite de slippage antes que a etapa final pudesse ser executada, então seus share tokens continuam retidos. Devolva-os à sua carteira e tente o saque novamente com uma tolerância de slippage maior.",
+          "subheading-slippage-deposit": "O preço ultrapassou seu limite de slippage antes que a etapa final pudesse ser executada, então seus fundos continuam retidos. Devolva-os à sua carteira e tente o depósito novamente com uma tolerância de slippage maior."
         },
         "withdraw": {
           "heading": "Seu saque está pronto",
@@ -380,12 +384,12 @@
       "recover-shares": "Recuperar shares",
       "recovering": "Recuperando...",
       "retry": "Tentar novamente",
+      "return-funds": "Devolver fundos",
       "return-share-tokens": "Devolver share tokens",
       "status": {
         "action-needed": "Ação necessária",
         "bridging-back": "Retornando para a Hemi",
         "cancelling": "Cancelando saque",
-        "cancelling-request": "Cancelando...",
         "cooldown-ready-in-days": "Cooldown · pronto em {value}d",
         "cooldown-ready-in-hours": "Cooldown · pronto em {value}h",
         "cooldown-ready-in-minutes": "Cooldown · pronto em {value}m",
@@ -401,6 +405,8 @@
         "recover-shares-needed": "Algo deu errado - Recuperar shares",
         "retrying": "Tentando novamente...",
         "returned": "Devolvido",
+        "returning-funds": "Devolvendo fundos...",
+        "returning-share-tokens": "Devolvendo share tokens...",
         "shares-returned": "Shares devolvidas",
         "shares-returned-cancelled": "Saque cancelado - Shares devolvidas",
         "slippage-exceeded": "Limite de slippage excedido",

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -1,4 +1,5 @@
 import { ProgressStatus } from 'components/reviewOperation/progressStatus'
+import { mainnet } from 'networks/mainnet'
 import { type EvmToken } from 'types/token'
 import { type Address, type Hash, zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
@@ -32,6 +33,7 @@ import {
   remoteFailedSettlement,
   remoteFailedStepStatus,
   resolveSettleStepStatus,
+  resolveStepExplorerChainId,
   shouldShowRemoteFailedCtas,
   unstakeSettlement,
 } from '../../../../../app/[locale]/hemi-earn/_utils'
@@ -1222,6 +1224,80 @@ describe('utils', function () {
       expect(remoteFailedStepStatus(false, undefined)).toBe(
         ProgressStatus.PROGRESS,
       )
+    })
+  })
+
+  describe('resolveStepExplorerChainId', function () {
+    const fallbackChainId = 999
+    const recoveryHash = '0xaaa' as Hash
+
+    it('is undefined when there is no tx hash', function () {
+      expect(
+        resolveStepExplorerChainId({
+          fallbackChainId,
+          settlement: {
+            failed: false,
+            kind: 'CANCEL_REQUEST',
+            txHash: recoveryHash,
+          },
+          txHash: undefined,
+        }),
+      ).toBeUndefined()
+    })
+
+    it('links a remote-failed retry/cancel tx to mainnet', function () {
+      expect(
+        resolveStepExplorerChainId({
+          fallbackChainId,
+          settlement: {
+            failed: false,
+            kind: 'CANCEL_REQUEST',
+            txHash: recoveryHash,
+          },
+          txHash: recoveryHash,
+        }),
+      ).toBe(mainnet.id)
+      expect(
+        resolveStepExplorerChainId({
+          fallbackChainId,
+          settlement: { failed: false, kind: 'RETRY', txHash: recoveryHash },
+          txHash: recoveryHash,
+        }),
+      ).toBe(mainnet.id)
+    })
+
+    it('uses the fallback chain when the hash is not the recovery tx', function () {
+      expect(
+        resolveStepExplorerChainId({
+          fallbackChainId,
+          settlement: {
+            failed: false,
+            kind: 'CANCEL_REQUEST',
+            txHash: recoveryHash,
+          },
+          txHash: '0xbbb' as Hash,
+        }),
+      ).toBe(fallbackChainId)
+    })
+
+    it('uses the fallback chain for a non-remote-failed settlement', function () {
+      expect(
+        resolveStepExplorerChainId({
+          fallbackChainId,
+          settlement: { failed: false, kind: 'CLAIM', txHash: recoveryHash },
+          txHash: recoveryHash,
+        }),
+      ).toBe(fallbackChainId)
+    })
+
+    it('uses the fallback chain when there is no settlement', function () {
+      expect(
+        resolveStepExplorerChainId({
+          fallbackChainId,
+          settlement: undefined,
+          txHash: recoveryHash,
+        }),
+      ).toBe(fallbackChainId)
     })
   })
 

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -23,6 +23,7 @@ import {
   isLocalEarnTransactionRow,
   isRecoverPath,
   isRemoteFailed,
+  isRemoteFailedCancel,
   isUserCancel,
   needsManualClaim,
   needsRecover,
@@ -355,8 +356,18 @@ describe('utils', function () {
       expect(isRemoteFailed({ ...remoteFailed, failed: false })).toBe(false)
     })
 
-    it('is false for a deposit', function () {
-      expect(isRemoteFailed({ ...remoteFailed, kind: 'DEPOSIT' })).toBe(false)
+    it('is true for a subgraph FAILED deposit flagged failed', function () {
+      expect(isRemoteFailed({ ...remoteFailed, kind: 'DEPOSIT' })).toBe(true)
+    })
+
+    it('is false for a local FAILED deposit', function () {
+      expect(
+        isRemoteFailed({
+          ...remoteFailed,
+          kind: 'DEPOSIT',
+          requestId: 'local-1700000000',
+        }),
+      ).toBe(false)
     })
 
     it('is false for a non-FAILED status', function () {
@@ -365,6 +376,48 @@ describe('utils', function () {
 
     it('is false for undefined', function () {
       expect(isRemoteFailed(undefined)).toBe(false)
+    })
+  })
+
+  describe('isRemoteFailedCancel', function () {
+    const remoteFailed: EarnTransaction = {
+      ...baseTx,
+      failed: true,
+      kind: 'DEPOSIT',
+      requestId: '42',
+      status: 'FAILED',
+    }
+
+    it('is true for a remote-failed row with a CANCEL_REQUEST marker', function () {
+      expect(
+        isRemoteFailedCancel({
+          ...remoteFailed,
+          settlement: { failed: false, kind: 'CANCEL_REQUEST' },
+        }),
+      ).toBe(true)
+    })
+
+    it('is false for a remote-failed row with a RETRY marker', function () {
+      expect(
+        isRemoteFailedCancel({
+          ...remoteFailed,
+          settlement: { failed: false, kind: 'RETRY' },
+        }),
+      ).toBe(false)
+    })
+
+    it('is false for a remote-failed row without a settlement', function () {
+      expect(isRemoteFailedCancel(remoteFailed)).toBe(false)
+    })
+
+    it('is false when the row is not remote-failed', function () {
+      expect(
+        isRemoteFailedCancel({
+          ...remoteFailed,
+          settlement: { failed: false, kind: 'CANCEL_REQUEST' },
+          status: 'PENDING',
+        }),
+      ).toBe(false)
     })
   })
 


### PR DESCRIPTION
### Description

This PR extends the Hemi Earn remote-failure recovery — shipped for redeems in #2083 — to deposits. On the Agent side the mechanism is symmetric: failed deposits land in the same failedRequests mapping and are resolved by the same retry/cancel, so a deposit that reverts on Ethereum (gateway slippage, out-of-gas) is just as recoverable. Until now it only showed a red "Tx Failed" with no way out.

The core change is dropping the redeem-only gate on isRemoteFailed, which lets the existing badge, banner, CTA and step machinery light up for deposits too. From there it's mostly wiring the pieces into the two deposit drawers (live + historical) and handling the deposit-vs-redeem asymmetries: a deposit cancel returns the funds (not shares), so the CTA reads "Return funds" and the fee top-up is quoted against the asset OFT instead of the share OFT.

I also cleaned up two things left behind in the shared flow when the cancel button was renamed from "Cancel" to "Return ...": the in-flight label still said "Cancelling..." (now "Returning funds/shares..."), and the terminal step kept showing the fulfillment token during a cancel instead of the token actually being returned. Both fixes apply to redeem as well.

### Screenshots

<img width="462" height="860" alt="Captura de Tela 2026-07-15 às 09 46 23" src="https://github.com/user-attachments/assets/c4edd716-d6fa-4adf-b302-0a7cc9bd25ef" />

Table

<img width="1186" height="666" alt="Captura de Tela 2026-07-15 às 10 24 20" src="https://github.com/user-attachments/assets/08404f27-5391-49e3-ad03-9f8cf78bbd68" />



### Related issue(s)

Closes #1943
Closes #2028 
Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
