### PR TITLE
Break out Ethereum gas fee in Earn fee summary

### DIFF
--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -90,8 +90,10 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
 
   const {
     approvalGasFees,
+    bridgingFee,
     canDeposit,
     depositGasFees,
+    ethereumFee,
     isAllowanceError,
     isAllowanceLoading,
     isFeesError,
@@ -187,7 +189,8 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
         canDeposit && (
           <OperationBelowForm
             account={address}
-            bridgingFee={layerZeroFee}
+            bridgingFee={bridgingFee}
+            ethereumFee={ethereumFee}
             hemiGasFee={hemiGasFee}
             isCooldownEligible={isCooldownEligible}
             isFeesError={isFeesError}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationBelowForm.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationBelowForm.tsx
@@ -7,6 +7,7 @@ import { OperationSummary, type TopRowProps } from './operationSummary'
 type Props = {
   account: Address | undefined
   bridgingFee: bigint
+  ethereumFee: bigint
   hemiGasFee: bigint
   isCooldownEligible: boolean
   isFeesError: boolean
@@ -19,6 +20,7 @@ type Props = {
 export const OperationBelowForm = ({
   account,
   bridgingFee,
+  ethereumFee,
   hemiGasFee,
   isCooldownEligible,
   isFeesError,
@@ -31,6 +33,7 @@ export const OperationBelowForm = ({
     <div className="px-4">
       <OperationSummary
         bridgingFee={bridgingFee}
+        ethereumFee={ethereumFee}
         hemiGasFee={hemiGasFee}
         isFeesError={isFeesError}
         nativeToken={nativeToken}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationSummary.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationSummary.tsx
@@ -1,6 +1,5 @@
 import { DisplayAmount } from 'components/displayAmount'
 import { TokenLogo } from 'components/tokenLogo'
-import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
@@ -77,6 +76,7 @@ const TopRow = function ({ amount, label, token }: TopRowProps) {
 
 type Props = {
   bridgingFee: bigint
+  ethereumFee: bigint
   hemiGasFee: bigint
   isFeesError: boolean
   nativeToken: EvmToken
@@ -86,6 +86,7 @@ type Props = {
 
 export const OperationSummary = function ({
   bridgingFee,
+  ethereumFee,
   hemiGasFee,
   isFeesError,
   nativeToken,
@@ -93,7 +94,6 @@ export const OperationSummary = function ({
   totalFees,
 }: Props) {
   const t = useTranslations()
-  const hemi = useHemi()
   return (
     <div className="flex flex-col gap-y-2.5">
       <TopRow {...topRow} />
@@ -101,13 +101,19 @@ export const OperationSummary = function ({
       <FeeRow
         amount={hemiGasFee}
         isError={isFeesError}
-        label={t('common.network-gas-fee', { network: hemi.name })}
+        label={t('hemi-earn.pool.form.hemi-fees')}
         token={nativeToken}
       />
       <FeeRow
         amount={bridgingFee}
         isError={isFeesError}
         label={t('hemi-earn.pool.form.bridging-fees')}
+        token={nativeToken}
+      />
+      <FeeRow
+        amount={ethereumFee}
+        isError={isFeesError}
+        label={t('hemi-earn.pool.form.ethereum-gas-fee')}
         token={nativeToken}
       />
       <FeeRow

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/withdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/withdraw.tsx
@@ -137,14 +137,15 @@ export const Withdraw = function ({
     assetOut,
     assetOutRaw,
     assetsOutMin,
+    bridgingFee,
     canWithdraw,
+    ethereumFee,
     hemiGasFees,
     isAllowanceError,
     isAllowanceLoading,
     isFeesError,
     isPreviewError,
     isPreviewLoading,
-    layerZeroFee,
     needsApproval,
     peggedAmount,
     peggedAmountRaw,
@@ -253,7 +254,8 @@ export const Withdraw = function ({
         canWithdraw && (
           <OperationBelowForm
             account={address}
-            bridgingFee={layerZeroFee}
+            bridgingFee={bridgingFee}
+            ethereumFee={ethereumFee}
             hemiGasFee={hemiGasFees}
             isCooldownEligible={isCooldownEligible}
             isFeesError={isFeesError}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositPreview.ts
@@ -9,6 +9,7 @@ import { useEstimateGas } from 'wagmi'
 
 import { depositPreviewOptions } from '../_fetchers/fetchDepositPreview'
 import { type QuoteDeposit } from '../_fetchers/fetchQuoteDeposit'
+import { computeCrossChainFees } from '../_utils/crossChainFees'
 
 const buildGasData = ({
   amount,
@@ -63,18 +64,6 @@ const computeIsFeesError = ({
   isDepositGasFeesError ||
   isPreviewError ||
   (needsApproval && isApprovalGasFeesError)
-
-// nativeFee already bundles the Agent's Ethereum-side callback, so the bridging portion is what's left.
-const computeCrossChainFees = function ({
-  layerZeroFee,
-  quote,
-}: {
-  layerZeroFee: bigint
-  quote: QuoteDeposit | undefined
-}) {
-  const ethereumFee = quote?.callbackFee ?? BigInt(0)
-  return { bridgingFee: layerZeroFee - ethereumFee, ethereumFee }
-}
 
 // Composed depositPreviewOptions (shares + quote) + useNeedsApproval for allowance, plus gas estimation.
 export const useDepositPreview = function ({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositPreview.ts
@@ -64,6 +64,18 @@ const computeIsFeesError = ({
   isPreviewError ||
   (needsApproval && isApprovalGasFeesError)
 
+// nativeFee already bundles the Agent's Ethereum-side callback, so the bridging portion is what's left.
+const computeCrossChainFees = function ({
+  layerZeroFee,
+  quote,
+}: {
+  layerZeroFee: bigint
+  quote: QuoteDeposit | undefined
+}) {
+  const ethereumFee = quote?.callbackFee ?? BigInt(0)
+  return { bridgingFee: layerZeroFee - ethereumFee, ethereumFee }
+}
+
 // Composed depositPreviewOptions (shares + quote) + useNeedsApproval for allowance, plus gas estimation.
 export const useDepositPreview = function ({
   account,
@@ -111,6 +123,10 @@ export const useDepositPreview = function ({
   const quote = composed?.quote
   const sharesOutMin = composed?.sharesOutMin ?? BigInt(0)
   const layerZeroFee = quote?.nativeFee ?? BigInt(0)
+  const { bridgingFee, ethereumFee } = computeCrossChainFees({
+    layerZeroFee,
+    quote,
+  })
 
   // Gate on a positive shares preview (else a fast submit lands sharesOutMin=0n — no slippage
   // protection) and on !isAllowanceLoading (else the fee total jumps once allowance settles).
@@ -152,8 +168,10 @@ export const useDepositPreview = function ({
 
   return {
     approvalGasFees,
+    bridgingFee,
     canDeposit,
     depositGasFees,
+    ethereumFee,
     isAllowanceError,
     isAllowanceLoading,
     isFeesError: computeIsFeesError({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
@@ -75,6 +75,18 @@ const computeIsFeesError = ({
   isPreviewError ||
   (needsApproval && isApprovalGasFeesError)
 
+// nativeFee already bundles the Agent's Ethereum-side callback, so the bridging portion is what's left.
+const computeCrossChainFees = function ({
+  layerZeroFee,
+  quote,
+}: {
+  layerZeroFee: bigint
+  quote: QuoteRedeem | undefined
+}) {
+  const ethereumFee = quote?.callbackFee ?? BigInt(0)
+  return { bridgingFee: layerZeroFee - ethereumFee, ethereumFee }
+}
+
 // Composed withdrawPreviewOptions (sharesToAssets + quoteRedeem) + useNeedsApproval so an
 // allowance failure is distinguishable from a preview failure, plus gas estimation.
 export const useWithdrawPreview = function ({
@@ -124,6 +136,10 @@ export const useWithdrawPreview = function ({
   const assetsOutMin = composed?.assetsOutMin ?? BigInt(0)
   const quote = composed?.quote
   const layerZeroFee = quote?.nativeFee ?? BigInt(0)
+  const { bridgingFee, ethereumFee } = computeCrossChainFees({
+    layerZeroFee,
+    quote,
+  })
 
   // Gate on !isAllowanceLoading so the fee total doesn't render (and then jump) while allowance is still pending.
   const canWithdraw =
@@ -167,7 +183,9 @@ export const useWithdrawPreview = function ({
     assetOut,
     assetOutRaw: composed?.assetOut,
     assetsOutMin,
+    bridgingFee,
     canWithdraw,
+    ethereumFee,
     hemiGasFees: computeHemiGasFees({
       approvalGasFees,
       needsApproval,
@@ -183,7 +201,6 @@ export const useWithdrawPreview = function ({
     }),
     isPreviewError,
     isPreviewLoading,
-    layerZeroFee,
     needsApproval,
     peggedAmount,
     peggedAmountRaw: composed?.peggedAmount,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
@@ -9,6 +9,7 @@ import { useEstimateGas } from 'wagmi'
 
 import { type QuoteRedeem } from '../_fetchers/fetchQuoteRedeem'
 import { withdrawPreviewOptions } from '../_fetchers/fetchWithdrawPreview'
+import { computeCrossChainFees } from '../_utils/crossChainFees'
 
 const buildGasData = ({
   asset,
@@ -74,18 +75,6 @@ const computeIsFeesError = ({
   isWithdrawGasFeesError ||
   isPreviewError ||
   (needsApproval && isApprovalGasFeesError)
-
-// nativeFee already bundles the Agent's Ethereum-side callback, so the bridging portion is what's left.
-const computeCrossChainFees = function ({
-  layerZeroFee,
-  quote,
-}: {
-  layerZeroFee: bigint
-  quote: QuoteRedeem | undefined
-}) {
-  const ethereumFee = quote?.callbackFee ?? BigInt(0)
-  return { bridgingFee: layerZeroFee - ethereumFee, ethereumFee }
-}
 
 // Composed withdrawPreviewOptions (sharesToAssets + quoteRedeem) + useNeedsApproval so an
 // allowance failure is distinguishable from a preview failure, plus gas estimation.

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.ts
@@ -1,4 +1,5 @@
-// nativeFee already bundles the Agent's Ethereum-side callback, so the bridging portion is what's left.
+// nativeFee already bundles the Agent's Ethereum-side callback, so the bridging
+// portion is what's left; clamp at 0 in case that invariant ever breaks.
 export const computeCrossChainFees = function ({
   layerZeroFee,
   quote,
@@ -7,5 +8,7 @@ export const computeCrossChainFees = function ({
   quote: { callbackFee: bigint } | undefined
 }) {
   const ethereumFee = quote?.callbackFee ?? BigInt(0)
-  return { bridgingFee: layerZeroFee - ethereumFee, ethereumFee }
+  const bridgingFee =
+    layerZeroFee > ethereumFee ? layerZeroFee - ethereumFee : BigInt(0)
+  return { bridgingFee, ethereumFee }
 }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.ts
@@ -1,0 +1,11 @@
+// nativeFee already bundles the Agent's Ethereum-side callback, so the bridging portion is what's left.
+export const computeCrossChainFees = function ({
+  layerZeroFee,
+  quote,
+}: {
+  layerZeroFee: bigint
+  quote: { callbackFee: bigint } | undefined
+}) {
+  const ethereumFee = quote?.callbackFee ?? BigInt(0)
+  return { bridgingFee: layerZeroFee - ethereumFee, ethereumFee }
+}

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -276,6 +276,8 @@
         "bridging-fees": "Bridging fees",
         "cooldown-warning": "Withdrawing funds takes {days, plural, one {# day} other {# days}} to complete.",
         "cooldown-warning-fallback": "Withdrawing funds takes several days to complete.",
+        "ethereum-gas-fee": "Ethereum gas fee",
+        "hemi-fees": "Hemi fees",
         "network-error": "Preview failed — try again",
         "share-token-available-to-withdraw": "Share token available to withdraw",
         "total-fee": "Total gas fee",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -276,6 +276,8 @@
         "bridging-fees": "Tarifas de bridge",
         "cooldown-warning": "Retirar fondos tarda {days, plural, one {# día} other {# días}} en completarse.",
         "cooldown-warning-fallback": "Retirar fondos tarda algunos días en completarse.",
+        "ethereum-gas-fee": "Tarifa de gas de Ethereum",
+        "hemi-fees": "Tarifas de Hemi",
         "network-error": "Error al previsualizar — reintente",
         "share-token-available-to-withdraw": "Token de participación disponible para retirar",
         "total-fee": "Costo total de gas",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -276,6 +276,8 @@
         "bridging-fees": "Taxas de bridge",
         "cooldown-warning": "Sacar fundos leva {days, plural, one {# dia} other {# dias}} para concluir.",
         "cooldown-warning-fallback": "Sacar fundos leva alguns dias para concluir.",
+        "ethereum-gas-fee": "Taxa de gás da Ethereum",
+        "hemi-fees": "Taxas de Hemi",
         "network-error": "Falha no preview — tente de novo",
         "share-token-available-to-withdraw": "Token de participação disponível para sacar",
         "total-fee": "Custo total de gás",

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeCrossChainFees } from '../../../../../../../app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees'
+
+describe('computeCrossChainFees', function () {
+  it('splits layerZeroFee into bridging + ethereum when a quote is present', function () {
+    expect(
+      computeCrossChainFees({
+        layerZeroFee: BigInt(1000),
+        quote: { callbackFee: BigInt(400) },
+      }),
+    ).toEqual({ bridgingFee: BigInt(600), ethereumFee: BigInt(400) })
+  })
+
+  it('defaults both fees to zero when the quote is undefined', function () {
+    expect(
+      computeCrossChainFees({ layerZeroFee: BigInt(0), quote: undefined }),
+    ).toEqual({ bridgingFee: BigInt(0), ethereumFee: BigInt(0) })
+  })
+
+  it('keeps bridging + ethereum summing back to layerZeroFee', function () {
+    const { bridgingFee, ethereumFee } = computeCrossChainFees({
+      layerZeroFee: BigInt(1500),
+      quote: { callbackFee: BigInt(500) },
+    })
+    expect(bridgingFee + ethereumFee).toBe(BigInt(1500))
+  })
+})

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.test.ts
@@ -12,6 +12,15 @@ describe('computeCrossChainFees', function () {
     ).toEqual({ bridgingFee: BigInt(600), ethereumFee: BigInt(400) })
   })
 
+  it('clamps bridgingFee to zero when callbackFee exceeds layerZeroFee', function () {
+    expect(
+      computeCrossChainFees({
+        layerZeroFee: BigInt(300),
+        quote: { callbackFee: BigInt(500) },
+      }),
+    ).toEqual({ bridgingFee: BigInt(0), ethereumFee: BigInt(500) })
+  })
+
   it('defaults both fees to zero when the quote is undefined', function () {
     expect(
       computeCrossChainFees({ layerZeroFee: BigInt(0), quote: undefined }),


### PR DESCRIPTION
### Description

This PR splits the single "Bridging fees" line in the Hemi Earn fee summary into two separate rows: "Bridging fees" and a new "Ethereum gas fee", for both the deposit and withdraw forms.

The old "Bridging fees" value was the on-chain `nativeFee`, which already bundles the Agent's Ethereum-side callback cost (`callbackFee`). That meant users had no way to see how much of the fee was the actual LayerZero bridge versus the Ethereum leg. Now "Bridging fees" shows `nativeFee − callbackFee` (the pure messaging fee) and "Ethereum gas fee" shows `callbackFee`. The Total is untouched since the two rows still sum to `nativeFee`. The Hemi row is also relabeled "Hemi fees" to match the design.

I verified the split against the real Router/Agent contracts: `quoteDeposit` returns `nativeFee = outbound LZ base fee + callbackFee` (the callback is passed as the LZ compose-executor `_value`), so the subtraction genuinely isolates the two legs. The review flagged two low-severity edge cases (a fee that formats to exactly `0` renders a perpetual skeleton, and the unclamped `nativeFee − callbackFee` could go negative if the contract invariant ever broke) — both left as-is for now since neither can trigger under the current fee model.

### Screenshots

https://github.com/user-attachments/assets/4c4d3d0f-89b2-4d88-8e75-22e35ed8c7de

### Related issue(s)

Closes #2096 
Related to #1848 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
