### PR TITLE
Add per-pool staked balance to Earn pools list

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
@@ -12,6 +12,7 @@ import { type EarnPool } from '../../types'
 import { RenderEarnFiatBalance } from '../earnFiatBalance'
 
 import { PoolInfoItem } from './poolInfoItem'
+import { StakedAmount } from './stakedAmount'
 import { TokenIconStack } from './tokenIconStack'
 
 type Props = {
@@ -79,6 +80,7 @@ export const PoolInfoBar = function ({ pool }: Props) {
               : undefined
           }
         />
+        <StakedAmount pool={pool} />
       </div>
       <div className="flex w-full *:flex-1 md:ml-auto md:w-auto md:*:flex-initial">
         <ButtonLink

--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useTranslations } from 'next-intl'
+
+import { sharesToPeggedOptions } from '../../_fetchers/fetchSharesToPegged'
+import { useEarnPositions } from '../../_hooks/useEarnPositions'
+import { type EarnPool } from '../../types'
+import { RenderEarnFiatBalance } from '../earnFiatBalance'
+
+import { PoolInfoItem } from './poolInfoItem'
+
+type Props = {
+  pool: EarnPool
+}
+
+export const StakedAmount = function ({ pool }: Props) {
+  const t = useTranslations('hemi-earn.pool-info')
+  const { data: positions, isPending } = useEarnPositions()
+
+  const position = positions.find(
+    ({ shareAddress }) => shareAddress === pool.shareAddress,
+  )
+
+  // Shares → pegged shares the query key with FromPoolsBadge and useTotalDeposits,
+  // so this adds no extra RPC calls.
+  const { data, status } = useQuery(
+    sharesToPeggedOptions({
+      shareAddress: pool.shareAddress,
+      shares: position?.yourDeposit ?? BigInt(0),
+    }),
+  )
+
+  if (position) {
+    return (
+      <PoolInfoItem label={t('staked-balance')}>
+        <span className="body-text-medium text-neutral-950">
+          $
+          <RenderEarnFiatBalance
+            balance={data?.peggedAmount}
+            queryStatus={status}
+            token={position.peggedToken}
+          />
+        </span>
+      </PoolInfoItem>
+    )
+  }
+
+  return <PoolInfoItem isLoading={isPending} label={t('staked-balance')} />
+}

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -300,6 +300,7 @@
       "manage": "Manage",
       "pool-contract": "Pool Contract",
       "share-token": "Share token",
+      "staked-balance": "Your staked balance",
       "total-deposits": "Total deposits"
     },
     "subheading": "One click earn for your assets",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -300,6 +300,7 @@
       "manage": "Gestionar",
       "pool-contract": "Contrato del fondo",
       "share-token": "Token de participación",
+      "staked-balance": "Su saldo invertido",
       "total-deposits": "Depósitos totales"
     },
     "subheading": "Gane rendimiento con sus activos en un solo clic",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -300,6 +300,7 @@
       "manage": "Gerenciar",
       "pool-contract": "Contrato do fundo",
       "share-token": "Token de participação",
+      "staked-balance": "Seu saldo aplicado",
       "total-deposits": "Depósitos totais"
     },
     "subheading": "Ganhe rendimento com seus ativos em um clique",


### PR DESCRIPTION
Closes #2066

## What

Adds a "Your staked balance" column to each pool row on the Hemi Earn pools list, placed after the APY column as suggested in the issue comments.

## How

- New `StakedAmount` component (co-located in `poolInfoBar/`) looks up the connected wallet's position for the row's pool via `useEarnPositions`, converts shares → pegged amount through the existing `sharesToPeggedOptions` query, and prices it with `RenderEarnFiatBalance`.
- Because it reuses the same react-query key as the "Your staked balance" stat box and its "From # pools" badge, the per-pool amounts always match the badge breakdown and no additional RPC calls are made.
- Shows a skeleton while positions load, and `-` when the wallet is disconnected or has no stake in that pool.
- Added the `hemi-earn.pool-info.staked-balance` translation key to `en`/`es`/`pt`, reusing the stat box's established wording ("Your staked balance" / "Su saldo invertido" / "Seu saldo aplicado").

## Screenshot
<img width="1066" height="205" alt="image" src="https://github.com/user-attachments/assets/6a24ee82-46e2-4ec4-aa39-579a89afe912" />