### PR TITLE
Reload tunnel history when the account changes

### DIFF
--- a/portal/context/tunnelHistoryContext/historyLoader.tsx
+++ b/portal/context/tunnelHistoryContext/historyLoader.tsx
@@ -247,6 +247,9 @@ export const HistoryLoader = function ({
       if (!forceResync) {
         return
       }
+      // cancel any pending debounced save - otherwise its trailing call can
+      // run after the clear below and repopulate storage with stale data
+      debouncedSaveToStorage.cancel()
       // clear local storage
       clearHistoryInLocalStorage({
         address: address!,

--- a/portal/context/tunnelHistoryContext/historyLoader.tsx
+++ b/portal/context/tunnelHistoryContext/historyLoader.tsx
@@ -145,32 +145,30 @@ export const HistoryLoader = function ({
   const { remoteNetworks } = useNetworks()
   const [networkType] = useNetworkType()
 
-  // use this boolean to check if the past history was restored from local storage
-  const [loadedFromLocalStorage, setLoadedFromLocalStorage] = useState(false)
+  // the address whose history is loaded in the reducer - tracking it (instead of
+  // a boolean) lets the state reset and reload when the user switches accounts
+  const [loadedAddress, setLoadedAddress] = useState<Address | undefined>(
+    undefined,
+  )
 
   const supportedEvmChain = useConnectedToSupportedEvmChain()
 
   useEffect(
     function resetState() {
-      if (!supportedEvmChain || !loadedFromLocalStorage) {
-        setLoadedFromLocalStorage(false)
+      if (!supportedEvmChain || address !== loadedAddress) {
+        setLoadedAddress(undefined)
         dispatch({ type: 'reset' })
       }
     },
-    [
-      loadedFromLocalStorage,
-      dispatch,
-      setLoadedFromLocalStorage,
-      supportedEvmChain,
-    ],
+    [address, dispatch, loadedAddress, setLoadedAddress, supportedEvmChain],
   )
 
   useEffect(
     function restoreFromLocalStorage() {
-      if (!address || loadedFromLocalStorage || !supportedEvmChain) {
+      if (!address || loadedAddress || !supportedEvmChain) {
         return
       }
-      setLoadedFromLocalStorage(true)
+      setLoadedAddress(address)
       // Load all the deposits given the Hemi address
       const deposits = remoteNetworks
         .map(
@@ -204,9 +202,9 @@ export const HistoryLoader = function ({
       address,
       dispatch,
       l2ChainId,
-      loadedFromLocalStorage,
+      loadedAddress,
       remoteNetworks,
-      setLoadedFromLocalStorage,
+      setLoadedAddress,
       supportedEvmChain,
     ],
   )
@@ -216,7 +214,10 @@ export const HistoryLoader = function ({
       if (
         !address ||
         !supportedEvmChain ||
-        !loadedFromLocalStorage ||
+        // only save the history of the address it belongs to - on an account
+        // switch, this effect re-runs with the new address while the reducer
+        // still holds the previous account's history
+        address !== loadedAddress ||
         !['finished', 'syncing'].includes(history.status) ||
         // if we started resync, do not save!
         forceResync
@@ -230,7 +231,7 @@ export const HistoryLoader = function ({
       forceResync,
       history,
       l2ChainId,
-      loadedFromLocalStorage,
+      loadedAddress,
       remoteNetworks,
       supportedEvmChain,
     ],
@@ -255,7 +256,7 @@ export const HistoryLoader = function ({
       // reset the history in memory
       dispatch({ type: 'reset' })
       // update flag so data is reloaded again
-      setLoadedFromLocalStorage(false)
+      setLoadedAddress(undefined)
       // mark resync as finished
       setForceResync(false)
     },
@@ -266,7 +267,7 @@ export const HistoryLoader = function ({
       l2ChainId,
       remoteNetworks,
       setForceResync,
-      setLoadedFromLocalStorage,
+      setLoadedAddress,
     ],
   )
 

--- a/portal/context/tunnelHistoryContext/historyLoader.tsx
+++ b/portal/context/tunnelHistoryContext/historyLoader.tsx
@@ -213,9 +213,6 @@ export const HistoryLoader = function ({
       if (
         !address ||
         !supportedEvmChain ||
-        // only save the history of the address it belongs to - on an account
-        // switch, this effect re-runs with the new address while the reducer
-        // still holds the previous account's history
         address !== loadedAddress ||
         !['finished', 'syncing'].includes(history.status) ||
         // if we started resync, do not save!
@@ -246,8 +243,6 @@ export const HistoryLoader = function ({
       if (!forceResync) {
         return
       }
-      // cancel any pending debounced save - otherwise its trailing call can
-      // run after the clear below and repopulate storage with stale data
       debouncedSaveToStorage.cancel()
       // clear local storage
       clearHistoryInLocalStorage({

--- a/portal/context/tunnelHistoryContext/historyLoader.tsx
+++ b/portal/context/tunnelHistoryContext/historyLoader.tsx
@@ -145,8 +145,6 @@ export const HistoryLoader = function ({
   const { remoteNetworks } = useNetworks()
   const [networkType] = useNetworkType()
 
-  // the address whose history is loaded in the reducer - tracking it (instead of
-  // a boolean) lets the state reset and reload when the user switches accounts
   const [loadedAddress, setLoadedAddress] = useState<Address | undefined>(
     undefined,
   )
@@ -156,11 +154,6 @@ export const HistoryLoader = function ({
   useEffect(
     function resetState() {
       if (!supportedEvmChain || address !== loadedAddress) {
-        // flush any pending debounced save for the previous account before
-        // resetting - otherwise the next account's save call would replace
-        // its queued args (the debounce is shared across addresses), and
-        // the previous account's latest history/sync cursor would never
-        // be persisted
         debouncedSaveToStorage.flush()
         setLoadedAddress(undefined)
         dispatch({ type: 'reset' })

--- a/portal/context/tunnelHistoryContext/historyLoader.tsx
+++ b/portal/context/tunnelHistoryContext/historyLoader.tsx
@@ -156,6 +156,12 @@ export const HistoryLoader = function ({
   useEffect(
     function resetState() {
       if (!supportedEvmChain || address !== loadedAddress) {
+        // flush any pending debounced save for the previous account before
+        // resetting - otherwise the next account's save call would replace
+        // its queued args (the debounce is shared across addresses), and
+        // the previous account's latest history/sync cursor would never
+        // be persisted
+        debouncedSaveToStorage.flush()
         setLoadedAddress(undefined)
         dispatch({ type: 'reset' })
       }


### PR DESCRIPTION
Closes #1558

## Problem

Switching accounts in the wallet (both connected to the portal) kept the previous account's transaction history rendered. The history loader tracked restoration with a plain `loadedFromLocalStorage` boolean:

- The restore effect bailed out because the flag was still `true` after a switch, so the reducer kept the old account's operations.
- The reset effect only fired on disconnect/unsupported chain — it didn't react to the address changing.
- Worse: the save effect *does* depend on `address`, so right after a switch it re-ran with the **new** address while the reducer still held the **old** account's history, persisting account A's operations under account B's localStorage keys. After that, even a page refresh showed the wrong history.

## Fix

Replace the boolean with `loadedAddress` — the address whose history is loaded in the reducer:

- The state resets whenever the connected address differs from the loaded one (not just on disconnect), and the restore effect then reloads from the new account's storage keys.
- Saving to localStorage is guarded with `address === loadedAddress`, which also covers the same-commit race where the save effect runs before the reset takes effect.
- The manual resync path clears `loadedAddress`, keeping its behavior unchanged.

The sync workers were already keyed by address, so they restart on their own and now dispatch into a reducer holding the right account's state.

Note: the fix prevents new corruption but does not clean up localStorage already polluted by previous switches — the existing resync button handles that.

## Screenshots

<img width="1352" height="692" alt="image" src="https://github.com/user-attachments/assets/1e4817f0-c4ff-43a7-9713-434a44d8fa3f" />


<img width="1352" height="692" alt="image" src="https://github.com/user-attachments/assets/56d6a108-d0c7-4968-97b6-73dc18f38c03" />

