### PR TITLE
Distinguish loading from zero in Earn fees

### DIFF
--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -42,12 +42,6 @@ type Props = {
   onSwitchToWithdraw: VoidFunction
 }
 
-const computeHemiGasFee = (
-  depositGasFees: bigint,
-  approvalGasFees: bigint,
-  needsApproval: boolean,
-) => depositGasFees + (needsApproval ? approvalGasFees : BigInt(0))
-
 export const Deposit = function ({ onSwitchToWithdraw }: Props) {
   const t = useTranslations()
   const [operationRunning, setOperationRunning] =
@@ -89,11 +83,11 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
   })
 
   const {
-    approvalGasFees,
     bridgingFee,
     canDeposit,
     depositGasFees,
     ethereumFee,
+    hemiGasFee,
     isAllowanceError,
     isAllowanceLoading,
     isFeesError,
@@ -153,11 +147,6 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
   }
 
   const nativeToken = getNativeToken(selectedAsset.token.chainId) as EvmToken
-  const hemiGasFee = computeHemiGasFee(
-    depositGasFees,
-    approvalGasFees,
-    needsApproval,
-  )
   const hasQuote = !!quote
 
   const previewIssue = resolvePreviewIssue({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationBelowForm.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationBelowForm.tsx
@@ -6,15 +6,15 @@ import { OperationSummary, type TopRowProps } from './operationSummary'
 
 type Props = {
   account: Address | undefined
-  bridgingFee: bigint
-  ethereumFee: bigint
-  hemiGasFee: bigint
+  bridgingFee: bigint | undefined
+  ethereumFee: bigint | undefined
+  hemiGasFee: bigint | undefined
   isCooldownEligible: boolean
   isFeesError: boolean
   nativeToken: EvmToken
   stakingVault: Address
   topRow: TopRowProps
-  totalFees: bigint
+  totalFees: bigint | undefined
 }
 
 export const OperationBelowForm = ({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationSummary.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/operationSummary.tsx
@@ -14,22 +14,13 @@ const Row = ({ children, label }: { children: ReactNode; label: string }) => (
 )
 
 type FeeRowProps = {
-  amount: bigint
+  amount: bigint | undefined
   isError: boolean
   label: string
   token: EvmToken
 }
 
 const FeeRow = function ({ amount, isError, label, token }: FeeRowProps) {
-  const formatted = formatUnits(amount, token.decimals)
-
-  if (!isError && formatted !== '0') {
-    return (
-      <Row label={label}>
-        <DisplayAmount amount={formatted} showTokenLogo={false} token={token} />
-      </Row>
-    )
-  }
   if (isError) {
     return (
       <Row label={label}>
@@ -37,9 +28,20 @@ const FeeRow = function ({ amount, isError, label, token }: FeeRowProps) {
       </Row>
     )
   }
+  if (amount === undefined) {
+    return (
+      <Row label={label}>
+        <Skeleton className="w-12" />
+      </Row>
+    )
+  }
   return (
     <Row label={label}>
-      <Skeleton className="w-12" />
+      <DisplayAmount
+        amount={formatUnits(amount, token.decimals)}
+        showTokenLogo={false}
+        token={token}
+      />
     </Row>
   )
 }
@@ -75,13 +77,13 @@ const TopRow = function ({ amount, label, token }: TopRowProps) {
 }
 
 type Props = {
-  bridgingFee: bigint
-  ethereumFee: bigint
-  hemiGasFee: bigint
+  bridgingFee: bigint | undefined
+  ethereumFee: bigint | undefined
+  hemiGasFee: bigint | undefined
   isFeesError: boolean
   nativeToken: EvmToken
   topRow: TopRowProps
-  totalFees: bigint
+  totalFees: bigint | undefined
 }
 
 export const OperationSummary = function ({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useDepositPreview.ts
@@ -37,7 +37,8 @@ const buildGasData = ({
         sharesOutMin,
       })
 
-const computeTotalFees = ({
+// Gas never resolves to exactly 0, so a 0 total means the estimate is still loading.
+const computeTotalFees = function ({
   approvalGasFees,
   depositGasFees,
   layerZeroFee,
@@ -47,8 +48,26 @@ const computeTotalFees = ({
   depositGasFees: bigint
   layerZeroFee: bigint
   needsApproval: boolean
-}) =>
-  depositGasFees + layerZeroFee + (needsApproval ? approvalGasFees : BigInt(0))
+}) {
+  const total =
+    depositGasFees +
+    layerZeroFee +
+    (needsApproval ? approvalGasFees : BigInt(0))
+  return total === BigInt(0) ? undefined : total
+}
+
+const computeHemiGasFee = function ({
+  approvalGasFees,
+  depositGasFees,
+  needsApproval,
+}: {
+  approvalGasFees: bigint
+  depositGasFees: bigint
+  needsApproval: boolean
+}) {
+  const total = depositGasFees + (needsApproval ? approvalGasFees : BigInt(0))
+  return total === BigInt(0) ? undefined : total
+}
 
 const computeIsFeesError = ({
   isApprovalGasFeesError,
@@ -156,11 +175,15 @@ export const useDepositPreview = function ({
     })
 
   return {
-    approvalGasFees,
     bridgingFee,
     canDeposit,
     depositGasFees,
     ethereumFee,
+    hemiGasFee: computeHemiGasFee({
+      approvalGasFees,
+      depositGasFees,
+      needsApproval,
+    }),
     isAllowanceError,
     isAllowanceLoading,
     isFeesError: computeIsFeesError({

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useWithdrawPreview.ts
@@ -38,7 +38,8 @@ const buildGasData = ({
         shares,
       })
 
-const computeTotalFees = ({
+// Gas never resolves to exactly 0, so a 0 total means the estimate is still loading.
+const computeTotalFees = function ({
   approvalGasFees,
   layerZeroFee,
   needsApproval,
@@ -48,10 +49,15 @@ const computeTotalFees = ({
   layerZeroFee: bigint
   needsApproval: boolean
   withdrawGasFees: bigint
-}) =>
-  withdrawGasFees + layerZeroFee + (needsApproval ? approvalGasFees : BigInt(0))
+}) {
+  const total =
+    withdrawGasFees +
+    layerZeroFee +
+    (needsApproval ? approvalGasFees : BigInt(0))
+  return total === BigInt(0) ? undefined : total
+}
 
-const computeHemiGasFees = ({
+const computeHemiGasFees = function ({
   approvalGasFees,
   needsApproval,
   withdrawGasFees,
@@ -59,7 +65,10 @@ const computeHemiGasFees = ({
   approvalGasFees: bigint
   needsApproval: boolean
   withdrawGasFees: bigint
-}) => withdrawGasFees + (needsApproval ? approvalGasFees : BigInt(0))
+}) {
+  const total = withdrawGasFees + (needsApproval ? approvalGasFees : BigInt(0))
+  return total === BigInt(0) ? undefined : total
+}
 
 const computeIsFeesError = ({
   isApprovalGasFeesError,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.ts
@@ -7,7 +7,10 @@ export const computeCrossChainFees = function ({
   layerZeroFee: bigint
   quote: { callbackFee: bigint } | undefined
 }) {
-  const ethereumFee = quote?.callbackFee ?? BigInt(0)
+  if (quote === undefined) {
+    return { bridgingFee: undefined, ethereumFee: undefined }
+  }
+  const ethereumFee = quote.callbackFee
   const bridgingFee =
     layerZeroFee > ethereumFee ? layerZeroFee - ethereumFee : BigInt(0)
   return { bridgingFee, ethereumFee }

--- a/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/pool/[shareAddress]/_utils/crossChainFees.test.ts
@@ -21,17 +21,18 @@ describe('computeCrossChainFees', function () {
     ).toEqual({ bridgingFee: BigInt(0), ethereumFee: BigInt(500) })
   })
 
-  it('defaults both fees to zero when the quote is undefined', function () {
+  it('returns undefined fees when the quote is undefined', function () {
     expect(
       computeCrossChainFees({ layerZeroFee: BigInt(0), quote: undefined }),
-    ).toEqual({ bridgingFee: BigInt(0), ethereumFee: BigInt(0) })
+    ).toEqual({ bridgingFee: undefined, ethereumFee: undefined })
   })
 
-  it('keeps bridging + ethereum summing back to layerZeroFee', function () {
-    const { bridgingFee, ethereumFee } = computeCrossChainFees({
-      layerZeroFee: BigInt(1500),
-      quote: { callbackFee: BigInt(500) },
-    })
-    expect(bridgingFee + ethereumFee).toBe(BigInt(1500))
+  it('splits into parts that sum back to layerZeroFee', function () {
+    expect(
+      computeCrossChainFees({
+        layerZeroFee: BigInt(1500),
+        quote: { callbackFee: BigInt(500) },
+      }),
+    ).toEqual({ bridgingFee: BigInt(1000), ethereumFee: BigInt(500) })
   })
 })


### PR DESCRIPTION
### Description

This PR fixes the Hemi Earn fee summary so a genuinely zero fee shows "0" instead of a perpetual loading skeleton (issue #2098). `FeeRow` used to treat any fee that formatted to "0" as its loading state, which was fine until the deposit/withdraw split introduced bridging/Ethereum rows that can legitimately be 0 — those showed a skeleton forever. `FeeRow` now takes `bigint | undefined`, where `undefined` means "still loading" (skeleton) and a real value, including 0, is rendered. The cross-chain fees come through as `undefined` until the quote resolves; the gas rows keep the "a 0 total means still estimating" heuristic (safe because on-chain gas is never genuinely 0), so they behave exactly as before.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Closes #2098 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
