### PR TITLE
Validate stake drawer mode before rendering

### DIFF
--- a/portal/app/[locale]/stake/_components/stakeLayoutClient.tsx
+++ b/portal/app/[locale]/stake/_components/stakeLayoutClient.tsx
@@ -6,7 +6,10 @@ import { useStakeTokens } from 'hooks/useStakeTokens'
 import { Suspense } from 'react'
 import { isStakeEnabledOnTestnet } from 'utils/stake'
 
-import { useDrawerStakeQueryString } from '../_hooks/useDrawerStakeQueryString'
+import {
+  isDrawerMode,
+  useDrawerStakeQueryString,
+} from '../_hooks/useDrawerStakeQueryString'
 
 import { ManageStake } from './manageStake'
 import { StakeDisabledTestnet } from './stakeDisabledTestnet'
@@ -16,7 +19,7 @@ const SideDrawer = function () {
     useDrawerStakeQueryString()
   const stakeTokens = useStakeTokens()
 
-  if (!tokenAddress || !drawerMode) {
+  if (!tokenAddress || !isDrawerMode(drawerMode)) {
     return null
   }
 

--- a/portal/app/[locale]/stake/_hooks/useDrawerStakeQueryString.ts
+++ b/portal/app/[locale]/stake/_hooks/useDrawerStakeQueryString.ts
@@ -3,6 +3,12 @@ import { parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs'
 const drawerModes = ['manage', 'stake'] as const
 export type DrawerModes = (typeof drawerModes)[number]
 
+// Needed on top of the parser's validation: nuqs syncs values set by other
+// hooks sharing the "drawerMode" url key (other pages define their own modes
+// for it) without re-parsing, so an invalid value can reach consumers.
+export const isDrawerMode = (value: string | null): value is DrawerModes =>
+  drawerModes.includes(value as DrawerModes)
+
 export const useDrawerStakeQueryString = function () {
   const [tokenAddress, setTokenAddress] = useQueryState(
     'tokenAddress',

--- a/portal/app/[locale]/stake/_hooks/useDrawerStakeQueryString.ts
+++ b/portal/app/[locale]/stake/_hooks/useDrawerStakeQueryString.ts
@@ -3,11 +3,8 @@ import { parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs'
 const drawerModes = ['manage', 'stake'] as const
 export type DrawerModes = (typeof drawerModes)[number]
 
-// Needed on top of the parser's validation: nuqs syncs values set by other
-// hooks sharing the "drawerMode" url key (other pages define their own modes
-// for it) without re-parsing, so an invalid value can reach consumers.
-export const isDrawerMode = (value: string | null): value is DrawerModes =>
-  drawerModes.includes(value as DrawerModes)
+export const isDrawerMode = (value: unknown): value is DrawerModes =>
+  (drawerModes as readonly unknown[]).includes(value)
 
 export const useDrawerStakeQueryString = function () {
   const [tokenAddress, setTokenAddress] = useQueryState(

--- a/portal/test/app/[locale]/stake/_hooks/useDrawerStakeQueryString.test.ts
+++ b/portal/test/app/[locale]/stake/_hooks/useDrawerStakeQueryString.test.ts
@@ -1,0 +1,15 @@
+import { isDrawerMode } from 'app/[locale]/stake/_hooks/useDrawerStakeQueryString'
+import { describe, expect, it } from 'vitest'
+
+describe('isDrawerMode', function () {
+  it.each(['manage', 'stake'])('returns true for %s', function (value) {
+    expect(isDrawerMode(value)).toBe(true)
+  })
+
+  it.each([null, undefined, '', 'staking', 'depositing', 42, {}])(
+    'returns false for %s',
+    function (value) {
+      expect(isDrawerMode(value)).toBe(false)
+    },
+  )
+})


### PR DESCRIPTION
Closes #2064

## Problem

Sentry PORTAL-287: `TypeError: Cannot destructure property 'heading' of '...[a]' as it is undefined` in `ManageStake`. The `heading`/`subheading` lookup only has `manage` and `stake` keys, so any other `mode` value crashes the stake page.

## Root cause

Three pages register the **same `drawerMode` query key** with disjoint literal sets:

| Page | Allowed values |
|---|---|
| stake | `manage`, `stake` |
| staking-dashboard | `staking`, `unlocking`, `claimingRewards`, `increasingAmount`, `increasingUnlockTime` |
| hemi-earn pool | `depositing`, `withdrawing` |

Reading from the URL is safe (`parseAsStringLiteral` nulls invalid values), but nuqs setters bypass per-hook parsing: `emitter.emit(urlKey, { state: value })` pushes the raw value to every hook subscribed to that key ("cross-hook key sync"), which stores it without running its own literal check. So if another page's component sets `drawerMode` while the stake page's `SideDrawer` is still mounted (e.g. during an App Router transition, where the previous page stays rendered), the stake hook receives a foreign value. It passes the previous truthy-only guard, and `ManageStake` crashes on the lookup.

The staking-dashboard and hemi-earn drawers are incidentally protected because their guards also require in-memory operation state that only exists mid-flow on their own pages.

## Fix

Export an `isDrawerMode` type guard from `useDrawerStakeQueryString` and use it in `SideDrawer` — the single render site of `ManageStake` — so only `manage`/`stake` open the drawer. A foreign value now renders no drawer (correct, since it belongs to a different page's drawer) instead of crashing. TypeScript narrowing keeps the `mode` prop typed with no casts.

## Follow-up suggestion

Giving each page a unique query key (e.g. `stakeDrawerMode`, `stakingDrawerMode`, `poolDrawerMode`) would eliminate this class of collision entirely. Left out of this PR since it changes user-visible URLs — happy to do it as a follow-up if you want it.