### PR TITLE
Add sandbox dispatcher and mining subcommand

### DIFF
--- a/portal/package.json
+++ b/portal/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "dev:wifi": "WIFI=true LOCAL_IP=$(ipconfig getifaddr en0) PORT=3000 pnpm run dev",
     "generate:htaccess": "node ./scripts/generateServerConfig.js",
-    "sandbox:hemi-earn:setup": "node scripts/hemi-earn/setup.ts",
+    "sandbox:hemi-earn": "node scripts/hemi-earn/index.ts",
     "preserve": "pnpm run build",
     "serve": "serve out",
     "storybook": "storybook dev -p 6006",

--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -14,12 +14,12 @@ Foundry (`anvil`) is auto-installed by [`@hemilabs/anvil-fork-setup`](https://ww
 From the repo root:
 
 ```bash
-pnpm --filter portal sandbox:hemi-earn:setup -- --address 0xYourEOA
+pnpm --filter portal sandbox:hemi-earn -- setup --address 0xYourEOA
 ```
 
 That single command starts an Anvil fork of Hemi mainnet on port 8545, deploys the required mocks, funds the test account, and enables cooldown. Anvil is detached (`child.unref()` inside `@hemilabs/anvil-fork-setup`), so it keeps running after the script exits and the portal can talk to it.
 
-The `--` before the script flags is required — otherwise pnpm intercepts `--address` as its own option.
+The `--` before the subcommand is required — otherwise pnpm intercepts flags like `--address` as its own options.
 
 The setup script prints the deployed addresses at the end. The Vetro-aliased mocks (`vetBTC`, `Gateway`, `Staking`) live at their production addresses via `anvil_setCode`; the sandbox `Router`, `Agent`, `hemiBTC`, `WBTC`, and `cbBTC` are freshly deployed with deterministic addresses.
 
@@ -28,7 +28,7 @@ The setup script prints the deployed addresses at the end. The Vetro-aliased moc
 If you already have Anvil running (say, from a separate workflow), point the setup at it and skip the auto-start:
 
 ```bash
-pnpm --filter portal sandbox:hemi-earn:setup -- \
+pnpm --filter portal sandbox:hemi-earn -- setup \
   --address 0xYourEOA \
   --fork-url http://127.0.0.1:8547
 ```
@@ -36,37 +36,52 @@ pnpm --filter portal sandbox:hemi-earn:setup -- \
 ### Custom port or upstream RPC
 
 ```bash
-pnpm --filter portal sandbox:hemi-earn:setup -- \
+pnpm --filter portal sandbox:hemi-earn -- setup \
   --address 0xYourEOA \
   --port 8547 \
   --upstream-rpc https://your-hemi-rpc.example.com
 ```
 
-## Available scripts
+## Subcommands
 
-Each script is a standalone `.ts` module that exports its main function and can also be run as a CLI. Run them from anywhere via:
+All sandbox actions are dispatched through a single pnpm script that forwards its first positional token to the matching handler:
 
 ```bash
-node portal/scripts/hemi-earn/<script>.ts [flags]
+pnpm --filter portal sandbox:hemi-earn -- <subcommand> [flags]
 ```
 
-| Script           | Purpose                                                          |
-| ---------------- | ---------------------------------------------------------------- |
-| `setup.ts`       | Start Anvil + deploy mocks + fund the test account.              |
-| `deployMocks.ts` | Deploy mocks only. Requires a running Anvil.                     |
-| `fundAccount.ts` | Fund an EOA with ETH + tokens. Requires deployed mock addresses. |
+| Subcommand | Purpose                                                                      |
+| ---------- | ---------------------------------------------------------------------------- |
+| `setup`    | Start Anvil + deploy mocks + fund the test account.                          |
+| `mining`   | Toggle Anvil's interval mining at runtime (see [Slow mining](#slow-mining)). |
+
+Building blocks used by `setup` (`deployMocks.ts`, `fundAccount.ts`) are still invocable directly for advanced cases:
+
+```bash
+node portal/scripts/hemi-earn/deployMocks.ts [flags]
+node portal/scripts/hemi-earn/fundAccount.ts [flags]
+```
 
 ### Common flags
 
-- `--address` / `-a`: the test EOA to fund (required for `setup.ts`).
-- `--port` / `-p`: local port for the Anvil fork (default `8545`).
-- `--upstream-rpc` / `-u`: RPC to fork from (default `https://rpc.hemi.network/rpc`).
-- `--fork-url` / `-f`: URL of an already-running Anvil; when set, skips the auto-start.
-- `--deployer-pk`: private key used to sign deploy/write txs (default is Anvil's well-known account #0, re-exported from `@hemilabs/anvil-fork-setup/utils`).
+Flags are parsed by the handler of each subcommand.
+
+- `setup` — `--address` / `-a` (required), `--port` / `-p` (default `8545`), `--upstream-rpc` / `-u` (default `https://rpc.hemi.network/rpc`), `--fork-url` / `-f` (skips auto-start), `--deployer-pk` (default is Anvil's well-known account #0).
+- `mining` — `--seconds` / `-s` (default `6`, `0` returns to instant mining), `--fork-url` / `-f` (default `http://127.0.0.1:8545`).
 
 ## Cooldown
 
 The setup script enables cooldown on the staking vault with a 1-day duration, exercising the 2-step withdraw flow (request + claim after cooldown) by default.
+
+## Slow mining
+
+Slow-block mining is useful for reproducing intermediate UI states (pending tx spinners, cross-chain step indicators) without racing against Anvil's default instant mining. The `mining` subcommand toggles Anvil's `anvil_setIntervalMining` at runtime — on-chain state and Envio indexing are preserved, no restart needed.
+
+```bash
+pnpm --filter portal sandbox:hemi-earn -- mining --seconds 6   # a block every 6s
+pnpm --filter portal sandbox:hemi-earn -- mining --seconds 3   # a block every 3s
+pnpm --filter portal sandbox:hemi-earn -- mining --seconds 0   # back to instant
+```
 
 ## Mock contracts
 

--- a/portal/scripts/hemi-earn/constants.ts
+++ b/portal/scripts/hemi-earn/constants.ts
@@ -22,3 +22,5 @@ export const STAKING_PROD: Address = sVetBtcAddress
 export const DEFAULT_FORK_URL = 'http://127.0.0.1:8545'
 
 export const DEFAULT_DEPLOYER_PK = TEST_PRIVATE_KEY
+
+export const DEFAULT_INTERVAL_MINING_SECS = 6

--- a/portal/scripts/hemi-earn/index.ts
+++ b/portal/scripts/hemi-earn/index.ts
@@ -1,0 +1,37 @@
+import { scriptArgs } from './cli.ts'
+import { runSetIntervalMining } from './setIntervalMining.ts'
+import { runSetup } from './setup.ts'
+
+const SUBCOMMANDS = ['setup', 'mining'] as const
+
+function printUsage() {
+  console.error(
+    'Usage: pnpm --filter portal sandbox:hemi-earn -- <subcommand> [flags]',
+  )
+  console.error(`Subcommands: ${SUBCOMMANDS.join(', ')}`)
+}
+
+const [subcommand, ...rest] = scriptArgs()
+
+try {
+  switch (subcommand) {
+    case 'setup':
+      await runSetup(rest)
+      break
+    case 'mining':
+      await runSetIntervalMining(rest)
+      break
+    default:
+      printUsage()
+      process.exit(1)
+  }
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err)
+  console.error(`\n✗ sandbox:hemi-earn ${subcommand ?? ''}: ${message}`)
+  if (subcommand === 'setup') {
+    console.error(
+      '  The anvil fork may be in a partial state. Restart anvil and re-run.',
+    )
+  }
+  process.exit(1)
+}

--- a/portal/scripts/hemi-earn/index.ts
+++ b/portal/scripts/hemi-earn/index.ts
@@ -2,32 +2,31 @@ import { scriptArgs } from './cli.ts'
 import { runSetIntervalMining } from './setIntervalMining.ts'
 import { runSetup } from './setup.ts'
 
-const SUBCOMMANDS = ['setup', 'mining'] as const
+const HANDLERS = {
+  mining: runSetIntervalMining,
+  setup: runSetup,
+} as const
 
 function printUsage() {
   console.error(
     'Usage: pnpm --filter portal sandbox:hemi-earn -- <subcommand> [flags]',
   )
-  console.error(`Subcommands: ${SUBCOMMANDS.join(', ')}`)
+  console.error(`Subcommands: ${Object.keys(HANDLERS).join(', ')}`)
 }
 
 const [subcommand, ...rest] = scriptArgs()
+const handler = HANDLERS[subcommand as keyof typeof HANDLERS]
+
+if (!handler) {
+  printUsage()
+  process.exit(1)
+}
 
 try {
-  switch (subcommand) {
-    case 'setup':
-      await runSetup(rest)
-      break
-    case 'mining':
-      await runSetIntervalMining(rest)
-      break
-    default:
-      printUsage()
-      process.exit(1)
-  }
+  await handler(rest)
 } catch (err) {
   const message = err instanceof Error ? err.message : String(err)
-  console.error(`\n✗ sandbox:hemi-earn ${subcommand ?? ''}: ${message}`)
+  console.error(`\n✗ sandbox:hemi-earn ${subcommand}: ${message}`)
   if (subcommand === 'setup') {
     console.error(
       '  The anvil fork may be in a partial state. Restart anvil and re-run.',

--- a/portal/scripts/hemi-earn/setIntervalMining.ts
+++ b/portal/scripts/hemi-earn/setIntervalMining.ts
@@ -44,7 +44,9 @@ export async function runSetIntervalMining(argv: string[]) {
       'Usage: pnpm --filter portal sandbox:hemi-earn -- mining --seconds <N>',
     )
     console.error('  [-s N]                 interval in seconds (0 = instant)')
-    console.error('  [-f FORK_URL]          anvil RPC (default 127.0.0.1:8545)')
+    console.error(
+      '  [-f FORK_URL]          anvil RPC (default http://127.0.0.1:8545)',
+    )
     process.exit(1)
   }
 

--- a/portal/scripts/hemi-earn/setIntervalMining.ts
+++ b/portal/scripts/hemi-earn/setIntervalMining.ts
@@ -1,0 +1,62 @@
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from 'node:util'
+
+import { scriptArgs } from './cli.ts'
+import { DEFAULT_FORK_URL, DEFAULT_INTERVAL_MINING_SECS } from './constants.ts'
+import { anvilRpc } from './rpcClients.ts'
+
+async function setIntervalMining({
+  forkUrl = DEFAULT_FORK_URL,
+  seconds,
+}: {
+  forkUrl?: string
+  seconds: number
+}) {
+  await anvilRpc({
+    forkUrl,
+    method: 'anvil_setIntervalMining',
+    params: [seconds],
+  })
+  if (seconds === 0) {
+    console.log('✓ Anvil mining: instant (mines on every tx)')
+  } else {
+    console.log(`✓ Anvil interval mining: every ${seconds}s`)
+  }
+}
+
+export async function runSetIntervalMining(argv: string[]) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      'fork-url': { short: 'f', type: 'string' },
+      'seconds': { short: 's', type: 'string' },
+    },
+    strict: true,
+  })
+
+  const seconds =
+    values.seconds !== undefined
+      ? Number(values.seconds)
+      : DEFAULT_INTERVAL_MINING_SECS
+
+  if (!Number.isInteger(seconds) || seconds < 0) {
+    console.error(
+      'Usage: pnpm --filter portal sandbox:hemi-earn -- mining --seconds <N>',
+    )
+    console.error('  [-s N]                 interval in seconds (0 = instant)')
+    console.error('  [-f FORK_URL]          anvil RPC (default 127.0.0.1:8545)')
+    process.exit(1)
+  }
+
+  await setIntervalMining({ forkUrl: values['fork-url'], seconds })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await runSetIntervalMining(scriptArgs())
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`\n✗ setIntervalMining failed: ${message}`)
+    process.exit(1)
+  }
+}

--- a/portal/scripts/hemi-earn/setup.ts
+++ b/portal/scripts/hemi-earn/setup.ts
@@ -1,4 +1,5 @@
 import { startAnvilFork } from '@hemilabs/anvil-fork-setup'
+import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
 import { isAddress, type Address, type Hex } from 'viem'
 import { hemi } from 'viem/chains'
@@ -10,9 +11,9 @@ import { fundAccount } from './fundAccount.ts'
 
 const BOX_WIDTH = 78
 
-async function main() {
+export async function runSetup(argv: string[]) {
   const { values } = parseArgs({
-    args: scriptArgs(),
+    args: argv,
     options: {
       'address': { short: 'a', type: 'string' },
       'deployer-pk': { type: 'string' },
@@ -25,7 +26,7 @@ async function main() {
 
   if (!values.address || !isAddress(values.address, { strict: false })) {
     console.error(
-      'Usage: pnpm --filter portal sandbox:hemi-earn:setup -- --address 0xYourEOA',
+      'Usage: pnpm --filter portal sandbox:hemi-earn -- setup --address 0xYourEOA',
     )
     console.error('  [-p PORT]              port for the fork (default 8545)')
     console.error(
@@ -93,13 +94,15 @@ async function main() {
   )
 }
 
-try {
-  await main()
-} catch (err) {
-  const message = err instanceof Error ? err.message : String(err)
-  console.error(`\n✗ Sandbox setup failed: ${message}`)
-  console.error(
-    '  The anvil fork may be in a partial state. Restart anvil and re-run.',
-  )
-  process.exit(1)
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await runSetup(scriptArgs())
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`\n✗ Sandbox setup failed: ${message}`)
+    console.error(
+      '  The anvil fork may be in a partial state. Restart anvil and re-run.',
+    )
+    process.exit(1)
+  }
 }


### PR DESCRIPTION
### Description

This PR refactors the Hemi Earn sandbox tooling to route through a single dispatcher and adds the first new subcommand — `mining`.

Previously `portal/package.json` had a dedicated `sandbox:hemi-earn:setup` script. As more sandbox helpers get ported from the private tooling repo (there are a handful queued), that pattern would balloon into a wall of `sandbox:hemi-earn:*` entries. The new dispatcher (`sandbox:hemi-earn`) reads a positional subcommand and hands off to the right handler, keeping the pnpm surface flat as we grow.

The new `mining` subcommand toggles anvil's `anvil_setIntervalMining` at runtime — the equivalent of the shell `slow-mining.sh` helper we've been using from the private repo. Handy for reproducing intermediate UI states (pending tx spinners, cross-chain step indicators) without racing against anvil's instant mining. On-chain state and Envio indexing are preserved, so no restart is required.

`setup.ts`'s inline `main()` was extracted into an exported `runSetup(argv)` so the dispatcher can call it. Direct-node invocation (`node portal/scripts/hemi-earn/setup.ts ...`) still works via the standard `import.meta.url` bootstrap guard.

### Screenshots

<img width="1045" height="86" alt="Captura de Tela 2026-07-20 às 10 48 08" src="https://github.com/user-attachments/assets/2f7fdbca-19da-431c-aca5-de11f715ed6d" />


### Related issue(s)

Related to #2092 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
