### PR TITLE
Add debounce

### DIFF
--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useDebounce } from '@hemilabs/react-hooks/useDebounce'
 import { useAccounts } from 'hooks/useAccounts'
 import { useBitcoin } from 'hooks/useBitcoin'
 import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
@@ -95,7 +96,8 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
     isMinDepositsSatsLoading,
   })
 
-  const amountBigInt = parseTokenUnits(fromInput, fromToken)
+  const debouncedFromInput = useDebounce(fromInput, 300)
+  const amountBigInt = parseTokenUnits(debouncedFromInput, fromToken)
 
   const {
     btcDepositFee,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Tunneling BTC to hemiBTC fired a fee-estimate request on every keystroke. This debounces (300 ms) the amount that drives that request, so a burst of keystrokes collapses into a single request. Uses useDebounce from @hemilabs/react-hooks (already used elsewhere):

const debouncedFromInput = useDebounce(fromInput, 300)
const amountBigInt = parseTokenUnits(debouncedFromInput, fromToken)

Why debounce the derived amount and not the input itself (as the ticket suggests): fromInput keeps updating instantly, so the field stays responsive and validateSubmit/submit react immediately. Only the network-bound fee estimate is throttled. Each new amount still recalculates its own fee.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/e74d5a12-842c-426c-aca8-53c6835472ea



### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #1810 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
