### PR TITLE
Truncate token symbols

### DIFF
--- a/portal/components/tokenLogo.tsx
+++ b/portal/components/tokenLogo.tsx
@@ -42,7 +42,7 @@ export function TokenLogo({ size, token, version = 'default' }: Props) {
     bitcoinToken.address
   if (isBtcNetworkId(token.chainId) || (isTestnet && isHemiBtc)) {
     return (
-      <div className={`relative ${sizes[size]}`}>
+      <div className={`relative shrink-0 ${sizes[size]}`}>
         <div className="flex size-full items-center justify-center">
           <BtcLogo className="size-full" />
         </div>
@@ -57,7 +57,7 @@ export function TokenLogo({ size, token, version = 'default' }: Props) {
       : token.logoURI
 
   return logoURI ? (
-    <div className={`relative ${sizes[size]}`}>
+    <div className={`relative shrink-0 ${sizes[size]}`}>
       <Image
         alt={`${token.symbol} Logo`}
         className="w-full"
@@ -67,7 +67,7 @@ export function TokenLogo({ size, token, version = 'default' }: Props) {
       />
     </div>
   ) : (
-    <div className={`relative ${sizes[size]}`}>
+    <div className={`relative shrink-0 ${sizes[size]}`}>
       <CustomTokenLogo size={size} token={token} />
     </div>
   )

--- a/portal/components/tokenSelector/index.tsx
+++ b/portal/components/tokenSelector/index.tsx
@@ -12,6 +12,8 @@ import { Token } from 'types/token'
 import { Chevron } from '../icons/chevron'
 import { TokenLogo } from '../tokenLogo'
 
+import { TokenSymbol } from './tokenSymbol'
+
 const TokenListLoading = function () {
   const { width } = useWindowSize()
   const { height: viewportHeight } = useVisualViewportSize()
@@ -74,9 +76,10 @@ export const TokenSelector = function ({
         type="button"
       >
         <TokenLogo size="small" token={selectedToken} />
-        <span className="font-semibold text-neutral-950">
-          {selectedToken.symbol}
-        </span>
+        <TokenSymbol
+          className="font-semibold text-neutral-950"
+          symbol={selectedToken.symbol}
+        />
         {tokens.length > 1 && (
           <Chevron.Bottom className="ml-auto flex-shrink-0 [&>path]:fill-neutral-500 [&>path]:group-hover/token-selector:fill-neutral-950" />
         )}

--- a/portal/components/tokenSelector/readonly.tsx
+++ b/portal/components/tokenSelector/readonly.tsx
@@ -2,6 +2,8 @@ import { TokenLogo } from 'components/tokenLogo'
 import { ComponentProps } from 'react'
 import { Token } from 'types/token'
 
+import { TokenSymbol } from './tokenSymbol'
+
 type Props = {
   logoVersion?: ComponentProps<typeof TokenLogo>['version']
   token: Token
@@ -10,6 +12,9 @@ type Props = {
 export const TokenSelectorReadOnly = ({ logoVersion, token }: Props) => (
   <div className="flex items-center justify-between gap-x-2">
     <TokenLogo size="small" token={token} version={logoVersion} />
-    <span className="font-medium text-neutral-950">{token.symbol}</span>
+    <TokenSymbol
+      className="font-medium text-neutral-950"
+      symbol={token.symbol}
+    />
   </div>
 )

--- a/portal/components/tokenSelector/tokenSymbol.tsx
+++ b/portal/components/tokenSelector/tokenSymbol.tsx
@@ -10,7 +10,7 @@ type Props = {
 // Truncation is done by the CSS, so the symbol adapts to the width available.
 // Both the selector and the read-only row bound it to the same width, so they
 // truncate alike.
-export const TokenSymbol = ({ className, symbol }: Props) => (
+export const TokenSymbol = ({ className = '', symbol }: Props) => (
   <Tooltip
     disabled={!isSymbolTooLong(symbol)}
     id={`token-symbol-${symbol}`}

--- a/portal/components/tokenSelector/tokenSymbol.tsx
+++ b/portal/components/tokenSelector/tokenSymbol.tsx
@@ -1,0 +1,24 @@
+import { Tooltip } from 'components/tooltip'
+
+import { isSymbolTooLong } from './utils'
+
+type Props = {
+  className?: string
+  symbol: string
+}
+
+// Truncation is done by the CSS, so the symbol adapts to the width available.
+// Both the selector and the read-only row bound it to the same width, so they
+// truncate alike.
+export const TokenSymbol = ({ className, symbol }: Props) => (
+  <Tooltip
+    disabled={!isSymbolTooLong(symbol)}
+    id={`token-symbol-${symbol}`}
+    text={symbol}
+    // the selector opens a modal on click, so the tooltip must not react to it
+    trigger={['hover', 'focus']}
+    variant="simple"
+  >
+    <span className={`block max-w-20 truncate ${className}`}>{symbol}</span>
+  </Tooltip>
+)

--- a/portal/components/tokenSelector/utils.ts
+++ b/portal/components/tokenSelector/utils.ts
@@ -1,0 +1,8 @@
+// Symbols are read from the token contract, so they can be arbitrarily long
+// (i.e. mooStakeDao-VUSD-crvUSD). The CSS truncates them to the width the
+// layout gives them - this is only used to decide whether the full symbol is
+// worth showing in a tooltip.
+export const maxSymbolLength = 10
+
+export const isSymbolTooLong = (symbol: string) =>
+  symbol.length > maxSymbolLength

--- a/portal/components/tokenSelector/utils.ts
+++ b/portal/components/tokenSelector/utils.ts
@@ -1,8 +1,10 @@
-// Symbols are read from the token contract, so they can be arbitrarily long
-// (i.e. mooStakeDao-VUSD-crvUSD). The CSS truncates them to the width the
-// layout gives them - this is only used to decide whether the full symbol is
-// worth showing in a tooltip.
 export const maxSymbolLength = 10
 
+/**
+ * Symbols are read from the token contract, so they can be arbitrarily long
+ * (i.e. mooStakeDao-VUSD-crvUSD). The CSS truncates them to the width the
+ * layout gives them, so this only decides whether the full symbol is worth
+ * showing in a tooltip.
+ */
 export const isSymbolTooLong = (symbol: string) =>
   symbol.length > maxSymbolLength

--- a/portal/test/components/tokenSelector/utils.test.ts
+++ b/portal/test/components/tokenSelector/utils.test.ts
@@ -1,0 +1,19 @@
+import {
+  isSymbolTooLong,
+  maxSymbolLength,
+} from 'components/tokenSelector/utils'
+import { describe, expect, it } from 'vitest'
+
+describe('isSymbolTooLong', function () {
+  it('returns false for short symbols', function () {
+    expect(isSymbolTooLong('ETH')).toBe(false)
+  })
+
+  it('returns false for symbols of exactly the max length', function () {
+    expect(isSymbolTooLong('a'.repeat(maxSymbolLength))).toBe(false)
+  })
+
+  it('returns true for longer symbols', function () {
+    expect(isSymbolTooLong('mooStakeDao-VUSD-crvUSD')).toBe(true)
+  })
+})


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Token symbols come from the contract, so they can be arbitrarily long.
`mooStakeDao-VUSD-crvUSD` is 23 characters and wrapped onto two lines in the
token selector. Symbols are now truncated by the CSS to the width available, and
the full symbol is shown in a tooltip — same approach already used for tokens in
`tokenTable/tokenCell.tsx`.

Two fixes were needed along the way:

- `TokenLogo` had no `shrink-0`, so it collapsed to 0px once the text no longer
  fit. The sibling `Chevron` already sets it.
- The tooltip's default `trigger` includes `click`, which left it stuck open
  over the modal the selector opens. Restricted to `hover` and `focus`.

### Screenshots
<!-- For UI changes, include screenshots or even videos if possible. -->


https://github.com/user-attachments/assets/9203ea8d-1f85-4b35-934a-6d7de8f6ad98

<img alt="Captura de pantalla 2026-07-20 a la(s) 3 14 11 p  m" src="https://github.com/user-attachments/assets/d66e0b34-556c-4a3c-bbc2-2eb0cabb6114" />

<img  alt="Captura de pantalla 2026-07-20 a la(s) 3 37 41 p  m" src="https://github.com/user-attachments/assets/c9b9db0d-a816-4530-8265-6ee2e0bbd968" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #2094 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
