### PR TITLE
Narrow share token and total deposits pool cells

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
@@ -48,7 +48,7 @@ export const PoolInfoBar = function ({ pool }: Props) {
             </span>
           </PoolInfoItem>
         </div>
-        <div className="md:w-32">
+        <div className="md:w-24">
           <PoolInfoItem label={t('share-token')}>
             <div className="flex items-center gap-x-1.5">
               <div className="flex items-center justify-center rounded-full border border-gray-200">
@@ -60,16 +60,18 @@ export const PoolInfoBar = function ({ pool }: Props) {
             </div>
           </PoolInfoItem>
         </div>
-        <PoolInfoItem label={t('total-deposits')}>
-          <span className="body-text-medium text-neutral-950">
-            <RenderEarnFiatBalance
-              balance={pool.totalDeposits}
-              customFormatter={usd => formatCompactFiat(Number(usd), locale)}
-              queryStatus={pool.totalDepositsStatus}
-              token={pool.peggedToken}
-            />
-          </span>
-        </PoolInfoItem>
+        <div className="md:w-24">
+          <PoolInfoItem label={t('total-deposits')}>
+            <span className="body-text-medium text-neutral-950">
+              <RenderEarnFiatBalance
+                balance={pool.totalDeposits}
+                customFormatter={usd => formatCompactFiat(Number(usd), locale)}
+                queryStatus={pool.totalDepositsStatus}
+                token={pool.peggedToken}
+              />
+            </span>
+          </PoolInfoItem>
+        </div>
         <PoolInfoItem
           isLoading={pool.apy === undefined}
           label={t('apy')}


### PR DESCRIPTION
### Description

This PR implements the design tweak from the Hemi Earn pool tables issue, narrowing the nested item containers so the pool list reads a bit cleaner.

Two cells change on the desktop (md+) layout: the share token cell drops from 128px to 96px (md:w-32 → md:w-24), and total deposits — which previously just sized to its content (~86px) — now gets a matching 96px wrapper. Both use the standard w-24 Tailwind class and keep the md: prefix, so the mobile grid-cols-2 layout is untouched. The pool contract cell is left at 128px on purpose, since the brief only called out share token and total deposits.

### Screenshots

<img width="1352" height="279" alt="Captura de Tela 2026-07-20 às 17 10 42" src="https://github.com/user-attachments/assets/b17e88bd-b481-485b-9fc7-4c52afed477b" />
<img width="1348" height="266" alt="Captura de Tela 2026-07-20 às 17 10 55" src="https://github.com/user-attachments/assets/e4315c4b-4c0f-4d71-b212-e015fa8d619c" />


### Related issue(s)

Closes #2108 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
