### PR TITLE
Add relayer subcommand for sandbox keeper flows

### DIFF
--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -69,7 +69,7 @@ Flags are parsed by the handler of each subcommand.
 
 - `setup` — `--address` / `-a` (required), `--port` / `-p` (default `8545`), `--upstream-rpc` / `-u` (default `https://rpc.hemi.network/rpc`), `--fork-url` / `-f` (skips auto-start), `--deployer-pk` (default is Anvil's well-known account #0).
 - `mining` — `--seconds` / `-s` (default `6`, `0` returns to instant mining), `--fork-url` / `-f` (default `http://127.0.0.1:8545`).
-- `relayer` — `--router` / `-r` (required), `--agent` / `-a` (required) — both come from the address banner `setup` prints; `--fork-url` / `-f`, `--deployer-pk`, `--poll` (seconds between ticks, default `1`), `--disable-autoclaim` (observe events but skip the claim; simulates a downed keeper).
+- `relayer` — `--router` / `-r` (required), `--agent` / `-a` (required) — both come from the address banner `setup` prints; `--fork-url` / `-f`, `--deployer-pk`, `--poll` (seconds between ticks, default `1`), `--from-block N` (first block to backfill from, default `0` — full history), `--disable-autoclaim` (observe events but skip the claim; simulates a downed keeper).
 
 ## Cooldown
 
@@ -93,6 +93,8 @@ It's a **foreground daemon** — run it in its own terminal alongside the portal
 
 `--router` and `--agent` are required — copy them from the address banner `setup` prints. This avoids silent drift if the deploy sequence in `deployMocks.ts` ever changes.
 
+By default the relayer backfills from block 0, so unstake requests emitted **before** you started it are still picked up and claimed. Pass `--from-block N` to skip earlier history (rarely useful on a fresh sandbox, but handy if the anvil fork has a lot of pre-existing state).
+
 ```bash
 # Default poll (1s), watching the Router/Agent that setup printed
 pnpm --filter portal sandbox:hemi-earn -- relayer \
@@ -105,7 +107,7 @@ pnpm --filter portal sandbox:hemi-earn -- relayer \
   --fork-url http://127.0.0.1:8547
 
 # Observe UnstakeRequested but skip the claim — exercises the portal's
-# "Claim from vault" manual scape-hatch CTA (simulates keeper offline).
+# "Claim from vault" manual escape-hatch CTA (simulates keeper offline).
 pnpm --filter portal sandbox:hemi-earn -- relayer \
   --router 0x... --agent 0x... \
   --disable-autoclaim

--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -50,10 +50,11 @@ All sandbox actions are dispatched through a single pnpm script that forwards it
 pnpm --filter portal sandbox:hemi-earn -- <subcommand> [flags]
 ```
 
-| Subcommand | Purpose                                                                      |
-| ---------- | ---------------------------------------------------------------------------- |
-| `setup`    | Start Anvil + deploy mocks + fund the test account.                          |
-| `mining`   | Toggle Anvil's interval mining at runtime (see [Slow mining](#slow-mining)). |
+| Subcommand | Purpose                                                                                               |
+| ---------- | ----------------------------------------------------------------------------------------------------- |
+| `setup`    | Start Anvil + deploy mocks + fund the test account.                                                   |
+| `mining`   | Toggle Anvil's interval mining at runtime (see [Slow mining](#slow-mining)).                          |
+| `relayer`  | Emulate the production keeper: claim mature cooldown redeems automatically (see [Relayer](#relayer)). |
 
 Building blocks used by `setup` (`deployMocks.ts`, `fundAccount.ts`) are still invocable directly for advanced cases:
 
@@ -68,10 +69,11 @@ Flags are parsed by the handler of each subcommand.
 
 - `setup` — `--address` / `-a` (required), `--port` / `-p` (default `8545`), `--upstream-rpc` / `-u` (default `https://rpc.hemi.network/rpc`), `--fork-url` / `-f` (skips auto-start), `--deployer-pk` (default is Anvil's well-known account #0).
 - `mining` — `--seconds` / `-s` (default `6`, `0` returns to instant mining), `--fork-url` / `-f` (default `http://127.0.0.1:8545`).
+- `relayer` — `--router` / `-r` (required), `--agent` / `-a` (required) — both come from the address banner `setup` prints; `--fork-url` / `-f`, `--deployer-pk`, `--poll` (seconds between ticks, default `1`), `--disable-autoclaim` (observe events but skip the claim; simulates a downed keeper).
 
 ## Cooldown
 
-The setup script enables cooldown on the staking vault with a 1-day duration, exercising the 2-step withdraw flow (request + claim after cooldown) by default.
+The setup script enables cooldown on the staking vault with a 1-day duration, exercising the 2-step withdraw flow (request + claim after cooldown) by default. The claim step is dispatched by the production keeper; locally, run the [`relayer`](#relayer) subcommand alongside the portal to reproduce that behavior.
 
 ## Slow mining
 
@@ -81,6 +83,32 @@ Slow-block mining is useful for reproducing intermediate UI states (pending tx s
 pnpm --filter portal sandbox:hemi-earn -- mining --seconds 6   # a block every 6s
 pnpm --filter portal sandbox:hemi-earn -- mining --seconds 3   # a block every 3s
 pnpm --filter portal sandbox:hemi-earn -- mining --seconds 0   # back to instant
+```
+
+## Relayer
+
+The production Hemi Earn keeper watches the Agent for `UnstakeRequested` events and calls `claimUnstake(requestId)` once the on-chain `claimableAt` matures. Without it, redeems that fall on the cooldown branch stall at `COOLDOWN_MATURE` and the portal's step 2 never fires. The `relayer` subcommand ports that keeper for the local sandbox.
+
+It's a **foreground daemon** — run it in its own terminal alongside the portal and stop it with `Ctrl+C`. Uses the on-chain block timestamp (not `Date.now()`) so `evm_increaseTime` in tests takes effect on the maturity check.
+
+`--router` and `--agent` are required — copy them from the address banner `setup` prints. This avoids silent drift if the deploy sequence in `deployMocks.ts` ever changes.
+
+```bash
+# Default poll (1s), watching the Router/Agent that setup printed
+pnpm --filter portal sandbox:hemi-earn -- relayer \
+  --router 0x8a791620dd6260079bf849dc5567adc3f2fdc318 \
+  --agent 0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6
+
+# Point at a different fork URL
+pnpm --filter portal sandbox:hemi-earn -- relayer \
+  --router 0x... --agent 0x... \
+  --fork-url http://127.0.0.1:8547
+
+# Observe UnstakeRequested but skip the claim — exercises the portal's
+# "Claim from vault" manual scape-hatch CTA (simulates keeper offline).
+pnpm --filter portal sandbox:hemi-earn -- relayer \
+  --router 0x... --agent 0x... \
+  --disable-autoclaim
 ```
 
 ## Mock contracts

--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -50,11 +50,11 @@ All sandbox actions are dispatched through a single pnpm script that forwards it
 pnpm --filter portal sandbox:hemi-earn -- <subcommand> [flags]
 ```
 
-| Subcommand | Purpose                                                                                               |
-| ---------- | ----------------------------------------------------------------------------------------------------- |
-| `setup`    | Start Anvil + deploy mocks + fund the test account.                                                   |
-| `mining`   | Toggle Anvil's interval mining at runtime (see [Slow mining](#slow-mining)).                          |
-| `relayer`  | Emulate the production keeper: claim mature cooldown redeems automatically (see [Relayer](#relayer)). |
+| Subcommand | Purpose                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `setup`    | Start Anvil + deploy mocks + fund the test account.                                                                      |
+| `mining`   | Toggle Anvil's interval mining at runtime (see [Slow mining](#slow-mining)).                                             |
+| `relayer`  | Emulate the production keeper: claim mature cooldown redeems and bridge cancellation requests (see [Relayer](#relayer)). |
 
 Building blocks used by `setup` (`deployMocks.ts`, `fundAccount.ts`) are still invocable directly for advanced cases:
 
@@ -87,13 +87,16 @@ pnpm --filter portal sandbox:hemi-earn -- mining --seconds 0   # back to instant
 
 ## Relayer
 
-The production Hemi Earn keeper watches the Agent for `UnstakeRequested` events and calls `claimUnstake(requestId)` once the on-chain `claimableAt` matures. Without it, redeems that fall on the cooldown branch stall at `COOLDOWN_MATURE` and the portal's step 2 never fires. The `relayer` subcommand ports that keeper for the local sandbox.
+The production Hemi Earn keeper handles two flows that a local sandbox has no equivalent for:
+
+1. **Cooldown auto-claim.** Watches the Agent for `UnstakeRequested` events and calls `claimUnstake(requestId)` once the on-chain `claimableAt` matures. Without it, redeems that fall on the cooldown branch stall at `COOLDOWN_MATURE` and the portal's step 2 never fires.
+2. **Cancel bridge.** Watches the Router for `CancellationRequested` events (fired by the portal's Cancel CTA mid-cooldown) and immediately calls `Agent.cancel(requestId)` to bridge the intent cross-chain. One-shot per event: if the on-chain cancel reverts, the entry is dropped and the user re-triggers from the UI.
 
 It's a **foreground daemon** — run it in its own terminal alongside the portal and stop it with `Ctrl+C`. Uses the on-chain block timestamp (not `Date.now()`) so `evm_increaseTime` in tests takes effect on the maturity check.
 
 `--router` and `--agent` are required — copy them from the address banner `setup` prints. This avoids silent drift if the deploy sequence in `deployMocks.ts` ever changes.
 
-By default the relayer backfills from block 0, so unstake requests emitted **before** you started it are still picked up and claimed. Pass `--from-block N` to skip earlier history (rarely useful on a fresh sandbox, but handy if the anvil fork has a lot of pre-existing state).
+By default the relayer backfills from block 0 for both event types, so unstake requests and cancellations emitted **before** you started it are still picked up. Pass `--from-block N` to skip earlier history (rarely useful on a fresh sandbox, but handy if the anvil fork has a lot of pre-existing state).
 
 ```bash
 # Default poll (1s), watching the Router/Agent that setup printed

--- a/portal/scripts/hemi-earn/index.ts
+++ b/portal/scripts/hemi-earn/index.ts
@@ -1,9 +1,11 @@
 import { scriptArgs } from './cli.ts'
+import { runRelayer } from './relayer.ts'
 import { runSetIntervalMining } from './setIntervalMining.ts'
 import { runSetup } from './setup.ts'
 
 const HANDLERS = {
   mining: runSetIntervalMining,
+  relayer: runRelayer,
   setup: runSetup,
 } as const
 

--- a/portal/scripts/hemi-earn/relayer.ts
+++ b/portal/scripts/hemi-earn/relayer.ts
@@ -1,0 +1,196 @@
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from 'node:util'
+import { isAddress, parseAbiItem, type Address, type Hex } from 'viem'
+
+import { scriptArgs } from './cli.ts'
+import { DEFAULT_DEPLOYER_PK, DEFAULT_FORK_URL } from './constants.ts'
+import { buildClients } from './rpcClients.ts'
+
+const DEFAULT_POLL_SECS = 1
+
+const unstakeRequestedAbi = parseAbiItem(
+  'event UnstakeRequested(uint256 indexed requestId, uint256 claimableAt)',
+)
+const claimUnstakeAbi = parseAbiItem(
+  'function claimUnstake(uint256 requestId) payable',
+)
+
+const stamp = () => new Date().toTimeString().slice(0, 8)
+const log = (msg: string) => console.log(`[${stamp()}] [autoclaim] ${msg}`)
+const sleep = (ms: number) =>
+  new Promise<void>(resolve => setTimeout(resolve, ms))
+
+function printUsage() {
+  console.error(
+    'Usage: pnpm --filter portal sandbox:hemi-earn -- relayer --router 0x… --agent 0x… [flags]',
+  )
+  console.error(
+    '  -r, --router ADDR       Router address printed by setup (required)',
+  )
+  console.error(
+    '  -a, --agent ADDR        Agent address printed by setup (required)',
+  )
+  console.error(
+    '  [-f FORK_URL]           anvil RPC (default http://127.0.0.1:8545)',
+  )
+  console.error('  [--deployer-pk PK]      signer for claimUnstake txs')
+  console.error(
+    `  [--poll N]              poll interval in seconds (default ${DEFAULT_POLL_SECS})`,
+  )
+  console.error(
+    '  [--disable-autoclaim]   observe UnstakeRequested but skip claim (keeper-offline sim)',
+  )
+}
+
+function parseRelayerArgs(argv: string[]) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      'agent': { short: 'a', type: 'string' },
+      'deployer-pk': { type: 'string' },
+      'disable-autoclaim': { type: 'boolean' },
+      'fork-url': { short: 'f', type: 'string' },
+      'poll': { type: 'string' },
+      'router': { short: 'r', type: 'string' },
+    },
+    strict: true,
+  })
+
+  const router = values.router as Address | undefined
+  const agent = values.agent as Address | undefined
+  if (!router || !agent || !isAddress(router) || !isAddress(agent)) {
+    printUsage()
+    process.exit(1)
+  }
+  const pollSecs = values.poll ? Number(values.poll) : DEFAULT_POLL_SECS
+  if (!Number.isFinite(pollSecs) || pollSecs <= 0) {
+    printUsage()
+    process.exit(1)
+  }
+
+  return {
+    agent,
+    deployerPk:
+      (values['deployer-pk'] as Hex | undefined) ?? DEFAULT_DEPLOYER_PK,
+    disableAutoclaim: values['disable-autoclaim'] === true,
+    forkUrl: values['fork-url'] ?? DEFAULT_FORK_URL,
+    pollMs: Math.round(pollSecs * 1000),
+    router,
+  }
+}
+
+export async function runRelayer(argv: string[]) {
+  const { agent, deployerPk, disableAutoclaim, forkUrl, pollMs, router } =
+    parseRelayerArgs(argv)
+  const { publicClient, walletClient } = await buildClients({
+    deployerPk,
+    forkUrl,
+  })
+  const account = walletClient.account!
+
+  log(`starting against ${forkUrl}`)
+  log(`  router=${router}`)
+  log(`  agent=${agent}`)
+  log(`  poll=${pollMs / 1000}s${disableAutoclaim ? ' · autoclaim=OFF' : ''}`)
+
+  const queue = new Map<string, bigint>()
+  const processed = new Set<string>()
+  let lastBlock = await publicClient.getBlockNumber()
+  log(`starting from block ${lastBlock}`)
+
+  function enqueue(id: bigint, claimableAt: bigint) {
+    const key = id.toString()
+    if (processed.has(key) || queue.has(key)) return
+    if (disableAutoclaim) {
+      processed.add(key)
+      log(`observed requestId=${id} claimableAt=${claimableAt} (autoclaim OFF)`)
+      return
+    }
+    queue.set(key, claimableAt)
+    log(`queued requestId=${id} claimableAt=${claimableAt}`)
+  }
+
+  async function claimOne(id: bigint) {
+    const key = id.toString()
+    try {
+      const hash = await walletClient.writeContract({
+        abi: [claimUnstakeAbi],
+        account,
+        address: agent,
+        args: [id],
+        chain: walletClient.chain,
+        functionName: 'claimUnstake',
+      })
+      await publicClient.waitForTransactionReceipt({ hash })
+      log(`claimed requestId=${id} (tx ${hash.slice(0, 14)}…)`)
+      processed.add(key)
+      queue.delete(key)
+    } catch (err) {
+      const raw = (err as Error).message ?? ''
+      const oneLine = raw.split('\n')[0].slice(0, 200)
+
+      if (raw.includes('UnstakeRequestNotFound')) {
+        log(`requestId=${id} already claimed elsewhere — dropping`)
+        processed.add(key)
+        queue.delete(key)
+        return
+      }
+      log(`claim failed requestId=${id}: ${oneLine}`)
+    }
+  }
+
+  async function scanAndDrain() {
+    const head = await publicClient.getBlockNumber()
+    if (head > lastBlock) {
+      const logs = await publicClient.getLogs({
+        address: agent,
+        event: unstakeRequestedAbi,
+        fromBlock: lastBlock + 1n,
+        toBlock: head,
+      })
+      for (const entry of logs) {
+        enqueue(entry.args.requestId!, entry.args.claimableAt!)
+      }
+      lastBlock = head
+    }
+
+    if (queue.size === 0) return
+    // On-chain time (not `Date.now()`) so `evm_increaseTime` in tests takes
+    // effect on the maturity check.
+    const block = await publicClient.getBlock()
+    for (const [key, claimableAt] of [...queue.entries()]) {
+      if (claimableAt > block.timestamp) continue
+      if (processed.has(key)) {
+        queue.delete(key)
+        continue
+      }
+      await claimOne(BigInt(key))
+    }
+  }
+
+  let stopped = false
+  const stop = () => (stopped = true)
+  process.on('SIGINT', stop)
+  process.on('SIGTERM', stop)
+
+  while (!stopped) {
+    try {
+      await scanAndDrain()
+    } catch (err) {
+      const msg = (err as Error).message?.split('\n')[0].slice(0, 120) ?? ''
+      log(`tick error: ${msg}`)
+    }
+    await sleep(pollMs)
+  }
+  log('shutting down')
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await runRelayer(scriptArgs())
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`\n✗ relayer failed: ${message}`)
+    process.exit(1)
+  }
+}

--- a/portal/scripts/hemi-earn/relayer.ts
+++ b/portal/scripts/hemi-earn/relayer.ts
@@ -38,8 +38,23 @@ function printUsage() {
     `  [--poll N]              poll interval in seconds (default ${DEFAULT_POLL_SECS})`,
   )
   console.error(
+    '  [--from-block N]        first block to scan for UnstakeRequested (default 0 — full backfill)',
+  )
+  console.error(
     '  [--disable-autoclaim]   observe UnstakeRequested but skip claim (keeper-offline sim)',
   )
+}
+
+function parseFromBlock(raw: string | undefined): bigint {
+  if (raw === undefined) return 0n
+  try {
+    const parsed = BigInt(raw)
+    if (parsed < 0n) throw new Error('negative')
+    return parsed
+  } catch {
+    printUsage()
+    return process.exit(1)
+  }
 }
 
 function parseRelayerArgs(argv: string[]) {
@@ -50,6 +65,7 @@ function parseRelayerArgs(argv: string[]) {
       'deployer-pk': { type: 'string' },
       'disable-autoclaim': { type: 'boolean' },
       'fork-url': { short: 'f', type: 'string' },
+      'from-block': { type: 'string' },
       'poll': { type: 'string' },
       'router': { short: 'r', type: 'string' },
     },
@@ -74,14 +90,22 @@ function parseRelayerArgs(argv: string[]) {
       (values['deployer-pk'] as Hex | undefined) ?? DEFAULT_DEPLOYER_PK,
     disableAutoclaim: values['disable-autoclaim'] === true,
     forkUrl: values['fork-url'] ?? DEFAULT_FORK_URL,
+    fromBlock: parseFromBlock(values['from-block']),
     pollMs: Math.round(pollSecs * 1000),
     router,
   }
 }
 
 export async function runRelayer(argv: string[]) {
-  const { agent, deployerPk, disableAutoclaim, forkUrl, pollMs, router } =
-    parseRelayerArgs(argv)
+  const {
+    agent,
+    deployerPk,
+    disableAutoclaim,
+    forkUrl,
+    fromBlock,
+    pollMs,
+    router,
+  } = parseRelayerArgs(argv)
   const { publicClient, walletClient } = await buildClients({
     deployerPk,
     forkUrl,
@@ -95,8 +119,9 @@ export async function runRelayer(argv: string[]) {
 
   const queue = new Map<string, bigint>()
   const processed = new Set<string>()
-  let lastBlock = await publicClient.getBlockNumber()
-  log(`starting from block ${lastBlock}`)
+  // fromBlock - 1n so the initial scan (fromBlock+1..head) starts at fromBlock.
+  let lastBlock = fromBlock === 0n ? -1n : fromBlock - 1n
+  log(`scanning from block ${fromBlock}`)
 
   function enqueue(id: bigint, claimableAt: bigint) {
     const key = id.toString()

--- a/portal/scripts/hemi-earn/relayer.ts
+++ b/portal/scripts/hemi-earn/relayer.ts
@@ -14,9 +14,16 @@ const unstakeRequestedAbi = parseAbiItem(
 const claimUnstakeAbi = parseAbiItem(
   'function claimUnstake(uint256 requestId) payable',
 )
+const cancellationRequestedAbi = parseAbiItem(
+  'event CancellationRequested(uint256 indexed requestId)',
+)
+const agentCancelAbi = parseAbiItem(
+  'function cancel(uint256 requestId) payable',
+)
 
 const stamp = () => new Date().toTimeString().slice(0, 8)
-const log = (msg: string) => console.log(`[${stamp()}] [autoclaim] ${msg}`)
+const log = (tag: string, msg: string) =>
+  console.log(`[${stamp()}] [${tag}] ${msg}`)
 const sleep = (ms: number) =>
   new Promise<void>(resolve => setTimeout(resolve, ms))
 
@@ -33,12 +40,12 @@ function printUsage() {
   console.error(
     '  [-f FORK_URL]           anvil RPC (default http://127.0.0.1:8545)',
   )
-  console.error('  [--deployer-pk PK]      signer for claimUnstake txs')
+  console.error('  [--deployer-pk PK]      signer for keeper txs')
   console.error(
     `  [--poll N]              poll interval in seconds (default ${DEFAULT_POLL_SECS})`,
   )
   console.error(
-    '  [--from-block N]        first block to scan for UnstakeRequested (default 0 — full backfill)',
+    '  [--from-block N]        first block to scan for keeper events (default 0 — full backfill)',
   )
   console.error(
     '  [--disable-autoclaim]   observe UnstakeRequested but skip claim (keeper-offline sim)',
@@ -112,27 +119,42 @@ export async function runRelayer(argv: string[]) {
   })
   const account = walletClient.account!
 
-  log(`starting against ${forkUrl}`)
-  log(`  router=${router}`)
-  log(`  agent=${agent}`)
-  log(`  poll=${pollMs / 1000}s${disableAutoclaim ? ' · autoclaim=OFF' : ''}`)
+  log('relayer', `starting against ${forkUrl}`)
+  log('relayer', `  router=${router}`)
+  log('relayer', `  agent=${agent}`)
+  log(
+    'relayer',
+    `  poll=${pollMs / 1000}s${disableAutoclaim ? ' · autoclaim=OFF' : ''}`,
+  )
 
-  const queue = new Map<string, bigint>()
-  const processed = new Set<string>()
+  const claimQueue = new Map<string, bigint>()
+  const claimProcessed = new Set<string>()
+  const cancelQueue = new Set<string>()
+  const cancelProcessed = new Set<string>()
   // fromBlock - 1n so the initial scan (fromBlock+1..head) starts at fromBlock.
   let lastBlock = fromBlock === 0n ? -1n : fromBlock - 1n
-  log(`scanning from block ${fromBlock}`)
+  log('relayer', `scanning from block ${fromBlock}`)
 
-  function enqueue(id: bigint, claimableAt: bigint) {
+  function enqueueClaim(id: bigint, claimableAt: bigint) {
     const key = id.toString()
-    if (processed.has(key) || queue.has(key)) return
+    if (claimProcessed.has(key) || claimQueue.has(key)) return
     if (disableAutoclaim) {
-      processed.add(key)
-      log(`observed requestId=${id} claimableAt=${claimableAt} (autoclaim OFF)`)
+      claimProcessed.add(key)
+      log(
+        'autoclaim',
+        `observed requestId=${id} claimableAt=${claimableAt} (autoclaim OFF)`,
+      )
       return
     }
-    queue.set(key, claimableAt)
-    log(`queued requestId=${id} claimableAt=${claimableAt}`)
+    claimQueue.set(key, claimableAt)
+    log('autoclaim', `queued requestId=${id} claimableAt=${claimableAt}`)
+  }
+
+  function enqueueCancel(id: bigint) {
+    const key = id.toString()
+    if (cancelProcessed.has(key) || cancelQueue.has(key)) return
+    cancelQueue.add(key)
+    log('cancel', `queued cancel requestId=${id}`)
   }
 
   async function claimOne(id: bigint) {
@@ -147,50 +169,104 @@ export async function runRelayer(argv: string[]) {
         functionName: 'claimUnstake',
       })
       await publicClient.waitForTransactionReceipt({ hash })
-      log(`claimed requestId=${id} (tx ${hash.slice(0, 14)}…)`)
-      processed.add(key)
-      queue.delete(key)
+      log('autoclaim', `claimed requestId=${id} (tx ${hash.slice(0, 14)}…)`)
+      claimProcessed.add(key)
+      claimQueue.delete(key)
     } catch (err) {
       const raw = (err as Error).message ?? ''
       const oneLine = raw.split('\n')[0].slice(0, 200)
 
       if (raw.includes('UnstakeRequestNotFound')) {
-        log(`requestId=${id} already claimed elsewhere — dropping`)
-        processed.add(key)
-        queue.delete(key)
+        log('autoclaim', `requestId=${id} already claimed elsewhere — dropping`)
+        claimProcessed.add(key)
+        claimQueue.delete(key)
         return
       }
-      log(`claim failed requestId=${id}: ${oneLine}`)
+      log('autoclaim', `claim failed requestId=${id}: ${oneLine}`)
     }
   }
 
-  async function scanAndDrain() {
+  async function cancelOne(id: bigint) {
+    const key = id.toString()
+    try {
+      const hash = await walletClient.writeContract({
+        abi: [agentCancelAbi],
+        account,
+        address: agent,
+        args: [id],
+        chain: walletClient.chain,
+        functionName: 'cancel',
+      })
+      await publicClient.waitForTransactionReceipt({ hash })
+      log('cancel', `cancelled requestId=${id} (tx ${hash.slice(0, 14)}…)`)
+    } catch (err) {
+      const oneLine = ((err as Error).message ?? '')
+        .split('\n')[0]
+        .slice(0, 200)
+      log('cancel', `cancel failed requestId=${id}: ${oneLine}`)
+    } finally {
+      // one-shot regardless: on failure the user re-triggers from the UI
+      // (a fresh CancellationRequested lands on the next tick).
+      cancelProcessed.add(key)
+      cancelQueue.delete(key)
+    }
+  }
+
+  async function scanEvents() {
     const head = await publicClient.getBlockNumber()
-    if (head > lastBlock) {
-      const logs = await publicClient.getLogs({
+    if (head <= lastBlock) return
+    const [unstakeLogs, cancelLogs] = await Promise.all([
+      publicClient.getLogs({
         address: agent,
         event: unstakeRequestedAbi,
         fromBlock: lastBlock + 1n,
         toBlock: head,
-      })
-      for (const entry of logs) {
-        enqueue(entry.args.requestId!, entry.args.claimableAt!)
-      }
-      lastBlock = head
+      }),
+      publicClient.getLogs({
+        address: router,
+        event: cancellationRequestedAbi,
+        fromBlock: lastBlock + 1n,
+        toBlock: head,
+      }),
+    ])
+    for (const entry of unstakeLogs) {
+      enqueueClaim(entry.args.requestId!, entry.args.claimableAt!)
     }
+    for (const entry of cancelLogs) {
+      enqueueCancel(entry.args.requestId!)
+    }
+    lastBlock = head
+  }
 
-    if (queue.size === 0) return
+  async function drainCancels() {
+    for (const key of [...cancelQueue]) {
+      if (cancelProcessed.has(key)) {
+        cancelQueue.delete(key)
+        continue
+      }
+      await cancelOne(BigInt(key))
+    }
+  }
+
+  async function drainAutoclaim() {
+    if (claimQueue.size === 0) return
     // On-chain time (not `Date.now()`) so `evm_increaseTime` in tests takes
     // effect on the maturity check.
     const block = await publicClient.getBlock()
-    for (const [key, claimableAt] of [...queue.entries()]) {
+    for (const [key, claimableAt] of [...claimQueue.entries()]) {
       if (claimableAt > block.timestamp) continue
-      if (processed.has(key)) {
-        queue.delete(key)
+      if (claimProcessed.has(key)) {
+        claimQueue.delete(key)
         continue
       }
       await claimOne(BigInt(key))
     }
+  }
+
+  async function scanAndDrain() {
+    await scanEvents()
+    await drainCancels()
+    await drainAutoclaim()
   }
 
   let stopped = false
@@ -203,11 +279,11 @@ export async function runRelayer(argv: string[]) {
       await scanAndDrain()
     } catch (err) {
       const msg = (err as Error).message?.split('\n')[0].slice(0, 120) ?? ''
-      log(`tick error: ${msg}`)
+      log('relayer', `tick error: ${msg}`)
     }
     await sleep(pollMs)
   }
-  log('shutting down')
+  log('relayer', 'shutting down')
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/portal/scripts/hemi-earn/relayer.ts
+++ b/portal/scripts/hemi-earn/relayer.ts
@@ -281,7 +281,7 @@ export async function runRelayer(argv: string[]) {
       const msg = (err as Error).message?.split('\n')[0].slice(0, 120) ?? ''
       log('relayer', `tick error: ${msg}`)
     }
-    await sleep(pollMs)
+    if (!stopped) await sleep(pollMs)
   }
   log('relayer', 'shutting down')
 }


### PR DESCRIPTION
### Description

This PR adds a `relayer` subcommand to the Hemi Earn sandbox dispatcher — a foreground daemon that emulates the production keeper for two flows the local sandbox has no equivalent for.

**Cooldown auto-claim.** Any redeem that falls on the cooldown branch emits `UnstakeRequested` and then just sits at `COOLDOWN_MATURE` forever, because nobody calls `claimUnstake(id)` when the timer matures. Step 2 of the withdraw UI never fires. The relayer polls the Agent for `UnstakeRequested` logs, uses the on-chain block timestamp (so `evm_increaseTime` in tests still works) to detect maturity, and fires `claimUnstake` from the well-known sandbox deployer.

**Cancel bridge.** The portal's Cancel CTA (mid-cooldown) emits `Router.CancellationRequested`, but production requires a keeper to translate that into `Agent.cancel(id)` on the remote chain — that's the tx that actually drives status to CANCELLED via the return leg. Without the bridge, the request sits at `PENDING_CANCELLATION` forever and the UI looks broken. One-shot per event: on failure the entry is dropped and the user re-triggers from the UI.

It's a foreground daemon — run it in its own terminal alongside the portal, `Ctrl+C` shuts it down cleanly. There's also a `--disable-autoclaim` flag that observes cooldown events but skips the claim, useful for exercising the portal's "Claim from vault" manual escape-hatch CTA.

`--router` and `--agent` are required (copied from the address banner `setup` prints) rather than hardcoded defaults. The deploy sequence in `deployMocks.ts` has drifted before (WBTC/cbBTC swapped slots back in June), so required flags fail fast instead of silently watching the wrong addresses. `--from-block N` (default `0`) backfills both event types, so requests emitted before the relayer started are still picked up.

Log lines are tagged `[autoclaim]` / `[cancel]` / `[relayer]` to keep the two paths distinct in the output.

### Screenshots

<img width="1273" height="129" alt="Captura de Tela 2026-07-21 às 09 35 07" src="https://github.com/user-attachments/assets/2d9cd4cd-7098-4815-82b6-493f6ea9b78a" />

### Related issue(s)

Related to #2092 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
