### PR TITLE
Adjust h4 line height

### DIFF
--- a/portal/stories/typography.stories.tsx
+++ b/portal/stories/typography.stories.tsx
@@ -49,7 +49,7 @@ export const Headers: Story = {
       <Row name="H3" size="17/24">
         <h3>{SAMPLE}</h3>
       </Row>
-      <Row name="H4" size="13/18">
+      <Row name="H4" size="13/20">
         <h4>{SAMPLE}</h4>
       </Row>
     </>

--- a/portal/styles/globals.css
+++ b/portal/styles/globals.css
@@ -51,7 +51,7 @@ h3 {
 }
 
 h4 {
-  @apply text-sm font-semibold;
+  @apply text-sm font-semibold leading-5;
 }
 
 h1,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->
Change H4 line-height from 18px to 20px

portal/styles/globals.css: Added leading-5 to the h4 selector's @apply directive (text-sm font-semibold → text-sm font-semibold leading-5), changing the line-height from 18px to 20px while keeping the font-size (13px) unchanged. Only h4 is affected; other elements using text-sm (e.g. p) keep their original 18px line-height.
portal/stories/typography.stories.tsx: Updated the H4 row's size label in the Headers story from "13/18" to "13/20" to match the new line-height.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img  alt="Captura de pantalla 2026-07-23 a la(s) 11 20 09 a  m" src="https://github.com/user-attachments/assets/579415ad-831f-49e4-82d6-9eb74ea6fdf3" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #2116 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
