### PR TITLE
Add badge component

### DIFF
--- a/portal/components/badge.tsx
+++ b/portal/components/badge.tsx
@@ -1,0 +1,20 @@
+import { ComponentProps } from 'react'
+
+const variants = {
+  negative: 'bg-rose-50 text-rose-600',
+  negativeB: 'bg-rose-600 text-rose-50',
+  positive: 'bg-emerald-100 text-emerald-600',
+  primary: 'bg-orange-100 text-orange-600',
+  secondary: 'bg-neutral-50 text-neutral-600 shadow-bs',
+} as const
+
+type Props = Omit<ComponentProps<'span'>, 'className'> & {
+  variant?: keyof typeof variants
+}
+
+export const Badge = ({ variant = 'primary', ...props }: Props) => (
+  <span
+    className={`body-text-caption inline-flex h-4 items-center justify-center overflow-hidden rounded-md px-1.5 ${variants[variant]}`}
+    {...props}
+  />
+)

--- a/portal/stories/badge.stories.tsx
+++ b/portal/stories/badge.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Badge } from 'components/badge'
+
+const meta = {
+  args: {
+    children: 'Badge Label',
+    variant: 'primary',
+  },
+  argTypes: {
+    children: { control: 'text' },
+    variant: {
+      control: 'inline-radio',
+      options: ['primary', 'secondary', 'positive', 'negative', 'negativeB'],
+    },
+  },
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  title: 'Components/Badge',
+} satisfies Meta<typeof Badge>
+
+export default meta
+
+type Story = StoryObj<typeof Badge>
+
+export const Default: Story = {}
+
+export const Variants: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex flex-col items-center gap-y-6">
+      <Badge>Badge Label</Badge>
+      <Badge variant="secondary">Badge Label</Badge>
+      <Badge variant="positive">Badge Label</Badge>
+      <Badge variant="negative">Badge Label</Badge>
+      <Badge variant="negativeB">Badge Label</Badge>
+    </div>
+  ),
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Adds the `Badge` component to the design system, with the five variants from the
designs (`Primary`, `Secondary`, `Positive`, `Negative`, `Negative - B`).

It reuses what the project already has instead of adding new tokens: `shadow-bs`
for the `Secondary` outline (identical to the `bs` effect in the design) and

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
<img width="1512" height="736" alt="components-badge--default--ui" src="https://github.com/user-attachments/assets/88e1f5f0-7ed6-42ab-abea-1d53abc3eea2" />

<img alt="components-badge--default" src="https://github.com/user-attachments/assets/0ea277c8-0fb9-417c-8122-ea22e3f45a3b" />

<img  alt="components-badge--variants--ui" src="https://github.com/user-attachments/assets/75efcf62-9be4-443e-bd34-5c02b98dbcab" />

<img  alt="components-badge--variants" src="https://github.com/user-attachments/assets/ef7bab2f-5ada-4596-996a-818f6de86740" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #2071 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
