### PR TITLE
Add staked amount and receiver index to requests

### DIFF
--- a/subgraphs/hemi-earn-requests-subgraph/README.md
+++ b/subgraphs/hemi-earn-requests-subgraph/README.md
@@ -14,7 +14,7 @@ A deposit/redeem is a request that spans two contracts on two chains:
 Every event carries the same `requestId`. That `requestId` is the `Request` entity id, so each event upserts the **same** entity — it is created as a partial view by whichever chain is indexed first and progressively filled in by later events from either chain (see `src/mappings/eventHandlers.ts`). Cross-chain ordering uses Envio's default
 ordered multichain mode, and `status` is guarded so it never regresses.
 
-The resulting `Request` entity (see `schema.graphql`) holds who/what (`initiator`, `receiver`, `asset`, `kind`), the amounts (`amountIn`, `amountOut`), the lifecycle `status`, and per-milestone timestamps/tx hashes.
+The resulting `Request` entity (see `schema.graphql`) holds who/what (`initiator`, `receiver`, `asset`, `kind`), the amounts (`amountIn`, `amountOut`, and the pegged `stakedAmount` used as the earned-value cost basis), the lifecycle `status`, and per-milestone timestamps/tx hashes.
 
 ### `initiator` caveat
 

--- a/subgraphs/hemi-earn-requests-subgraph/schema.graphql
+++ b/subgraphs/hemi-earn-requests-subgraph/schema.graphql
@@ -35,11 +35,12 @@ type Request {
   processedAt: BigInt
   processTxHash: String
   receivedAt: BigInt
-  receiver: String
+  receiver: String @index # indexed: cost basis is looked up per receiver
   recoverTxHash: String
   requestedAt: BigInt
   requestId: BigInt!
   requestTxHash: String
   retryCount: Int!
+  stakedAmount: BigInt
   status: RequestStatus!
 }

--- a/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
@@ -41,6 +41,7 @@ const baseRequest = (id: string, requestId: bigint): Request => ({
   requestId,
   requestTxHash: undefined,
   retryCount: 0,
+  stakedAmount: undefined,
   status: 'PENDING',
 })
 
@@ -256,6 +257,7 @@ indexer.onEvent(
         kind: existing.kind ?? 'DEPOSIT',
         processedAt: BigInt(event.block.timestamp),
         processTxHash: event.transaction.hash,
+        stakedAmount: existing.stakedAmount ?? event.params.staked, // pegged staked into the vault
       }),
       requestId: event.params.requestId,
     }),

--- a/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
@@ -257,7 +257,7 @@ indexer.onEvent(
         kind: existing.kind ?? 'DEPOSIT',
         processedAt: BigInt(event.block.timestamp),
         processTxHash: event.transaction.hash,
-        stakedAmount: existing.stakedAmount ?? event.params.staked, // pegged staked into the vault
+        stakedAmount: event.params.staked, // pegged staked into the vault
       }),
       requestId: event.params.requestId,
     }),

--- a/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
@@ -497,5 +497,6 @@ describe('Agent receives', () => {
     const req = await ti.Request.getOrThrow('63')
     expect(req.amountIn).toBe(1000n) // Router value kept, not clobbered to 999n
     expect(req.amountOut).toBe(12n)
+    expect(req.stakedAmount).toBe(999n) // pegged staked into the vault
   })
 })


### PR DESCRIPTION
### Description

This PR extends the `hemi-earn-requests` subgraph so the backend can compute a per-user "Total earned" figure in a follow-up PR.

It adds a `stakedAmount` field to the Request entity, filled from the `staked` param of the Agent's `DepositRequestProcessed` event, and indexes `receiver` so requests can be looked up per share holder. The staked amount is the pegged value actually deposited into the vault — the only quantity comparable to `convertToAssets(shares)` when measuring earnings. The deposit's raw input (`assets`) can't be reused for that because it goes through a gateway
conversion (with slippage) before being staked, and redeems don't need a new field at all since the cost basis is reduced proportionally to the already-indexed shares burned.

Second of the sequence (package → subgraph → api → ui) behind the earned card.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #1965 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
