### PR TITLE
Add Hemi Earn cost-basis API endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -118,6 +118,19 @@
       }
     },
     {
+      "files": ["portal-backend/api/test/**/*.ts"],
+      "rules": {
+        "node/no-unpublished-import": ["error", { "allowModules": ["vitest"] }]
+      }
+    },
+    {
+      "files": ["portal-backend/api/*.config.ts"],
+      "rules": {
+        "node/no-missing-import": "off",
+        "node/no-unpublished-import": "off"
+      }
+    },
+    {
       "extends": ["bloq/node", "bloq/typescript", "prettier"],
       "files": ["subgraphs/hemi-earn-requests-subgraph/{src,tests}/**/*.ts"],
       "rules": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,9 @@ importers:
       express:
         specifier: 5.1.0
         version: 5.1.0
+      hemi-earn-actions:
+        specifier: workspace:*
+        version: link:../../packages/hemi-earn-actions
       hemi-viem:
         specifier: 2.8.0
         version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
@@ -552,6 +555,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.10.2)(vite@7.3.2(@types/node@24.10.2)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
   portal-backend/cron/hemi-supply:
     dependencies:

--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -172,7 +172,16 @@ $ curl http://localhost:3006/subgraphs/43111/earn-requests/0x0000000000000000000
 {"requests":[{"amountIn":"1000000000000000000","amountOut":"1000000000000000000","asset":"0x...","automatic":true,"claimableAt":"1759162804","claimTxHash":"0xabc...","failed":false,"failureReason":null,"kind":"DEPOSIT","receiver":"0x1234...","recoverTxHash":null,"requestedAt":"1759162804","requestId":"6","requestTxHash":"0xdef...","status":"FINALIZED"}]}
 ```
 
-Requires the following env vars to be set on the backend:
+##### `GET /subgraphs/:chain-id/earn-cost-basis/:address`
+
+Returns the per-share cost basis of the given address' Hemi Earn positions, keyed by the Hemi share OFT. Hemi mainnet only. Replays the holder's processed deposits/redeems and peer-to-peer share transfers: deposits add their pegged cost, redeems and transfers out reduce it proportionally, and transfers in are priced at fair market value (the share→asset rate closest to the transfer). Filtered by `receiver` (the holder), so the value reflects what the address currently holds. Values are decimal strings on the token's base-unit scale (may be fractional after proportional reductions).
+
+```console
+$ curl http://localhost:3006/subgraphs/43111/earn-cost-basis/0x0000000000000000000000000000000000000001
+{"costBasis":{"0x0000000000000000000000000000000000000002":"1010000000000000000"}}
+```
+
+Both Hemi Earn endpoints require the following env vars to be set on the backend:
 
 - `SUBGRAPH_HEMI_EARN_REQUESTS_API_URL` — the full GraphQL URL of the Envio `hemi-earn-requests` indexer.
 - `SUBGRAPH_HEMI_EARN_REQUESTS_API_KEY` — Bearer token for the Envio indexer (only sent when set; can be left empty against an unauthenticated local Envio).

--- a/portal-backend/api/Dockerfile
+++ b/portal-backend/api/Dockerfile
@@ -18,7 +18,7 @@ RUN pnpm install --frozen-lockfile --filter portal-backend...
 # Node can't type-strip .ts under node_modules, so compile the workspace packages
 # the api consumes to JS. Their package.json "compiled" export condition
 # points at this dist; the runtime activates it via NODE_OPTIONS below.
-RUN pnpm --filter ve-hemi-actions --filter ve-hemi-rewards run build
+RUN pnpm --filter ve-hemi-actions --filter ve-hemi-rewards --filter hemi-earn-actions run build
 # Self-contained app dir: prod deps + api files, workspace packages copied in.
 # --legacy: this workspace doesn't set inject-workspace-packages, which pnpm v10's
 # default deploy now requires.
@@ -42,9 +42,9 @@ ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 WORKDIR /app
 
 ENV NODE_ENV=production
-# Resolve the ve-hemi packages to their compiled JS. They ship raw .ts for local
-# dev and the portal bundler (the exports "default"); Node can't strip .ts under
-# node_modules, so here we opt into their "compiled" export condition.
+# Resolve the workspace action packages to their compiled JS. They ship raw .ts
+# for local dev and the portal bundler (the exports "default"); Node can't strip
+# .ts under node_modules, so here we opt into their "compiled" export condition.
 ENV NODE_OPTIONS=--conditions=compiled
 
 COPY --from=build --chown=node:node /app .

--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,9 +1,10 @@
 {
   "name": "portal-backend",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "scripts": {
     "build": "tsc",
-    "start": "node --import=./src/instrument.ts server.ts"
+    "start": "node --import=./src/instrument.ts server.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@sentry/node": "10.53.1",
@@ -11,6 +12,7 @@
     "cors": "2.8.5",
     "esplora-client": "1.2.0",
     "express": "5.1.0",
+    "hemi-earn-actions": "workspace:*",
     "hemi-viem": "2.8.0",
     "promise-mem": "1.0.4",
     "promise-swr": "1.0.2",
@@ -30,7 +32,8 @@
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",
     "p-map": "4.0.0",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "4.1.6"
   },
   "engines": {
     "node": ">=22"

--- a/portal-backend/api/src/hemi-earn/costBasis.ts
+++ b/portal-backend/api/src/hemi-earn/costBasis.ts
@@ -48,7 +48,7 @@ const resolveShareByAsset = function (asset: string) {
       // A zero share means the asset isn't registered — fail loudly instead of
       // silently mis-keying the cost basis to the zero address.
       if (resolved === zeroAddress) {
-        throw new Error(`assetsData returned no share for asset ${asset}`)
+        throw new Error(`getAssetData returned a zero share for asset ${asset}`)
       }
       return resolved
     })
@@ -68,8 +68,9 @@ type GetEarnCostBasisQueryResponse = GraphResponse<{ Request: CostBasisRow[] }>
  * Computes a user's per-vault Hemi Earn cost basis by replaying their processed
  * requests. Filtered by `receiver` (the holder of the shares) — unlike
  * `getEarnRequests`, which follows `initiator` — because the earned card values
- * what the user holds. Keyed by the Hemi share OFT (== the portal shareAddress),
- * value in pegged base units (decimal string).
+ * what the user holds. Keyed by the Hemi share OFT (== the portal shareAddress);
+ * the value is a decimal string on the base-unit scale, which may be fractional
+ * after proportional redeems (WAD precision) — so it is not `BigInt`-safe.
  *
  * Known limitation: only Router deposits/redeems are replayed, so peer-to-peer
  * share-OFT transfers are not tracked — shares acquired outside a deposit read

--- a/portal-backend/api/src/hemi-earn/costBasis.ts
+++ b/portal-backend/api/src/hemi-earn/costBasis.ts
@@ -1,0 +1,127 @@
+import { getAssetData } from 'hemi-earn-actions/actions'
+import {
+  type Address,
+  type PublicClient,
+  createPublicClient,
+  formatUnits,
+  http,
+  zeroAddress,
+} from 'viem'
+import { hemi } from 'viem/chains'
+
+import {
+  type GraphResponse,
+  checkGraphQLErrors,
+  paginateHemiEarnSubgraph,
+  requestHemiEarn,
+} from '../subgraphs/subgraph.ts'
+import type { EarnCostBasis } from '../subgraphs/types/earn.ts'
+
+import { type CostBasisRow, WAD_DECIMALS, replayCostBasis } from './replay.ts'
+
+// Lazily created and reused across cost-basis lookups so the Hemi client is only
+// built when the endpoint is hit. Chain-default RPC with batching, matching how
+// the ve-hemi module consumes its package actions.
+let hemiEarnRpcClient: PublicClient | undefined
+const getHemiEarnRpcClient = function () {
+  if (!hemiEarnRpcClient) {
+    hemiEarnRpcClient = createPublicClient({
+      chain: hemi,
+      transport: http(undefined, { batch: true }),
+    })
+  }
+  return hemiEarnRpcClient
+}
+
+// asset -> Hemi share OFT via the Router registry. Memoized because the mapping
+// is immutable and there are only a handful of assets.
+const shareByAssetCache = new Map<string, Promise<Address>>()
+const resolveShareByAsset = function (asset: string) {
+  const key = asset.toLowerCase()
+  const cached = shareByAssetCache.get(key)
+  if (cached) return cached
+  const share = getAssetData(getHemiEarnRpcClient(), {
+    asset: asset as Address,
+  })
+    .then(function (data) {
+      const resolved = data.share.toLowerCase() as Address
+      // A zero share means the asset isn't registered — fail loudly instead of
+      // silently mis-keying the cost basis to the zero address.
+      if (resolved === zeroAddress) {
+        throw new Error(`assetsData returned no share for asset ${asset}`)
+      }
+      return resolved
+    })
+    // Evict on failure so a transient RPC error (or the guard above) can't
+    // poison the cache forever.
+    .catch(function (error) {
+      shareByAssetCache.delete(key)
+      throw error
+    })
+  shareByAssetCache.set(key, share)
+  return share
+}
+
+type GetEarnCostBasisQueryResponse = GraphResponse<{ Request: CostBasisRow[] }>
+
+/**
+ * Computes a user's per-vault Hemi Earn cost basis by replaying their processed
+ * requests. Filtered by `receiver` (the holder of the shares) — unlike
+ * `getEarnRequests`, which follows `initiator` — because the earned card values
+ * what the user holds. Keyed by the Hemi share OFT (== the portal shareAddress),
+ * value in pegged base units (decimal string).
+ *
+ * Known limitation: only Router deposits/redeems are replayed, so peer-to-peer
+ * share-OFT transfers are not tracked — shares acquired outside a deposit read
+ * as pure profit. The normal deposit→receiver flow is fully covered.
+ */
+export const getEarnCostBasis = async function ({
+  address,
+}: {
+  address: Address
+}): Promise<EarnCostBasis> {
+  const receiver = address.toLowerCase()
+
+  const rows = await paginateHemiEarnSubgraph<CostBasisRow>({
+    async fetchPage({ limit, offset }) {
+      const schema = {
+        query: `query GetEarnCostBasis($limit: Int!, $offset: Int!, $receiver: String!) {
+          Request(
+            where: { receiver: { _eq: $receiver }, processedAt: { _is_null: false } }
+            order_by: [{ processedAt: asc }, { requestId: asc }]
+            limit: $limit
+            offset: $offset
+          ) {
+            amountIn
+            amountOut
+            asset
+            kind
+            stakedAmount
+          }
+        }`,
+        variables: { limit, offset, receiver },
+      }
+
+      const response =
+        await requestHemiEarn<GetEarnCostBasisQueryResponse>(schema)
+      checkGraphQLErrors(response)
+      return response.data.Request
+    },
+  })
+
+  const assets = [...new Set(rows.map(row => row.asset.toLowerCase()))]
+  const shareByAsset: Record<string, Address> = Object.fromEntries(
+    await Promise.all(
+      assets.map(async asset => [asset, await resolveShareByAsset(asset)]),
+    ),
+  )
+
+  const positions = replayCostBasis(rows, shareByAsset)
+
+  return Object.fromEntries(
+    [...positions].map(([share, { costBasis }]) => [
+      share,
+      formatUnits(costBasis, WAD_DECIMALS),
+    ]),
+  )
+}

--- a/portal-backend/api/src/hemi-earn/costBasis.ts
+++ b/portal-backend/api/src/hemi-earn/costBasis.ts
@@ -17,7 +17,12 @@ import {
 } from '../subgraphs/subgraph.ts'
 import type { EarnCostBasis } from '../subgraphs/types/earn.ts'
 
-import { type CostBasisRow, WAD_DECIMALS, replayCostBasis } from './replay.ts'
+import {
+  type CostBasisEvent,
+  type RatePoint,
+  WAD_DECIMALS,
+  replayCostBasis,
+} from './replay.ts'
 
 let hemiEarnRpcClient: PublicClient | undefined
 const getHemiEarnRpcClient = function () {
@@ -59,28 +64,32 @@ const resolveShareByAsset = function (asset: string) {
   return share
 }
 
-type GetEarnCostBasisQueryResponse = GraphResponse<{ Request: CostBasisRow[] }>
+type RequestRow = {
+  amountIn: string | null
+  amountOut: string | null
+  asset: string
+  kind: 'DEPOSIT' | 'REDEEM'
+  processedAt: string
+  requestedAt: string | null
+  stakedAmount: string | null
+}
 
-/**
- * Computes a user's per-vault Hemi Earn cost basis by replaying their processed
- * requests. Filtered by `receiver` (the holder of the shares) — unlike
- * `getEarnRequests`, which follows `initiator` — because the earned card values
- * what the user holds. Keyed by the Hemi share OFT (== the portal shareAddress);
- * the value is a decimal string on the base-unit scale, which may be fractional
- * after proportional redeems (WAD precision) — so it is not `BigInt`-safe.
- *
- * Known limitation: only Router deposits/redeems are replayed, so peer-to-peer
- * share-OFT transfers are not tracked — shares acquired outside a deposit read
- * as pure profit. The normal deposit→receiver flow is fully covered.
- */
-export const getEarnCostBasis = async function ({
-  address,
-}: {
-  address: Address
-}): Promise<EarnCostBasis> {
-  const receiver = address.toLowerCase()
+type ShareTransferRow = {
+  from: string
+  share: string
+  timestamp: string
+  to: string
+  value: string
+}
 
-  const rows = await paginateHemiEarnSubgraph<CostBasisRow>({
+type RateSnapshotRow = {
+  rateDenominator: string
+  rateNumerator: string
+  timestamp: string
+}
+
+const getRequests = ({ receiver }: { receiver: string }) =>
+  paginateHemiEarnSubgraph<RequestRow>({
     async fetchPage({ limit, offset }) {
       const schema = {
         query: `query GetEarnCostBasis($limit: Int!, $offset: Int!, $receiver: String!) {
@@ -94,27 +103,230 @@ export const getEarnCostBasis = async function ({
             amountOut
             asset
             kind
+            processedAt
+            requestedAt
             stakedAmount
           }
         }`,
         variables: { limit, offset, receiver },
       }
-
       const response =
-        await requestHemiEarn<GetEarnCostBasisQueryResponse>(schema)
+        await requestHemiEarn<GraphResponse<{ Request: RequestRow[] }>>(schema)
       checkGraphQLErrors(response)
       return response.data.Request
     },
   })
 
-  const assets = [...new Set(rows.map(row => row.asset.toLowerCase()))]
-  const shareByAsset: Record<string, Address> = Object.fromEntries(
-    await Promise.all(
-      assets.map(async asset => [asset, await resolveShareByAsset(asset)]),
+const getShareTransfers = ({ account }: { account: string }) =>
+  paginateHemiEarnSubgraph<ShareTransferRow>({
+    async fetchPage({ limit, offset }) {
+      const schema = {
+        query: `query GetShareTransfers($account: String!, $limit: Int!, $offset: Int!) {
+          ShareTransfer(
+            where: { _or: [{ from: { _eq: $account } }, { to: { _eq: $account } }] }
+            order_by: [{ timestamp: asc }, { id: asc }]
+            limit: $limit
+            offset: $offset
+          ) {
+            from
+            share
+            timestamp
+            to
+            value
+          }
+        }`,
+        variables: { account, limit, offset },
+      }
+      const response =
+        await requestHemiEarn<
+          GraphResponse<{ ShareTransfer: ShareTransferRow[] }>
+        >(schema)
+      checkGraphQLErrors(response)
+      return response.data.ShareTransfer
+    },
+  })
+
+const getEarnAssets = async function () {
+  const schema = {
+    query: `query GetEarnAssets {
+      RateSnapshot(distinct_on: asset) { asset }
+    }`,
+  }
+  const response =
+    await requestHemiEarn<GraphResponse<{ RateSnapshot: { asset: string }[] }>>(
+      schema,
+    )
+  checkGraphQLErrors(response)
+  return response.data.RateSnapshot.map(row => row.asset.toLowerCase())
+}
+
+const fetchRateBound = async function ({
+  asset,
+  comparator,
+  order,
+  timestamp,
+}: {
+  asset: string
+  comparator: '_gte' | '_lte'
+  order: 'asc' | 'desc'
+  timestamp: string
+}) {
+  const schema = {
+    query: `query GetRateBound($asset: String!, $timestamp: numeric!) {
+      RateSnapshot(
+        where: { asset: { _eq: $asset }, timestamp: { ${comparator}: $timestamp } }
+        order_by: { timestamp: ${order} }
+        limit: 1
+      ) {
+        rateDenominator
+        rateNumerator
+        timestamp
+      }
+    }`,
+    variables: { asset, timestamp },
+  }
+  const response =
+    await requestHemiEarn<GraphResponse<{ RateSnapshot: RateSnapshotRow[] }>>(
+      schema,
+    )
+  checkGraphQLErrors(response)
+  return response.data.RateSnapshot[0] ?? null
+}
+
+const toRatePoint = (row: RateSnapshotRow): RatePoint => ({
+  denominator: row.rateDenominator,
+  numerator: row.rateNumerator,
+})
+
+// The RateSnapshot closest in time to `timestamp` (before or after), approximating
+// the on-chain convertToAssets at the transfer moment.
+const getNearestRate = async function ({
+  asset,
+  timestamp,
+}: {
+  asset: string
+  timestamp: string
+}): Promise<RatePoint | null> {
+  const [below, above] = await Promise.all([
+    fetchRateBound({ asset, comparator: '_lte', order: 'desc', timestamp }),
+    fetchRateBound({ asset, comparator: '_gte', order: 'asc', timestamp }),
+  ])
+  if (!below) return above ? toRatePoint(above) : null
+  if (!above) return toRatePoint(below)
+  const target = BigInt(timestamp)
+  const closest =
+    target - BigInt(below.timestamp) <= BigInt(above.timestamp) - target
+      ? below
+      : above
+  return toRatePoint(closest)
+}
+
+type TimedEvent = { event: CostBasisEvent; timestamp: bigint }
+
+const requestToEvent = function (
+  row: RequestRow,
+  shareByAsset: Record<string, Address>,
+): TimedEvent | null {
+  const share = shareByAsset[row.asset.toLowerCase()]
+  if (!share) return null
+  const timestamp = BigInt(row.requestedAt ?? row.processedAt)
+  if (row.kind === 'DEPOSIT') {
+    if (row.amountOut === null) return null
+    return {
+      event: {
+        kind: 'DEPOSIT',
+        share,
+        shares: row.amountOut,
+        staked: row.stakedAmount,
+      },
+      timestamp,
+    }
+  }
+  if (row.amountIn === null) return null
+  return { event: { kind: 'REDEEM', share, shares: row.amountIn }, timestamp }
+}
+
+const transferToEvent = async function (
+  row: ShareTransferRow,
+  account: string,
+  assetByShare: Record<string, string>,
+): Promise<TimedEvent | null> {
+  const from = row.from.toLowerCase()
+  const share = row.share.toLowerCase()
+  const to = row.to.toLowerCase()
+  const timestamp = BigInt(row.timestamp)
+  if (to === account && from !== account) {
+    const asset = assetByShare[share]
+    const rate = asset
+      ? await getNearestRate({ asset, timestamp: row.timestamp })
+      : null
+    return {
+      event: { kind: 'TRANSFER_IN', rate, share, value: row.value },
+      timestamp,
+    }
+  }
+  if (from === account && to !== account) {
+    return {
+      event: { kind: 'TRANSFER_OUT', share, value: row.value },
+      timestamp,
+    }
+  }
+  return null
+}
+
+// Per-share cost basis, replayed from the user's processed deposits/redeems and
+// peer-to-peer share transfers in chronological order: transfers in are priced at
+// the nearest share->asset rate (FMV), disposals reduce the basis proportionally.
+// Filtered by `receiver` (the holder), not `initiator`. Keyed by the Hemi share
+// OFT; the value is a decimal string, fractional after proportional reductions.
+export const getEarnCostBasis = async function ({
+  address,
+}: {
+  address: Address
+}): Promise<EarnCostBasis> {
+  const account = address.toLowerCase()
+
+  const [requestRows, transferRows] = await Promise.all([
+    getRequests({ receiver: account }),
+    getShareTransfers({ account }),
+  ])
+
+  // The user's request assets always resolve (they deposited through the Router).
+  // Global assets are only needed to map a transfer's share back to an asset for
+  // pricing, so skip that enumeration (and its RPC calls) when there are no
+  // transfers. Resolution is defensive: one de-registered asset must not fail the
+  // whole request.
+  const requestAssets = requestRows.map(row => row.asset.toLowerCase())
+  const globalAssets = transferRows.length > 0 ? await getEarnAssets() : []
+  const resolved = await Promise.all(
+    [...new Set([...requestAssets, ...globalAssets])].map(asset =>
+      resolveShareByAsset(asset).then(
+        share => [asset, share] as const,
+        () => null,
+      ),
     ),
   )
+  const shareByAsset: Record<string, Address> = Object.fromEntries(
+    resolved.filter(
+      (entry): entry is readonly [string, Address] => entry !== null,
+    ),
+  )
+  const assetByShare: Record<string, string> = Object.fromEntries(
+    Object.entries(shareByAsset).map(([asset, share]) => [share, asset]),
+  )
 
-  const positions = replayCostBasis(rows, shareByAsset)
+  const timed = (
+    await Promise.all([
+      ...requestRows.map(row => requestToEvent(row, shareByAsset)),
+      ...transferRows.map(row => transferToEvent(row, account, assetByShare)),
+    ])
+  ).filter((entry): entry is TimedEvent => entry !== null)
+
+  timed.sort((a, b) =>
+    a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0,
+  )
+
+  const positions = replayCostBasis(timed.map(entry => entry.event))
 
   return Object.fromEntries(
     [...positions].map(([share, { costBasis }]) => [

--- a/portal-backend/api/src/hemi-earn/costBasis.ts
+++ b/portal-backend/api/src/hemi-earn/costBasis.ts
@@ -149,7 +149,7 @@ const getShareTransfers = ({ account }: { account: string }) =>
 const getEarnAssets = async function () {
   const schema = {
     query: `query GetEarnAssets {
-      RateSnapshot(distinct_on: asset) { asset }
+      RateSnapshot(distinct_on: asset, order_by: { asset: asc }) { asset }
     }`,
   }
   const response =

--- a/portal-backend/api/src/hemi-earn/costBasis.ts
+++ b/portal-backend/api/src/hemi-earn/costBasis.ts
@@ -19,9 +19,6 @@ import type { EarnCostBasis } from '../subgraphs/types/earn.ts'
 
 import { type CostBasisRow, WAD_DECIMALS, replayCostBasis } from './replay.ts'
 
-// Lazily created and reused across cost-basis lookups so the Hemi client is only
-// built when the endpoint is hit. Chain-default RPC with batching, matching how
-// the ve-hemi module consumes its package actions.
 let hemiEarnRpcClient: PublicClient | undefined
 const getHemiEarnRpcClient = function () {
   if (!hemiEarnRpcClient) {

--- a/portal-backend/api/src/hemi-earn/costBasis.ts
+++ b/portal-backend/api/src/hemi-earn/costBasis.ts
@@ -42,7 +42,7 @@ const resolveShareByAsset = function (asset: string) {
   const key = asset.toLowerCase()
   const cached = shareByAssetCache.get(key)
   if (cached) return cached
-  const share = getAssetData(getHemiEarnRpcClient(), {
+  const sharePromise = getAssetData(getHemiEarnRpcClient(), {
     asset: asset as Address,
   })
     .then(function (data) {
@@ -60,8 +60,8 @@ const resolveShareByAsset = function (asset: string) {
       shareByAssetCache.delete(key)
       throw error
     })
-  shareByAssetCache.set(key, share)
-  return share
+  shareByAssetCache.set(key, sharePromise)
+  return sharePromise
 }
 
 type RequestRow = {
@@ -300,10 +300,9 @@ export const getEarnCostBasis = async function ({
   const globalAssets = transferRows.length > 0 ? await getEarnAssets() : []
   const resolved = await Promise.all(
     [...new Set([...requestAssets, ...globalAssets])].map(asset =>
-      resolveShareByAsset(asset).then(
-        share => [asset, share] as const,
-        () => null,
-      ),
+      resolveShareByAsset(asset)
+        .then(share => [asset, share] as const)
+        .catch(() => null),
     ),
   )
   const shareByAsset: Record<string, Address> = Object.fromEntries(

--- a/portal-backend/api/src/hemi-earn/costBasis.ts
+++ b/portal-backend/api/src/hemi-earn/costBasis.ts
@@ -329,9 +329,11 @@ export const getEarnCostBasis = async function ({
   const positions = replayCostBasis(timed.map(entry => entry.event))
 
   return Object.fromEntries(
-    [...positions].map(([share, { costBasis }]) => [
-      share,
-      formatUnits(costBasis, WAD_DECIMALS),
-    ]),
+    [...positions]
+      .filter(([, { shares }]) => shares > 0n)
+      .map(([share, { costBasis }]) => [
+        share,
+        formatUnits(costBasis, WAD_DECIMALS),
+      ]),
   )
 }

--- a/portal-backend/api/src/hemi-earn/replay.ts
+++ b/portal-backend/api/src/hemi-earn/replay.ts
@@ -29,11 +29,18 @@ const applyDeposit = function (
   position: Position,
   row: CostBasisRow,
 ): Position {
-  const staked = row.stakedAmount ?? null
   const minted = row.amountOut ?? null
-  if (staked === null || minted === null) return position
+  // No shares minted (deposit not processed yet) → nothing to accrue.
+  if (minted === null) return position
+  const staked = row.stakedAmount ?? null
   return {
-    costBasis: position.costBasis + BigInt(staked) * WAD,
+    // Always track the minted shares so a later redeem's proportional reduction
+    // divides by the true balance. Only accrue cost basis when the staked amount
+    // is known; an unknown one reads as pure profit.
+    costBasis:
+      staked === null
+        ? position.costBasis
+        : position.costBasis + BigInt(staked) * WAD,
     shares: position.shares + BigInt(minted),
   }
 }

--- a/portal-backend/api/src/hemi-earn/replay.ts
+++ b/portal-backend/api/src/hemi-earn/replay.ts
@@ -1,0 +1,76 @@
+import { type Address } from 'viem'
+
+// Pure Vetro-parity cost-basis accounting for Hemi Earn, replayed from a user's
+// processed requests: each deposit adds its pegged `stakedAmount`; each redeem
+// reduces the cost basis proportionally to the burned shares (so realized gains
+// from withdrawals drop out). WAD scaling preserves precision through the
+// proportional division. No I/O here — kept pure so it can be unit-tested.
+
+export type CostBasisRow = {
+  amountIn: string | null
+  amountOut: string | null
+  asset: string
+  kind: 'DEPOSIT' | 'REDEEM'
+  stakedAmount: string | null
+}
+
+type Position = { costBasis: bigint; shares: bigint }
+
+// Fixed precision factor, NOT any token's decimals: the cost basis is scaled up
+// by WAD so the integer proportional-redeem division keeps sub-unit precision.
+// Callers divide back out by the same WAD_DECIMALS.
+export const WAD_DECIMALS = 18
+const WAD = 10n ** BigInt(WAD_DECIMALS)
+
+const emptyPosition: Position = { costBasis: 0n, shares: 0n }
+
+// Accrue the deposit's pegged cost basis and minted shares.
+const applyDeposit = function (
+  position: Position,
+  row: CostBasisRow,
+): Position {
+  const staked = row.stakedAmount ?? null
+  const minted = row.amountOut ?? null
+  if (staked === null || minted === null) return position
+  return {
+    costBasis: position.costBasis + BigInt(staked) * WAD,
+    shares: position.shares + BigInt(minted),
+  }
+}
+
+// Vetro handleTransfer parity: reduce cost basis proportionally to the burned
+// shares (realized gains drop out), zeroing on a full exit.
+const applyRedeem = function (position: Position, row: CostBasisRow): Position {
+  const redeemed = row.amountIn ?? null
+  if (redeemed === null) return position
+  const burned = BigInt(redeemed)
+  if (burned >= position.shares) return emptyPosition
+  return {
+    costBasis:
+      (position.costBasis * (position.shares - burned)) / position.shares,
+    shares: position.shares - burned,
+  }
+}
+
+// `rows` must be ordered oldest-first; `shareByAsset` maps each row's asset to
+// its Hemi share OFT. Returns the WAD-scaled cost basis per share.
+export const replayCostBasis = function (
+  rows: CostBasisRow[],
+  shareByAsset: Record<string, Address>,
+) {
+  const positions = new Map<Address, Position>()
+
+  rows.forEach(function (row) {
+    const share = shareByAsset[row.asset.toLowerCase()]
+    if (!share) return
+    const position = positions.get(share) ?? emptyPosition
+    positions.set(
+      share,
+      row.kind === 'DEPOSIT'
+        ? applyDeposit(position, row)
+        : applyRedeem(position, row),
+    )
+  })
+
+  return positions
+}

--- a/portal-backend/api/src/hemi-earn/replay.ts
+++ b/portal-backend/api/src/hemi-earn/replay.ts
@@ -16,9 +16,7 @@ export type CostBasisRow = {
 
 type Position = { costBasis: bigint; shares: bigint }
 
-// Fixed precision factor, NOT any token's decimals: the cost basis is scaled up
-// by WAD so the integer proportional-redeem division keeps sub-unit precision.
-// Callers divide back out by the same WAD_DECIMALS.
+// WAD scaling for the proportional-redeem division; not a token's decimals.
 export const WAD_DECIMALS = 18
 const WAD = 10n ** BigInt(WAD_DECIMALS)
 

--- a/portal-backend/api/src/hemi-earn/replay.ts
+++ b/portal-backend/api/src/hemi-earn/replay.ts
@@ -1,81 +1,86 @@
 import { type Address } from 'viem'
 
-// Pure Vetro-parity cost-basis accounting for Hemi Earn, replayed from a user's
-// processed requests: each deposit adds its pegged `stakedAmount`; each redeem
-// reduces the cost basis proportionally to the burned shares (so realized gains
-// from withdrawals drop out). WAD scaling preserves precision through the
-// proportional division. No I/O here — kept pure so it can be unit-tested.
+// Pure Vetro-parity cost-basis accounting for Hemi Earn. Acquisitions (deposits,
+// peer-to-peer transfers in) add their cost + shares; disposals (redeems,
+// transfers out) reduce the cost basis proportionally to the shares that leave,
+// so realized value drops out. WAD scaling preserves precision through the
+// proportional division. No I/O — kept pure so it can be unit-tested.
 
-export type CostBasisRow = {
-  amountIn: string | null
-  amountOut: string | null
-  asset: string
-  kind: 'DEPOSIT' | 'REDEEM'
-  stakedAmount: string | null
-}
+export type RatePoint = { denominator: string; numerator: string }
+
+export type CostBasisEvent =
+  | { kind: 'DEPOSIT'; share: string; shares: string; staked: string | null }
+  | { kind: 'REDEEM'; share: string; shares: string }
+  | {
+      kind: 'TRANSFER_IN'
+      rate: RatePoint | null
+      share: string
+      value: string
+    }
+  | { kind: 'TRANSFER_OUT'; share: string; value: string }
 
 type Position = { costBasis: bigint; shares: bigint }
 
-// WAD scaling for the proportional-redeem division; not a token's decimals.
 export const WAD_DECIMALS = 18
 const WAD = 10n ** BigInt(WAD_DECIMALS)
 
 const emptyPosition: Position = { costBasis: 0n, shares: 0n }
 
-// Accrue the deposit's pegged cost basis and minted shares.
-const applyDeposit = function (
+// FMV of a received share: priced by the share->asset rate closest to the
+// transfer, WAD-scaled to match the deposit cost basis.
+const priceTransferIn = (value: string, rate: RatePoint): bigint =>
+  (BigInt(value) * BigInt(rate.numerator) * WAD) / BigInt(rate.denominator)
+
+const acquire = (
   position: Position,
-  row: CostBasisRow,
+  { cost, shares }: { cost: bigint; shares: bigint },
+): Position => ({
+  costBasis: position.costBasis + cost,
+  shares: position.shares + shares,
+})
+
+// Vetro handleTransfer parity: realized value drops out; a full exit zeroes.
+const dispose = function (position: Position, shares: bigint): Position {
+  if (shares >= position.shares) return emptyPosition
+  return {
+    costBasis:
+      (position.costBasis * (position.shares - shares)) / position.shares,
+    shares: position.shares - shares,
+  }
+}
+
+const applyEvent = function (
+  position: Position,
+  event: CostBasisEvent,
 ): Position {
-  const minted = row.amountOut ?? null
-  // No shares minted (deposit not processed yet) → nothing to accrue.
-  if (minted === null) return position
-  const staked = row.stakedAmount ?? null
-  return {
-    // Always track the minted shares so a later redeem's proportional reduction
-    // divides by the true balance. Only accrue cost basis when the staked amount
-    // is known; an unknown one reads as pure profit.
-    costBasis:
-      staked === null
-        ? position.costBasis
-        : position.costBasis + BigInt(staked) * WAD,
-    shares: position.shares + BigInt(minted),
+  if (event.kind === 'DEPOSIT') {
+    return acquire(position, {
+      cost: event.staked === null ? 0n : BigInt(event.staked) * WAD,
+      shares: BigInt(event.shares),
+    })
   }
+  if (event.kind === 'TRANSFER_IN') {
+    return acquire(position, {
+      cost: event.rate === null ? 0n : priceTransferIn(event.value, event.rate),
+      shares: BigInt(event.value),
+    })
+  }
+  if (event.kind === 'REDEEM') {
+    return dispose(position, BigInt(event.shares))
+  }
+  return dispose(position, BigInt(event.value))
 }
 
-// Vetro handleTransfer parity: reduce cost basis proportionally to the burned
-// shares (realized gains drop out), zeroing on a full exit.
-const applyRedeem = function (position: Position, row: CostBasisRow): Position {
-  const redeemed = row.amountIn ?? null
-  if (redeemed === null) return position
-  const burned = BigInt(redeemed)
-  if (burned >= position.shares) return emptyPosition
-  return {
-    costBasis:
-      (position.costBasis * (position.shares - burned)) / position.shares,
-    shares: position.shares - burned,
-  }
-}
-
-// `rows` must be ordered oldest-first; `shareByAsset` maps each row's asset to
-// its Hemi share OFT. Returns the WAD-scaled cost basis per share.
-export const replayCostBasis = function (
-  rows: CostBasisRow[],
-  shareByAsset: Record<string, Address>,
-) {
+// `events` must be ordered oldest-first and keyed by the Hemi share OFT (asset
+// -> share is resolved upstream). Returns the WAD-scaled cost basis per share.
+export const replayCostBasis = function (events: CostBasisEvent[]) {
   const positions = new Map<Address, Position>()
-
-  rows.forEach(function (row) {
-    const share = shareByAsset[row.asset.toLowerCase()]
-    if (!share) return
-    const position = positions.get(share) ?? emptyPosition
+  events.forEach(function (event) {
+    const share = event.share as Address
     positions.set(
       share,
-      row.kind === 'DEPOSIT'
-        ? applyDeposit(position, row)
-        : applyRedeem(position, row),
+      applyEvent(positions.get(share) ?? emptyPosition, event),
     )
   })
-
   return positions
 }

--- a/portal-backend/api/src/subgraphs/router.ts
+++ b/portal-backend/api/src/subgraphs/router.ts
@@ -3,6 +3,7 @@ import type { NextFunction, Request, Response } from 'express'
 import type { Address } from 'viem'
 import { hemi, hemiSepolia, mainnet, sepolia } from 'viem/chains'
 
+import { getEarnCostBasis } from '../hemi-earn/costBasis.ts'
 import { toJsonMiddleware } from '../to-middleware.ts'
 import type { ChainIdPathParams, ReqData } from '../types.ts'
 
@@ -161,6 +162,13 @@ function parseQueryParams(
 const getStaked = (chainIdStr: string) =>
   getTotalStaked(Number(chainIdStr)).then(staked => ({ staked }))
 
+// `_chainIdStr` is unused but must stay the first param — toJsonMiddleware passes
+// the route params positionally, so `address` needs to land as the second arg.
+const getCostBasis = (_chainIdStr: string, address: string) =>
+  getEarnCostBasis({ address: address as Address }).then(costBasis => ({
+    costBasis,
+  }))
+
 export function createSubgraphsRouter() {
   // eslint-disable-next-line new-cap -- express.Router is a factory, not a constructor
   const router = express.Router()
@@ -272,6 +280,18 @@ export function createSubgraphsRouter() {
     validateAddress,
     validateChainIsHemiMainnet,
     getEarnRequestsHandler,
+  )
+
+  router.get(
+    '/:chainIdStr/earn-cost-basis/:address',
+    parseChainId,
+    validateAddress,
+    validateChainIsHemiMainnet,
+    toJsonMiddleware(getCostBasis, {
+      maxAge: 30 * 1000,
+      resolver: (chainIdStr, address) =>
+        `${chainIdStr}-${String(address).toLowerCase()}`,
+    }),
   )
 
   return router

--- a/portal-backend/api/src/subgraphs/router.ts
+++ b/portal-backend/api/src/subgraphs/router.ts
@@ -162,9 +162,7 @@ function parseQueryParams(
 const getStaked = (chainIdStr: string) =>
   getTotalStaked(Number(chainIdStr)).then(staked => ({ staked }))
 
-// `_chainIdStr` is unused but must stay the first param — toJsonMiddleware passes
-// the route params positionally, so `address` needs to land as the second arg.
-const getCostBasis = (_chainIdStr: string, address: string) =>
+const getCostBasis = (_: string, address: string) =>
   getEarnCostBasis({ address: address as Address }).then(costBasis => ({
     costBasis,
   }))

--- a/portal-backend/api/src/subgraphs/router.ts
+++ b/portal-backend/api/src/subgraphs/router.ts
@@ -162,8 +162,8 @@ function parseQueryParams(
 const getStaked = (chainIdStr: string) =>
   getTotalStaked(Number(chainIdStr)).then(staked => ({ staked }))
 
-const getCostBasis = (_: string, address: string) =>
-  getEarnCostBasis({ address: address as Address }).then(costBasis => ({
+const getCostBasis = (_: string, address: Address) =>
+  getEarnCostBasis({ address }).then(costBasis => ({
     costBasis,
   }))
 

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -32,7 +32,7 @@ type Schema = {
 
 type SuccessResponse<T> = { data: T }
 type ErrorResponse = { errors: { message: string }[] }
-type GraphResponse<T> = SuccessResponse<T> | ErrorResponse
+export type GraphResponse<T> = SuccessResponse<T> | ErrorResponse
 
 type ConfigType = typeof import('../../config/default.json')
 
@@ -86,7 +86,7 @@ const getTunnelSubgraphUrl = function (chainId: Chain['id']) {
  * @param response The GraphQL response to check
  * @throws UpstreamGraphQLError if the response contains errors
  */
-function checkGraphQLErrors<T>(
+export function checkGraphQLErrors<T>(
   response: GraphResponse<T>,
 ): asserts response is SuccessResponse<T> {
   // Check if response has errors
@@ -733,7 +733,7 @@ const toEarnRequestRow = (row: SubgraphRequest): EarnRequestRow => ({
 // Envio HyperIndex uses Bearer-token auth. Header is only added when an
 // API key is configured so local dev against an unauthenticated indexer
 // (Hasura at `localhost:8080`) keeps working.
-function requestHemiEarn<TResponse>(schema: Schema): Promise<TResponse> {
+export function requestHemiEarn<TResponse>(schema: Schema): Promise<TResponse> {
   const { apiKey, apiUrl } = subgraphConfig.hemiEarnRequests
   if (!apiUrl) {
     throw new UpstreamGraphQLError(
@@ -761,7 +761,7 @@ function requestHemiEarn<TResponse>(schema: Schema): Promise<TResponse> {
  * page's rows.
  * @param pageSize Rows to request per page. Defaults to 100.
  */
-const paginateHemiEarnSubgraph = async function <TRow>({
+export const paginateHemiEarnSubgraph = async function <TRow>({
   fetchPage,
   pageSize = 100,
 }: {

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -53,9 +53,10 @@ export type SubgraphRequest = EarnRequestCommonFields & {
 // Per-vault cost basis for a user, as returned by
 // `GET /subgraphs/:chainId/earn-cost-basis/:address`. Keyed by the Hemi share
 // OFT (lowercased, == the portal's `EarnPosition.shareAddress`); the value is
-// the pegged-token cost basis in base units (decimal string, WAD precision
-// preserved). The portal subtracts it from `convertToAssets(shares)` to derive
-// "Total earned".
+// the pegged-token cost basis on the base-unit scale, as a decimal string. It
+// may carry a fractional part from WAD-precision proportional redeems, so it is
+// not necessarily an integer — don't parse it as `BigInt`. The portal subtracts
+// it from `convertToAssets(shares)` to derive "Total earned".
 export type EarnCostBasis = Record<Address, string>
 
 // One Hemi Earn cross-chain request, as returned by

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -50,6 +50,14 @@ export type SubgraphRequest = EarnRequestCommonFields & {
   status: SubgraphRequestStatus
 }
 
+// Per-vault cost basis for a user, as returned by
+// `GET /subgraphs/:chainId/earn-cost-basis/:address`. Keyed by the Hemi share
+// OFT (lowercased, == the portal's `EarnPosition.shareAddress`); the value is
+// the pegged-token cost basis in base units (decimal string, WAD precision
+// preserved). The portal subtracts it from `convertToAssets(shares)` to derive
+// "Total earned".
+export type EarnCostBasis = Record<Address, string>
+
 // One Hemi Earn cross-chain request, as returned by
 // `GET /subgraphs/:chainId/earn-requests/:address`. Shape mirrors the
 // portal's `EarnTransaction` type (minus the localStorage-only fields).

--- a/portal-backend/api/src/subgraphs/types/earn.ts
+++ b/portal-backend/api/src/subgraphs/types/earn.ts
@@ -50,13 +50,9 @@ export type SubgraphRequest = EarnRequestCommonFields & {
   status: SubgraphRequestStatus
 }
 
-// Per-vault cost basis for a user, as returned by
-// `GET /subgraphs/:chainId/earn-cost-basis/:address`. Keyed by the Hemi share
-// OFT (lowercased, == the portal's `EarnPosition.shareAddress`); the value is
-// the pegged-token cost basis on the base-unit scale, as a decimal string. It
-// may carry a fractional part from WAD-precision proportional redeems, so it is
-// not necessarily an integer — don't parse it as `BigInt`. The portal subtracts
-// it from `convertToAssets(shares)` to derive "Total earned".
+// Per-user cost basis keyed by the Hemi share OFT (lowercased). Value is a
+// decimal string on the base-unit scale — may be fractional, so not
+// `BigInt`-safe.
 export type EarnCostBasis = Record<Address, string>
 
 // One Hemi Earn cross-chain request, as returned by

--- a/portal-backend/api/test/hemi-earn/replay.test.ts
+++ b/portal-backend/api/test/hemi-earn/replay.test.ts
@@ -104,7 +104,7 @@ describe('replayCostBasis', function () {
     expect(positions.size).toBe(0)
   })
 
-  it('skips a deposit missing its stakedAmount (accrues nothing)', function () {
+  it('tracks shares but no cost basis for a deposit missing its stakedAmount', function () {
     const positions = replayCostBasis(
       [
         {
@@ -117,6 +117,33 @@ describe('replayCostBasis', function () {
       ],
       shareByAsset,
     )
-    expect(positions.get(SHARE_A)).toEqual({ costBasis: 0n, shares: 0n })
+    // Shares counted (so later redeems divide by the true balance), but the
+    // unknown staked amount adds no cost basis — it reads as pure profit.
+    expect(positions.get(SHARE_A)).toEqual({ costBasis: 0n, shares: 50n })
+  })
+
+  it('reduces cost basis against the full balance when a deposit lacks stakedAmount', function () {
+    // Known deposit (100 basis / 100 shares) + unknown-basis deposit (50 shares),
+    // then burn 60 of the 150 total. The reduction must divide by 150, not 100 —
+    // otherwise the known cost basis is wiped out too fast.
+    const positions = replayCostBasis(
+      [
+        deposit(ASSET_A1, '100', '100'),
+        {
+          amountIn: null,
+          amountOut: '50',
+          asset: ASSET_A1,
+          kind: 'DEPOSIT' as const,
+          stakedAmount: null,
+        },
+        redeem(ASSET_A1, '60'),
+      ],
+      shareByAsset,
+    )
+    // 100*WAD * (150 - 60) / 150 = 60*WAD
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: 60n * WAD,
+      shares: 90n,
+    })
   })
 })

--- a/portal-backend/api/test/hemi-earn/replay.test.ts
+++ b/portal-backend/api/test/hemi-earn/replay.test.ts
@@ -1,0 +1,122 @@
+import { type Address } from 'viem'
+import { describe, expect, it } from 'vitest'
+
+import { replayCostBasis } from '../../src/hemi-earn/replay.ts'
+
+const WAD = 10n ** 18n
+
+// Two assets settle into share A, one into share B (a share accepts many assets).
+const SHARE_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const SHARE_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+const ASSET_A1 = '0x1111111111111111111111111111111111111111'
+const ASSET_A2 = '0x2222222222222222222222222222222222222222'
+const ASSET_B = '0x3333333333333333333333333333333333333333'
+
+const shareByAsset: Record<string, Address> = {
+  [ASSET_A1]: SHARE_A,
+  [ASSET_A2]: SHARE_A,
+  [ASSET_B]: SHARE_B,
+}
+
+const deposit = (asset: string, staked: string, shares: string) => ({
+  amountIn: null,
+  amountOut: shares,
+  asset,
+  kind: 'DEPOSIT' as const,
+  stakedAmount: staked,
+})
+
+const redeem = (asset: string, shares: string) => ({
+  amountIn: shares,
+  amountOut: null,
+  asset,
+  kind: 'REDEEM' as const,
+  stakedAmount: null,
+})
+
+describe('replayCostBasis', function () {
+  it('accrues a deposit as WAD-scaled cost basis + minted shares', function () {
+    const positions = replayCostBasis(
+      [deposit(ASSET_A1, '100', '50')],
+      shareByAsset,
+    )
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: 100n * WAD,
+      shares: 50n,
+    })
+  })
+
+  it('sums deposits into the same share across different assets', function () {
+    const positions = replayCostBasis(
+      [deposit(ASSET_A1, '100', '50'), deposit(ASSET_A2, '40', '10')],
+      shareByAsset,
+    )
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: 140n * WAD,
+      shares: 60n,
+    })
+  })
+
+  it('reduces cost basis proportionally on a partial redeem', function () {
+    // deposit 100 for 100 shares, then burn 40 shares → 60% of the basis remains.
+    const positions = replayCostBasis(
+      [deposit(ASSET_A1, '100', '100'), redeem(ASSET_A1, '40')],
+      shareByAsset,
+    )
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: 60n * WAD,
+      shares: 60n,
+    })
+  })
+
+  it('zeroes the position on a full (or over-) redeem', function () {
+    const positions = replayCostBasis(
+      [deposit(ASSET_A1, '100', '100'), redeem(ASSET_A1, '100')],
+      shareByAsset,
+    )
+    expect(positions.get(SHARE_A)).toEqual({ costBasis: 0n, shares: 0n })
+  })
+
+  it('keeps shares isolated — a redeem on one does not touch another', function () {
+    const positions = replayCostBasis(
+      [
+        deposit(ASSET_A1, '100', '100'),
+        deposit(ASSET_B, '200', '50'),
+        redeem(ASSET_A1, '50'),
+      ],
+      shareByAsset,
+    )
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: 50n * WAD,
+      shares: 50n,
+    })
+    expect(positions.get(SHARE_B)).toEqual({
+      costBasis: 200n * WAD,
+      shares: 50n,
+    })
+  })
+
+  it('ignores rows whose asset has no share mapping', function () {
+    const positions = replayCostBasis(
+      [deposit('0x9999999999999999999999999999999999999999', '100', '50')],
+      shareByAsset,
+    )
+    expect(positions.size).toBe(0)
+  })
+
+  it('skips a deposit missing its stakedAmount (accrues nothing)', function () {
+    const positions = replayCostBasis(
+      [
+        {
+          amountIn: null,
+          amountOut: '50',
+          asset: ASSET_A1,
+          kind: 'DEPOSIT' as const,
+          stakedAmount: null,
+        },
+      ],
+      shareByAsset,
+    )
+    expect(positions.get(SHARE_A)).toEqual({ costBasis: 0n, shares: 0n })
+  })
+})

--- a/portal-backend/api/test/hemi-earn/replay.test.ts
+++ b/portal-backend/api/test/hemi-earn/replay.test.ts
@@ -1,56 +1,51 @@
-import { type Address } from 'viem'
 import { describe, expect, it } from 'vitest'
 
 import { replayCostBasis } from '../../src/hemi-earn/replay.ts'
 
 const WAD = 10n ** 18n
 
-// Two assets settle into share A, one into share B (a share accepts many assets).
 const SHARE_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 const SHARE_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-const ASSET_A1 = '0x1111111111111111111111111111111111111111'
-const ASSET_A2 = '0x2222222222222222222222222222222222222222'
-const ASSET_B = '0x3333333333333333333333333333333333333333'
 
-const shareByAsset: Record<string, Address> = {
-  [ASSET_A1]: SHARE_A,
-  [ASSET_A2]: SHARE_A,
-  [ASSET_B]: SHARE_B,
-}
-
-const deposit = (asset: string, staked: string, shares: string) => ({
-  amountIn: null,
-  amountOut: shares,
-  asset,
+const deposit = (share: string, staked: string | null, shares: string) => ({
   kind: 'DEPOSIT' as const,
-  stakedAmount: staked,
+  share,
+  shares,
+  staked,
 })
 
-const redeem = (asset: string, shares: string) => ({
-  amountIn: shares,
-  amountOut: null,
-  asset,
+const redeem = (share: string, shares: string) => ({
   kind: 'REDEEM' as const,
-  stakedAmount: null,
+  share,
+  shares,
+})
+
+const transferIn = (
+  share: string,
+  value: string,
+  rate: { denominator: string; numerator: string } | null,
+) => ({ kind: 'TRANSFER_IN' as const, rate, share, value })
+
+const transferOut = (share: string, value: string) => ({
+  kind: 'TRANSFER_OUT' as const,
+  share,
+  value,
 })
 
 describe('replayCostBasis', function () {
   it('accrues a deposit as WAD-scaled cost basis + minted shares', function () {
-    const positions = replayCostBasis(
-      [deposit(ASSET_A1, '100', '50')],
-      shareByAsset,
-    )
+    const positions = replayCostBasis([deposit(SHARE_A, '100', '50')])
     expect(positions.get(SHARE_A)).toEqual({
       costBasis: 100n * WAD,
       shares: 50n,
     })
   })
 
-  it('sums deposits into the same share across different assets', function () {
-    const positions = replayCostBasis(
-      [deposit(ASSET_A1, '100', '50'), deposit(ASSET_A2, '40', '10')],
-      shareByAsset,
-    )
+  it('sums deposits into the same share', function () {
+    const positions = replayCostBasis([
+      deposit(SHARE_A, '100', '50'),
+      deposit(SHARE_A, '40', '10'),
+    ])
     expect(positions.get(SHARE_A)).toEqual({
       costBasis: 140n * WAD,
       shares: 60n,
@@ -58,11 +53,10 @@ describe('replayCostBasis', function () {
   })
 
   it('reduces cost basis proportionally on a partial redeem', function () {
-    // deposit 100 for 100 shares, then burn 40 shares → 60% of the basis remains.
-    const positions = replayCostBasis(
-      [deposit(ASSET_A1, '100', '100'), redeem(ASSET_A1, '40')],
-      shareByAsset,
-    )
+    const positions = replayCostBasis([
+      deposit(SHARE_A, '100', '100'),
+      redeem(SHARE_A, '40'),
+    ])
     expect(positions.get(SHARE_A)).toEqual({
       costBasis: 60n * WAD,
       shares: 60n,
@@ -70,22 +64,19 @@ describe('replayCostBasis', function () {
   })
 
   it('zeroes the position on a full (or over-) redeem', function () {
-    const positions = replayCostBasis(
-      [deposit(ASSET_A1, '100', '100'), redeem(ASSET_A1, '100')],
-      shareByAsset,
-    )
+    const positions = replayCostBasis([
+      deposit(SHARE_A, '100', '100'),
+      redeem(SHARE_A, '100'),
+    ])
     expect(positions.get(SHARE_A)).toEqual({ costBasis: 0n, shares: 0n })
   })
 
   it('keeps shares isolated — a redeem on one does not touch another', function () {
-    const positions = replayCostBasis(
-      [
-        deposit(ASSET_A1, '100', '100'),
-        deposit(ASSET_B, '200', '50'),
-        redeem(ASSET_A1, '50'),
-      ],
-      shareByAsset,
-    )
+    const positions = replayCostBasis([
+      deposit(SHARE_A, '100', '100'),
+      deposit(SHARE_B, '200', '50'),
+      redeem(SHARE_A, '50'),
+    ])
     expect(positions.get(SHARE_A)).toEqual({
       costBasis: 50n * WAD,
       shares: 50n,
@@ -96,54 +87,73 @@ describe('replayCostBasis', function () {
     })
   })
 
-  it('ignores rows whose asset has no share mapping', function () {
-    const positions = replayCostBasis(
-      [deposit('0x9999999999999999999999999999999999999999', '100', '50')],
-      shareByAsset,
-    )
-    expect(positions.size).toBe(0)
-  })
-
   it('tracks shares but no cost basis for a deposit missing its stakedAmount', function () {
-    const positions = replayCostBasis(
-      [
-        {
-          amountIn: null,
-          amountOut: '50',
-          asset: ASSET_A1,
-          kind: 'DEPOSIT' as const,
-          stakedAmount: null,
-        },
-      ],
-      shareByAsset,
-    )
-    // Shares counted (so later redeems divide by the true balance), but the
-    // unknown staked amount adds no cost basis — it reads as pure profit.
+    const positions = replayCostBasis([deposit(SHARE_A, null, '50')])
     expect(positions.get(SHARE_A)).toEqual({ costBasis: 0n, shares: 50n })
   })
 
-  it('reduces cost basis against the full balance when a deposit lacks stakedAmount', function () {
-    // Known deposit (100 basis / 100 shares) + unknown-basis deposit (50 shares),
-    // then burn 60 of the 150 total. The reduction must divide by 150, not 100 —
-    // otherwise the known cost basis is wiped out too fast.
-    const positions = replayCostBasis(
-      [
-        deposit(ASSET_A1, '100', '100'),
-        {
-          amountIn: null,
-          amountOut: '50',
-          asset: ASSET_A1,
-          kind: 'DEPOSIT' as const,
-          stakedAmount: null,
-        },
-        redeem(ASSET_A1, '60'),
-      ],
-      shareByAsset,
-    )
+  it('reduces against the full balance when a deposit lacks stakedAmount', function () {
+    const positions = replayCostBasis([
+      deposit(SHARE_A, '100', '100'),
+      deposit(SHARE_A, null, '50'),
+      redeem(SHARE_A, '60'),
+    ])
     // 100*WAD * (150 - 60) / 150 = 60*WAD
     expect(positions.get(SHARE_A)).toEqual({
       costBasis: 60n * WAD,
       shares: 90n,
+    })
+  })
+
+  it('prices a transfer-in at the nearest rate (FMV), not pure profit', function () {
+    // 10 shares received at rate 1.05 pegged/share → 10.5 pegged cost basis.
+    const positions = replayCostBasis([
+      transferIn(SHARE_A, '10', { denominator: '100', numerator: '105' }),
+    ])
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: (10n * 105n * WAD) / 100n,
+      shares: 10n,
+    })
+  })
+
+  it('adds no cost basis for a transfer-in with no rate available', function () {
+    const positions = replayCostBasis([transferIn(SHARE_A, '10', null)])
+    expect(positions.get(SHARE_A)).toEqual({ costBasis: 0n, shares: 10n })
+  })
+
+  it('reduces cost basis proportionally on a transfer-out', function () {
+    const positions = replayCostBasis([
+      deposit(SHARE_A, '100', '100'),
+      transferOut(SHARE_A, '40'),
+    ])
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: 60n * WAD,
+      shares: 60n,
+    })
+  })
+
+  it('replays deposits and transfers together in order', function () {
+    // deposit 100/100, transfer in 50 @ rate 1.0 (50 cost) → 150 basis / 150
+    // shares, then redeem 30 → 150*WAD * 120/150 = 120*WAD.
+    const positions = replayCostBasis([
+      deposit(SHARE_A, '100', '100'),
+      transferIn(SHARE_A, '50', { denominator: '1', numerator: '1' }),
+      redeem(SHARE_A, '30'),
+    ])
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: 120n * WAD,
+      shares: 120n,
+    })
+  })
+
+  it('prices a transfer-only position (never deposited) at FMV', function () {
+    // 20 shares at rate 1.5 → 30 pegged, not zero (pure profit).
+    const positions = replayCostBasis([
+      transferIn(SHARE_A, '20', { denominator: '2', numerator: '3' }),
+    ])
+    expect(positions.get(SHARE_A)).toEqual({
+      costBasis: 30n * WAD,
+      shares: 20n,
     })
   })
 })

--- a/portal-backend/api/vitest.config.ts
+++ b/portal-backend/api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    clearMocks: true,
+  },
+})


### PR DESCRIPTION
### Description

This PR adds the Hemi Earn cost-basis API endpoint and prices peer-to-peer share transfers at fair market value, so "Total earned" reflects what a user actually holds.

It replays a user's processed deposits/redeems keyed by the Hemi share OFT — deposits add their pegged cost basis, redeems reduce it proportionally. On its own that treats a share received via a peer-to-peer transfer as pure profit
(zero cost), inflating earned. So it also consumes the subgraph's ShareTransfer and RateSnapshot signals: transfers are merged into the chronological replay, a transfer in priced at the share->asset rate closest to it (FMV), a transfer out reducing the basis proportionally like a redeem.

Asset resolution is scoped to the caller's own assets and made defensive (a de-registered asset can't 500 the endpoint), and the event timestamp falls back to processedAt when the Hemi request isn't indexed yet.

Third of the sequence (package → subgraph → api → ui). The endpoint returns real data once the subgraph is deployed with the `stakedAmount` field.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #1965 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
