### PR TITLE
Bump hemi-viem to 2.8.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,6 +89,12 @@
           }
         ],
         "no-console": "off",
+        "node/no-missing-import": [
+          "error",
+          {
+            "allowModules": ["hemi-viem"]
+          }
+        ],
         "node/no-unpublished-import": [
           "error",
           {

--- a/packages/genesis-drop-actions/package.json
+++ b/packages/genesis-drop-actions/package.json
@@ -20,7 +20,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.6.1",
+    "hemi-viem": "2.8.0",
     "to-promise-event": "1.0.0"
   },
   "devDependencies": {

--- a/packages/hemi-earn-actions/package.json
+++ b/packages/hemi-earn-actions/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@vetro-protocol/earn": "1.0.0",
-    "hemi-viem": "2.6.1",
+    "hemi-viem": "2.8.0",
     "to-promise-event": "1.0.0",
     "viem-erc20": "2.0.0"
   },

--- a/packages/hemi-tunnel-actions/package.json
+++ b/packages/hemi-tunnel-actions/package.json
@@ -19,7 +19,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.6.1",
+    "hemi-viem": "2.8.0",
     "to-promise-event": "1.0.0",
     "viem-erc20": "2.0.0"
   },

--- a/packages/hemi-viem-stake-actions/package.json
+++ b/packages/hemi-viem-stake-actions/package.json
@@ -19,7 +19,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.6.1"
+    "hemi-viem": "2.8.0"
   },
   "devDependencies": {
     "@tsconfig/node24": "24.0.3",

--- a/packages/ve-hemi-actions/package.json
+++ b/packages/ve-hemi-actions/package.json
@@ -21,7 +21,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.6.1",
+    "hemi-viem": "2.8.0",
     "promise-mem": "1.0.4",
     "to-promise-event": "1.0.0",
     "viem-erc20": "2.0.0"

--- a/packages/ve-hemi-rewards/package.json
+++ b/packages/ve-hemi-rewards/package.json
@@ -22,7 +22,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.6.1",
+    "hemi-viem": "2.8.0",
     "to-promise-event": "1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
   packages/genesis-drop-actions:
     dependencies:
       hemi-viem:
-        specifier: 2.6.1
-        version: 2.6.1(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.8.0
+        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       to-promise-event:
         specifier: 1.0.0
         version: 1.0.0
@@ -117,8 +117,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hemi-viem:
-        specifier: 2.6.1
-        version: 2.6.1(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.8.0
+        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       to-promise-event:
         specifier: 1.0.0
         version: 1.0.0
@@ -145,8 +145,8 @@ importers:
   packages/hemi-tunnel-actions:
     dependencies:
       hemi-viem:
-        specifier: 2.6.1
-        version: 2.6.1(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.8.0
+        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       to-promise-event:
         specifier: 1.0.0
         version: 1.0.0
@@ -173,8 +173,8 @@ importers:
   packages/hemi-viem-stake-actions:
     dependencies:
       hemi-viem:
-        specifier: 2.6.1
-        version: 2.6.1(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.8.0
+        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
     devDependencies:
       '@tsconfig/node24':
         specifier: 24.0.3
@@ -189,8 +189,8 @@ importers:
   packages/ve-hemi-actions:
     dependencies:
       hemi-viem:
-        specifier: 2.6.1
-        version: 2.6.1(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.8.0
+        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       promise-mem:
         specifier: 1.0.4
         version: 1.0.4
@@ -220,8 +220,8 @@ importers:
   packages/ve-hemi-rewards:
     dependencies:
       hemi-viem:
-        specifier: 2.6.1
-        version: 2.6.1(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.8.0
+        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       to-promise-event:
         specifier: 1.0.0
         version: 1.0.0
@@ -326,8 +326,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/hemi-tunnel-actions
       hemi-viem:
-        specifier: 2.7.0
-        version: 2.7.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.8.0
+        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hemi-viem-stake-actions:
         specifier: workspace:*
         version: link:../packages/hemi-viem-stake-actions
@@ -498,8 +498,8 @@ importers:
         specifier: 5.1.0
         version: 5.1.0
       hemi-viem:
-        specifier: 2.6.1
-        version: 2.6.1(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.8.0
+        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       promise-mem:
         specifier: 1.0.4
         version: 1.0.4
@@ -11363,18 +11363,10 @@ packages:
         integrity: sha512-CRCFsr+kM5cWHWhOu+cJbZvjnSpLCknMoJY+QnwAWIIjg2xJezfbmN1U/CRTh2ATXQ0uDZPbqhGtGObp0ZivtQ==,
       }
 
-  hemi-viem@2.6.1:
+  hemi-viem@2.8.0:
     resolution:
       {
-        integrity: sha512-XuNAX2p8/lpk+CWks+kCgi761qxhwMkL3zpf4/8l4G1kYejOTe2IJVY1qZ/ri1T1kRp5S1r5ZG1RtJfwf0Twgw==,
-      }
-    peerDependencies:
-      viem: ^2.x
-
-  hemi-viem@2.7.0:
-    resolution:
-      {
-        integrity: sha512-vqodW5YV8EBnf9qAvYzCTzV1Sap0DZ3e01kJ49ZZapEq2tkIvO94pWbNPWeAjUl2UGVIILylgMrbXLZe4byNQg==,
+        integrity: sha512-dRaG6RaFa8R8JeXU5cjxGNggQzU7E8ZY61U33ARSgZ/DDkh26u1/lAL/n44zQqSMjY4s6CBmqkrrFcG7VkqFAw==,
       }
     peerDependencies:
       viem: ^2.x
@@ -26008,11 +26000,7 @@ snapshots:
 
   hemi-socials@2.1.0: {}
 
-  hemi-viem@2.6.1(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)):
-    dependencies:
-      viem: 2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-
-  hemi-viem@2.7.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)):
+  hemi-viem@2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)):
     dependencies:
       viem: 2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 

--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -11,7 +11,7 @@
     "cors": "2.8.5",
     "esplora-client": "1.2.0",
     "express": "5.1.0",
-    "hemi-viem": "2.6.1",
+    "hemi-viem": "2.8.0",
     "promise-mem": "1.0.4",
     "promise-swr": "1.0.2",
     "redis": "4.7.1",

--- a/portal-backend/api/src/btc-vaults.ts
+++ b/portal-backend/api/src/btc-vaults.ts
@@ -1,4 +1,5 @@
 import { esploraClient } from 'esplora-client'
+import { hemi, hemiSepolia } from 'hemi-viem'
 import {
   getBitcoinChainLastHeader,
   getBitcoinCustodyAddress,
@@ -9,9 +10,7 @@ import {
   getVaultByIndex,
   getVaultCounter,
   getVaultStatus,
-  hemi,
-  hemiSepolia,
-} from 'hemi-viem'
+} from 'hemi-viem/actions'
 import { type Address, createPublicClient, http, type PublicClient } from 'viem'
 
 function getHemiClient(chainId: string) {

--- a/portal/package.json
+++ b/portal/package.json
@@ -43,7 +43,7 @@
     "hemi-earn-actions": "workspace:*",
     "hemi-socials": "2.1.0",
     "hemi-tunnel-actions": "workspace:*",
-    "hemi-viem": "2.7.0",
+    "hemi-viem": "2.8.0",
     "hemi-viem-stake-actions": "workspace:*",
     "lodash": "4.18.1",
     "next": "15.5.3",

--- a/portal/utils/hemi.ts
+++ b/portal/utils/hemi.ts
@@ -4,10 +4,11 @@ import {
   acknowledgedDeposits,
   calculateDepositFee,
   calculateWithdrawalFee,
+  getTransactionByTxId,
+  getTxConfirmations,
   isBitcoinWithdrawalChallenged,
   isBitcoinWithdrawalFulfilled,
 } from 'hemi-viem/actions'
-import { getTransactionByTxId, getTxConfirmations } from 'hemi-viem/actions'
 import { bitcoinTunnelManagerAbi } from 'hemi-viem/contracts'
 import { HemiWalletClient } from 'hooks/useHemiClient'
 import {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps `hemi-viem` to `2.8.0`. Note that due to a bug in the older version of `eslint-plugin-node`, it gives a `no-missing-import` error because it can't follow the `exports` from the package. This should be fixed once we use the newer version in ESLint 10 (See https://github.com/bloq/eslint-config-bloq/issues/64)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #1886

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
