### PR TITLE
Add FMV data layer to the Hemi Earn requests subgraph

### DIFF
--- a/subgraphs/hemi-earn-requests-subgraph/README.md
+++ b/subgraphs/hemi-earn-requests-subgraph/README.md
@@ -6,15 +6,23 @@ A multichain [Envio HyperIndex](https://docs.envio.dev) indexer for the Hemi Ear
 
 A deposit/redeem is a request that spans two contracts on two chains:
 
-| Chain          | Contract | Role                                                           |
-| -------------- | -------- | -------------------------------------------------------------- |
-| Hemi (`43111`) | `Router` | Mints the `requestId`, emits `*Requested`, tracks lifecycle.   |
-| Ethereum (`1`) | `Agent`  | Stakes/unstakes remotely, emits `*Processed` with the amounts. |
+| Chain          | Contract     | Role                                                           |
+| -------------- | ------------ | -------------------------------------------------------------- |
+| Hemi (`43111`) | `Router`     | Mints the `requestId`, emits `*Requested`, tracks lifecycle.   |
+| Hemi (`43111`) | `ShareToken` | Share OFTs — `Transfer` events feed peer-to-peer FMV pricing.  |
+| Ethereum (`1`) | `Agent`      | Stakes/unstakes remotely, emits `*Processed` with the amounts. |
 
 Every event carries the same `requestId`. That `requestId` is the `Request` entity id, so each event upserts the **same** entity — it is created as a partial view by whichever chain is indexed first and progressively filled in by later events from either chain (see `src/mappings/eventHandlers.ts`). Cross-chain ordering uses Envio's default
 ordered multichain mode, and `status` is guarded so it never regresses.
 
 The resulting `Request` entity (see `schema.graphql`) holds who/what (`initiator`, `receiver`, `asset`, `kind`), the amounts (`amountIn`, `amountOut`, and the pegged `stakedAmount` used as the earned-value cost basis), the lifecycle `status`, and per-milestone timestamps/tx hashes.
+
+### Fair-market-value signals
+
+Two extra entities support future FMV cost-basis pricing of share tokens received outside a deposit (see `schema.graphql`):
+
+- **`ShareTransfer`** — genuine wallet-to-wallet share-OFT transfers on Hemi (mints, burns, and the Router's in-transit legs are excluded).
+- **`RateSnapshot`** — a share→asset rate timeline (`rateNumerator`/`rateDenominator`) reconstructed from each processed deposit/redeem, approximating the vault's `convertToAssets` at a past timestamp without a same-chain read.
 
 ### `initiator` caveat
 
@@ -27,6 +35,7 @@ contract / smart-account wallet it is that contract's address, not the logical u
 
 - **Ethereum (Agent)**
 - **Hemi (Router)**
+- **Hemi (ShareToken)** — share OFTs, source of `ShareTransfer`
 
 ## Prerequisites
 

--- a/subgraphs/hemi-earn-requests-subgraph/config.yaml
+++ b/subgraphs/hemi-earn-requests-subgraph/config.yaml
@@ -19,6 +19,14 @@ chains:
           - event: 'CancellationRequested(uint256 indexed requestId)'
         handler: src/mappings/eventHandlers.ts
         name: Router
+      # Share OFTs on Hemi
+      - address:
+          - '0xfe875CC86cC6BC2E93ab330D6b2c408C3Cd79710' # sVUSD share OFT on Hemi.
+          - '0xD8D63De3b64bd06d99F8F5AD8B78Ed2fE7525eC0' # svetBTC share OFT on Hemi.
+        events:
+          - event: 'Transfer(address indexed from, address indexed to, uint256 value)'
+        handler: src/mappings/eventHandlers.ts
+        name: ShareToken
     id: 43111
     # Hemi is NOT served by Envio HyperSync (43111.hypersync.xyz 404s), so the
     # Router is indexed over RPC (`for: sync` makes RPC the data source for both

--- a/subgraphs/hemi-earn-requests-subgraph/schema.graphql
+++ b/subgraphs/hemi-earn-requests-subgraph/schema.graphql
@@ -45,8 +45,8 @@ type Request {
   status: RequestStatus!
 }
 
-# Share transfers minus mints and burns. Router in-transit legs are NOT excluded
-# here (the Router address isn't available to an Envio handler) — deduped later.
+# Genuine wallet-to-wallet share transfers for FMV pricing: mints, burns, and the
+# Router's in-transit deposit/redeem legs are all excluded by the handler.
 type ShareTransfer {
   from: String! @index
   id: ID!

--- a/subgraphs/hemi-earn-requests-subgraph/schema.graphql
+++ b/subgraphs/hemi-earn-requests-subgraph/schema.graphql
@@ -55,3 +55,15 @@ type ShareTransfer {
   to: String! @index
   value: BigInt!
 }
+
+# Share->asset rate points reconstructed as num/den from each processed
+# deposit/redeem, since the vault's convertToAssets lives on another chain.
+# rateNumerator is the pegged staked/unstaked amount (the cost-basis unit),
+# NOT the underlying asset's unit; `asset` is only the timeline grouping key.
+type RateSnapshot {
+  asset: String! @index
+  id: ID!
+  rateDenominator: BigInt!
+  rateNumerator: BigInt!
+  timestamp: BigInt!
+}

--- a/subgraphs/hemi-earn-requests-subgraph/schema.graphql
+++ b/subgraphs/hemi-earn-requests-subgraph/schema.graphql
@@ -44,3 +44,14 @@ type Request {
   stakedAmount: BigInt
   status: RequestStatus!
 }
+
+# Share transfers minus mints and burns. Router in-transit legs are NOT excluded
+# here (the Router address isn't available to an Envio handler) — deduped later.
+type ShareTransfer {
+  from: String! @index
+  id: ID!
+  share: String!
+  timestamp: BigInt!
+  to: String! @index
+  value: BigInt!
+}

--- a/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
@@ -86,6 +86,36 @@ const upsertRequest = async function ({
   context.Request.set({ ...existing, ...patch(existing) })
 }
 
+// Record a global share->asset rate point for a processed request. The asset is
+// read off the Request (set by an earlier event); a missing asset or zero
+// denominator yields no point. `id` is per-log (append-only) so a re-processed
+// request adds a point rather than overwriting the earlier one.
+const recordRate = async function ({
+  context,
+  denominator,
+  id,
+  numerator,
+  requestId,
+  timestamp,
+}: {
+  context: EvmOnEventContext
+  denominator: bigint
+  id: string
+  numerator: bigint
+  requestId: bigint
+  timestamp: bigint
+}): Promise<void> {
+  const request = await context.Request.get(requestId.toString())
+  if (!request?.asset || denominator <= 0n) return
+  context.RateSnapshot.set({
+    asset: request.asset,
+    id,
+    rateDenominator: denominator,
+    rateNumerator: numerator,
+    timestamp,
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Router (Hemi) — request creation and lifecycle.
 // ---------------------------------------------------------------------------
@@ -272,8 +302,8 @@ indexer.onEvent(
 // a value the Router side may have already set (ordering is not guaranteed).
 indexer.onEvent(
   { contract: 'Agent', event: 'DepositRequestProcessed' },
-  async ({ context, event }) =>
-    upsertRequest({
+  async function ({ context, event }) {
+    await upsertRequest({
       context,
       patch: existing => ({
         amountIn: existing.amountIn ?? event.params.assets, // deposit input
@@ -284,7 +314,16 @@ indexer.onEvent(
         stakedAmount: event.params.staked, // pegged staked into the vault
       }),
       requestId: event.params.requestId,
-    }),
+    })
+    await recordRate({
+      context,
+      denominator: event.params.shares,
+      id: `${event.transaction.hash}-${event.logIndex}`,
+      numerator: event.params.staked,
+      requestId: event.params.requestId,
+      timestamp: BigInt(event.block.timestamp),
+    })
+  },
 )
 
 indexer.onEvent(
@@ -305,8 +344,8 @@ indexer.onEvent(
 // Emitted by both the instant-redeem path and the cooldown claim path.
 indexer.onEvent(
   { contract: 'Agent', event: 'RedeemRequestProcessed' },
-  async ({ context, event }) =>
-    upsertRequest({
+  async function ({ context, event }) {
+    await upsertRequest({
       context,
       patch: existing => ({
         amountIn: existing.amountIn ?? event.params.shares, // redeem input
@@ -316,7 +355,16 @@ indexer.onEvent(
         processTxHash: event.transaction.hash,
       }),
       requestId: event.params.requestId,
-    }),
+    })
+    await recordRate({
+      context,
+      denominator: event.params.shares,
+      id: `${event.transaction.hash}-${event.logIndex}`,
+      numerator: event.params.unstaked,
+      requestId: event.params.requestId,
+      timestamp: BigInt(event.block.timestamp),
+    })
+  },
 )
 
 indexer.onEvent(

--- a/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
@@ -11,6 +11,8 @@ import type { EvmOnEventContext, Request } from 'envio'
 
 const lc = (address: string): string => address.toLowerCase()
 
+const zeroAddress = '0x0000000000000000000000000000000000000000'
+
 // A fully-defaulted Request, so partial-view creation is identical from either
 // chain. Optional schema fields default to `undefined`; required fields get a
 // concrete default.
@@ -222,6 +224,28 @@ indexer.onEvent(
       }),
       requestId: event.params.requestId,
     }),
+)
+
+// ---------------------------------------------------------------------------
+// Share OFT (Hemi) — genuine peer-to-peer transfers for FMV cost basis.
+// ---------------------------------------------------------------------------
+
+indexer.onEvent(
+  { contract: 'ShareToken', event: 'Transfer' },
+  async function ({ context, event }) {
+    const from = lc(event.params.from)
+    const to = lc(event.params.to)
+    // Skip mints and burns. Router in-transit legs pass through and are deduped
+    if (from === zeroAddress || to === zeroAddress) return
+    context.ShareTransfer.set({
+      from,
+      id: `${event.transaction.hash}-${event.logIndex}`,
+      share: lc(event.srcAddress),
+      timestamp: BigInt(event.block.timestamp),
+      to,
+      value: event.params.value,
+    })
+  },
 )
 
 // ---------------------------------------------------------------------------

--- a/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/src/mappings/eventHandlers.ts
@@ -12,6 +12,7 @@ import type { EvmOnEventContext, Request } from 'envio'
 const lc = (address: string): string => address.toLowerCase()
 
 const zeroAddress = '0x0000000000000000000000000000000000000000'
+const routerAddresses = new Set(indexer.chains[43111].Router.addresses.map(lc))
 
 // A fully-defaulted Request, so partial-view creation is identical from either
 // chain. Optional schema fields default to `undefined`; required fields get a
@@ -265,8 +266,10 @@ indexer.onEvent(
   async function ({ context, event }) {
     const from = lc(event.params.from)
     const to = lc(event.params.to)
-    // Skip mints and burns. Router in-transit legs pass through and are deduped
+    // Keep only genuine peer-to-peer transfers: skip mints/burns (0x0) and the
+    // Router's in-transit deposit/redeem legs.
     if (from === zeroAddress || to === zeroAddress) return
+    if (routerAddresses.has(from) || routerAddresses.has(to)) return
     context.ShareTransfer.set({
       from,
       id: `${event.transaction.hash}-${event.logIndex}`,

--- a/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
@@ -552,11 +552,14 @@ describe('ShareToken transfers', () => {
     expect(await ti.ShareTransfer.get('0xburn-1')).toBeUndefined()
   })
 
-  it('keeps Router in-transit legs (deduped downstream)', async () => {
-    await onChain(HEMI, [leg('0xrouterleg', 2, ROUTER, RECEIVER)])
+  it('skips Router in-transit legs (both directions)', async () => {
+    await onChain(HEMI, [
+      leg('0xrouterin', 2, ROUTER, RECEIVER),
+      leg('0xrouterout', 3, SENDER, ROUTER),
+    ])
 
-    const stored = await ti.ShareTransfer.getOrThrow('0xrouterleg-2')
-    expect(stored.from).toBe(ROUTER.toLowerCase())
+    expect(await ti.ShareTransfer.get('0xrouterin-2')).toBeUndefined()
+    expect(await ti.ShareTransfer.get('0xrouterout-3')).toBeUndefined()
   })
 })
 

--- a/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
@@ -18,6 +18,8 @@ const ASSET = mockAddresses[0]
 const RECEIVER = mockAddresses[1]
 const SENDER = mockAddresses[2]
 const SHARE = mockAddresses[3]
+const zeroAddress = '0x0000000000000000000000000000000000000000'
+const ROUTER = '0x8a23df259c6798f9eacc51ae816461218c3acddc'
 
 let ti: ReturnType<typeof createTestIndexer>
 beforeEach(() => {
@@ -498,5 +500,60 @@ describe('Agent receives', () => {
     expect(req.amountIn).toBe(1000n) // Router value kept, not clobbered to 999n
     expect(req.amountOut).toBe(12n)
     expect(req.stakedAmount).toBe(999n) // pegged staked into the vault
+  })
+})
+
+describe('ShareToken transfers', () => {
+  const leg = (
+    hash: string,
+    logIndex: number,
+    from: `0x${string}`,
+    to: `0x${string}`,
+  ) => ({
+    block: { number: HEMI_START, timestamp: 1_700_000_000 },
+    contract: 'ShareToken' as const,
+    event: 'Transfer' as const,
+    logIndex,
+    params: { from, to, value: 1n },
+    srcAddress: SHARE,
+    transaction: { from: SENDER, hash },
+  })
+
+  it('stores a wallet-to-wallet transfer', async () => {
+    await onChain(HEMI, [
+      {
+        block: { number: HEMI_START, timestamp: 1_700_000_000 },
+        contract: 'ShareToken',
+        event: 'Transfer',
+        logIndex: 5,
+        params: { from: SENDER, to: RECEIVER, value: 1000n },
+        srcAddress: SHARE,
+        transaction: { from: SENDER, hash: '0xtransfer' },
+      },
+    ])
+
+    const transfer = await ti.ShareTransfer.getOrThrow('0xtransfer-5')
+    expect(transfer.from).toBe(SENDER.toLowerCase())
+    expect(transfer.to).toBe(RECEIVER.toLowerCase())
+    expect(transfer.value).toBe(1000n)
+    expect(transfer.share).toBe(SHARE.toLowerCase())
+    expect(transfer.timestamp).toBe(1_700_000_000n)
+  })
+
+  it('skips mints and burns', async () => {
+    await onChain(HEMI, [
+      leg('0xmint', 0, zeroAddress, RECEIVER),
+      leg('0xburn', 1, SENDER, zeroAddress),
+    ])
+
+    expect(await ti.ShareTransfer.get('0xmint-0')).toBeUndefined()
+    expect(await ti.ShareTransfer.get('0xburn-1')).toBeUndefined()
+  })
+
+  it('keeps Router in-transit legs (deduped downstream)', async () => {
+    await onChain(HEMI, [leg('0xrouterleg', 2, ROUTER, RECEIVER)])
+
+    const stored = await ti.ShareTransfer.getOrThrow('0xrouterleg-2')
+    expect(stored.from).toBe(ROUTER.toLowerCase())
   })
 })

--- a/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
+++ b/subgraphs/hemi-earn-requests-subgraph/tests/eventHandlers.test.ts
@@ -171,6 +171,7 @@ describe('cross-chain partial view', () => {
               block: { number: ETH_START, timestamp: 1_700_000_050 },
               contract: 'Agent',
               event: 'DepositRequestProcessed',
+              logIndex: 0,
               params: {
                 assets: 1000n,
                 requestId: 20n,
@@ -466,6 +467,7 @@ describe('Agent receives', () => {
               block: { number: ETH_START, timestamp: 1_700_000_050 },
               contract: 'Agent',
               event: 'DepositRequestProcessed',
+              logIndex: 0,
               params: {
                 assets: 999n, // Agent echo differs from the Router value
                 requestId: 63n,
@@ -555,5 +557,106 @@ describe('ShareToken transfers', () => {
 
     const stored = await ti.ShareTransfer.getOrThrow('0xrouterleg-2')
     expect(stored.from).toBe(ROUTER.toLowerCase())
+  })
+})
+
+describe('rate snapshots', () => {
+  it('records a deposit rate point (staked/shares)', async () => {
+    await onChain(ETH, [
+      {
+        block: { number: ETH_START, timestamp: 1_700_000_100 },
+        contract: 'Agent',
+        event: 'DepositRequestReceived',
+        params: { asset: ASSET, assets: 1000n, requestId: 70n },
+        transaction: { from: SENDER, hash: '0xrecv' },
+      },
+      {
+        block: { number: ETH_START, timestamp: 1_700_000_200 },
+        contract: 'Agent',
+        event: 'DepositRequestProcessed',
+        logIndex: 3,
+        params: { assets: 1000n, requestId: 70n, shares: 12n, staked: 999n },
+        transaction: { from: SENDER, hash: '0xproc' },
+      },
+    ])
+
+    const rate = await ti.RateSnapshot.getOrThrow('0xproc-3')
+    expect(rate.asset).toBe(ASSET.toLowerCase())
+    expect(rate.rateNumerator).toBe(999n)
+    expect(rate.rateDenominator).toBe(12n)
+    expect(rate.timestamp).toBe(1_700_000_200n)
+  })
+
+  it('records a redeem rate point consuming unstaked', async () => {
+    await onChain(ETH, [
+      {
+        block: { number: ETH_START, timestamp: 1_700_000_100 },
+        contract: 'Agent',
+        event: 'RedeemRequestReceived',
+        params: { asset: ASSET, requestId: 71n, share: SHARE, shares: 500n },
+        transaction: { from: SENDER, hash: '0xrrecv' },
+      },
+      {
+        block: { number: ETH_START, timestamp: 1_700_000_200 },
+        contract: 'Agent',
+        event: 'RedeemRequestProcessed',
+        logIndex: 4,
+        params: { assets: 470n, requestId: 71n, shares: 500n, unstaked: 480n },
+        transaction: { from: SENDER, hash: '0xrproc' },
+      },
+    ])
+
+    const rate = await ti.RateSnapshot.getOrThrow('0xrproc-4')
+    expect(rate.asset).toBe(ASSET.toLowerCase())
+    expect(rate.rateNumerator).toBe(480n)
+    expect(rate.rateDenominator).toBe(500n)
+  })
+
+  it('records no rate point when the asset is unknown', async () => {
+    await onChain(ETH, [
+      {
+        block: { number: ETH_START, timestamp: 1_700_000_200 },
+        contract: 'Agent',
+        event: 'DepositRequestProcessed',
+        logIndex: 5,
+        params: { assets: 1000n, requestId: 72n, shares: 12n, staked: 999n },
+        transaction: { from: SENDER, hash: '0xnoasset' },
+      },
+    ])
+
+    expect(await ti.RateSnapshot.get('0xnoasset-5')).toBeUndefined()
+  })
+
+  it('appends a point per processing (a re-processed request keeps both)', async () => {
+    await onChain(ETH, [
+      {
+        block: { number: ETH_START, timestamp: 1_700_000_100 },
+        contract: 'Agent',
+        event: 'DepositRequestReceived',
+        params: { asset: ASSET, assets: 1000n, requestId: 73n },
+        transaction: { from: SENDER, hash: '0xrecv2' },
+      },
+      {
+        block: { number: ETH_START, timestamp: 1_700_000_200 },
+        contract: 'Agent',
+        event: 'DepositRequestProcessed',
+        logIndex: 1,
+        params: { assets: 1000n, requestId: 73n, shares: 10n, staked: 1000n },
+        transaction: { from: SENDER, hash: '0xp1' },
+      },
+      {
+        block: { number: ETH_START, timestamp: 1_700_000_300 },
+        contract: 'Agent',
+        event: 'DepositRequestProcessed',
+        logIndex: 1,
+        params: { assets: 1000n, requestId: 73n, shares: 10n, staked: 1010n },
+        transaction: { from: SENDER, hash: '0xp2' },
+      },
+    ])
+
+    const first = await ti.RateSnapshot.getOrThrow('0xp1-1')
+    const second = await ti.RateSnapshot.getOrThrow('0xp2-1')
+    expect(first.rateNumerator).toBe(1000n)
+    expect(second.rateNumerator).toBe(1010n)
   })
 })


### PR DESCRIPTION
### Description

This PR adds the subgraph data layer for fair-market-value cost basis, so the Total earned card can eventually price share tokens received via a peer-to-peer transfer instead of treating them as pure profit.

Reading the share->asset rate inline (the way the single-chain Vetro subgraph does) isn't possible here: the shares are OFTs on Hemi while the vault's convertToAssets lives on Ethereum. So this indexes two new signals the backend can join later — the raw peer-to-peer share transfers, and a global share->asset rate timeline reconstructed from the pegged amounts every processed deposit/redeem already emits. Mints, burns and the Router's in-transit legs are filtered out at the source (the Router address comes from config via the indexer, so nothing is hardcoded twice), so ShareTransfer holds only genuine wallet-to-wallet moves. Nothing consumes these yet; the backend replay lands in a follow-up.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #1965

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
