### PR TITLE
Schedule TVL data refreshes

### DIFF
--- a/.github/workflows/refresh-tvl.yml
+++ b/.github/workflows/refresh-tvl.yml
@@ -1,0 +1,32 @@
+# Triggers a Dune execution so the portal-backend /tvl endpoint reads fresh
+# data. The portal-backend only reads Dune's cached result, so this scheduled
+# run replaces the manual "Run" click on the Dune query.
+
+name: Refresh TVL
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  refresh-tvl:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl --fail-with-body --max-time 30 --silent --show-error \
+            -X POST "https://api.dune.com/api/v1/query/${{ vars.TVL_DUNE_QUERY_ID }}/execute" \
+            -H "X-Dune-API-Key: ${{ secrets.TVL_DUNE_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{}'
+      - if: failure()
+        run: |
+          curl --fail-with-body --max-time 30 --silent --show-error \
+            -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"text": "${{ vars.SLACK_MENTION }} :boom: TVL refresh failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'

--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -78,6 +78,12 @@ $ curl http://localhost:3006/tvl
 {"tvl":808500187.3738999}
 ```
 
+##### Note
+
+This endpoint only reads Dune's latest cached result; it never triggers a new query run. The [`Refresh TVL`](../.github/workflows/refresh-tvl.yml) scheduled workflow keeps that cache fresh by executing the Dune query on a schedule, replacing the manual "Run" click on the [TVL query page](https://dune.com/queries/6346834/10099987). It needs the `TVL_DUNE_API_KEY` repository secret and the `TVL_DUNE_QUERY_ID` repository variable.
+
+On failure, a message will be posted to Slack using `SLACK_WEBHOOK_URL` and `SLACK_MENTION` as the deploy notifications do.
+
 #### `GET /ve-hemi-rewards/:chain-id`
 
 Returns the veHemi rewards per unit of veHemi weight (voting power) for the next year (60 epochs of 6 days).


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

TVL data in Dune had to be manually refreshed the free tier account does not allow scheduling such actions. This PR automates the process so no manual actions are needed.

#### Details

This pull request introduces a scheduled GitHub Actions workflow to automatically refresh the TVL data cache and updates the documentation to clarify how the `/tvl` endpoint retrieves data. The workflow replaces the previous manual refresh process and notifies Slack on failure.

**Automation and Monitoring:**

* Added a new GitHub Actions workflow (`.github/workflows/refresh-tvl.yml`) that triggers the Dune TVL query daily at 06:00 UTC and sends a Slack notification if the refresh fails.

**Documentation Updates:**

* Updated `portal-backend/README.md` to explain that the `/tvl` endpoint only reads Dune's cached result, and describes the new scheduled refresh workflow, required secrets/variables, and Slack notification on failure.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
