### PR TITLE
Bump eslint-config-bloq to 4.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "better-sort-package-json": "1.1.1",
     "commitlint-config-bloq": "1.1.0",
     "eslint": "8.57.0",
-    "eslint-config-bloq": "4.7.0",
+    "eslint-config-bloq": "4.8.2",
     "husky": "9.1.7",
     "knip": "6.13.1",
     "lint-staged": "17.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 8.57.0
         version: 8.57.0
       eslint-config-bloq:
-        specifier: 4.7.0
-        version: 4.7.0(@types/estree@1.0.8)(eslint@8.57.0)(typescript@5.8.3)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.10.2)(vite@7.3.2(@types/node@24.10.2)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)))
+        specifier: 4.8.2
+        version: 4.8.2(@types/estree@1.0.8)(eslint@8.57.0)(typescript@5.8.3)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.10.2)(vite@7.3.2(@types/node@24.10.2)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)))
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -10144,11 +10144,12 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-config-bloq@4.7.0:
+  eslint-config-bloq@4.8.2:
     resolution:
       {
-        integrity: sha512-lUrMh4C5+sfp5TKpA4/Np1R0kfgaMtT7At6BkY/jeok3WfGEpBtlvg1sGaF/a+FtKEJlpeIaDprNXES+cT5iVg==,
+        integrity: sha512-LHpaTtRX7e6YgK9uypiVhjOFk+aieE3GG0c/lrsFFxauuvP20w+a7ndhWccUASBul/gfQ7z6On0cdb0G7dEiRg==,
       }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.0.0
 
@@ -10357,6 +10358,15 @@ packages:
     engines: { node: '>=10' }
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+
+  eslint-plugin-react-hooks@6.1.1:
+    resolution:
+      {
+        integrity: sha512-St9EKZzOAQF704nt2oJvAKZHjhrpg25ClQoaAlHmPZuajFldVLqRDW4VBNAS01NzeiQF0m0qhG1ZA807K6aVaQ==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react@7.37.5:
     resolution:
@@ -17860,6 +17870,15 @@ packages:
         integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==,
       }
 
+  zod-validation-error@4.0.2:
+    resolution:
+      {
+        integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==,
+      }
+    engines: { node: '>=18.0.0' }
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   zod@3.22.4:
     resolution:
       {
@@ -25017,7 +25036,7 @@ snapshots:
       eslint: 8.57.0
       semver: 7.7.4
 
-  eslint-config-bloq@4.7.0(@types/estree@1.0.8)(eslint@8.57.0)(typescript@5.8.3)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.10.2)(vite@7.3.2(@types/node@24.10.2)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))):
+  eslint-config-bloq@4.8.2(@types/estree@1.0.8)(eslint@8.57.0)(typescript@5.8.3)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.10.2)(vite@7.3.2(@types/node@24.10.2)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
       '@typescript-eslint/parser': 8.59.2(eslint@8.57.0)(typescript@5.8.3)
@@ -25028,12 +25047,15 @@ snapshots:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)
       eslint-plugin-jsdoc: 43.2.0(eslint@8.57.0)
       eslint-plugin-jsonc: 2.21.1(eslint@8.57.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-markdownlint: 0.6.0(eslint@8.57.0)
       eslint-plugin-mocha: 10.5.0(eslint@8.57.0)
       eslint-plugin-node: 11.1.0(eslint@8.57.0)
       eslint-plugin-package-json: 0.31.0(@types/estree@1.0.8)(eslint@8.57.0)(jsonc-eslint-parser@2.4.2)
       eslint-plugin-prefer-arrow: 1.2.3(eslint@8.57.0)
       eslint-plugin-promise: 6.6.0(eslint@8.57.0)
+      eslint-plugin-react: 7.37.5(eslint@8.57.0)
+      eslint-plugin-react-hooks: 6.1.1(eslint@8.57.0)
       eslint-plugin-sort-destructure-keys: 2.0.0(eslint@8.57.0)
       jsonc-eslint-parser: 2.4.2
     transitivePeerDependencies:
@@ -25247,6 +25269,16 @@ snapshots:
   eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
+
+  eslint-plugin-react-hooks@6.1.1(eslint@8.57.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.7
+      eslint: 8.57.0
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@8.57.0):
     dependencies:
@@ -30218,6 +30250,10 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoga-layout@3.2.1: {}
+
+  zod-validation-error@4.0.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@3.22.4: {}
 

--- a/portal/app/[locale]/_components/appLayout.tsx
+++ b/portal/app/[locale]/_components/appLayout.tsx
@@ -79,15 +79,14 @@ export const AppLayout = function ({ children }: Props) {
 
   useEffect(
     function closeNavbarWhenDesktopLayout() {
-      if (width != null && width >= screenBreakpoints.xl) {
+      if (width >= screenBreakpoints.xl) {
         closeNavbar()
       }
     },
     [closeNavbar, width],
   )
 
-  const showNavbarDrawer =
-    navbarDrawerMounted && (width == null || width < screenBreakpoints.xl)
+  const showNavbarDrawer = navbarDrawerMounted && width < screenBreakpoints.xl
 
   return (
     <>

--- a/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
@@ -133,7 +133,7 @@ const DexImpl = function () {
   // Below `xl`, the navbar is rendered inside a Drawer portaled to body, so
   // portal the dropdown to body too — otherwise it lands in #app-layout-container
   // which sits behind the Drawer and the content stays hidden.
-  const isInlineNavbar = width != null && width >= screenBreakpoints.xl
+  const isInlineNavbar = width >= screenBreakpoints.xl
   const dropdownPortalContainer = isInlineNavbar
     ? getPortalContainer()
     : getDrawerPortalContainer()

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -126,7 +126,7 @@ const pickDisplay = (
   shareToken: EvmToken,
   assetToken: EvmToken | undefined,
 ) =>
-  tx.amountOut != null
+  tx.amountOut !== null
     ? { amount: tx.amountOut, token: assetToken }
     : { amount: tx.amountIn, token: shareToken }
 

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -233,6 +233,11 @@ function encodeRedeemForGasEstimate({
   })
 }
 
+const toCooldownSeconds = (claimableAt: EarnTransaction['claimableAt']) =>
+  claimableAt !== null && claimableAt !== undefined
+    ? BigInt(claimableAt)
+    : undefined
+
 export const ReviewWithdraw = function ({ onClose }: Props) {
   const { input, pool, selectedAsset, withdrawOperation } = usePoolForm()
   const t = useTranslations('hemi-earn.pool.drawer')
@@ -267,9 +272,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
     stakingVault: pool.stakingVault,
   })
   const cooldownRemainingSec = useEarnCooldownRemaining(
-    subgraphRow?.claimableAt != null
-      ? BigInt(subgraphRow.claimableAt)
-      : undefined,
+    toCooldownSeconds(subgraphRow?.claimableAt),
   )
 
   const withdrawStatus =


### PR DESCRIPTION
### Description

Bumps `eslint-config-bloq` from 4.7.0 to 4.8.2. The new config pulls in `eslint-plugin-jsx-a11y` and `eslint-plugin-react-hooks@6.1.1`, and its stricter rules reject loose equality against `null`, which forced small, behavior-preserving adaptations in four files. `pnpm-lock.yaml` is regenerated for the bump.

Worth calling out for the `width != null` guards dropped in `appLayout.tsx` and the DEX navbar: `useWindowSize` always returns a defined number (it's backed by `useSyncExternalStore` with a server snapshot of `0`), so `width` was never null or undefined and those checks were dead code. Removing them changes nothing.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
