### PR TITLE
Fix brace-expansion vulnerable version

### DIFF
--- a/.github/workflows/docker-checks.yml
+++ b/.github/workflows/docker-checks.yml
@@ -9,11 +9,13 @@ on:
       # a dynamic-matrix rework — tracked for a future PR/issue.
       - 'packages/ve-hemi-actions/**'
       - 'packages/ve-hemi-rewards/**'
+      - 'pnpm-lock.yaml'
       - 'portal-backend/**'
   push:
     paths:
       - 'packages/ve-hemi-actions/**'
       - 'packages/ve-hemi-rewards/**'
+      - 'pnpm-lock.yaml'
       - 'portal-backend/**'
 
 permissions:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion@5: 5.0.8
   postcss: 8.5.14
 
 patchedDependencies:
@@ -8180,12 +8181,12 @@ packages:
         integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==,
       }
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.8:
     resolution:
       {
-        integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==,
+        integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==,
       }
-    engines: { node: 18 || 20 || >=22 }
+    engines: { node: 20 || >=22 }
 
   braces@3.0.3:
     resolution:
@@ -23849,7 +23850,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -27002,7 +27003,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.8
 
   minimatch@3.1.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ onlyBuiltDependencies:
   - 'unrs-resolver' # Rust resolver required by eslint-import-resolver-typescript during lint
 
 overrides:
+  brace-expansion@5: '5.0.8' # CVE-2026-13149 / CVE-2026-14257 DoS fixes
   postcss: '8.5.14' # Needed as Next pins 8.4.31 exactly
 
 patchedDependencies:


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Updates to `brace-expansion@5.0.8` to solve CVE-2026-13149 and CVE-2026-14257 in [the failing Docker checks](https://github.com/hemilabs/ui-monorepo/pull/2140#issuecomment-5133264817).

It also adds changes to `pnpm-lock.yaml` as a trigger for Docker checks, which makes sense since any change in dependencies could introduce changes to the Docker images.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
