### PR TITLE
Align staked balance loading skeleton

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
@@ -35,7 +35,7 @@ export const StakedAmount = function ({ pool }: Props) {
     return (
       <PoolInfoItem label={t('staked-balance')}>
         <span className="body-text-medium inline-flex items-center text-neutral-950">
-          $
+          <span className="mr-1">$</span>
           <RenderEarnFiatBalance
             balance={data?.peggedAmount}
             queryStatus={status}

--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
@@ -34,7 +34,7 @@ export const StakedAmount = function ({ pool }: Props) {
   if (position) {
     return (
       <PoolInfoItem label={t('staked-balance')}>
-        <span className="body-text-medium text-neutral-950">
+        <span className="body-text-medium flex items-center text-neutral-950">
           $
           <RenderEarnFiatBalance
             balance={data?.peggedAmount}

--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
@@ -34,7 +34,7 @@ export const StakedAmount = function ({ pool }: Props) {
   if (position) {
     return (
       <PoolInfoItem label={t('staked-balance')}>
-        <span className="body-text-medium flex items-center text-neutral-950">
+        <span className="body-text-medium inline-flex items-center text-neutral-950">
           $
           <RenderEarnFiatBalance
             balance={data?.peggedAmount}


### PR DESCRIPTION
### Description

This PR fixes the vertical alignment of the staked-balance value in the pool info bar while it's loading.

The `$` sign sits inline next to `RenderEarnFiatBalance`, which renders a skeleton placeholder until the pegged value resolves. Without a flex container the skeleton didn't line up with the `$`, so the loading state looked slightly off. Wrapping the two in a `flex items-center` span keeps them vertically centered in both the loading and loaded states.

### Screenshots

<img width="1253" height="521" alt="Captura de Tela 2026-07-31 às 10 50 37" src="https://github.com/user-attachments/assets/f6454507-0a3b-497b-ae6f-139bc8d05784" />

### Related issue(s)

Closes #2117 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
