### PR TITLE
Add `mint` subcommand to hemi-earn sandbox

### DIFF
--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -70,7 +70,7 @@ node portal/scripts/hemi-earn/fundAccount.ts [flags]
 Flags are parsed by the handler of each subcommand.
 
 - `setup` — `--address` / `-a` (required), `--port` / `-p` (default `8545`), `--upstream-rpc` / `-u` (default `https://rpc.hemi.network/rpc`), `--fork-url` / `-f` (skips auto-start), `--deployer-pk` (default is Anvil's well-known account #0).
-- `mint` — `--token` / `-t` (required), `--to` (required), `--amount` / `-n` (default `10`, parsed as 18-dec units). Optional: `--fork-url` / `-f`, `--deployer-pk`.
+- `mint` — `--token` / `-t` (required), `--to` (required), `--amount` / `-n` (default `10`, parsed via `parseEther` — sandbox mocks are all 18-decimal by design, no `decimals()` lookup). Optional: `--fork-url` / `-f`, `--deployer-pk`.
 - `mining` — `--seconds` / `-s` (default `6`, `0` returns to instant mining), `--fork-url` / `-f` (default `http://127.0.0.1:8545`).
 - `relayer` — `--router` / `-r` (required), `--agent` / `-a` (required) — both come from the address banner `setup` prints; `--fork-url` / `-f`, `--deployer-pk`, `--poll` (seconds between ticks, default `1`), `--from-block N` (first block to backfill from, default `0` — full history), `--disable-autoclaim` (observe events but skip the claim; simulates a downed keeper).
 - `fail-gateway` — either `--status` (read-only, prints the current state) or `--kind` / `-k` (`deposit` | `redeem`) + `--mode` / `-m` (`off` | `on` | `slippage` | `fee` | `unknown`). Optional: `--fork-url` / `-f`, `--deployer-pk`.
@@ -89,7 +89,7 @@ Every sandbox token exposes the OpenZeppelin `mint(address,uint256)` shape, so a
 ```bash
 # Top up an EOA with 5 hemiBTC (copy the token address from the setup banner)
 pnpm --filter portal sandbox:hemi-earn -- mint \
-  --token 0x5FbDB2315678afecb367f032d93F642f64180aa3 \
+  --token 0xYourHemiBTC \
   --to    0xYourEOA \
   --amount 5
 

--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -53,6 +53,7 @@ pnpm --filter portal sandbox:hemi-earn -- <subcommand> [flags]
 | Subcommand     | Purpose                                                                                                                  |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `setup`        | Start Anvil + deploy mocks + fund the test account.                                                                      |
+| `mint`         | Mint from any ERC20-mock — top up an EOA or inject yield into the vault (see [Minting](#minting)).                       |
 | `mining`       | Toggle Anvil's interval mining at runtime (see [Slow mining](#slow-mining)).                                             |
 | `relayer`      | Emulate the production keeper: claim mature cooldown redeems and bridge cancellation requests (see [Relayer](#relayer)). |
 | `fail-gateway` | Toggle `PreviewableGatewayMock` into a failure mode (see [Failure simulation](#failure-simulation)).                     |
@@ -69,6 +70,7 @@ node portal/scripts/hemi-earn/fundAccount.ts [flags]
 Flags are parsed by the handler of each subcommand.
 
 - `setup` — `--address` / `-a` (required), `--port` / `-p` (default `8545`), `--upstream-rpc` / `-u` (default `https://rpc.hemi.network/rpc`), `--fork-url` / `-f` (skips auto-start), `--deployer-pk` (default is Anvil's well-known account #0).
+- `mint` — `--token` / `-t` (required), `--to` (required), `--amount` / `-n` (default `10`, parsed as 18-dec units). Optional: `--fork-url` / `-f`, `--deployer-pk`.
 - `mining` — `--seconds` / `-s` (default `6`, `0` returns to instant mining), `--fork-url` / `-f` (default `http://127.0.0.1:8545`).
 - `relayer` — `--router` / `-r` (required), `--agent` / `-a` (required) — both come from the address banner `setup` prints; `--fork-url` / `-f`, `--deployer-pk`, `--poll` (seconds between ticks, default `1`), `--from-block N` (first block to backfill from, default `0` — full history), `--disable-autoclaim` (observe events but skip the claim; simulates a downed keeper).
 - `fail-gateway` — either `--status` (read-only, prints the current state) or `--kind` / `-k` (`deposit` | `redeem`) + `--mode` / `-m` (`off` | `on` | `slippage` | `fee` | `unknown`). Optional: `--fork-url` / `-f`, `--deployer-pk`.
@@ -76,6 +78,27 @@ Flags are parsed by the handler of each subcommand.
 ## Cooldown
 
 The setup script enables cooldown on the staking vault with a 1-day duration, exercising the 2-step withdraw flow (request + claim after cooldown) by default. The claim step is dispatched by the production keeper; locally, run the [`relayer`](#relayer) subcommand alongside the portal to reproduce that behavior.
+
+## Minting
+
+Every sandbox token exposes the OpenZeppelin `mint(address,uint256)` shape, so a single subcommand covers both common flows:
+
+- **Top up an EOA** — mint deposit assets to a wallet you're testing with. `setup` already funds the test account with 10 of each on init; use this to bump balances mid-session or fund a second wallet.
+- **Inject yield** — mint the pegged token directly into the staking vault. That inflates `totalAssets()` without issuing new shares, so `convertToAssets(userShares)` grows proportionally and the portal's "Total earned" card starts showing profit.
+
+```bash
+# Top up an EOA with 5 hemiBTC (copy the token address from the setup banner)
+pnpm --filter portal sandbox:hemi-earn -- mint \
+  --token 0x5FbDB2315678afecb367f032d93F642f64180aa3 \
+  --to    0xYourEOA \
+  --amount 5
+
+# Inject 1 vetBTC of yield into the staking vault (Vetro-aliased addresses)
+pnpm --filter portal sandbox:hemi-earn -- mint \
+  --token 0xf196C68233464A16CFDa319a47c21f4cECa62001 \
+  --to    0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e \
+  --amount 1
+```
 
 ## Slow mining
 

--- a/portal/scripts/hemi-earn/index.ts
+++ b/portal/scripts/hemi-earn/index.ts
@@ -1,5 +1,6 @@
 import { scriptArgs } from './cli.ts'
 import { runFailGateway } from './failGateway.ts'
+import { runMint } from './mint.ts'
 import { runRelayer } from './relayer.ts'
 import { runSetIntervalMining } from './setIntervalMining.ts'
 import { runSetup } from './setup.ts'
@@ -7,6 +8,7 @@ import { runSetup } from './setup.ts'
 const HANDLERS = {
   'fail-gateway': runFailGateway,
   'mining': runSetIntervalMining,
+  'mint': runMint,
   'relayer': runRelayer,
   'setup': runSetup,
 } as const

--- a/portal/scripts/hemi-earn/mint.ts
+++ b/portal/scripts/hemi-earn/mint.ts
@@ -21,12 +21,28 @@ function printUsage() {
   console.error('  -t, --token TOKEN       ERC20-mock address (required)')
   console.error('      --to RECIPIENT      recipient address (required)')
   console.error(
-    '  -n, --amount AMOUNT     amount in 18-decimal units (default 10)',
+    '  -n, --amount AMOUNT     amount in `parseEther` units (default 10)',
   )
   console.error(
     '  [-f FORK_URL]           anvil RPC (default http://127.0.0.1:8545)',
   )
   console.error('  [--deployer-pk PK]      signer for the mint tx')
+}
+
+function parseAmount(raw: string | undefined) {
+  const amountLabel = raw ?? '10'
+  if (!/^\d+(\.\d+)?$/.test(amountLabel)) {
+    console.error('✗ --amount must be a positive decimal number')
+    printUsage()
+    process.exit(1)
+  }
+  const amount = parseEther(amountLabel)
+  if (amount === 0n) {
+    console.error('✗ --amount must be greater than 0')
+    printUsage()
+    process.exit(1)
+  }
+  return { amount, amountLabel }
 }
 
 function parseMintArgs(argv: string[]) {
@@ -65,8 +81,7 @@ function parseMintArgs(argv: string[]) {
   }
 
   return {
-    amount: parseEther(values.amount ?? '10'),
-    amountLabel: values.amount ?? '10',
+    ...parseAmount(values.amount),
     deployerPk,
     forkUrl: values['fork-url'] ?? DEFAULT_FORK_URL,
     to: to as Address,

--- a/portal/scripts/hemi-earn/mint.ts
+++ b/portal/scripts/hemi-earn/mint.ts
@@ -20,7 +20,9 @@ function printUsage() {
   )
   console.error('  -t, --token TOKEN       ERC20-mock address (required)')
   console.error('      --to RECIPIENT      recipient address (required)')
-  console.error('  -n, --amount AMOUNT     amount in ether units (default 10)')
+  console.error(
+    '  -n, --amount AMOUNT     amount in 18-decimal units (default 10)',
+  )
   console.error(
     '  [-f FORK_URL]           anvil RPC (default http://127.0.0.1:8545)',
   )

--- a/portal/scripts/hemi-earn/mint.ts
+++ b/portal/scripts/hemi-earn/mint.ts
@@ -1,0 +1,114 @@
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from 'node:util'
+import {
+  isAddress,
+  parseAbiItem,
+  parseEther,
+  type Address,
+  type Hex,
+} from 'viem'
+
+import { scriptArgs } from './cli.ts'
+import { DEFAULT_DEPLOYER_PK, DEFAULT_FORK_URL } from './constants.ts'
+import { buildClients } from './rpcClients.ts'
+
+const mintAbi = parseAbiItem('function mint(address,uint256)')
+
+function printUsage() {
+  console.error(
+    'Usage: pnpm --filter portal sandbox:hemi-earn -- mint --token 0x... --to 0x... [--amount 10] [flags]',
+  )
+  console.error('  -t, --token TOKEN       ERC20-mock address (required)')
+  console.error('      --to RECIPIENT      recipient address (required)')
+  console.error('  -n, --amount AMOUNT     amount in ether units (default 10)')
+  console.error(
+    '  [-f FORK_URL]           anvil RPC (default http://127.0.0.1:8545)',
+  )
+  console.error('  [--deployer-pk PK]      signer for the mint tx')
+}
+
+function parseMintArgs(argv: string[]) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      'amount': { short: 'n', type: 'string' },
+      'deployer-pk': { type: 'string' },
+      'fork-url': { short: 'f', type: 'string' },
+      'to': { type: 'string' },
+      'token': { short: 't', type: 'string' },
+    },
+    strict: true,
+  })
+
+  const token = values.token
+  const to = values.to
+  if (!token || !isAddress(token, { strict: false })) {
+    console.error('✗ --token must be a valid address')
+    printUsage()
+    process.exit(1)
+  }
+  if (!to || !isAddress(to, { strict: false })) {
+    console.error('✗ --to must be a valid address')
+    printUsage()
+    process.exit(1)
+  }
+
+  const deployerPk = (values['deployer-pk'] ?? DEFAULT_DEPLOYER_PK) as Hex
+  if (!/^0x[0-9a-fA-F]{64}$/.test(deployerPk)) {
+    console.error(
+      '✗ --deployer-pk must be a 32-byte hex string starting with 0x',
+    )
+    printUsage()
+    process.exit(1)
+  }
+
+  return {
+    amount: parseEther(values.amount ?? '10'),
+    amountLabel: values.amount ?? '10',
+    deployerPk,
+    forkUrl: values['fork-url'] ?? DEFAULT_FORK_URL,
+    to: to as Address,
+    token: token as Address,
+  }
+}
+
+export async function runMint(argv: string[]) {
+  const parsed = parseMintArgs(argv)
+  const { publicClient, walletClient } = await buildClients({
+    deployerPk: parsed.deployerPk,
+    forkUrl: parsed.forkUrl,
+  })
+  const account = walletClient.account
+  if (!account) {
+    throw new Error(
+      'buildClients did not return an account — check --deployer-pk',
+    )
+  }
+
+  const hash = await walletClient.writeContract({
+    abi: [mintAbi],
+    account,
+    address: parsed.token,
+    args: [parsed.to, parsed.amount],
+    chain: walletClient.chain,
+    functionName: 'mint',
+  })
+  const receipt = await publicClient.waitForTransactionReceipt({ hash })
+  if (receipt.status !== 'success') {
+    throw new Error(`mint reverted (tx ${hash})`)
+  }
+
+  console.log(
+    `✓ minted ${parsed.amountLabel} to ${parsed.to} (token ${parsed.token}, tx ${hash})`,
+  )
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await runMint(scriptArgs())
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`\n✗ mint failed: ${message}`)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
### Description

This PR ports the `mint` sandbox subcommand that calls `mint(address,uint256)` on any ERC20-mock running under the local sandbox.

Before this, two flows still needed raw `cast send`: topping up an EOA mid-session (past what `setup` funds on init) and injecting yield into the staking vault (mint the pegged token straight to the vault so `totalAssets()` inflates without new shares — that's what makes the portal's "Total earned" card start showing profit). Both now go through `pnpm --filter portal sandbox:hemi-earn -- mint`.

Implementation follows the same shape as `fail-gateway`: inline `parseAbiItem`, no artifact dependency, `writeContract` + receipt-status check, and registered in the top-level dispatcher. All existing mocks (`LabeledERC20Mock`, `PeggedTokenMock`, aliased Vetro contracts) share the same OZ-style `mint` signature so a single subcommand covers them all.

Broken down into:
- `b886c7fd` — Add mint sandbox subcommand
- `ba24c8ae` — Document mint in sandbox README

### Screenshots

<img width="1343" height="440" alt="Captura de Tela 2026-08-04 às 10 41 31" src="https://github.com/user-attachments/assets/0f7bea6f-93a5-4119-bb35-f44ab77a0086" />

### Related issue(s)

Related to #2092 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
