### PR TITLE
Update 'Receiving Bitcoin address' tooltip content

### DIFF
--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -639,7 +639,7 @@
     "form": {
       "balance": "Balance",
       "bitcoin-receiving-address": "Receiving Bitcoin address",
-      "bitcoin-receiving-address-description": "Deposited {symbol} is sent to the address associated with your connected Ethereum wallet.",
+      "bitcoin-receiving-address-description": "Withdrawn {symbol} is sent to the address associated with your connected Bitcoin wallet.",
       "from-network": "From Network",
       "hemi-receiving-address": "Receiving Hemi address",
       "hemi-receiving-address-description": "Deposited {symbol} is sent to the address associated with your connected EVM wallet.",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -639,7 +639,7 @@
     "form": {
       "balance": "Balance",
       "bitcoin-receiving-address": "Dirección de recepción en Bitcoin",
-      "bitcoin-receiving-address-description": "El {symbol} depositado se envía a la dirección asociada con su billetera Ethereum conectada.",
+      "bitcoin-receiving-address-description": "El {symbol} retirado se envía a la dirección asociada con su billetera Bitcoin conectada.",
       "from-network": "Desde la Red",
       "hemi-receiving-address": "Dirección de recepción en Hemi",
       "hemi-receiving-address-description": "El {symbol} depositado se envía a la dirección asociada con su billetera EVM conectada.",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -639,7 +639,7 @@
     "form": {
       "balance": "Saldo",
       "bitcoin-receiving-address": "Endereço de receção Bitcoin",
-      "bitcoin-receiving-address-description": "O {symbol} depositado é enviado para o endereço associado à sua carteira Ethereum conectada.",
+      "bitcoin-receiving-address-description": "O {symbol} retirado é enviado para o endereço associado à sua carteira Bitcoin conectada.",
       "from-network": "Da Rede",
       "hemi-receiving-address": "Endereço de receção Hemi",
       "hemi-receiving-address-description": "O {symbol} depositado é enviado para o endereço associado à sua carteira EVM conectada.",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The tooltip next to "Receiving Bitcoin address" in the Hemi → Bitcoin withdrawal
form was reusing the deposit copy, pointing the user to their Ethereum wallet.
It now describes the withdrawal: the funds go to the connected Bitcoin wallet.

Only the `bitcoin-receiving-address-description` message changed in the three
locales. Deposits use a separate key (`hemi-receiving-address-description`) and
are untouched.


### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
**Before**

<img alt="01-en-before" src="https://github.com/user-attachments/assets/6dd35512-611f-4687-bb9a-ca19beee2d44" />

**After**
<img  alt="02-en-after" src="https://github.com/user-attachments/assets/3a8729b1-bb24-4849-8ca5-bb6025f9b24c" />

<img  alt="03-es-after" src="https://github.com/user-attachments/assets/955f7869-8f8d-4f55-8984-2a8654ee2eb3" />

<img  alt="04-pt-after" src="https://github.com/user-attachments/assets/77a40cd5-1659-40a6-8a86-13b0174a8f32" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #2131 
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
