### PR TITLE
Add VEX for brace-expansion

### DIFF
--- a/vex.json
+++ b/vex.json
@@ -10,8 +10,17 @@
       "vulnerability": {
         "name": "CVE-2026-48779"
       }
+    },
+    {
+      "justification": "vulnerable_code_not_in_execute_path",
+      "products": [{ "@id": "pkg:npm/brace-expansion@5.0.8" }],
+      "status": "not_affected",
+      "timestamp": "2026-08-04T00:00:00.000Z",
+      "vulnerability": {
+        "name": "CVE-2026-69152"
+      }
     }
   ],
-  "timestamp": "2026-07-02T00:00:00.000Z",
+  "timestamp": "2026-08-04T00:00:00.000Z",
   "version": 1
 }


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This fixes the `Docker Checks` again, after a vulnerability reported today on `brace-expansion@5.0.8`. Since the code is not executed, the better path forward is to just add the exception (VEX). We could add and override as in #2142 if needed in the future.

#### Description

This pull request updates the `vex.json` file to document the status of a new vulnerability and refresh the overall timestamp.

Vulnerability status updates:

* Added a new entry indicating that `pkg:npm/brace-expansion@5.0.8` is not affected by `CVE-2026-69152` due to the vulnerable code not being in the execute path.

Metadata updates:

* Updated the top-level `timestamp` to `2026-08-04T00:00:00.000Z` to reflect the latest assessment.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
