### PR TITLE
Reconcile in-transit shares in Total earned

### DIFF
--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnedAmount.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnedAmount.ts
@@ -5,9 +5,11 @@ import Big from 'big.js'
 import { getTokenPrice } from 'utils/token'
 
 import { sharesToPeggedOptions } from '../_fetchers/fetchSharesToPegged'
+import { inTransitOnlyPositions } from '../_utils'
 import { positionEarnedUsd } from '../_utils/earnedAmount'
 
 import { useEarnCostBasis } from './useEarnCostBasis'
+import { useEarnPools } from './useEarnPools'
 import { useEarnPositions } from './useEarnPositions'
 import { useEarnTokenPrices } from './useEarnTokenPrices'
 import { useInTransitShares } from './useInTransitShares'
@@ -33,9 +35,15 @@ export const useEarnedAmount = function () {
   } = useEarnCostBasis()
   const { data: inTransitByShare, isPending: isInTransitPending } =
     useInTransitShares()
+  const { data: pools = [] } = useEarnPools()
+
+  const rows = [
+    ...positions,
+    ...inTransitOnlyPositions(inTransitByShare, positions, pools),
+  ]
 
   const peggedAmountQueries = useQueries({
-    queries: positions.map(position =>
+    queries: rows.map(position =>
       sharesToPeggedOptions({
         shareAddress: position.shareAddress,
         shares:
@@ -45,7 +53,7 @@ export const useEarnedAmount = function () {
     ),
   })
 
-  const total = positions.reduce(function (acc, position, index) {
+  const total = rows.reduce(function (acc, position, index) {
     const currentPegged = peggedAmountQueries[index]?.data?.peggedAmount
 
     if (costBasis === undefined || currentPegged === undefined) return acc
@@ -62,15 +70,15 @@ export const useEarnedAmount = function () {
 
   const totalUsd = total.toFixed(2)
 
-  const hasPositions = positions.length > 0
+  const hasRows = rows.length > 0
   const isPending =
     isPositionsPending ||
-    (hasPositions &&
-      (isPricesPending || isCostBasisLoading || isInTransitPending)) ||
+    isInTransitPending ||
+    (hasRows && (isPricesPending || isCostBasisLoading)) ||
     peggedAmountQueries.some(q => q.isPending && q.isFetching)
   const isError =
     isPositionsError ||
-    (hasPositions && (isPricesError || isCostBasisError)) ||
+    (hasRows && (isPricesError || isCostBasisError)) ||
     peggedAmountQueries.some(q => q.isError)
 
   return { data: { totalUsd }, isError, isPending }

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnedAmount.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnedAmount.ts
@@ -10,6 +10,7 @@ import { positionEarnedUsd } from '../_utils/earnedAmount'
 import { useEarnCostBasis } from './useEarnCostBasis'
 import { useEarnPositions } from './useEarnPositions'
 import { useEarnTokenPrices } from './useEarnTokenPrices'
+import { useInTransitShares } from './useInTransitShares'
 
 // Total earned = Σ (convertToAssets(shares) − cost basis) per position, priced.
 // Cost basis (Vetro-parity, unrealized) comes from the earn-cost-basis endpoint;
@@ -30,12 +31,16 @@ export const useEarnedAmount = function () {
     isError: isCostBasisError,
     isLoading: isCostBasisLoading,
   } = useEarnCostBasis()
+  const { data: inTransitByShare, isPending: isInTransitPending } =
+    useInTransitShares()
 
   const peggedAmountQueries = useQueries({
     queries: positions.map(position =>
       sharesToPeggedOptions({
         shareAddress: position.shareAddress,
-        shares: position.yourDeposit,
+        shares:
+          position.yourDeposit +
+          (inTransitByShare[position.shareAddress.toLowerCase()] ?? BigInt(0)),
       }),
     ),
   })
@@ -60,7 +65,8 @@ export const useEarnedAmount = function () {
   const hasPositions = positions.length > 0
   const isPending =
     isPositionsPending ||
-    (hasPositions && (isPricesPending || isCostBasisLoading)) ||
+    (hasPositions &&
+      (isPricesPending || isCostBasisLoading || isInTransitPending)) ||
     peggedAmountQueries.some(q => q.isPending && q.isFetching)
   const isError =
     isPositionsError ||

--- a/portal/app/[locale]/hemi-earn/_hooks/useInTransitShares.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useInTransitShares.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import { sumInTransitSharesByShare } from '../_utils'
+
+import { useEarnPools } from './useEarnPools'
+import { useEarnTransactions } from './useEarnTransactions'
+
+export const useInTransitShares = function () {
+  const { data: transactions = [], isPending: isTransactionsPending } =
+    useEarnTransactions()
+  const { data: pools = [], isPending: isPoolsPending } = useEarnPools()
+
+  return {
+    data: sumInTransitSharesByShare(transactions, pools),
+    isPending: isTransactionsPending || isPoolsPending,
+  }
+}

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -217,6 +217,27 @@ export const isEarnRowInFlight = (tx: EarnTransaction) =>
   !isEarnRowTerminal(tx) &&
   !(tx.status === 'FAILED' && isLocalEarnTransactionRow(tx))
 
+// Shares an in-flight redeem locked in the Router: gone from the wallet, but the cost
+// basis hasn't disposed them yet, so the earned card adds them back to stay consistent.
+export const sumInTransitSharesByShare = (
+  transactions: EarnTransaction[],
+  pools: EarnPool[],
+) =>
+  transactions.reduce<Record<string, bigint>>(function (acc, tx) {
+    if (
+      tx.kind !== 'REDEEM' ||
+      tx.status === 'TX_PENDING' ||
+      tx.amountOut !== null ||
+      !isEarnRowInFlight(tx)
+    )
+      return acc
+    const shareAddress = findPoolByAsset(pools, tx.asset)?.shareAddress
+    if (!shareAddress) return acc
+    const key = shareAddress.toLowerCase()
+    acc[key] = (acc[key] ?? BigInt(0)) + BigInt(tx.amountIn)
+    return acc
+  }, {})
+
 // Any earn action still settling — drives polling for the transactions list and
 // the earned card: local ops before they index, plus subgraph rows not yet terminal.
 export const hasInFlightEarnActions = ({

--- a/portal/app/[locale]/hemi-earn/_utils/index.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/index.ts
@@ -9,6 +9,7 @@ import { type Address, type Chain, type Hash, isAddressEqual } from 'viem'
 
 import {
   type EarnPool,
+  type EarnPosition,
   type EarnSettlement,
   type EarnTransaction,
   type LocalEarnOperation,
@@ -237,6 +238,27 @@ export const sumInTransitSharesByShare = (
     acc[key] = (acc[key] ?? BigInt(0)) + BigInt(tx.amountIn)
     return acc
   }, {})
+
+// Shares with in-transit balance but no live position: a 100% withdraw zeroes balanceOf,
+// so the share drops out of positions. Synthesize a zero-balance row so the earned card
+// still reconciles it against the cost basis instead of silently reading $0.
+export const inTransitOnlyPositions = function (
+  inTransitByShare: Record<string, bigint>,
+  positions: EarnPosition[],
+  pools: EarnPool[],
+) {
+  const held = new Set(positions.map(p => p.shareAddress.toLowerCase()))
+  return Object.keys(inTransitByShare)
+    .filter(share => !held.has(share))
+    .map(share => findPoolByShare(pools, share as Address))
+    .filter((pool): pool is EarnPool => pool !== undefined)
+    .map(pool => ({
+      peggedToken: pool.peggedToken,
+      shareAddress: pool.shareAddress,
+      shareToken: pool.shareToken,
+      yourDeposit: BigInt(0),
+    }))
+}
 
 // Any earn action still settling — drives polling for the transactions list and
 // the earned card: local ops before they index, plus subgraph rows not yet terminal.

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -16,6 +16,7 @@ import {
   hasFailedSettlement,
   hasInFlightEarnActions,
   hashesMatch,
+  inTransitOnlyPositions,
   isAwaitingFinalize,
   isCooldownMature,
   isDeliberateCancel,
@@ -41,6 +42,7 @@ import {
 } from '../../../../../app/[locale]/hemi-earn/_utils'
 import {
   type EarnPool,
+  type EarnPosition,
   type EarnSettlement,
   type EarnTransaction,
   type EarnTransactionStatusType,
@@ -777,6 +779,64 @@ describe('utils', function () {
           pools,
         ),
       ).toEqual({})
+    })
+  })
+
+  describe('inTransitOnlyPositions', function () {
+    const shareA = '0x00000000000000000000000000000000000000e1' as Address
+    const shareB = '0x00000000000000000000000000000000000000e2' as Address
+    const peggedToken = { decimals: 18 } as unknown as EvmToken
+    const shareToken = { symbol: 'S' } as unknown as EvmToken
+    const makePool = (shareAddress: Address) =>
+      ({
+        assets: [],
+        peggedToken,
+        shareAddress,
+        shareToken,
+      }) as unknown as EarnPool
+    const pools = [makePool(shareA), makePool(shareB)]
+
+    it('synthesizes a zero-balance row for an in-transit share with no position', function () {
+      expect(
+        inTransitOnlyPositions(
+          { [shareA.toLowerCase()]: BigInt(5) },
+          [],
+          pools,
+        ),
+      ).toEqual([
+        {
+          peggedToken,
+          shareAddress: shareA,
+          shareToken,
+          yourDeposit: BigInt(0),
+        },
+      ])
+    })
+
+    it('skips a share already covered by a position', function () {
+      const position = {
+        peggedToken,
+        shareAddress: shareA,
+        shareToken,
+        yourDeposit: BigInt(100),
+      } as unknown as EarnPosition
+      expect(
+        inTransitOnlyPositions(
+          { [shareA.toLowerCase()]: BigInt(5) },
+          [position],
+          pools,
+        ),
+      ).toEqual([])
+    })
+
+    it('drops an in-transit share that maps to no pool', function () {
+      expect(
+        inTransitOnlyPositions(
+          { [`0x${'f'.repeat(40)}`]: BigInt(5) },
+          [],
+          pools,
+        ),
+      ).toEqual([])
     })
   })
 

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -36,6 +36,7 @@ import {
   resolveSettleStepStatus,
   resolveStepExplorerChainId,
   shouldShowRemoteFailedCtas,
+  sumInTransitSharesByShare,
   unstakeSettlement,
 } from '../../../../../app/[locale]/hemi-earn/_utils'
 import {
@@ -691,6 +692,91 @@ describe('utils', function () {
           transactions: [{ ...baseTx, status: 'FINALIZED' }],
         }),
       ).toBe(false)
+    })
+  })
+
+  describe('sumInTransitSharesByShare', function () {
+    const redeemAsset = '0x00000000000000000000000000000000000000c1' as Address
+    const share = '0x00000000000000000000000000000000000000d2' as Address
+    const makePool = (shareAddress: Address, assets: Address[]) =>
+      ({
+        assets: assets.map(address => ({ address })),
+        shareAddress,
+      }) as unknown as EarnPool
+    const pools = [makePool(share, [redeemAsset])]
+    const redeem = (
+      overrides: Partial<EarnTransaction> = {},
+    ): EarnTransaction => ({
+      ...baseTx,
+      amountIn: '2000000000000000000',
+      amountOut: null,
+      asset: redeemAsset,
+      kind: 'REDEEM',
+      status: 'PENDING',
+      ...overrides,
+    })
+
+    it('sums the amountIn of an in-flight redeem under its share', function () {
+      expect(sumInTransitSharesByShare([redeem()], pools)).toEqual({
+        [share.toLowerCase()]: BigInt('2000000000000000000'),
+      })
+    })
+
+    it('counts a CANCELLED redeem (shares still out, pre-recover)', function () {
+      expect(
+        sumInTransitSharesByShare([redeem({ status: 'CANCELLED' })], pools),
+      ).toEqual({ [share.toLowerCase()]: BigInt('2000000000000000000') })
+    })
+
+    it('excludes terminal redeems (RECOVERED / FINALIZED)', function () {
+      expect(
+        sumInTransitSharesByShare(
+          [redeem({ status: 'RECOVERED' }), redeem({ status: 'FINALIZED' })],
+          pools,
+        ),
+      ).toEqual({})
+    })
+
+    it('excludes a FULFILLED redeem whose amountOut has landed', function () {
+      expect(
+        sumInTransitSharesByShare(
+          [redeem({ amountOut: '1900000', status: 'FULFILLED' })],
+          pools,
+        ),
+      ).toEqual({})
+    })
+
+    it('excludes a TX_PENDING redeem (request tx not mined, shares still held)', function () {
+      expect(
+        sumInTransitSharesByShare([redeem({ status: 'TX_PENDING' })], pools),
+      ).toEqual({})
+    })
+
+    it('excludes deposits', function () {
+      expect(
+        sumInTransitSharesByShare([redeem({ kind: 'DEPOSIT' })], pools),
+      ).toEqual({})
+    })
+
+    it('sums multiple in-flight redeems for the same share', function () {
+      expect(
+        sumInTransitSharesByShare(
+          [
+            redeem({ amountIn: '2000000000000000000' }),
+            redeem({ amountIn: '1500000000000000000', requestId: '1' }),
+          ],
+          pools,
+        ),
+      ).toEqual({ [share.toLowerCase()]: BigInt('3500000000000000000') })
+    })
+
+    it('ignores a redeem whose asset maps to no pool', function () {
+      expect(
+        sumInTransitSharesByShare(
+          [redeem({ asset: `0x${'e'.repeat(40)}` })],
+          pools,
+        ),
+      ).toEqual({})
     })
   })
 


### PR DESCRIPTION
### Description

This PR fixes the "Total earned" card showing a phantom loss while a withdrawal is in cooldown.

When you request a redeem, the share tokens leave your wallet immediately (they move to the Router and stay there through the ~7-day cooldown), so `balanceOf` — which drives the card's current value — drops right away. The cost basis correctly still includes those shares, since the endpoint only disposes a redeem once it's processed. So a reduced current value
was being subtracted from a full cost basis, reading as a loss that isn't real (e.g. -$2.02 after a 2.0-share withdraw of a 6 USDT deposit).

The fix adds the shares locked by in-flight redeems back into the current value, using the transactions the UI already fetches — so it stays consistent with the cost basis. TX_PENDING redeems are skipped because the request tx hasn't mined yet and the shares are still in the wallet. It's earned-only: "Your staked balance" keeps showing the real wallet balance, since those shares really did leave the wallet.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Closes #2154 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
