### PR TITLE
Show skeleton for earn amounts until pools load

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
@@ -25,7 +25,7 @@ function AmountCell({ transaction }: { transaction: EarnTransaction }) {
     address: transaction.asset,
     chainId: hemi.id,
   })
-  const { data: pools = [] } = useEarnPools()
+  const { data: pools = [], isPending: isPoolsPending } = useEarnPools()
   const pool =
     transaction.kind === 'REDEEM'
       ? findPoolByAsset(pools, transaction.asset)
@@ -37,7 +37,7 @@ function AmountCell({ transaction }: { transaction: EarnTransaction }) {
   })
 
   if (!token) {
-    if (isLoading) return <Skeleton className="w-16" />
+    if (isLoading || isPoolsPending) return <Skeleton className="w-16" />
     return <span className="text-neutral-950">{rawAmount}</span>
   }
   return (

--- a/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_utils/index.test.ts
@@ -775,6 +775,15 @@ describe('utils', function () {
         ),
       ).toEqual({ rawAmount: '7777', token: assetToken })
     })
+
+    it('returns an undefined token for an in-flight REDEEM while the share token is still loading', function () {
+      expect(
+        pickEarnRowAmount(
+          { ...baseTx, amountIn: '5000', amountOut: null, kind: 'REDEEM' },
+          { assetToken },
+        ),
+      ).toEqual({ rawAmount: '5000', token: undefined })
+    })
   })
 
   describe('hashesMatch', function () {


### PR DESCRIPTION
### Description

This PR fixes the Hemi Earn transactions table showing raw base-unit amounts (e.g. `2000000000000000000` instead of `2 sVUSD`) for in-flight withdrawals while the pools/shares registry is still loading.

The `AmountCell` loading guard only tracked `useToken` (the asset token), but an in-flight redeem's display token is the share token, which comes from `useEarnPools` — a different query. Once the asset token resolved, the guard fell through and dumped the unformatted amount. The fix folds `useEarnPools`' pending state into the skeleton guard, so the cell waits for the share token's source before formatting. Once pools load it resolves the share token and formats normally.

Also adds a `pickEarnRowAmount` regression test for the undefined-share-token case.

### Screenshots

<img width="809" height="345" alt="Captura de Tela 2026-08-05 às 14 16 52" src="https://github.com/user-attachments/assets/14341a34-c35d-4ea7-bd9c-f25b886b17f5" />

### Related issue(s)

Closes #2155 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
