### PR TITLE
Index vault on BTC withdrawals subgraph

### DIFF
--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/package.json
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-tunnel-withdrawals-subgraph",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "build": "graph build",
     "build:hemi": "pnpm run build -- --network hemi",

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/schema.graphql
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/schema.graphql
@@ -28,4 +28,5 @@ type BtcWithdrawal @entity(immutable: true) {
   to: String # btc address, optional
   transactionHash: Bytes!
   uuid: BigInt!
+  vault: Bytes!
 }

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/src/entities/btcWithdrawal.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/src/entities/btcWithdrawal.ts
@@ -69,6 +69,19 @@ export class BtcWithdrawal extends BaseWithdrawal {
     this.set('uuid', Value.fromBigInt(value))
   }
 
+  get vault(): Bytes {
+    const value = this.get('vault')
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error('Cannot return null for a required field.')
+    } else {
+      return value.toBytes()
+    }
+  }
+
+  set vault(value: Bytes) {
+    this.set('vault', Value.fromBytes(value))
+  }
+
   get l1ChainId(): string {
     const value = this.get('l1ChainId')
     if (!value || value.kind == ValueKind.NULL) {

--- a/subgraphs/hemi-tunnel-withdrawals-subgraph/src/mappings/bitcoin-tunnel-manager.ts
+++ b/subgraphs/hemi-tunnel-withdrawals-subgraph/src/mappings/bitcoin-tunnel-manager.ts
@@ -50,6 +50,7 @@ export function handleWithdrawalInitiated(
   entity.transactionHash = event.transaction.hash
 
   entity.uuid = event.params.uuid
+  entity.vault = event.params.vault
 
   // Decoding the input data is not that stable for The Graph. There are
   // several issues, and the tool they use (https://github.com/rust-ethereum/ethabi)


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The vault a withdrawal targets was not indexed, so consumers had to assume it from configuration. Once deposits and withdrawals can use different vaults, that assumption breaks: a withdrawal made against a previous vault would be checked in the wrong vault state.

WithdrawalInitiated already emits the vault, and the BTC deposits subgraph indexes the same field, so just store it.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #2008

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
