### PR TITLE
Return the vault of BTC withdrawals in the API

### DIFF
--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "scripts": {
     "build": "tsc",
     "start": "node --import=./src/instrument.ts server.ts",

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -182,7 +182,8 @@ export const getBtcWithdrawals = function ({
         timestamp,
         to,
         transactionHash,
-        uuid
+        uuid,
+        vault
       }
     }`,
     variables: { address, fromBlock, limit, orderBy, orderDirection, skip },
@@ -204,6 +205,7 @@ export const getBtcWithdrawals = function ({
         // @ts-expect-error OP-SDK does not properly type addresses as Address
         l2Token: toChecksum(d.l2Token),
         timestamp: Number(d.timestamp),
+        vault: toChecksum(d.vault),
       }))
     },
   ) satisfies Promise<ToBtcWithdrawOperation[]>

--- a/portal-backend/api/src/subgraphs/types/tunnel.ts
+++ b/portal-backend/api/src/subgraphs/types/tunnel.ts
@@ -1,6 +1,6 @@
 // Copied from https://github.com/hemilabs/ui-monorepo/blob/853f366d/webapp/types/tunnel.ts and modified to remove unused types
 
-import { type Chain, type Hash } from 'viem'
+import { type Address, type Chain, type Hash } from 'viem'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const MessageDirection = {
@@ -63,6 +63,7 @@ export type ToBtcWithdrawOperation = CommonOperation &
     challengeTxHash?: Hash
     uuid?: string // bigint can't be serialized into local storage
     netSatsAfterFee: string
+    vault: Address
   }
 
 export type BtcDepositOperation = {


### PR DESCRIPTION
### Description

The BTC withdrawals subgraph now indexes the vault each withdrawal was initiated against. This exposes it through the API: `GET /subgraphs/:chain-id/withdrawals/:address/btc` now returns a `vault` field per withdrawal.

Until now consumers had to assume the vault from configuration. That assumption only holds while a single vault serves both deposits and withdrawals — once they diverge, a withdrawal initiated against a previous vault gets checked against the wrong vault state, and the portal would offer to challenge a withdrawal that was already fulfilled.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #2008

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
