### PR TITLE
Align token input layout with Figma spacing

### DIFF
--- a/portal/components/tokenInput/index.tsx
+++ b/portal/components/tokenInput/index.tsx
@@ -76,12 +76,12 @@ export const TokenInput = function <T extends Token>({
   const BalanceComponent = balanceComponent ?? Balance
   const FiatBalanceComponent = fiatBalanceComponent ?? RenderFiatBalance
   return (
-    <div className="min-h-[124px] rounded-lg border border-solid border-transparent bg-neutral-50 p-4 font-medium text-neutral-500 hover:shadow-bs">
-      <div className="flex h-full items-center justify-between">
-        <div className="flex h-full min-w-0 flex-shrink flex-grow flex-col items-start">
-          <span className="text-sm">{label}</span>
+    <div className="flex min-h-31 flex-col justify-between rounded-lg border border-solid border-transparent bg-neutral-50 p-4 font-medium text-neutral-500 hover:shadow-bs">
+      <span className="block text-sm">{label}</span>
+      <div className="flex items-center justify-between gap-x-2 text-sm">
+        <div className="min-w-0 flex-1">
           <input
-            className={`max-w-1/2 my-2 w-full bg-transparent text-4xl ${getTextColor(
+            className={`w-full bg-transparent text-4xl ${getTextColor(
               value,
               errorKey,
             )} outline-none`}
@@ -90,36 +90,36 @@ export const TokenInput = function <T extends Token>({
             type="text"
             value={value}
           />
-          {showFiatBalance && (
-            <div className="flex items-center text-sm text-neutral-500">
-              <span className="mr-1">$</span>
-              {fiatBalance ? (
-                <FiatBalanceComponent
-                  balance={fiatBalance.balance}
-                  queryStatus="success"
-                  token={fiatBalance.token}
-                />
-              ) : !Number.isNaN(value) ? (
-                <FiatBalanceComponent
-                  balance={parseTokenUnits(value, token)}
-                  queryStatus="success"
-                  token={token}
-                />
-              ) : null}
-            </div>
-          )}
         </div>
-        <div className="flex h-full flex-col items-end justify-end text-sm">
-          {tokenSelector}
-          <div className="mt-3 flex items-center justify-end gap-x-2 whitespace-nowrap text-sm">
-            <span className="text-neutral-500">
-              {balanceLabel ?? t('form.balance')}:
-            </span>
-            <span className="text-neutral-950">
-              <BalanceComponent token={token} />
-            </span>
-            {maxBalanceButton}
+        <div className="shrink-0">{tokenSelector}</div>
+      </div>
+      <div className="flex items-center gap-x-2 text-sm">
+        {showFiatBalance && (
+          <div className="flex items-center text-neutral-500">
+            <span className="mr-1">$</span>
+            {fiatBalance ? (
+              <FiatBalanceComponent
+                balance={fiatBalance.balance}
+                queryStatus="success"
+                token={fiatBalance.token}
+              />
+            ) : !Number.isNaN(value) ? (
+              <FiatBalanceComponent
+                balance={parseTokenUnits(value, token)}
+                queryStatus="success"
+                token={token}
+              />
+            ) : null}
           </div>
+        )}
+        <div className="ml-auto flex items-center justify-end gap-x-2 whitespace-nowrap">
+          <span className="text-neutral-500">
+            {balanceLabel ?? t('form.balance')}:
+          </span>
+          <span className="text-neutral-950">
+            <BalanceComponent token={token} />
+          </span>
+          {maxBalanceButton}
         </div>
       </div>
     </div>

--- a/portal/components/tokenInput/index.tsx
+++ b/portal/components/tokenInput/index.tsx
@@ -103,7 +103,7 @@ export const TokenInput = function <T extends Token>({
                 queryStatus="success"
                 token={fiatBalance.token}
               />
-            ) : !Number.isNaN(value) ? (
+            ) : !Number.isNaN(Number(value)) ? (
               <FiatBalanceComponent
                 balance={parseTokenUnits(value, token)}
                 queryStatus="success"

--- a/portal/tailwind.config.ts
+++ b/portal/tailwind.config.ts
@@ -272,6 +272,7 @@ const config: Config = {
         '85vh': '85vh',
       },
       minHeight: {
+        '31': '7.75rem',
         '136': '34rem',
       },
       opacity: {


### PR DESCRIPTION
### Description

This PR reworks the Hemi Earn withdraw form stacks to match the Figma spacing.

The two stacks are rendered by the shared TokenInput, which used a two-column layout. With the long "Share token available to withdraw" / "Withdraw share token as" labels that meant the label wrapped to two lines, the `$0.00` and `Balance:`/`Available:` lines sat on different baselines, and the token selector aligned with the label instead of the amount. I restructured it into three rows — label, amount + selector, fiat + balance — so everything lines up as designed. Since TokenInput is shared, tunnel and staking pick up the same layout and stay consistent (their short labels look unchanged).

While testing I hit a width regression: the big `text-4xl` input leaks its intrinsic width, and once the label was pulled out of the old `min-w-0` column that width pushed content-sized flex columns (the earn pool sidebar) past their `basis-1/3`, rendering the form at ~half width. Wrapping the input in a `min-w-0` div contains it at the source, so every consumer is fixed at once. I also swapped the arbitrary `min-h-[124px]` for a `min-h-31` config token to follow the spacing scale.

### Screenshots

https://github.com/user-attachments/assets/883c6d03-3372-4c7c-97ff-b36956f2bf10


### Related issue(s)

Closes #2159 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
