### PR TITLE
Check BTC withdrawals against their own vault

### DIFF
--- a/portal/components/tunnelStatusUpdaters/bitcoinWithdrawalsStatusUpdater.tsx
+++ b/portal/components/tunnelStatusUpdaters/bitcoinWithdrawalsStatusUpdater.tsx
@@ -9,7 +9,10 @@ import { useTunnelHistory } from 'hooks/useTunnelHistory'
 import { useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 import { BtcWithdrawStatus, ToBtcWithdrawOperation } from 'types/tunnel'
-import { isPendingOperation } from 'utils/tunnel'
+import {
+  isBtcWithdrawalMissingInformation,
+  isPendingOperation,
+} from 'utils/tunnel'
 import { hasKeys } from 'utils/utilities'
 import { Hash } from 'viem'
 import { useAccount as useEvmAccount } from 'wagmi'
@@ -116,11 +119,6 @@ const getWorker = () =>
     new URL('../../workers/watchBitcoinWithdrawals.ts', import.meta.url),
   )
 
-// Unless the "initiateWithdraw" tx is not confirmed, the other 2 fields should be available
-const missingInformation = (withdrawal: ToBtcWithdrawOperation) =>
-  withdrawal.status !== BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING &&
-  (!withdrawal.timestamp || !withdrawal.uuid)
-
 export function BitcoinWithdrawalsStatusUpdater() {
   const withdrawals = useBtcWithdrawals()
   // Withdrawals  are checked against an hemi address
@@ -134,7 +132,8 @@ export function BitcoinWithdrawalsStatusUpdater() {
 
   const withdrawalsToWatch = withdrawals.filter(
     withdrawal =>
-      isPendingOperation(withdrawal) || missingInformation(withdrawal),
+      isPendingOperation(withdrawal) ||
+      isBtcWithdrawalMissingInformation(withdrawal),
   )
 
   return (

--- a/portal/hooks/useBtcTunnel.ts
+++ b/portal/hooks/useBtcTunnel.ts
@@ -18,9 +18,10 @@ import {
   getBitcoinDepositFee,
   getBitcoinWithdrawalFee,
   getBitcoinWithdrawalUuid,
+  getBitcoinWithdrawalVault,
   initiateBtcDeposit,
-  initiateBtcWithdrawal,
 } from 'utils/hemi'
+import { getVaultChildIndex } from 'utils/hemiClientExtraActions'
 import { getNativeToken } from 'utils/nativeToken'
 import { type Chain, zeroAddress, type Address } from 'viem'
 import {
@@ -320,13 +321,14 @@ export const useWithdrawBitcoin = function () {
     }) {
       await ensureConnectedTo(hemi.id)
 
+      const vaultIndex = await getVaultChildIndex(hemiClient)
+
       const [transactionHash, vaultFee] = await Promise.all([
-        initiateBtcWithdrawal({
+        hemiWalletClient!.initiateWithdrawal({
           amount,
           btcAddress: btcAddress!,
           from: hemiAddress!,
-          hemiClient,
-          hemiWalletClient,
+          vaultIndex,
         }),
         getBitcoinWithdrawalFee({
           amount,
@@ -417,6 +419,7 @@ export const useWithdrawBitcoin = function () {
         blockNumber: Number(withdrawBitcoinReceipt.blockNumber),
         status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
         uuid: uuid?.toString(),
+        vault: getBitcoinWithdrawalVault(withdrawBitcoinReceipt),
       })
 
       clearWithdrawBitcoinState()

--- a/portal/test/utils/hemi.test.ts
+++ b/portal/test/utils/hemi.test.ts
@@ -37,10 +37,6 @@ vi.mock('hemi-viem/actions', () => ({
   isBitcoinWithdrawalFulfilled: vi.fn(),
 }))
 
-vi.mock('utils/hemiClientExtraActions', () => ({
-  getVaultChildIndex: vi.fn().mockResolvedValue(1),
-}))
-
 vi.mocked(getBitcoinVaultStateAddress).mockResolvedValue(zeroAddress)
 vi.mocked(getVaultByIndex).mockResolvedValue(zeroAddress)
 
@@ -51,12 +47,15 @@ const hemiClient: PublicClient = {
 
 const deposit: Omit<BtcDepositOperation, 'status'> = {}
 
+const vault = '0x0000000000000000000000000000000000000456'
+
 const withdrawal: ToBtcWithdrawOperation = {
   l2ChainId: hemiSepolia.id,
   status: BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING,
   timestamp: Math.floor(new Date().getTime() / 1000) - 3600 * 24, // 1 day hour ago
   transactionHash: '0x0000000000000000000000000000000000000003',
   uuid: '1',
+  vault,
 }
 
 describe('utils/hemi', function () {
@@ -175,6 +174,11 @@ describe('utils/hemi', function () {
       })
 
       expect(status).toBe(BtcWithdrawStatus.WITHDRAWAL_SUCCEEDED)
+
+      expect(vi.mocked(getBitcoinVaultStateAddress)).toHaveBeenCalledWith(
+        hemiClient,
+        { vaultAddress: vault },
+      )
       expect(vi.mocked(isBitcoinWithdrawalFulfilled)).toHaveBeenCalledOnce()
       expect(vi.mocked(isBitcoinWithdrawalFulfilled)).toHaveBeenLastCalledWith(
         hemiClient,
@@ -182,6 +186,21 @@ describe('utils/hemi', function () {
           uuid: BigInt(withdrawal.uuid),
           vaultStateAddress: zeroAddress,
         },
+      )
+    })
+
+    it('should throw if the withdrawal has no vault', async function () {
+      await expect(
+        getHemiStatusOfBtcWithdrawal({
+          hemiClient,
+          withdrawal: {
+            ...withdrawal,
+            status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+            vault: undefined,
+          },
+        }),
+      ).rejects.toThrow(
+        `Missing vault for withdrawal ${withdrawal.transactionHash}`,
       )
     })
 

--- a/portal/test/utils/tunnel.test.ts
+++ b/portal/test/utils/tunnel.test.ts
@@ -7,11 +7,12 @@ import {
 } from 'types/tunnel'
 import {
   getEvmWithdrawalStatus,
+  isBtcWithdrawalMissingInformation,
   isDeposit,
   isPendingOperation,
   isWithdrawalMissingInformation,
 } from 'utils/tunnel'
-import { zeroHash } from 'viem'
+import { zeroAddress, zeroHash } from 'viem'
 import { hemiSepolia } from 'viem/chains'
 import { getWithdrawalStatus } from 'viem/op-stack'
 import { describe, it, expect, vi } from 'vitest'
@@ -324,6 +325,73 @@ describe('utils/tunnel', function () {
     it('should return false if all required fields are present for status RELAYED', function () {
       const withdrawal = { ...baseWithdrawal, status: MessageStatus.RELAYED }
       expect(isWithdrawalMissingInformation(withdrawal)).toBe(false)
+    })
+  })
+
+  describe('isBtcWithdrawalMissingInformation', function () {
+    // @ts-expect-error baseWithdrawal is partial for test construction
+    const baseWithdrawal: ToBtcWithdrawOperation = {
+      status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+      timestamp: 1234567890,
+      uuid: '1',
+      vault: zeroAddress,
+    }
+
+    it('should return false if the withdrawal is still pending', function () {
+      const withdrawal = {
+        ...baseWithdrawal,
+        status: BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING,
+        timestamp: undefined,
+        uuid: undefined,
+        vault: undefined,
+      }
+      expect(isBtcWithdrawalMissingInformation(withdrawal)).toBe(false)
+    })
+
+    it('should return true if uuid is missing', function () {
+      const { uuid, ...withdrawal } = baseWithdrawal
+      expect(isBtcWithdrawalMissingInformation(withdrawal)).toBe(true)
+    })
+
+    it('should return true if timestamp is missing', function () {
+      const { timestamp, ...withdrawal } = baseWithdrawal
+      expect(isBtcWithdrawalMissingInformation(withdrawal)).toBe(true)
+    })
+
+    it('should return true if vault is missing', function () {
+      const { vault, ...withdrawal } = baseWithdrawal
+      expect(isBtcWithdrawalMissingInformation(withdrawal)).toBe(true)
+    })
+
+    it('should return false if vault is missing but the withdrawal failed', function () {
+      const { vault, ...rest } = baseWithdrawal
+      const withdrawal = {
+        ...rest,
+        status: BtcWithdrawStatus.WITHDRAWAL_FAILED,
+      }
+      expect(isBtcWithdrawalMissingInformation(withdrawal)).toBe(false)
+    })
+
+    it('should return false if uuid is missing but the withdrawal failed', function () {
+      const { uuid, ...rest } = baseWithdrawal
+      const withdrawal = {
+        ...rest,
+        status: BtcWithdrawStatus.WITHDRAWAL_FAILED,
+      }
+      expect(isBtcWithdrawalMissingInformation(withdrawal)).toBe(false)
+    })
+
+    it('should return true if vault is missing and only the challenge failed', function () {
+      const { vault, ...rest } = baseWithdrawal
+      const withdrawal = {
+        ...rest,
+        status: BtcWithdrawStatus.CHALLENGE_FAILED,
+      }
+      expect(isBtcWithdrawalMissingInformation(withdrawal)).toBe(true)
+    })
+
+    it('should return false if all required fields are present', function () {
+      expect(isBtcWithdrawalMissingInformation(baseWithdrawal)).toBe(false)
     })
   })
 })

--- a/portal/test/utils/watch/bitcoinWithdrawals.test.ts
+++ b/portal/test/utils/watch/bitcoinWithdrawals.test.ts
@@ -4,6 +4,7 @@ import { type ToBtcWithdrawOperation, BtcWithdrawStatus } from 'types/tunnel'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import {
   getBitcoinWithdrawalUuid,
+  getBitcoinWithdrawalVault,
   getHemiStatusOfBtcWithdrawal,
 } from 'utils/hemi'
 import { watchBitcoinWithdrawal } from 'utils/watch/bitcoinWithdrawals'
@@ -29,6 +30,8 @@ const block = {
 
 const uuid = BigInt(1)
 
+const vault = '0x0000000000000000000000000000000000000456'
+
 vi.mock('utils/chainClients', () => ({
   getPublicClient: vi.fn(),
 }))
@@ -40,6 +43,7 @@ vi.mock('utils/evmApi', () => ({
 
 vi.mock('utils/hemi', () => ({
   getBitcoinWithdrawalUuid: vi.fn(),
+  getBitcoinWithdrawalVault: vi.fn(),
   getHemiStatusOfBtcWithdrawal: vi.fn(),
 }))
 
@@ -61,6 +65,7 @@ describe('utils/watch/bitcoinWithdrawals', function () {
       )
       vi.mocked(getEvmTransactionReceipt).mockResolvedValue(withdrawalReceipt)
       vi.mocked(getBitcoinWithdrawalUuid).mockReturnValue(uuid)
+      vi.mocked(getBitcoinWithdrawalVault).mockReturnValue(vault)
       vi.mocked(getEvmBlock).mockResolvedValue(block)
 
       const updates = await watchBitcoinWithdrawal(withdrawal)
@@ -70,6 +75,7 @@ describe('utils/watch/bitcoinWithdrawals', function () {
         status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
         timestamp: Number(block.timestamp),
         uuid: uuid.toString(),
+        vault,
       })
 
       expect(getEvmTransactionReceipt).toHaveBeenCalledExactlyOnceWith(
@@ -94,6 +100,7 @@ describe('utils/watch/bitcoinWithdrawals', function () {
         status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
       })
       vi.mocked(getBitcoinWithdrawalUuid).mockReturnValue(uuid)
+      vi.mocked(getBitcoinWithdrawalVault).mockReturnValue(vault)
       vi.mocked(getEvmBlock).mockResolvedValue(block)
 
       const updates = await watchBitcoinWithdrawal({
@@ -105,6 +112,7 @@ describe('utils/watch/bitcoinWithdrawals', function () {
         blockNumber: Number(block.blockNumber),
         timestamp: Number(block.timestamp),
         uuid: uuid.toString(),
+        vault,
       })
 
       expect(getEvmTransactionReceipt).toHaveBeenCalledExactlyOnceWith(
@@ -137,12 +145,39 @@ describe('utils/watch/bitcoinWithdrawals', function () {
         status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
         timestamp: Number(block.timestamp),
         uuid: uuid.toString(),
+        vault,
       })
 
       expect(updates).toEqual({})
 
       expect(getBitcoinWithdrawalUuid).not.toHaveBeenCalled()
       expect(getEvmBlock).not.toHaveBeenCalled()
+    })
+
+    it('should restore the vault before checking the status', async function () {
+      vi.mocked(getHemiStatusOfBtcWithdrawal).mockResolvedValue(
+        BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+      )
+      vi.mocked(getEvmTransactionReceipt).mockResolvedValue(withdrawalReceipt)
+      vi.mocked(getBitcoinWithdrawalVault).mockReturnValue(vault)
+
+      const confirmedWithdrawal = {
+        ...withdrawal,
+        blockNumber: Number(block.blockNumber),
+        status: BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED,
+        timestamp: Number(block.timestamp),
+        uuid: uuid.toString(),
+      }
+
+      const updates = await watchBitcoinWithdrawal(confirmedWithdrawal)
+
+      expect(updates).toEqual({ vault })
+
+      expect(getHemiStatusOfBtcWithdrawal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          withdrawal: { ...confirmedWithdrawal, vault },
+        }),
+      )
     })
   })
 })

--- a/portal/types/tunnel.ts
+++ b/portal/types/tunnel.ts
@@ -1,6 +1,6 @@
 import { BtcChain } from 'btc-wallet/chains'
 import { BtcTransaction } from 'btc-wallet/unisat'
-import { type Chain, type Hash } from 'viem'
+import { type Address, type Chain, type Hash } from 'viem'
 
 // Prefer ordering by value instead of keys
 // Based on https://sdk.optimism.io/classes/crosschainmessenger#getMessageStatus
@@ -204,6 +204,8 @@ export type ToBtcWithdrawOperation = CommonOperation &
     challengeTxHash?: Hash
     status: BtcWithdrawStatusType
     uuid?: string // bigint can't be serialized into local storage
+    // Withdrawals synced before the vault was indexed may not have it
+    vault?: Address
   }
 
 export type DepositTunnelOperation = BtcDepositOperation | EvmDepositOperation

--- a/portal/utils/hemi.ts
+++ b/portal/utils/hemi.ts
@@ -1,5 +1,5 @@
 import { WalletConnector } from 'btc-wallet/connectors/types'
-import { Account as BtcAccount, Satoshis } from 'btc-wallet/unisat'
+import { Satoshis } from 'btc-wallet/unisat'
 import {
   acknowledgedDeposits,
   calculateDepositFee,
@@ -112,20 +112,19 @@ export const getHemiStatusOfBtcDeposit = ({
 const getIsBitcoinWithdrawalChallenged = ({
   hemiClient,
   uuid,
-  vaultIndex,
+  vaultAddress,
 }: {
   hemiClient: PublicClient
-  vaultIndex: number
   uuid: bigint
+  vaultAddress: Address
 }) =>
-  getVaultAddressByIndex(hemiClient, vaultIndex)
-    .then(vaultAddress => getBitcoinVaultStateAddress(hemiClient, vaultAddress))
-    .then(vaultStateAddress =>
+  getBitcoinVaultStateAddress(hemiClient, vaultAddress).then(
+    vaultStateAddress =>
       isBitcoinWithdrawalChallenged(hemiClient, {
         uuid,
         vaultStateAddress,
       }),
-    )
+  )
 
 /**
  * Returns true if a fulfillment transaction exists on Bitcoin and it has been communicated
@@ -134,20 +133,19 @@ const getIsBitcoinWithdrawalChallenged = ({
 const getIsBitcoinWithdrawalFulfilled = ({
   hemiClient,
   uuid,
-  vaultIndex,
+  vaultAddress,
 }: {
   hemiClient: PublicClient
-  vaultIndex: number
   uuid: bigint
+  vaultAddress: Address
 }) =>
-  getVaultAddressByIndex(hemiClient, vaultIndex)
-    .then(vaultAddress => getBitcoinVaultStateAddress(hemiClient, vaultAddress))
-    .then(vaultStateAddress =>
+  getBitcoinVaultStateAddress(hemiClient, vaultAddress).then(
+    vaultStateAddress =>
       isBitcoinWithdrawalFulfilled(hemiClient, {
         uuid,
         vaultStateAddress,
       }),
-    )
+  )
 
 export const getBitcoinWithdrawalGracePeriod = ({
   hemiClient,
@@ -194,6 +192,16 @@ const getUuid = function (withdrawal: ToBtcWithdrawOperation): bigint {
   return BigInt(withdrawal.uuid)
 }
 
+const getVault = function (withdrawal: ToBtcWithdrawOperation): Address {
+  if (!withdrawal.vault) {
+    throw new Error(
+      `Missing vault for withdrawal ${withdrawal.transactionHash}`,
+    )
+  }
+
+  return withdrawal.vault
+}
+
 export const getHemiStatusOfBtcWithdrawal = async function ({
   hemiClient,
   withdrawal,
@@ -211,18 +219,18 @@ export const getHemiStatusOfBtcWithdrawal = async function ({
   // present, move it to WITHDRAWAL_SUCCEEDED but if not and the withdrawal is
   // more than ${grace period}, move it to CHALLENGE_READY.
   if (withdrawal.status === BtcWithdrawStatus.INITIATE_WITHDRAW_CONFIRMED) {
-    const vaultIndex = await getVaultChildIndex(hemiClient)
+    const vaultAddress = getVault(withdrawal)
 
     const [isFulfilled, isChallenged] = await Promise.all([
       getIsBitcoinWithdrawalFulfilled({
         hemiClient,
         uuid,
-        vaultIndex,
+        vaultAddress,
       }),
       getIsBitcoinWithdrawalChallenged({
         hemiClient,
         uuid,
-        vaultIndex,
+        vaultAddress,
       }),
     ])
     if (isFulfilled) {
@@ -232,10 +240,10 @@ export const getHemiStatusOfBtcWithdrawal = async function ({
       return BtcWithdrawStatus.WITHDRAWAL_CHALLENGED
     }
     if (withdrawal.timestamp) {
-      const gracePeriod = await getBitcoinWithdrawalGracePeriod({
+      const gracePeriod = await getBitcoinVaultGracePeriod(
         hemiClient,
-        vaultIndex,
-      })
+        vaultAddress,
+      )
       const age = Math.floor(new Date().getTime() / 1000) - withdrawal.timestamp
       if (age > gracePeriod) {
         return BtcWithdrawStatus.READY_TO_CHALLENGE
@@ -348,37 +356,21 @@ export const confirmBtcDeposit = ({
     })
   })
 
+// The logs must be decoded as viem does not seem to do so automatically.
+const getWithdrawalInitiatedEvent = (receipt: TransactionReceipt) =>
+  parseEventLogs({ abi: bitcoinTunnelManagerAbi, logs: receipt.logs }).find(
+    event => event.eventName === 'WithdrawalInitiated',
+  )
+
 // The withdrawal uuid is a 64-bit number needed to challenge the
 // operation if the operator does not process it timely, within 12 hours.
 // It is an argument of the WithdrawalInitiated event and can be easily
-// read from the receipt logs. The logs must be decoded as viem does not
-// seem to do so automatically.
+// read from the receipt logs.
 export const getBitcoinWithdrawalUuid = (receipt: TransactionReceipt) =>
-  parseEventLogs({ abi: bitcoinTunnelManagerAbi, logs: receipt.logs }).find(
-    event => event.eventName === 'WithdrawalInitiated',
-  )?.args.uuid satisfies bigint | undefined
+  getWithdrawalInitiatedEvent(receipt)?.args.uuid satisfies bigint | undefined
 
-export const initiateBtcWithdrawal = ({
-  amount,
-  btcAddress,
-  from,
-  hemiClient,
-  hemiWalletClient,
-}: {
-  amount: bigint
-  btcAddress: BtcAccount
-  from: Address
-  hemiClient: PublicClient
-  hemiWalletClient: HemiWalletClient
-}) =>
-  getVaultChildIndex(hemiClient).then(vaultIndex =>
-    hemiWalletClient!.initiateWithdrawal({
-      amount,
-      btcAddress,
-      from,
-      vaultIndex,
-    }),
-  )
+export const getBitcoinWithdrawalVault = (receipt: TransactionReceipt) =>
+  getWithdrawalInitiatedEvent(receipt)?.args.vault satisfies Address | undefined
 
 const calculateBtcDepositFee = (
   hemiClient: PublicClient,

--- a/portal/utils/tunnel.ts
+++ b/portal/utils/tunnel.ts
@@ -162,3 +162,12 @@ export const isWithdrawalMissingInformation = (
   withdrawal.status === undefined ||
   isMissingProveTransaction(withdrawal) ||
   isMissingClaimTransaction(withdrawal)
+
+export const isBtcWithdrawalMissingInformation = (
+  withdrawal: ToBtcWithdrawOperation,
+) =>
+  withdrawal.status !== BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING &&
+  (!withdrawal.timestamp ||
+    // a reverted initiation emits no event to read the uuid and the vault from
+    (withdrawal.status !== BtcWithdrawStatus.WITHDRAWAL_FAILED &&
+      (withdrawal.uuid === undefined || !withdrawal.vault)))

--- a/portal/utils/watch/bitcoinWithdrawals.ts
+++ b/portal/utils/watch/bitcoinWithdrawals.ts
@@ -3,9 +3,13 @@ import { getPublicClient } from 'utils/chainClients'
 import { getEvmBlock, getEvmTransactionReceipt } from 'utils/evmApi'
 import {
   getBitcoinWithdrawalUuid,
+  getBitcoinWithdrawalVault,
   getHemiStatusOfBtcWithdrawal,
 } from 'utils/hemi'
-import { isPendingOperation } from 'utils/tunnel'
+import {
+  isBtcWithdrawalMissingInformation,
+  isPendingOperation,
+} from 'utils/tunnel'
 
 const addMissingInfo = async function (withdrawal: ToBtcWithdrawOperation) {
   const updates: Partial<ToBtcWithdrawOperation> = {}
@@ -23,6 +27,12 @@ const addMissingInfo = async function (withdrawal: ToBtcWithdrawOperation) {
       updates.uuid = uuid.toString()
     }
   }
+  if (!withdrawal.vault) {
+    const vault = getBitcoinWithdrawalVault(receipt)
+    if (vault) {
+      updates.vault = vault
+    }
+  }
   if (!withdrawal.timestamp) {
     const block = await getEvmBlock(receipt.blockNumber, withdrawal.l2ChainId)
     updates.timestamp = Number(block.timestamp)
@@ -36,31 +46,45 @@ const addMissingInfo = async function (withdrawal: ToBtcWithdrawOperation) {
 export const watchBitcoinWithdrawal = async function (
   withdrawal: ToBtcWithdrawOperation,
 ) {
-  const updates: Partial<ToBtcWithdrawOperation> = {}
-
   const hemiClient = getPublicClient(withdrawal.l2ChainId)
 
-  // if the withdrawal is on a final state, it won't change, so there's no need to re-check it
-  const newStatus = isPendingOperation(withdrawal)
-    ? await getHemiStatusOfBtcWithdrawal({
-        hemiClient,
-        withdrawal,
-      })
-    : withdrawal.status
-
-  if (withdrawal.status !== newStatus) {
-    updates.status = newStatus
-  }
-
-  // check for values that may be missing
-  if (
-    newStatus !== BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING &&
-    (withdrawal.uuid === undefined || !withdrawal.timestamp)
-  ) {
-    Object.assign(updates, {
-      ...(await addMissingInfo(withdrawal)),
+  // a pending withdrawal resolves its status from the receipt of the initiating
+  // transaction, so it needs no vault - and the receipt may not even exist yet
+  if (withdrawal.status === BtcWithdrawStatus.INITIATE_WITHDRAW_PENDING) {
+    const status = await getHemiStatusOfBtcWithdrawal({
+      hemiClient,
+      withdrawal,
     })
+
+    if (status === withdrawal.status) {
+      return {}
+    }
+    // it is no longer pending, so the receipt exists and the missing fields
+    // can be restored on this same run
+    const confirmed = { ...withdrawal, status }
+    return isBtcWithdrawalMissingInformation(confirmed)
+      ? { ...(await addMissingInfo(confirmed)), status }
+      : { status }
   }
 
-  return updates
+  // any other status is checked against the vault it was initiated with,
+  // so the vault must be restored first
+  const updates: Partial<ToBtcWithdrawOperation> =
+    isBtcWithdrawalMissingInformation(withdrawal)
+      ? await addMissingInfo(withdrawal)
+      : {}
+
+  const updatedWithdrawal = { ...withdrawal, ...updates }
+
+  // if the withdrawal is on a final state, it won't change, so there's no need to re-check it
+  if (!isPendingOperation(updatedWithdrawal)) {
+    return updates
+  }
+
+  const status = await getHemiStatusOfBtcWithdrawal({
+    hemiClient,
+    withdrawal: updatedWithdrawal,
+  })
+
+  return status === withdrawal.status ? updates : { ...updates, status }
 }


### PR DESCRIPTION
### Description

> [!WARNING]
> Do not merge until the portal-backend from #2171 is deployed. Until then the API does not return `vault`, and every BTC withdrawal coming from the subgraph makes the history sync throw — which takes BTC deposits down with it, not just withdrawals.

EDIT: API's been published - See https://github.com/hemilabs/ui-monorepo/pull/2176#issuecomment-5242560322

The status of a BTC withdrawal was resolved against the vault currently set in configuration. That only holds while a single vault serves both deposits and withdrawals: once they diverge, a withdrawal initiated against a previous vault is checked in the wrong vault state, so an already fulfilled withdrawal moves to `READY_TO_CHALLENGE` and the UI offers a challenge that reverts on chain.

Withdrawals now carry the vault they were initiated with, from three sources:

- synced ones read it from the subgraph, through the API added in #2171
- new ones read it from the `WithdrawalInitiated` event of the initiating receipt
- ones already in local storage are restored by the watcher before their status is checked

A second PR will do the actual split, adding separate deposit and withdrawal vault configuration and pointing each flow at its own vault. This one only makes the status check independent of that configuration, which is the part that has to land first.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #2008

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
