### PR TITLE
Bump api version to force deployment

### DIFF
--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-backend",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "scripts": {
     "build": "tsc",
     "start": "node --import=./src/instrument.ts server.ts",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps the version of `portal-backend`'s API as #2171 failed to run due to issues with GitHub Actions. I'll force-merge this PR as this is the only way to force the creation of the Docker image

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #2008

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
