### PR TITLE
Use shared RPC clients in the Hemi Earn build fetcher

### DIFF
--- a/portal/.env
+++ b/portal/.env
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_BTC_INPUTS_SIZE=105
 NEXT_PUBLIC_BTC_OUTPUTS_SIZE=25
+NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET=https://eth.drpc.org+https://ethereum-rpc.publicnode.com+https://1rpc.io/eth
 NEXT_PUBLIC_PORTAL_API_URL=https://portal-api.hemi.xyz
 NEXT_PUBLIC_SENTRY_FILTER_KEY_ID="portal-file-identifier-sentry"

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnAssetConfigs.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnAssetConfigs.ts
@@ -4,32 +4,11 @@ import { getTreasury } from '@vetro-protocol/gateway/actions'
 import { getWhitelistedTokens } from '@vetro-protocol/treasury/actions'
 import { type AssetData, getAssetData } from 'hemi-earn-actions/actions'
 import { hemi } from 'hemi-viem'
-import { hemiMainnet } from 'networks/hemiMainnet'
 import { mainnet } from 'networks/mainnet'
 import { tokenList } from 'tokenList'
 import { toChecksumAddress } from 'utils/address'
-import {
-  type Address,
-  createPublicClient,
-  http,
-  isAddressEqual,
-  zeroAddress,
-} from 'viem'
-
-// Build-time `generateStaticParams` runs this on the server, so clients are
-// constructed straight from the chain configs with a bare `http()` transport
-// rather than via `getPublicClient`/`buildTransport`. Two reasons:
-//   1. those resolve the chain through `findChainById`, which reads the
-//      `'use client'` `networks` barrel — unavailable in a server (RSC) context;
-//   2. `buildTransport` pulls in `eth-rpc-cache`, whose ESM resolution breaks
-//      under vitest, so importing it here would take the fetcher's tests down.
-// `http()` honors each chain's configured RPC and the result is cached by
-// react-query (`staleTime: Infinity`), so the rpc-cache buys nothing here.
-const l1PublicClient = () =>
-  createPublicClient({ chain: mainnet, transport: http() })
-
-const hemiPublicClient = () =>
-  createPublicClient({ chain: hemiMainnet, transport: http() })
+import { getPublicClient } from 'utils/chainClients'
+import { type Address, type Chain, isAddressEqual, zeroAddress } from 'viem'
 
 // One Router-registered deposit asset, resolved on-chain rather than hardcoded.
 // Mirrors `Router.assetsData(asset)` (`AssetData`) plus the Hemi-side `asset`
@@ -58,8 +37,8 @@ export const uniqueShareConfigs = (configs: HemiEarnAssetConfig[]) => [
 // checksum them. Reads fail-fast (`Promise.all`): an unreadable gateway means
 // a broken registry, so surface it and fail the build rather than ship a
 // partial token set.
-const fetchWhitelistedL1Tokens = async function () {
-  const l1Client = l1PublicClient()
+const fetchWhitelistedL1Tokens = async function (chainId: Chain['id']) {
+  const l1Client = getPublicClient(chainId)
   const perGateway = await Promise.all(
     gateways.map(async function (gateway) {
       const treasury = await getTreasury(l1Client, { address: gateway.address })
@@ -73,19 +52,27 @@ const fetchWhitelistedL1Tokens = async function () {
 // `bridgeInfo` (standard bridge) or `oft.peers` (LayerZero OFT, e.g. hemiBTC)
 // mapping. Returns `undefined` when the token has no Hemi version (e.g. not
 // tunneled), so callers skip it.
-const findHemiToken = (l1Address: Address) =>
-  tokenList.tokens.find(function (token) {
-    if (token.chainId !== hemi.id) {
-      return false
-    }
-    const hemiTokenL1Address =
-      token.extensions?.bridgeInfo?.[mainnet.id]?.tokenAddress ??
-      token.extensions?.oft?.peers?.[mainnet.id]?.tokenAddress
-    return (
-      hemiTokenL1Address !== undefined &&
-      isAddressEqual(hemiTokenL1Address, l1Address)
-    )
-  })
+const findHemiToken =
+  ({
+    l1ChainId,
+    l2ChainId,
+  }: {
+    l1ChainId: Chain['id']
+    l2ChainId: Chain['id']
+  }) =>
+  (l1Address: Address) =>
+    tokenList.tokens.find(function (token) {
+      if (token.chainId !== l2ChainId) {
+        return false
+      }
+      const hemiTokenL1Address =
+        token.extensions?.bridgeInfo?.[l1ChainId]?.tokenAddress ??
+        token.extensions?.oft?.peers?.[l1ChainId]?.tokenAddress
+      return (
+        hemiTokenL1Address !== undefined &&
+        isAddressEqual(hemiTokenL1Address, l1Address)
+      )
+    })
 
 // Builds the Hemi Earn asset registry on-chain: each gateway's whitelisted
 // Ethereum tokens → their Hemi counterparts → `Router.assetsData`. Pure async
@@ -93,11 +80,11 @@ const findHemiToken = (l1Address: Address) =>
 export const fetchHemiEarnAssetConfigs = async function (): Promise<
   HemiEarnAssetConfig[]
 > {
-  const hemiClient = hemiPublicClient()
-  const l1Tokens = await fetchWhitelistedL1Tokens()
+  const hemiClient = getPublicClient(hemi.id)
+  const l1Tokens = await fetchWhitelistedL1Tokens(mainnet.id)
 
   const hemiAssets = l1Tokens
-    .map(findHemiToken)
+    .map(findHemiToken({ l1ChainId: mainnet.id, l2ChainId: hemi.id }))
     .filter(token => token !== undefined)
 
   const configs = await Promise.all(

--- a/portal/networks/index.ts
+++ b/portal/networks/index.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { bitcoinTestnet, bitcoinMainnet } from 'btc-wallet/chains'
 import { hemiMainnet } from 'networks/hemiMainnet'
 import { hemiTestnet } from 'networks/hemiTestnet'

--- a/portal/utils/transport.ts
+++ b/portal/utils/transport.ts
@@ -45,11 +45,10 @@ export const buildTransport = function (network: Chain) {
   const rpcUrls = network.rpcUrls.default.http
   if (rpcUrls.length > 1) {
     return fallback(
-      rpcUrls.map(rpcUrl => createHttpClient(rpcUrl, httpConfig), {
-        // rank every 30 seconds
-        rank: { interval: 30_000 },
+      rpcUrls.map(rpcUrl => createHttpClient(rpcUrl, httpConfig)),
+      {
         retryCount: 1,
-      }),
+      },
     )
   }
   return createHttpClient(rpcUrls[0], httpConfig)


### PR DESCRIPTION
### Description

The Hemi Earn build-time fetcher built its own viem clients with a bare `http()` transport, so it ignored the configured RPC URLs. It did that because `getPublicClient` reads the `networks` barrel, which was marked `'use client'` and therefore unavailable during the static build. Removing that directive lets the fetcher use the shared clients.

Two smaller fixes along the way: `findHemiToken` now takes the L1 and L2 chain ids instead of hardcoding `mainnet.id`, and `buildTransport` passes its `fallback` options to `fallback` instead of to `.map()`, where they were being silently dropped. `rank` is dropped rather than restored — it has never actually run, and enabling it would start a ranking loop per client.

Also adds `NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET` to `.env`. JS Checks builds the portal without it, since it only exists in the staging and production environments, so mainnet fell back to viem's single default endpoint and a drpc free-plan timeout was failing the build — on `main` too, not just here. `.env` only applies when the variable is not already set, so deploys and local `.env.local` keep overriding it.

**Commits:**

580b3cfb Use shared public clients in Hemi Earn fetcher
70a60b99 Pass fallback config to fallback, not to map
bd0e9640 Add default mainnet RPC urls to .env

**Testing:** local `next build` passes and generates both pool pages; 795 tests pass. Also verified with `.env.local` moved aside, matching the JS Checks environment: the build passes where it currently fails.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
