### PR TITLE
Sort earn composition items by share

### DIFF
--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchComposition.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchComposition.ts
@@ -68,7 +68,7 @@ const toCompositionData = function (
   return data
 }
 
-// 'protocol' groups by strategy and appends idle funds (withdrawable − totalDebt)
+// 'protocol' groups by strategy and adds idle funds (withdrawable − totalDebt)
 // as a reserve buffer; 'token' groups by token (idle already included).
 export const toCompositionItems = function ({
   data,
@@ -104,7 +104,9 @@ export const toCompositionItems = function ({
     }
   }
 
-  const visible = items.filter(item => item.amount > 0)
+  const visible = items
+    .filter(item => item.amount > 0)
+    .sort((a, b) => b.amount - a.amount)
   const total = visible.reduce((sum, item) => sum + item.amount, 0)
   return visible.map(item => ({
     amount: item.amount,

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchComposition.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchComposition.ts
@@ -68,7 +68,7 @@ const toCompositionData = function (
   return data
 }
 
-// 'protocol' groups by strategy and adds idle funds (withdrawable − totalDebt)
+// 'protocol' groups by strategy and appends idle funds (withdrawable − totalDebt)
 // as a reserve buffer; 'token' groups by token (idle already included).
 export const toCompositionItems = function ({
   data,
@@ -87,6 +87,10 @@ export const toCompositionItems = function ({
         }))
       : data.flatMap(token => token.strategies)
 
+  const visible = items
+    .filter(item => item.amount > 0)
+    .sort((a, b) => b.amount - a.amount)
+
   if (viewMode === 'protocol') {
     const reserveBuffer = Math.max(
       0,
@@ -95,8 +99,9 @@ export const toCompositionItems = function ({
         0,
       ),
     )
+
     if (reserveBuffer > 0) {
-      items.push({
+      visible.push({
         amount: reserveBuffer,
         isReserveBuffer: true,
         name: reserveBufferLabel,
@@ -104,9 +109,6 @@ export const toCompositionItems = function ({
     }
   }
 
-  const visible = items
-    .filter(item => item.amount > 0)
-    .sort((a, b) => b.amount - a.amount)
   const total = visible.reduce((sum, item) => sum + item.amount, 0)
   return visible.map(item => ({
     amount: item.amount,

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchComposition.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchComposition.test.ts
@@ -189,23 +189,23 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchComposition', function () {
     const reserveBufferLabel = 'Reserve Buffer'
     const data: CompositionData = [
       {
-        strategies: [
-          { amount: 75, name: 'Strategy A1' },
-          { amount: 50, name: 'Strategy A2' },
-        ],
-        symbol: 'WBTC',
-        totalDebt: 125,
-        withdrawable: 150, // 25 idle
+        strategies: [{ amount: 50, name: 'Strategy B1' }],
+        symbol: 'cbBTC',
+        totalDebt: 50,
+        withdrawable: 60, // 10 idle
       },
       {
-        strategies: [{ amount: 25, name: 'Strategy B1' }],
-        symbol: 'cbBTC',
-        totalDebt: 25,
-        withdrawable: 50, // 25 idle
+        strategies: [
+          { amount: 30, name: 'Strategy A1' },
+          { amount: 80, name: 'Strategy A2' },
+        ],
+        symbol: 'WBTC',
+        totalDebt: 110,
+        withdrawable: 140, // 30 idle
       },
     ]
 
-    it('groups by strategy and appends the reserve buffer in protocol mode', function () {
+    it('groups by strategy and includes the reserve buffer in protocol mode', function () {
       const items = toCompositionItems({
         data,
         reserveBufferLabel,
@@ -214,28 +214,28 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchComposition', function () {
 
       expect(items).toEqual([
         {
-          amount: 75,
-          isReserveBuffer: false,
-          name: 'Strategy A1',
-          share: 37.5,
-        },
-        {
-          amount: 50,
+          amount: 80,
           isReserveBuffer: false,
           name: 'Strategy A2',
-          share: 25,
-        },
-        {
-          amount: 25,
-          isReserveBuffer: false,
-          name: 'Strategy B1',
-          share: 12.5,
+          share: 40,
         },
         {
           amount: 50,
+          isReserveBuffer: false,
+          name: 'Strategy B1',
+          share: 25,
+        },
+        {
+          amount: 40,
           isReserveBuffer: true,
           name: reserveBufferLabel,
-          share: 25,
+          share: 20,
+        },
+        {
+          amount: 30,
+          isReserveBuffer: false,
+          name: 'Strategy A1',
+          share: 15,
         },
       ])
     })
@@ -249,15 +249,83 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchComposition', function () {
 
       expect(items).toEqual([
         {
-          amount: 150,
+          amount: 140,
           isReserveBuffer: false,
           name: 'WBTC',
+          share: 70,
+        },
+        {
+          amount: 60,
+          isReserveBuffer: false,
+          name: 'cbBTC',
+          share: 30,
+        },
+      ])
+    })
+
+    it('orders items from the highest to the lowest share', function () {
+      const unordered: CompositionData = [
+        {
+          strategies: [{ amount: 3180, name: 'Strategy USDT' }],
+          symbol: 'USDT',
+          totalDebt: 3180,
+          withdrawable: 3180,
+        },
+        {
+          strategies: [{ amount: 6675, name: 'Strategy USDC' }],
+          symbol: 'USDC',
+          totalDebt: 6675,
+          withdrawable: 6675,
+        },
+        {
+          strategies: [{ amount: 145, name: 'Strategy frxUSD' }],
+          symbol: 'frxUSD',
+          totalDebt: 145,
+          withdrawable: 145,
+        },
+      ]
+
+      expect(
+        toCompositionItems({
+          data: unordered,
+          reserveBufferLabel,
+          viewMode: 'token',
+        }).map(item => item.name),
+      ).toEqual(['USDC', 'USDT', 'frxUSD'])
+      expect(
+        toCompositionItems({
+          data: unordered,
+          reserveBufferLabel,
+          viewMode: 'protocol',
+        }).map(item => item.name),
+      ).toEqual(['Strategy USDC', 'Strategy USDT', 'Strategy frxUSD'])
+    })
+
+    it('ranks the reserve buffer by size, like any other item', function () {
+      const items = toCompositionItems({
+        data: [
+          {
+            strategies: [{ amount: 25, name: 'Strategy' }],
+            symbol: 'WBTC',
+            totalDebt: 25,
+            withdrawable: 100, // 75 idle
+          },
+        ],
+        reserveBufferLabel,
+        viewMode: 'protocol',
+      })
+
+      expect(items).toEqual([
+        {
+          amount: 75,
+          isReserveBuffer: true,
+          name: reserveBufferLabel,
           share: 75,
         },
         {
-          amount: 50,
+          amount: 25,
           isReserveBuffer: false,
-          name: 'cbBTC',
+          name: 'Strategy',
           share: 25,
         },
       ])

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchComposition.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchComposition.test.ts
@@ -205,7 +205,7 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchComposition', function () {
       },
     ]
 
-    it('groups by strategy and includes the reserve buffer in protocol mode', function () {
+    it('groups by strategy and appends the reserve buffer in protocol mode', function () {
       const items = toCompositionItems({
         data,
         reserveBufferLabel,
@@ -226,16 +226,16 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchComposition', function () {
           share: 25,
         },
         {
-          amount: 40,
-          isReserveBuffer: true,
-          name: reserveBufferLabel,
-          share: 20,
-        },
-        {
           amount: 30,
           isReserveBuffer: false,
           name: 'Strategy A1',
           share: 15,
+        },
+        {
+          amount: 40,
+          isReserveBuffer: true,
+          name: reserveBufferLabel,
+          share: 20,
         },
       ])
     })
@@ -301,7 +301,8 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchComposition', function () {
       ).toEqual(['Strategy USDC', 'Strategy USDT', 'Strategy frxUSD'])
     })
 
-    it('ranks the reserve buffer by size, like any other item', function () {
+    // Idle funds aren't a position, so the grouping stays put no matter the size.
+    it('keeps the reserve buffer last even when it outweighs every strategy', function () {
       const items = toCompositionItems({
         data: [
           {
@@ -317,16 +318,16 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchComposition', function () {
 
       expect(items).toEqual([
         {
-          amount: 75,
-          isReserveBuffer: true,
-          name: reserveBufferLabel,
-          share: 75,
-        },
-        {
           amount: 25,
           isReserveBuffer: false,
           name: 'Strategy',
           share: 25,
+        },
+        {
+          amount: 75,
+          isReserveBuffer: true,
+          name: reserveBufferLabel,
+          share: 75,
         },
       ])
     })


### PR DESCRIPTION
### Description

This PR sorts the Hemi Earn composition breakdown from the largest slice to the smallest.

Until now items came out in fetch order, per token and per strategy within each token, so the biggest slice could show up anywhere in the legend. Two pools with the same composition could read completely differently depending on how the data happened to arrive. Sorting descending is what a breakdown is expected to do.

The reserve buffer stays pinned at the end, below the sorted slices. It isn't a position, it's leftover idle funds, so ranking it by size could drop it between two strategies and made the grouping shift around as the buffer grew (thanks @gabmontes for catching it). This only affects the protocol view, since the token view folds idle funds into each token and has no buffer row.

Test fixtures were reworked so the ordering is actually observable (the old amounts happened to already be descending), plus two new cases: one covering both view modes, one checking the buffer stays last even when it outweighs every strategy.

### Screenshots

<img width="693" height="361" alt="Captura de Tela 2026-08-12 às 13 47 05" src="https://github.com/user-attachments/assets/2f25c0ee-44cc-41f5-a73b-a48961c46ac5" />
<img width="703" height="371" alt="Captura de Tela 2026-08-12 às 13 47 13" src="https://github.com/user-attachments/assets/65d0f9ef-9afb-497b-9ae5-d7bad90f8309" />


### Related issue(s)

Closes #2158 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
