### PR TITLE
Add keeper subcommand to hemi-earn sandbox

### DIFF
--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -50,13 +50,14 @@ All sandbox actions are dispatched through a single pnpm script that forwards it
 pnpm --filter portal sandbox:hemi-earn -- <subcommand> [flags]
 ```
 
-| Subcommand     | Purpose                                                                                                                  |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `setup`        | Start Anvil + deploy mocks + fund the test account.                                                                      |
-| `mint`         | Mint from any ERC20-mock — top up an EOA or inject yield into the vault (see [Minting](#minting)).                       |
-| `mining`       | Toggle Anvil's interval mining at runtime (see [Slow mining](#slow-mining)).                                             |
-| `relayer`      | Emulate the production keeper: claim mature cooldown redeems and bridge cancellation requests (see [Relayer](#relayer)). |
-| `fail-gateway` | Toggle `PreviewableGatewayMock` into a failure mode (see [Failure simulation](#failure-simulation)).                     |
+| Subcommand     | Purpose                                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `setup`        | Start Anvil + deploy mocks + fund the test account.                                                                          |
+| `mint`         | Mint from any ERC20-mock — top up an EOA or inject yield into the vault (see [Minting](#minting)).                           |
+| `mining`       | Toggle Anvil's interval mining at runtime (see [Slow mining](#slow-mining)).                                                 |
+| `relayer`      | Emulate the production keeper: claim mature cooldown redeems and bridge cancellation requests (see [Relayer](#relayer)).     |
+| `fail-gateway` | Toggle `PreviewableGatewayMock` into a failure mode (see [Failure simulation](#failure-simulation)).                         |
+| `keeper`       | Fire `Agent.cancel` / `Agent.retry` to simulate the "keeper wins the race" scenario (see [Keeper actions](#keeper-actions)). |
 
 Building blocks used by `setup` (`deployMocks.ts`, `fundAccount.ts`) are still invocable directly for advanced cases:
 
@@ -74,6 +75,7 @@ Flags are parsed by the handler of each subcommand.
 - `mining` — `--seconds` / `-s` (default `6`, `0` returns to instant mining), `--fork-url` / `-f` (default `http://127.0.0.1:8545`).
 - `relayer` — `--router` / `-r` (required), `--agent` / `-a` (required) — both come from the address banner `setup` prints; `--fork-url` / `-f`, `--deployer-pk`, `--poll` (seconds between ticks, default `1`), `--from-block N` (first block to backfill from, default `0` — full history), `--disable-autoclaim` (observe events but skip the claim; simulates a downed keeper).
 - `fail-gateway` — either `--status` (read-only, prints the current state) or `--kind` / `-k` (`deposit` | `redeem`) + `--mode` / `-m` (`off` | `on` | `slippage` | `fee` | `unknown`). Optional: `--fork-url` / `-f`, `--deployer-pk`.
+- `keeper` — `--action` (`cancel` | `retry`), `--agent` / `-a` (from the `setup` banner), `--request-id` / `-i` (uint256). Optional: `--value` (wei, retry only), `--fork-url` / `-f`, `--deployer-pk`.
 
 ## Cooldown
 
@@ -168,6 +170,37 @@ pnpm --filter portal sandbox:hemi-earn -- fail-gateway --kind deposit --mode fee
 # Reset both sides so operations succeed again
 pnpm --filter portal sandbox:hemi-earn -- fail-gateway --kind deposit --mode off
 pnpm --filter portal sandbox:hemi-earn -- fail-gateway --kind redeem --mode off
+```
+
+## Keeper actions
+
+The production keeper can resolve a REMOTE_FAILED request (or a mid-cooldown redeem) before the user clicks the recovery CTA in the portal — the "keeper wins the race" path. When that happens on-chain, `Agent.failedRequests[id].tokenIn` (or `Agent.unstakeRequests[id].share`) goes to zero and the portal must hide its recovery CTAs on the next refetch. The `keeper` subcommand fires those Agent-side actions manually so that branch of the UI is testable end-to-end.
+
+Two actions, one dispatch:
+
+- `--action cancel` — pre-flight probes `failedRequests` then `unstakeRequests` (matches the production `Agent.cancel` order) and picks the branch automatically. Errors out with a diagnostic if the request is in neither map.
+- `--action retry` — pre-flight requires the request to be in `failedRequests`; post-flight re-reads and reports whether the entry cleared (success) or is still populated (underlying failure still active — clear it via `fail-gateway --mode off` first).
+
+Signer is the default anvil `#0`, which the sandbox `setup` registers as a keeper on the `ToggleableAgent`. `--agent` is required — copy it from the address banner `setup` prints.
+
+```bash
+# Cancel a stuck REMOTE_FAILED request (failed branch — after fail-gateway + submit)
+pnpm --filter portal sandbox:hemi-earn -- keeper \
+  --action cancel \
+  --agent 0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6 \
+  --request-id 42
+
+# Cancel a redeem mid-cooldown (unstake branch — before the relayer autoclaim fires)
+pnpm --filter portal sandbox:hemi-earn -- keeper \
+  --action cancel \
+  --agent 0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6 \
+  --request-id 43
+
+# Retry a REMOTE_FAILED redeem after clearing the failure mode
+pnpm --filter portal sandbox:hemi-earn -- keeper \
+  --action retry \
+  --agent 0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6 \
+  --request-id 44
 ```
 
 ## Mock contracts

--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -179,7 +179,7 @@ The production keeper can resolve a REMOTE_FAILED request (or a mid-cooldown red
 Two actions, one dispatch:
 
 - `--action cancel` — pre-flight probes `failedRequests` then `unstakeRequests` (matches the production `Agent.cancel` order) and picks the branch automatically. Errors out with a diagnostic if the request is in neither map.
-- `--action retry` — pre-flight requires the request to be in `failedRequests`; post-flight re-reads and reports whether the entry cleared (success) or is still populated (underlying failure still active — clear it via `fail-gateway --mode off` first).
+- `--action retry` — pre-flight requires the request to be in `failedRequests`; post-flight re-reads and reports whether the entry cleared (success) or is still populated (underlying failure still active — clear it via `fail-gateway --kind <deposit|redeem> --mode off` first).
 
 Signer is the default anvil `#0`, which the sandbox `setup` registers as a keeper on the `ToggleableAgent`. `--agent` is required — copy it from the address banner `setup` prints.
 

--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -75,7 +75,7 @@ Flags are parsed by the handler of each subcommand.
 - `mining` — `--seconds` / `-s` (default `6`, `0` returns to instant mining), `--fork-url` / `-f` (default `http://127.0.0.1:8545`).
 - `relayer` — `--router` / `-r` (required), `--agent` / `-a` (required) — both come from the address banner `setup` prints; `--fork-url` / `-f`, `--deployer-pk`, `--poll` (seconds between ticks, default `1`), `--from-block N` (first block to backfill from, default `0` — full history), `--disable-autoclaim` (observe events but skip the claim; simulates a downed keeper).
 - `fail-gateway` — either `--status` (read-only, prints the current state) or `--kind` / `-k` (`deposit` | `redeem`) + `--mode` / `-m` (`off` | `on` | `slippage` | `fee` | `unknown`). Optional: `--fork-url` / `-f`, `--deployer-pk`.
-- `keeper` — `--action` (`cancel` | `retry`), `--agent` / `-a` (from the `setup` banner), `--request-id` / `-i` (uint256). Optional: `--value` (wei, retry only), `--fork-url` / `-f`, `--deployer-pk`.
+- `keeper` — `--action` (`cancel` | `retry`), `--agent` / `-a` (from the `setup` banner), `--request-id` / `-i` (uint256). Optional: `--value` (wei, used to top up `msg.value` under the mock's strict-fee mode), `--fork-url` / `-f`, `--deployer-pk`.
 
 ## Cooldown
 

--- a/portal/scripts/hemi-earn/index.ts
+++ b/portal/scripts/hemi-earn/index.ts
@@ -1,5 +1,6 @@
 import { scriptArgs } from './cli.ts'
 import { runFailGateway } from './failGateway.ts'
+import { runKeeper } from './keeper.ts'
 import { runMint } from './mint.ts'
 import { runRelayer } from './relayer.ts'
 import { runSetIntervalMining } from './setIntervalMining.ts'
@@ -7,6 +8,7 @@ import { runSetup } from './setup.ts'
 
 const HANDLERS = {
   'fail-gateway': runFailGateway,
+  'keeper': runKeeper,
   'mining': runSetIntervalMining,
   'mint': runMint,
   'relayer': runRelayer,

--- a/portal/scripts/hemi-earn/keeper.ts
+++ b/portal/scripts/hemi-earn/keeper.ts
@@ -1,0 +1,319 @@
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from 'node:util'
+import {
+  isAddress,
+  isAddressEqual,
+  parseAbiItem,
+  zeroAddress,
+  type Address,
+  type Hex,
+} from 'viem'
+
+import { scriptArgs } from './cli.ts'
+import { DEFAULT_DEPLOYER_PK, DEFAULT_FORK_URL } from './constants.ts'
+import { buildClients } from './rpcClients.ts'
+
+const ACTION_VALUES = ['cancel', 'retry'] as const
+type Action = (typeof ACTION_VALUES)[number]
+
+const isAction = (v: unknown): v is Action =>
+  (ACTION_VALUES as readonly string[]).includes(v as string)
+
+const failedRequestsAbi = parseAbiItem(
+  'function failedRequests(uint256) view returns ((address tokenIn, uint256 amountIn, bytes msgIn, uint256 nativeFee))',
+)
+const unstakeRequestsAbi = parseAbiItem(
+  'function unstakeRequests(uint256) view returns ((address share, uint256 shares, address asset, address operator, uint256 amountOutMin, uint256 nativeFee, uint256 unstakingRequestId, uint256 claimableAt))',
+)
+const agentCancelAbi = parseAbiItem(
+  'function cancel(uint256 requestId) payable',
+)
+const agentRetryAbi = parseAbiItem('function retry(uint256 requestId) payable')
+
+const stamp = () => new Date().toTimeString().slice(0, 8)
+const log = (msg: string) => console.log(`[${stamp()}] [keeper] ${msg}`)
+
+function printUsage() {
+  console.error(
+    'Usage: pnpm --filter portal sandbox:hemi-earn -- keeper --action <cancel|retry> --agent 0x… --request-id N [flags]',
+  )
+  console.error('  --action ACTION         cancel | retry (required)')
+  console.error(
+    '  -a, --agent ADDR        Agent address printed by setup (required)',
+  )
+  console.error(
+    '  -i, --request-id ID     uint256 requestId to act on (required)',
+  )
+  console.error(
+    '  [--value WEI]           msg.value in wei (default 0; only used by retry)',
+  )
+  console.error(
+    '  [-f FORK_URL]           anvil RPC (default http://127.0.0.1:8545)',
+  )
+  console.error(
+    '  [--deployer-pk PK]      signer key (default anvil #0, registered as keeper)',
+  )
+}
+
+function parseNonNegativeBigInt(raw: string, flag: string) {
+  try {
+    const parsed = BigInt(raw)
+    if (parsed < 0n) throw new Error('negative')
+    return parsed
+  } catch {
+    console.error(`✗ ${flag} must be a non-negative integer`)
+    printUsage()
+    return process.exit(1)
+  }
+}
+
+function validateDeployerPk(pk: string) {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(pk)) {
+    console.error(
+      '✗ --deployer-pk must be a 32-byte hex string starting with 0x',
+    )
+    printUsage()
+    process.exit(1)
+  }
+  return pk as Hex
+}
+
+function parseKeeperArgs(argv: string[]) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      'action': { type: 'string' },
+      'agent': { short: 'a', type: 'string' },
+      'deployer-pk': { type: 'string' },
+      'fork-url': { short: 'f', type: 'string' },
+      'request-id': { short: 'i', type: 'string' },
+      'value': { type: 'string' },
+    },
+    strict: true,
+  })
+
+  const agent = values.agent as Address | undefined
+  const rawId = values['request-id']
+  if (!isAction(values.action) || !agent || !isAddress(agent) || !rawId) {
+    printUsage()
+    process.exit(1)
+  }
+
+  return {
+    action: values.action,
+    agent,
+    deployerPk: validateDeployerPk(
+      values['deployer-pk'] ?? DEFAULT_DEPLOYER_PK,
+    ),
+    forkUrl: values['fork-url'] ?? DEFAULT_FORK_URL,
+    requestId: parseNonNegativeBigInt(rawId, '--request-id'),
+    value:
+      values.value === undefined
+        ? 0n
+        : parseNonNegativeBigInt(values.value, '--value'),
+  }
+}
+
+type PublicClient = Awaited<ReturnType<typeof buildClients>>['publicClient']
+type WalletClient = Awaited<ReturnType<typeof buildClients>>['walletClient']
+
+async function readFailedTokenIn({
+  agent,
+  publicClient,
+  requestId,
+}: {
+  agent: Address
+  publicClient: PublicClient
+  requestId: bigint
+}) {
+  const entry = await publicClient.readContract({
+    abi: [failedRequestsAbi],
+    address: agent,
+    args: [requestId],
+    functionName: 'failedRequests',
+  })
+  return entry.tokenIn
+}
+
+async function readUnstakeShare({
+  agent,
+  publicClient,
+  requestId,
+}: {
+  agent: Address
+  publicClient: PublicClient
+  requestId: bigint
+}) {
+  const entry = await publicClient.readContract({
+    abi: [unstakeRequestsAbi],
+    address: agent,
+    args: [requestId],
+    functionName: 'unstakeRequests',
+  })
+  return entry.share
+}
+
+// Mirror production Agent.cancel dispatch order: failedRequests first, then
+// unstakeRequests. Keeps the logged branch matching the on-chain path.
+async function runCancel({
+  account,
+  agent,
+  publicClient,
+  requestId,
+  walletClient,
+}: {
+  account: NonNullable<WalletClient['account']>
+  agent: Address
+  publicClient: PublicClient
+  requestId: bigint
+  walletClient: WalletClient
+}) {
+  const failedTokenIn = await readFailedTokenIn({
+    agent,
+    publicClient,
+    requestId,
+  })
+  const failedBranch = !isAddressEqual(failedTokenIn, zeroAddress)
+
+  let unstakeBranch = false
+  if (!failedBranch) {
+    const unstakeShare = await readUnstakeShare({
+      agent,
+      publicClient,
+      requestId,
+    })
+    unstakeBranch = !isAddressEqual(unstakeShare, zeroAddress)
+  }
+
+  if (!failedBranch && !unstakeBranch) {
+    throw new Error(
+      `request ${requestId} is in neither failedRequests nor unstakeRequests — nothing to cancel.\n` +
+        '  Expected either a REMOTE_FAILED request (via `fail-gateway` + submit) or a mid-cooldown redeem.',
+    )
+  }
+
+  const hash = await walletClient.writeContract({
+    abi: [agentCancelAbi],
+    account,
+    address: agent,
+    args: [requestId],
+    chain: walletClient.chain,
+    functionName: 'cancel',
+  })
+  const receipt = await publicClient.waitForTransactionReceipt({ hash })
+  if (receipt.status !== 'success') {
+    throw new Error(`Agent.cancel(${requestId}) reverted (tx ${hash})`)
+  }
+
+  const branch = failedBranch ? 'FAILED' : 'UNSTAKE'
+  log(
+    `Agent.cancel(${requestId}) sent — ${branch} branch (tx ${hash.slice(0, 14)}…)`,
+  )
+  log('  → Envio: RequestCancellationTriggered → RequestCancelled')
+  log('  → Portal: CTAs disappear on next refetch; drawer shows Recover')
+}
+
+async function runRetry({
+  account,
+  agent,
+  publicClient,
+  requestId,
+  value,
+  walletClient,
+}: {
+  account: NonNullable<WalletClient['account']>
+  agent: Address
+  publicClient: PublicClient
+  requestId: bigint
+  value: bigint
+  walletClient: WalletClient
+}) {
+  const beforeTokenIn = await readFailedTokenIn({
+    agent,
+    publicClient,
+    requestId,
+  })
+  if (isAddressEqual(beforeTokenIn, zeroAddress)) {
+    throw new Error(
+      `request ${requestId} is not in failedRequests — nothing to retry.\n` +
+        '  Trigger via `fail-gateway --kind <deposit|redeem> --mode <slippage|fee|unknown>` + submit deposit/redeem.',
+    )
+  }
+
+  const hash = await walletClient.writeContract({
+    abi: [agentRetryAbi],
+    account,
+    address: agent,
+    args: [requestId],
+    chain: walletClient.chain,
+    functionName: 'retry',
+    value,
+  })
+  const receipt = await publicClient.waitForTransactionReceipt({ hash })
+  if (receipt.status !== 'success') {
+    throw new Error(`Agent.retry(${requestId}) reverted (tx ${hash})`)
+  }
+
+  const afterTokenIn = await readFailedTokenIn({
+    agent,
+    publicClient,
+    requestId,
+  })
+  if (isAddressEqual(afterTokenIn, zeroAddress)) {
+    log(
+      `Agent.retry(${requestId}) succeeded — failedRequests cleared (tx ${hash.slice(0, 14)}…)`,
+    )
+    log(
+      '  → Envio: retryCount++, failed=false, status advances (FULFILLED/FINALIZED)',
+    )
+    log('  → Portal: REMOTE_FAILED CTAs disappear on next refetch')
+    return
+  }
+
+  log(
+    `Agent.retry(${requestId}) fired but failedRequests still populated (tx ${hash.slice(0, 14)}…)`,
+  )
+  log(
+    '  → Underlying failure still active — clear via `fail-gateway --kind X --mode off` first',
+  )
+}
+
+export async function runKeeper(argv: string[]) {
+  const { action, agent, deployerPk, forkUrl, requestId, value } =
+    parseKeeperArgs(argv)
+  const { publicClient, walletClient } = await buildClients({
+    deployerPk,
+    forkUrl,
+  })
+  const account = walletClient.account
+  if (!account) {
+    throw new Error(
+      'buildClients did not return an account — check --deployer-pk',
+    )
+  }
+
+  log(`action=${action} agent=${agent} requestId=${requestId}`)
+
+  if (action === 'cancel') {
+    await runCancel({ account, agent, publicClient, requestId, walletClient })
+    return
+  }
+  await runRetry({
+    account,
+    agent,
+    publicClient,
+    requestId,
+    value,
+    walletClient,
+  })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await runKeeper(scriptArgs())
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`\n✗ keeper failed: ${message}`)
+    process.exit(1)
+  }
+}

--- a/portal/scripts/hemi-earn/keeper.ts
+++ b/portal/scripts/hemi-earn/keeper.ts
@@ -45,7 +45,7 @@ function printUsage() {
     '  -i, --request-id ID     uint256 requestId to act on (required)',
   )
   console.error(
-    '  [--value WEI]           msg.value in wei (default 0; only used by retry)',
+    '  [--value WEI]           msg.value in wei (default 0; top-up under strict-fee mode)',
   )
   console.error(
     '  [-f FORK_URL]           anvil RPC (default http://127.0.0.1:8545)',
@@ -160,12 +160,14 @@ async function runCancel({
   agent,
   publicClient,
   requestId,
+  value,
   walletClient,
 }: {
   account: NonNullable<WalletClient['account']>
   agent: Address
   publicClient: PublicClient
   requestId: bigint
+  value: bigint
   walletClient: WalletClient
 }) {
   const failedTokenIn = await readFailedTokenIn({
@@ -199,6 +201,7 @@ async function runCancel({
     args: [requestId],
     chain: walletClient.chain,
     functionName: 'cancel',
+    value,
   })
   const receipt = await publicClient.waitForTransactionReceipt({ hash })
   if (receipt.status !== 'success') {
@@ -295,7 +298,14 @@ export async function runKeeper(argv: string[]) {
   log(`action=${action} agent=${agent} requestId=${requestId}`)
 
   if (action === 'cancel') {
-    await runCancel({ account, agent, publicClient, requestId, walletClient })
+    await runCancel({
+      account,
+      agent,
+      publicClient,
+      requestId,
+      value,
+      walletClient,
+    })
     return
   }
   await runRetry({


### PR DESCRIPTION
### Description

This PR adds a `keeper` subcommand to the hemi-earn sandbox scripts so the "keeper wins the race" branch of the portal UI becomes testable locally.

The portal has two paths that only fire when a production keeper resolves a request before the user clicks the recovery CTA: a REMOTE_FAILED request whose `failedRequests[id].tokenIn` has gone to zero, and a mid-cooldown redeem cancelled cross-chain via `Agent.cancel`. There was no way to trigger those Agent-side actions from the ui-monorepo sandbox, so the corresponding UI branches were only exercised on real deployments.

The new subcommand dispatches `Agent.cancel` or `Agent.retry` by request id. For cancel, it probes `failedRequests` then `unstakeRequests` (matching the production `Agent.cancel` order) and picks the branch automatically, or bails out with a diagnostic if the request is in neither map. For retry, it requires the entry to exist in `failedRequests` and reads it back after the tx to report whether the entry cleared or the underlying failure still holds. Both actions guard on `receipt.status` so a reverting tx surfaces as an error rather than a false success.

Wired into the dispatcher alongside the other subcommands and documented under a new "Keeper actions" section in the sandbox README, with invocation examples for the failed branch, unstake branch, and retry.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #2092 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
