### PR TITLE
Bump Docker actions to their Node 24 majors

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -27,9 +27,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+    - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     - id: meta
-      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       with:
         images: ${{ inputs.images }}
         tags: |
@@ -38,11 +38,11 @@ runs:
           type=ref,event=tag
           type=sha,prefix=
           type=semver,pattern={{version}},value=${{ inputs.version }}
-    - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+    - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         password: ${{ inputs.dockerHubPassword }}
         username: ${{ inputs.dockerHubUsername }}
-    - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+    - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}

--- a/.github/workflows/docker-checks.yml
+++ b/.github/workflows/docker-checks.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: docker build --tag ${{ matrix.image }}:local ${{ matrix.dockerfile && format('-f {0} ', matrix.dockerfile) || '' }}.
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -1,6 +1,6 @@
 # Portal Backend
 
-The portal backend is composed by an API and several cron jobs.
+The portal backend is composed of an API and several cron jobs.
 
 ## API
 


### PR DESCRIPTION
### Description

GitHub Actions now force-runs Node 20 actions on Node 24 and annotates every `build-and-push` run with a deprecation warning. All four actions named in the warning have since shipped Node 24 majors, so this pins `.github/actions/docker-build-push` to them:

- `docker/setup-buildx-action` v3.12.0 → v4.2.0
- `docker/metadata-action` v5.10.0 → v6.2.0
- `docker/login-action` v3.7.0 → v4.6.0
- `docker/build-push-action` v6.19.2 → v7.3.0

`docker-checks.yml` pinned the same `docker/login-action@v3.7.0` and would emit the identical warning on its own runs, so it's bumped too.

`docker/scout-action` is left alone on purpose — it's already on Node 24, which is why it wasn't part of the warning.

The README typo fix is what makes CI cover any of this: with only `.github/**` touched, both Docker workflows' path filters skip the PR entirely. Touching a file under `portal-backend/**` gets `docker-checks.yml` to run, which exercises the new `login-action` pin. The other three pins live in the composite action, which only `build-push-images.yml` uses — and that one is `on: push` to `main`, so it can't run until this merges.

**Commits:**

- fac29839 Bump Docker actions to their Node 24 majors
- 69a000ae Fix grammar in portal-backend README

### Screenshots

N/A — CI-only change.

### Related issue(s)

Closes #2178

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
