### PR TITLE
Decouple evmApi from the wallet context

### DIFF
--- a/portal/context/evmWalletContext.tsx
+++ b/portal/context/evmWalletContext.tsx
@@ -72,7 +72,7 @@ const connectors = connectorsForWallets(
   },
 )
 
-export const allEvmNetworksWalletConfig = createConfig({
+const allEvmNetworksWalletConfig = createConfig({
   chains: allEvmNetworks,
   connectors: [
     walletConnect({

--- a/portal/test/utils/evmApi.test.ts
+++ b/portal/test/utils/evmApi.test.ts
@@ -1,45 +1,50 @@
 import { type Chain, type Hash } from 'viem'
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('utils/chainClients', () => ({
   getPublicClient: vi.fn(),
 }))
 
-type MockedClient = {
-  getBlock: Mock
-  getTransactionReceipt: Mock
-}
+vi.mock('viem/actions', () => ({
+  getBlock: vi.fn(),
+  getTransactionReceipt: vi.fn(),
+}))
 
 const chainId: Chain['id'] = 1
 const otherChainId: Chain['id'] = 10
 const hash: Hash =
   '0x0000000000000000000000000000000000000000000000000000000000000001'
 
-const createClient = () => ({
-  getBlock: vi.fn().mockResolvedValue({ timestamp: BigInt(0) }),
-  getTransactionReceipt: vi.fn().mockResolvedValue(null),
-})
-
 // evmApi memoizes public clients in module scope, so each test needs its own
-// copy of the module - and of the mocked factory it captured.
+// copy of the module and of the mocks it captured. The client itself is opaque
+// here: evmApi only forwards it to the viem actions, so asserting which
+// instance they got is what proves the memoization.
 const setup = async function () {
-  const clients = new Map<Chain['id'], MockedClient>()
-  // Get-or-create, so a test can stub a client without that lookup counting as
-  // a call to the factory under assertion.
+  const clients = new Map<Chain['id'], object>()
   const clientFor = function (id: Chain['id']) {
     if (!clients.has(id)) {
-      clients.set(id, createClient())
+      clients.set(id, { chain: id })
     }
-    return clients.get(id) as MockedClient
+    return clients.get(id) as object
   }
 
   const { getPublicClient } = await import('utils/chainClients')
   vi.mocked(getPublicClient).mockImplementation(
-    id => clientFor(id) as unknown as ReturnType<typeof getPublicClient>,
+    id => clientFor(id) as ReturnType<typeof getPublicClient>,
   )
 
+  const { getBlock, getTransactionReceipt } = await import('viem/actions')
+  vi.mocked(getBlock).mockResolvedValue({ timestamp: BigInt(0) } as never)
+  vi.mocked(getTransactionReceipt).mockResolvedValue(null as never)
+
   const evmApi = await import('utils/evmApi')
-  return { clientFor, evmApi, getPublicClient: vi.mocked(getPublicClient) }
+  return {
+    clientFor,
+    evmApi,
+    getBlock: vi.mocked(getBlock),
+    getPublicClient: vi.mocked(getPublicClient),
+    getTransactionReceipt: vi.mocked(getTransactionReceipt),
+  }
 }
 
 const notFoundError = function () {
@@ -54,8 +59,8 @@ beforeEach(function () {
 
 describe('getEvmTransactionReceipt', function () {
   it('should return null when the receipt is not found', async function () {
-    const { clientFor, evmApi } = await setup()
-    clientFor(chainId).getTransactionReceipt.mockRejectedValue(notFoundError())
+    const { evmApi, getTransactionReceipt } = await setup()
+    getTransactionReceipt.mockRejectedValue(notFoundError())
 
     await expect(
       evmApi.getEvmTransactionReceipt(hash, chainId),
@@ -63,10 +68,8 @@ describe('getEvmTransactionReceipt', function () {
   })
 
   it('should rethrow any other error', async function () {
-    const { clientFor, evmApi } = await setup()
-    clientFor(chainId).getTransactionReceipt.mockRejectedValue(
-      new Error('rpc is down'),
-    )
+    const { evmApi, getTransactionReceipt } = await setup()
+    getTransactionReceipt.mockRejectedValue(new Error('rpc is down'))
 
     await expect(
       evmApi.getEvmTransactionReceipt(hash, chainId),
@@ -74,63 +77,72 @@ describe('getEvmTransactionReceipt', function () {
   })
 
   it('should reuse the same client across calls to the same chain', async function () {
-    const { clientFor, evmApi, getPublicClient } = await setup()
+    const { clientFor, evmApi, getPublicClient, getTransactionReceipt } =
+      await setup()
 
     await evmApi.getEvmTransactionReceipt(hash, chainId)
     await evmApi.getEvmTransactionReceipt(hash, chainId)
 
     expect(getPublicClient).toHaveBeenCalledExactlyOnceWith(chainId)
-    expect(clientFor(chainId).getTransactionReceipt).toHaveBeenCalledTimes(2)
+    expect(getTransactionReceipt).toHaveBeenCalledTimes(2)
+    expect(getTransactionReceipt).toHaveBeenNthCalledWith(
+      2,
+      clientFor(chainId),
+      { hash },
+    )
   })
 
   it('should use a distinct client per chain', async function () {
-    const { clientFor, evmApi } = await setup()
+    const { clientFor, evmApi, getTransactionReceipt } = await setup()
 
     await evmApi.getEvmTransactionReceipt(hash, chainId)
     await evmApi.getEvmTransactionReceipt(hash, otherChainId)
 
     expect(clientFor(chainId)).not.toBe(clientFor(otherChainId))
-    expect(
-      clientFor(chainId).getTransactionReceipt,
-    ).toHaveBeenCalledExactlyOnceWith({ hash })
-    expect(
-      clientFor(otherChainId).getTransactionReceipt,
-    ).toHaveBeenCalledExactlyOnceWith({ hash })
+    expect(getTransactionReceipt).toHaveBeenNthCalledWith(
+      1,
+      clientFor(chainId),
+      { hash },
+    )
+    expect(getTransactionReceipt).toHaveBeenNthCalledWith(
+      2,
+      clientFor(otherChainId),
+      { hash },
+    )
   })
 })
 
 describe('getEvmBlock', function () {
   it('should convert the block number into a BigInt and go through the memoized client', async function () {
-    const { clientFor, evmApi } = await setup()
+    const { clientFor, evmApi, getBlock } = await setup()
     const block = { timestamp: BigInt(1630000000) }
-    clientFor(chainId).getBlock.mockResolvedValue(block)
+    getBlock.mockResolvedValue(block as never)
 
     await expect(evmApi.getEvmBlock(100, chainId)).resolves.toStrictEqual(block)
 
-    expect(clientFor(chainId).getBlock).toHaveBeenCalledExactlyOnceWith({
+    expect(getBlock).toHaveBeenCalledExactlyOnceWith(clientFor(chainId), {
       blockNumber: BigInt(100),
     })
   })
 
   it('should memoize repeated reads of the same block', async function () {
-    const { clientFor, evmApi } = await setup()
-    clientFor(chainId).getBlock.mockResolvedValue({ timestamp: BigInt(1) })
+    const { evmApi, getBlock } = await setup()
 
     await evmApi.getEvmBlock(100, chainId)
     await evmApi.getEvmBlock(100, chainId)
 
-    expect(clientFor(chainId).getBlock).toHaveBeenCalledOnce()
+    expect(getBlock).toHaveBeenCalledOnce()
   })
 
   it('should key the memo by chain, so the same block number does not collide', async function () {
-    const { clientFor, evmApi } = await setup()
-    clientFor(chainId).getBlock.mockResolvedValue({ timestamp: BigInt(1) })
-    clientFor(otherChainId).getBlock.mockResolvedValue({ timestamp: BigInt(2) })
+    const { clientFor, evmApi, getBlock } = await setup()
 
     await evmApi.getEvmBlock(100, chainId)
     await evmApi.getEvmBlock(100, otherChainId)
 
-    expect(clientFor(chainId).getBlock).toHaveBeenCalledOnce()
-    expect(clientFor(otherChainId).getBlock).toHaveBeenCalledOnce()
+    expect(getBlock).toHaveBeenCalledTimes(2)
+    expect(getBlock).toHaveBeenNthCalledWith(2, clientFor(otherChainId), {
+      blockNumber: BigInt(100),
+    })
   })
 })

--- a/portal/test/utils/evmApi.test.ts
+++ b/portal/test/utils/evmApi.test.ts
@@ -1,0 +1,136 @@
+import { type Chain, type Hash } from 'viem'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+
+vi.mock('utils/chainClients', () => ({
+  getPublicClient: vi.fn(),
+}))
+
+type MockedClient = {
+  getBlock: Mock
+  getTransactionReceipt: Mock
+}
+
+const chainId: Chain['id'] = 1
+const otherChainId: Chain['id'] = 10
+const hash: Hash =
+  '0x0000000000000000000000000000000000000000000000000000000000000001'
+
+const createClient = () => ({
+  getBlock: vi.fn().mockResolvedValue({ timestamp: BigInt(0) }),
+  getTransactionReceipt: vi.fn().mockResolvedValue(null),
+})
+
+// evmApi memoizes public clients in module scope, so each test needs its own
+// copy of the module - and of the mocked factory it captured.
+const setup = async function () {
+  const clients = new Map<Chain['id'], MockedClient>()
+  // Get-or-create, so a test can stub a client without that lookup counting as
+  // a call to the factory under assertion.
+  const clientFor = function (id: Chain['id']) {
+    if (!clients.has(id)) {
+      clients.set(id, createClient())
+    }
+    return clients.get(id) as MockedClient
+  }
+
+  const { getPublicClient } = await import('utils/chainClients')
+  vi.mocked(getPublicClient).mockImplementation(
+    id => clientFor(id) as unknown as ReturnType<typeof getPublicClient>,
+  )
+
+  const evmApi = await import('utils/evmApi')
+  return { clientFor, evmApi, getPublicClient: vi.mocked(getPublicClient) }
+}
+
+const notFoundError = function () {
+  const error = new Error('Transaction receipt not found')
+  error.name = 'TransactionReceiptNotFoundError'
+  return error
+}
+
+beforeEach(function () {
+  vi.resetModules()
+})
+
+describe('getEvmTransactionReceipt', function () {
+  it('should return null when the receipt is not found', async function () {
+    const { clientFor, evmApi } = await setup()
+    clientFor(chainId).getTransactionReceipt.mockRejectedValue(notFoundError())
+
+    await expect(
+      evmApi.getEvmTransactionReceipt(hash, chainId),
+    ).resolves.toBeNull()
+  })
+
+  it('should rethrow any other error', async function () {
+    const { clientFor, evmApi } = await setup()
+    clientFor(chainId).getTransactionReceipt.mockRejectedValue(
+      new Error('rpc is down'),
+    )
+
+    await expect(
+      evmApi.getEvmTransactionReceipt(hash, chainId),
+    ).rejects.toThrow('rpc is down')
+  })
+
+  it('should reuse the same client across calls to the same chain', async function () {
+    const { clientFor, evmApi, getPublicClient } = await setup()
+
+    await evmApi.getEvmTransactionReceipt(hash, chainId)
+    await evmApi.getEvmTransactionReceipt(hash, chainId)
+
+    expect(getPublicClient).toHaveBeenCalledExactlyOnceWith(chainId)
+    expect(clientFor(chainId).getTransactionReceipt).toHaveBeenCalledTimes(2)
+  })
+
+  it('should use a distinct client per chain', async function () {
+    const { clientFor, evmApi } = await setup()
+
+    await evmApi.getEvmTransactionReceipt(hash, chainId)
+    await evmApi.getEvmTransactionReceipt(hash, otherChainId)
+
+    expect(clientFor(chainId)).not.toBe(clientFor(otherChainId))
+    expect(
+      clientFor(chainId).getTransactionReceipt,
+    ).toHaveBeenCalledExactlyOnceWith({ hash })
+    expect(
+      clientFor(otherChainId).getTransactionReceipt,
+    ).toHaveBeenCalledExactlyOnceWith({ hash })
+  })
+})
+
+describe('getEvmBlock', function () {
+  it('should convert the block number into a BigInt and go through the memoized client', async function () {
+    const { clientFor, evmApi } = await setup()
+    const block = { timestamp: BigInt(1630000000) }
+    clientFor(chainId).getBlock.mockResolvedValue(block)
+
+    await expect(evmApi.getEvmBlock(100, chainId)).resolves.toStrictEqual(block)
+
+    expect(clientFor(chainId).getBlock).toHaveBeenCalledExactlyOnceWith({
+      blockNumber: BigInt(100),
+    })
+  })
+
+  it('should memoize repeated reads of the same block', async function () {
+    const { clientFor, evmApi } = await setup()
+    clientFor(chainId).getBlock.mockResolvedValue({ timestamp: BigInt(1) })
+
+    await evmApi.getEvmBlock(100, chainId)
+    await evmApi.getEvmBlock(100, chainId)
+
+    expect(clientFor(chainId).getBlock).toHaveBeenCalledOnce()
+  })
+
+  it('should key the memo by chain, so the same block number does not collide', async function () {
+    const { clientFor, evmApi } = await setup()
+    clientFor(chainId).getBlock.mockResolvedValue({ timestamp: BigInt(1) })
+    clientFor(otherChainId).getBlock.mockResolvedValue({ timestamp: BigInt(2) })
+
+    await evmApi.getEvmBlock(100, chainId)
+    await evmApi.getEvmBlock(100, otherChainId)
+
+    expect(clientFor(chainId).getBlock).toHaveBeenCalledOnce()
+    expect(clientFor(otherChainId).getBlock).toHaveBeenCalledOnce()
+  })
+})

--- a/portal/utils/evmApi.ts
+++ b/portal/utils/evmApi.ts
@@ -1,17 +1,24 @@
-import {
-  getBlock,
-  getTransactionReceipt as wagmiGetTransactionReceipt,
-} from '@wagmi/core'
-import { allEvmNetworksWalletConfig } from 'context/evmWalletContext'
 import pMemoize from 'promise-mem'
+import { getPublicClient } from 'utils/chainClients'
 import { type Chain, type Hash, type TransactionReceipt } from 'viem'
+
+const clients = new Map<Chain['id'], ReturnType<typeof getPublicClient>>()
+
+// buildTransport() wires an eth-rpc-cache whose state lives inside the
+// transport, so a fresh client per call would never hit the cache.
+const getClient = function (chainId: Chain['id']) {
+  const existing = clients.get(chainId)
+  if (existing) {
+    return existing
+  }
+  const client = getPublicClient(chainId)
+  clients.set(chainId, client)
+  return client
+}
 
 export const getEvmBlock = pMemoize(
   (blockNumber: bigint | number, chainId: Chain['id']) =>
-    getBlock(allEvmNetworksWalletConfig, {
-      blockNumber: BigInt(blockNumber),
-      chainId,
-    }),
+    getClient(chainId).getBlock({ blockNumber: BigInt(blockNumber) }),
   { resolver: (blockNumber, chainId) => `${blockNumber}-${chainId}` },
 )
 
@@ -19,13 +26,12 @@ export const getEvmTransactionReceipt = (
   hash: Hash,
   chainId: Chain['id'],
 ): Promise<TransactionReceipt | null> =>
-  wagmiGetTransactionReceipt(allEvmNetworksWalletConfig, {
-    chainId,
-    hash,
-  }).catch(function (err) {
-    // Do nothing if the TX was not found, as that throws
-    if (err.name === 'TransactionReceiptNotFoundError') {
-      return null
-    }
-    throw err
-  })
+  getClient(chainId)
+    .getTransactionReceipt({ hash })
+    .catch(function (err) {
+      // Do nothing if the TX was not found, as that throws
+      if (err.name === 'TransactionReceiptNotFoundError') {
+        return null
+      }
+      throw err
+    })

--- a/portal/utils/evmApi.ts
+++ b/portal/utils/evmApi.ts
@@ -1,6 +1,7 @@
 import pMemoize from 'promise-mem'
 import { getPublicClient } from 'utils/chainClients'
 import { type Chain, type Hash, type TransactionReceipt } from 'viem'
+import { getBlock, getTransactionReceipt } from 'viem/actions'
 
 const clients = new Map<Chain['id'], ReturnType<typeof getPublicClient>>()
 
@@ -18,7 +19,7 @@ const getClient = function (chainId: Chain['id']) {
 
 export const getEvmBlock = pMemoize(
   (blockNumber: bigint | number, chainId: Chain['id']) =>
-    getClient(chainId).getBlock({ blockNumber: BigInt(blockNumber) }),
+    getBlock(getClient(chainId), { blockNumber: BigInt(blockNumber) }),
   { resolver: (blockNumber, chainId) => `${blockNumber}-${chainId}` },
 )
 
@@ -26,12 +27,10 @@ export const getEvmTransactionReceipt = (
   hash: Hash,
   chainId: Chain['id'],
 ): Promise<TransactionReceipt | null> =>
-  getClient(chainId)
-    .getTransactionReceipt({ hash })
-    .catch(function (err) {
-      // Do nothing if the TX was not found, as that throws
-      if (err.name === 'TransactionReceiptNotFoundError') {
-        return null
-      }
-      throw err
-    })
+  getTransactionReceipt(getClient(chainId), { hash }).catch(function (err) {
+    // Do nothing if the TX was not found, as that throws
+    if (err.name === 'TransactionReceiptNotFoundError') {
+      return null
+    }
+    throw err
+  })


### PR DESCRIPTION
### Description

This PR removes the dependency between `utils/evmApi` and the EVM wallet context, which is the first step of the portal's Vite migration.

Reading a block or a transaction receipt only needs a chain and a transport, but `evmApi` was pulling the wagmi `Config` out of `context/evmWalletContext`. That dragged RainbowKit, wagmi connectors and `react-device-detect` into every web worker that imports it, and those touch `window` at module scope. Turbopack happens to tree-shake all of it away today (I checked the current export, and there is no wallet code anywhere in the worker chunks), so production is fine, but Rollup does not, and under Vite three of the five tunnel workers die on startup.

The replacement is `getPublicClient` from `utils/chainClients`, which already builds a plain viem client with no wallet dependency and is already used by `utils/watch/bitcoinWithdrawals.ts`. The transport is identical either way, since wagmi's config was built from the same `buildTransport` per chain. Clients are memoized per chain because `buildTransport` wires an `eth-rpc-cache` whose state lives inside the transport, so creating a fresh client on every call would never hit the cache. `allEvmNetworksWalletConfig` is no longer exported, since `evmApi` was its only consumer outside the context.

The three existing `utils/watch` test files mock `utils/evmApi` wholesale, so the module had no coverage of its own. The new tests cover the parts that actually hold logic, and I verified by mutation that they fail when the memoization or the memo key is broken.

Broken down into:
- `1086a98` - Use a wallet-free public client in evmApi
- `a242c52` - Add tests for evmApi

### Screenshots

N/A - No UI changes

### Related issue(s)

Related to #2194 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
