### PR TITLE
Use camelCase for hemi-earn constants

### DIFF
--- a/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
@@ -10,7 +10,7 @@ import { PoolToast } from '../pool/[shareAddress]/_components/poolToast'
 import { type EarnTransactionKindType } from '../types'
 
 // Match the <Toast> primitive's 10s auto-close so its close animation isn't cut short.
-const TOAST_MS = 10_000
+const toastMs = 10_000
 
 type Props = {
   kind: EarnTransactionKindType
@@ -83,7 +83,7 @@ export const EarnSuccessToast = function ({ kind, title }: Props) {
   useEffect(
     function unlatchAfterToastWindow() {
       if (latchedKey === undefined) return undefined
-      const timer = setTimeout(() => setLatched(null), TOAST_MS)
+      const timer = setTimeout(() => setLatched(null), toastMs)
       return () => clearTimeout(timer)
     },
     [latchedKey],

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
@@ -61,7 +61,7 @@ const SettleForm = ({
 type SettleOperation = 'CLAIM' | 'RECOVER'
 
 // (kind, operation) matrix so the Router action and its label stay in lockstep across call sites.
-const SETTLE_CONFIG = {
+const settleConfig = {
   DEPOSIT: {
     CLAIM: { action: claimDeposit, label: 'claim-share-tokens' },
     RECOVER: { action: recoverDeposit, label: 'recover-funds' },
@@ -96,7 +96,7 @@ export const SettleCta = function ({
   const tCommon = useTranslations('common')
   const [, setTxDrawerQueryString] = useTxDrawerQueryString()
 
-  const { action, label } = SETTLE_CONFIG[transaction.kind][operation]
+  const { action, label } = settleConfig[transaction.kind][operation]
   const deliversShares =
     (transaction.kind === 'DEPOSIT') === (operation === 'CLAIM')
 

--- a/portal/app/[locale]/hemi-earn/_constants/cooldown.ts
+++ b/portal/app/[locale]/hemi-earn/_constants/cooldown.ts
@@ -1,0 +1,4 @@
+import { secondsPerHour } from 'utils/time'
+
+// Governance-controlled and rarely changes; cache for hours to avoid refetch on every focus/reconnect.
+export const cooldownStaleTimeMs = 4 * secondsPerHour * 1000

--- a/portal/app/[locale]/hemi-earn/_constants/slippage.ts
+++ b/portal/app/[locale]/hemi-earn/_constants/slippage.ts
@@ -13,17 +13,17 @@ export const veryHighSlippageThreshold = 10
 export const lowSlippageThreshold = 0.1
 export const maxSlippage = 100
 
-const BPS_DENOMINATOR = BigInt(10000)
+const bpsDenominator = BigInt(10000)
 
 // Clamp to 1n so a floor-divided 0n can't become an on-chain "accept zero out";
 // reject out-of-range bps so a misconfigured value can't slip into the same failure mode.
 export function applySlippage(amount: bigint, bps: bigint): bigint {
-  if (bps < BigInt(0) || bps > BPS_DENOMINATOR) {
+  if (bps < BigInt(0) || bps > bpsDenominator) {
     throw new RangeError(
-      `applySlippage: bps must be in [0, ${BPS_DENOMINATOR}], got ${bps}`,
+      `applySlippage: bps must be in [0, ${bpsDenominator}], got ${bps}`,
     )
   }
   if (amount <= BigInt(0)) return BigInt(0)
-  const result = (amount * (BPS_DENOMINATOR - bps)) / BPS_DENOMINATOR
+  const result = (amount * (bpsDenominator - bps)) / bpsDenominator
   return result > BigInt(0) ? result : BigInt(1)
 }

--- a/portal/app/[locale]/hemi-earn/_context/localEarnOperationsContext.tsx
+++ b/portal/app/[locale]/hemi-earn/_context/localEarnOperationsContext.tsx
@@ -8,15 +8,16 @@ import {
   useMemo,
 } from 'react'
 import useLocalStorageState from 'use-local-storage-state'
+import { secondsPerDay } from 'utils/time'
 import { type Address, type Hash } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { hashesMatch } from '../_utils/hashes'
 import { type EarnSettlement, type LocalEarnOperation } from '../types'
 
-const STORAGE_KEY = 'hemi-earn:local-operations'
-const TTL_SECONDS = 90 * 24 * 60 * 60
-const MAX_ENTRIES_PER_ACCOUNT = 100
+const storageKey = 'hemi-earn:local-operations'
+const ttlSeconds = 90 * secondsPerDay
+const maxEntriesPerAccount = 100
 
 type Store = Record<string, LocalEarnOperation[]>
 
@@ -48,11 +49,11 @@ const normalizeAccount = (account: Address) => account.toLowerCase() as Address
 
 const garbageCollect = function (entries: LocalEarnOperation[]) {
   const nowSec = Math.floor(Date.now() / 1000)
-  const recent = entries.filter(e => nowSec - e.startedAt < TTL_SECONDS)
-  if (recent.length <= MAX_ENTRIES_PER_ACCOUNT) return recent
+  const recent = entries.filter(e => nowSec - e.startedAt < ttlSeconds)
+  if (recent.length <= maxEntriesPerAccount) return recent
   return [...recent]
     .sort((a, b) => b.startedAt - a.startedAt)
-    .slice(0, MAX_ENTRIES_PER_ACCOUNT)
+    .slice(0, maxEntriesPerAccount)
 }
 
 // Key by initiateTxHash once known; before that, the (account, startedAt) tuple identifies the signing session.
@@ -72,7 +73,7 @@ export const LocalEarnOperationsProvider = function ({
   children: ReactNode
 }) {
   const { address } = useAccount()
-  const [store, setStore] = useLocalStorageState<Store>(STORAGE_KEY, {
+  const [store, setStore] = useLocalStorageState<Store>(storageKey, {
     defaultValue: {},
   })
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useCooldownDuration.ts
@@ -4,8 +4,7 @@ import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 
-// Governance-controlled and rarely changes; cache for hours to avoid refetch on every focus/reconnect.
-const STALE_TIME_MS = 4 * 60 * 60 * 1000
+import { cooldownStaleTimeMs } from '../_constants/cooldown'
 
 // Raw cooldown duration in seconds (callers convert to days as needed).
 export const useCooldownDuration = ({
@@ -25,5 +24,5 @@ export const useCooldownDuration = ({
       return Number(seconds)
     },
     queryKey: ['hemi-earn', 'cooldown-duration', stakingVault],
-    staleTime: STALE_TIME_MS,
+    staleTime: cooldownStaleTimeMs,
   })

--- a/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useIsCooldownEligible.ts
@@ -4,8 +4,7 @@ import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'
 import { type Address } from 'viem'
 
-// Governance-controlled and rarely changes; cache for hours to avoid refetch on every focus/reconnect.
-const STALE_TIME_MS = 4 * 60 * 60 * 1000
+import { cooldownStaleTimeMs } from '../_constants/cooldown'
 
 // True when the caller is subject to the withdraw cooldown — the inverse of resolveIsInstant, for gating UI on one boolean.
 export const useIsCooldownEligible = ({
@@ -26,5 +25,5 @@ export const useIsCooldownEligible = ({
       return !isInstant
     },
     queryKey: ['hemi-earn', 'cooldown-eligible', stakingVault, account],
-    staleTime: STALE_TIME_MS,
+    staleTime: cooldownStaleTimeMs,
   })

--- a/portal/app/[locale]/hemi-earn/_utils/transactionPredicates.ts
+++ b/portal/app/[locale]/hemi-earn/_utils/transactionPredicates.ts
@@ -85,7 +85,7 @@ export const isCooldownMature = (
 
 // Grace before offering Retry/Cancel on a remote failure, so the keeper gets first crack at
 // auto-recovering it. Anchored on the request's receivedAt (== the failure block).
-const REMOTE_FAILED_GRACE_SECONDS = 120
+const remoteFailedGraceSeconds = 120
 
 // Grace gate for the remote-failed CTAs: stay quiet right after the failure so the keeper can
 // auto-recover, unless slippage (needs a user call), a keeper retry already failed, or the grace elapsed.
@@ -105,5 +105,5 @@ export const shouldShowRemoteFailedCtas = function ({
   if ((tx.retryCount ?? 0) > 0) return true
   // Guard against a missing / '0' / non-numeric receivedAt so the grace can't be skipped by Number(...) === 0.
   const receivedAt = Number(tx.receivedAt ?? 0)
-  return receivedAt > 0 && nowSec - receivedAt > REMOTE_FAILED_GRACE_SECONDS
+  return receivedAt > 0 && nowSec - receivedAt > remoteFailedGraceSeconds
 }

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
@@ -11,6 +11,7 @@ import {
   formatPercentage,
   formatShortDate,
 } from 'utils/format'
+import { secondsPerDay } from 'utils/time'
 import {
   VictoryArea,
   VictoryAxis,
@@ -64,10 +65,10 @@ const AreaGradient = () => (
 )
 
 const periodDurations: Record<MetricPeriod, number> = {
-  '1m': 30 * 24 * 60 * 60 * 1000,
-  '1w': 7 * 24 * 60 * 60 * 1000,
-  '1y': 365 * 24 * 60 * 60 * 1000,
-  '3m': 90 * 24 * 60 * 60 * 1000,
+  '1m': 30 * secondsPerDay * 1000,
+  '1w': 7 * secondsPerDay * 1000,
+  '1y': 365 * secondsPerDay * 1000,
+  '3m': 90 * secondsPerDay * 1000,
 }
 
 const getPlaceholderXTicks = function (period: MetricPeriod) {

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/cooldownPostAction.ts
@@ -4,7 +4,11 @@ import {
 } from 'components/reviewOperation/progressStatus'
 import { type useTranslations } from 'next-intl'
 import { type ReactNode } from 'react'
-import { secondsToDaysAndHours, secondsToWholeDays } from 'utils/time'
+import {
+  secondsPerHour,
+  secondsToDaysAndHours,
+  secondsToWholeDays,
+} from 'utils/time'
 
 export type CooldownPostAction = {
   description: ReactNode
@@ -20,7 +24,7 @@ export type CooldownInputs = {
   unstakeMined: boolean
 }
 
-const RECOVER_PATH_STATUSES = new Set<string | undefined>([
+const recoverPathStatuses = new Set<string | undefined>([
   'CANCELLED',
   'RECOVERED',
 ])
@@ -38,7 +42,7 @@ export function deriveCooldownPostAction({
 }: CooldownInputs): CooldownPostAction | undefined {
   if (isCooldownEligible === false) return undefined
   // Recover path: cooldown was bypassed, shares come straight back — no milestone here (the recover step carries the state).
-  if (RECOVER_PATH_STATUSES.has(subgraphStatus)) {
+  if (recoverPathStatuses.has(subgraphStatus)) {
     return undefined
   }
   // Cooldown is over once the timer elapses or the row reaches FULFILLED/FINALIZED (both imply
@@ -73,7 +77,7 @@ export function deriveCooldownPostAction({
   }
 
   // Under an hour: show "less than an hour" — a precise countdown would lie given the minute-resolution tick.
-  if (cooldownRemainingSec < 3600) {
+  if (cooldownRemainingSec < secondsPerHour) {
     return {
       description: t('wait-cooldown-countdown-soon'),
       status: ProgressStatus.PROGRESS,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -184,7 +184,7 @@ function buildReceiveStep({
   }
 }
 
-const FAILED_STATUSES: WithdrawStatusType[] = [
+const failedStatuses: WithdrawStatusType[] = [
   WithdrawStatus.APPROVAL_TX_FAILED,
   WithdrawStatus.WITHDRAW_TX_FAILED,
 ]
@@ -473,7 +473,7 @@ export const ReviewWithdraw = function ({ onClose }: Props) {
   }
 
   const getCallToAction = function () {
-    if (FAILED_STATUSES.includes(withdrawStatus)) {
+    if (failedStatuses.includes(withdrawStatus)) {
       return <RetryWithdraw />
     }
     if (isRemoteFailed(settledRow)) {

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
@@ -6,7 +6,7 @@ import { unixNowTimestamp } from 'utils/time'
 // Local countdown from the subgraph's claimableAt (unix seconds, set on Ethereum — authoritative
 // for maturity, free of the LayerZero drift a local requestedAt + duration would carry). Ticks
 // every 60s; returns undefined until the input exists.
-const TICK_MS = 60_000
+const tickMs = 60_000
 
 const nowInSeconds = () => Number(unixNowTimestamp())
 
@@ -27,7 +27,7 @@ export function useEarnCooldownRemaining(
   useEffect(
     function tick() {
       if (claimableAt === undefined) return undefined
-      const id = setInterval(() => setNowSec(nowInSeconds()), TICK_MS)
+      const id = setInterval(() => setNowSec(nowInSeconds()), tickMs)
       return () => clearInterval(id)
     },
     [claimableAt],

--- a/portal/app/[locale]/hemi-earn/types.ts
+++ b/portal/app/[locale]/hemi-earn/types.ts
@@ -115,7 +115,7 @@ type LocalEarnOperationBase = {
   // Percent — the unit the settings panel edits and clampSlippage works in. Holds the
   // effective value, so "Auto" is resolved at sign time and a retry replays the real number.
   slippage?: number
-  // Unix seconds — must match TTL_SECONDS' unit in localEarnOperationsContext (the GC compares them).
+  // Unix seconds — must match ttlSeconds' unit in localEarnOperationsContext (the GC compares them).
   startedAt: number
 }
 

--- a/portal/scripts/hemi-earn/constants.ts
+++ b/portal/scripts/hemi-earn/constants.ts
@@ -7,7 +7,7 @@ import { type Address } from 'viem'
 // package — in production the portal reads `Gateway.PEGGED_TOKEN()` on-chain,
 // but the sandbox setup needs the address BEFORE deploying the gateway. Update
 // this if Vetro ever redeploys the pegged token contract.
-export const VETBTC_PROD: Address = '0xf196C68233464A16CFDa319a47c21f4cECa62001'
+export const vetBtcProd: Address = '0xf196C68233464A16CFDa319a47c21f4cECa62001'
 
 const btcGateway = gateways.find(g => g.pegBaseSymbol === 'BTC')
 if (!btcGateway) {
@@ -15,12 +15,12 @@ if (!btcGateway) {
     "No gateway with pegBaseSymbol='BTC' in @vetro-protocol/gateway",
   )
 }
-export const GATEWAY_PROD: Address = btcGateway.address
+export const gatewayProd: Address = btcGateway.address
 
-export const STAKING_PROD: Address = sVetBtcAddress
+export const stakingProd: Address = sVetBtcAddress
 
-export const DEFAULT_FORK_URL = 'http://127.0.0.1:8545'
+export const defaultForkUrl = 'http://127.0.0.1:8545'
 
-export const DEFAULT_DEPLOYER_PK = TEST_PRIVATE_KEY
+export const defaultDeployerPk = TEST_PRIVATE_KEY
 
-export const DEFAULT_INTERVAL_MINING_SECS = 6
+export const defaultIntervalMiningSecs = 6

--- a/portal/scripts/hemi-earn/contracts/PreviewableGatewayMock.sol
+++ b/portal/scripts/hemi-earn/contracts/PreviewableGatewayMock.sol
@@ -15,7 +15,7 @@ import {ERC20Mock} from "src/mocks/ERC20Mock.sol";
 ///         exactly `amountOut` of `tokenOut` on redeem — the canonical
 ///         inverse of `previewRedeem`.
 /// @dev Storage layout mirrors `GatewayMock.sol` byte-for-byte so a hot
-///      `anvil_setCode` at GATEWAY_PROD preserves any storage already set
+///      `anvil_setCode` at gatewayProd preserves any storage already set
 ///      by the deploy (depositRateBps / redeemRateBps / fail flags).
 ///      Keep this file in sync if `GatewayMock.sol` changes.
 contract PreviewableGatewayMock {

--- a/portal/scripts/hemi-earn/contracts/README.md
+++ b/portal/scripts/hemi-earn/contracts/README.md
@@ -20,8 +20,8 @@ Since compilation happens outside this repo, keep the `.sol` here in sync with w
 | Contract                            | Purpose                                                                                                                                                   |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `LabeledERC20Mock.sol`              | ERC20 with `setLabel(name, symbol)` — used for hemiBTC / WBTC / cbBTC so on-chain metadata reads work post-PR#1996 (which removed the local `tokens.ts`). |
-| `PeggedTokenMock.sol`               | Minimal `IPeggedToken` with a `setGateway` accessor — aliased at `VETBTC_PROD`.                                                                           |
-| `PreviewableGatewayMock.sol`        | Gateway mock + `previewWithdraw(...)` — aliased at `GATEWAY_PROD`.                                                                                        |
-| `CooldownAwareStakingVaultMock.sol` | ERC4626 + `IStakingVault` with cooldown tracking — aliased at `STAKING_PROD`. Setup enables cooldown with a 1-day duration by default.                    |
+| `PeggedTokenMock.sol`               | Minimal `IPeggedToken` with a `setGateway` accessor — aliased at `vetBtcProd`.                                                                            |
+| `PreviewableGatewayMock.sol`        | Gateway mock + `previewWithdraw(...)` — aliased at `gatewayProd`.                                                                                         |
+| `CooldownAwareStakingVaultMock.sol` | ERC4626 + `IStakingVault` with cooldown tracking — aliased at `stakingProd`. Setup enables cooldown with a 1-day duration by default.                     |
 | `ToggleableRouter.sol`              | RouterMock + non-zero `_quote()` so the UI's fee-display path is exercised. Deploys locally (deterministic address).                                      |
 | `ToggleableAgent.sol`               | AgentMock + a `delayed` flag + `processBuffered(id)` — supports future relayer-driven tests without changing the deterministic address. Deploys locally.  |

--- a/portal/scripts/hemi-earn/deployMocks.ts
+++ b/portal/scripts/hemi-earn/deployMocks.ts
@@ -5,11 +5,11 @@ import { type Abi, type Address, type Hex } from 'viem'
 import { loadArtifact } from './artifacts.ts'
 import { scriptArgs } from './cli.ts'
 import {
-  DEFAULT_DEPLOYER_PK,
-  DEFAULT_FORK_URL,
-  GATEWAY_PROD,
-  STAKING_PROD,
-  VETBTC_PROD,
+  defaultDeployerPk,
+  defaultForkUrl,
+  gatewayProd,
+  stakingProd,
+  vetBtcProd,
 } from './constants.ts'
 import { anvilRpc, buildClients } from './rpcClients.ts'
 
@@ -25,8 +25,8 @@ export type DeployedMocks = {
 }
 
 export async function deployMocks({
-  deployerPk = DEFAULT_DEPLOYER_PK,
-  forkUrl = DEFAULT_FORK_URL,
+  deployerPk = defaultDeployerPk,
+  forkUrl = defaultForkUrl,
 }: {
   deployerPk?: Hex
   forkUrl?: string
@@ -132,55 +132,55 @@ export async function deployMocks({
   await aliasCode({
     artifact: peggedTokenMock,
     label: 'vetBTC',
-    prod: VETBTC_PROD,
+    prod: vetBtcProd,
   })
   await aliasCode({
     artifact: gatewayMock,
-    ctorArgs: [VETBTC_PROD],
+    ctorArgs: [vetBtcProd],
     label: 'Gateway',
-    prod: GATEWAY_PROD,
+    prod: gatewayProd,
   })
   // ERC4626Mock's constructor reads asset_.decimals(), so the pegged-token
   // alias must exist before the staking mock deploys.
   await aliasCode({
     artifact: stakingVaultMock,
-    ctorArgs: [VETBTC_PROD],
+    ctorArgs: [vetBtcProd],
     label: 'Staking',
-    prod: STAKING_PROD,
+    prod: stakingProd,
   })
 
   console.log('\nPhase 3 — wire state at aliased addresses:')
   await writeAndWait({
     abi: peggedTokenMock.abi,
-    address: VETBTC_PROD,
-    args: [GATEWAY_PROD],
+    address: vetBtcProd,
+    args: [gatewayProd],
     functionName: 'setGateway',
-    label: 'vetBTC.setGateway(GATEWAY_PROD)',
+    label: 'vetBTC.setGateway(gatewayProd)',
   })
   await writeAndWait({
     abi: gatewayMock.abi,
-    address: GATEWAY_PROD,
+    address: gatewayProd,
     args: [10_000n],
     functionName: 'setDepositRateBps',
     label: 'Gateway.setDepositRateBps(10000)',
   })
   await writeAndWait({
     abi: gatewayMock.abi,
-    address: GATEWAY_PROD,
+    address: gatewayProd,
     args: [10_000n],
     functionName: 'setRedeemRateBps',
     label: 'Gateway.setRedeemRateBps(10000)',
   })
 
-  console.log('\nPhase 4 — Router + Agent (local, share=STAKING_PROD):')
+  console.log('\nPhase 4 — Router + Agent (local, share=stakingProd):')
   const agent = await deploy({
-    args: [hemiBTC, STAKING_PROD],
+    args: [hemiBTC, stakingProd],
     artifact: agentMock,
     label: 'Agent',
   })
   console.log(`  Agent      ${agent}`)
   const router = await deploy({
-    args: [hemiBTC, STAKING_PROD],
+    args: [hemiBTC, stakingProd],
     artifact: routerMock,
     label: 'Router',
   })
@@ -232,7 +232,7 @@ export async function deployMocks({
     await writeAndWait({
       abi: routerMock.abi,
       address: router,
-      args: [addr, STAKING_PROD, addr, STAKING_PROD, true],
+      args: [addr, stakingProd, addr, stakingProd, true],
       functionName: 'updateAssetData',
       label: `router.updateAssetData(${name})`,
     })
@@ -241,14 +241,14 @@ export async function deployMocks({
   console.log('\nPhase 7 — enable cooldown (1 day):')
   await writeAndWait({
     abi: stakingVaultMock.abi,
-    address: STAKING_PROD,
+    address: stakingProd,
     args: [true],
     functionName: 'updateCooldownEnabled',
     label: 'staking.updateCooldownEnabled(true)',
   })
   await writeAndWait({
     abi: stakingVaultMock.abi,
-    address: STAKING_PROD,
+    address: stakingProd,
     args: [86_400n],
     functionName: 'updateCooldownDuration',
     label: 'staking.updateCooldownDuration(86400)',
@@ -257,11 +257,11 @@ export async function deployMocks({
   return {
     agent,
     cbBtc,
-    gateway: GATEWAY_PROD,
+    gateway: gatewayProd,
     hemiBTC,
     router,
-    staking: STAKING_PROD,
-    vetBTC: VETBTC_PROD,
+    staking: stakingProd,
+    vetBTC: vetBtcProd,
     wbtc,
   }
 }

--- a/portal/scripts/hemi-earn/failGateway.ts
+++ b/portal/scripts/hemi-earn/failGateway.ts
@@ -9,17 +9,13 @@ import {
 } from 'viem'
 
 import { scriptArgs } from './cli.ts'
-import {
-  DEFAULT_DEPLOYER_PK,
-  DEFAULT_FORK_URL,
-  GATEWAY_PROD,
-} from './constants.ts'
+import { defaultDeployerPk, defaultForkUrl, gatewayProd } from './constants.ts'
 import { buildClients } from './rpcClients.ts'
 
-const MODE_NAMES = ['NONE', 'SLIPPAGE', 'FEE', 'UNKNOWN'] as const
-type ModeName = (typeof MODE_NAMES)[number]
+const modeNames = ['NONE', 'SLIPPAGE', 'FEE', 'UNKNOWN'] as const
+type ModeName = (typeof modeNames)[number]
 
-const MODE_ARG_TO_UINT: Record<string, number> = {
+const modeArgToUint: Record<string, number> = {
   fee: 2,
   slippage: 1,
   unknown: 3,
@@ -72,15 +68,15 @@ function printUsage() {
   console.error('  [--deployer-pk PK]      signer for setter txs')
 }
 
-const KIND_VALUES = ['deposit', 'redeem'] as const
-type Kind = (typeof KIND_VALUES)[number]
-const MODE_VALUES = ['off', 'on', 'slippage', 'fee', 'unknown'] as const
-type Mode = (typeof MODE_VALUES)[number]
+const kindValues = ['deposit', 'redeem'] as const
+type Kind = (typeof kindValues)[number]
+const modeValues = ['off', 'on', 'slippage', 'fee', 'unknown'] as const
+type Mode = (typeof modeValues)[number]
 
 const isKind = (v: unknown): v is Kind =>
-  (KIND_VALUES as readonly string[]).includes(v as string)
+  (kindValues as readonly string[]).includes(v as string)
 const isMode = (v: unknown): v is Mode =>
-  (MODE_VALUES as readonly string[]).includes(v as string)
+  (modeValues as readonly string[]).includes(v as string)
 
 function parseFailGatewayArgs(argv: string[]) {
   const { values } = parseArgs({
@@ -95,7 +91,7 @@ function parseFailGatewayArgs(argv: string[]) {
     strict: true,
   })
 
-  const forkUrl = values['fork-url'] ?? DEFAULT_FORK_URL
+  const forkUrl = values['fork-url'] ?? defaultForkUrl
 
   if (values.status === true) {
     if (values.kind !== undefined || values.mode !== undefined) {
@@ -106,13 +102,13 @@ function parseFailGatewayArgs(argv: string[]) {
     // --status is read-only, so any user-supplied --deployer-pk is unused;
     // fall back to the default so a stale env var can't gate the read.
     return {
-      deployerPk: DEFAULT_DEPLOYER_PK as Hex,
+      deployerPk: defaultDeployerPk as Hex,
       forkUrl,
       status: true as const,
     }
   }
 
-  const deployerPk = (values['deployer-pk'] ?? DEFAULT_DEPLOYER_PK) as Hex
+  const deployerPk = (values['deployer-pk'] ?? defaultDeployerPk) as Hex
   if (!/^0x[0-9a-fA-F]{64}$/.test(deployerPk)) {
     console.error(
       '✗ --deployer-pk must be a 32-byte hex string starting with 0x',
@@ -161,7 +157,7 @@ async function writeAndWait<
   const hash = await walletClient.writeContract({
     abi: abi as Abi,
     account,
-    address: GATEWAY_PROD,
+    address: gatewayProd,
     args: args as never,
     chain: walletClient.chain,
     functionName: functionName as never,
@@ -176,22 +172,22 @@ async function readStatus(publicClient: PublicClient) {
   const [deposit, redeem, depositMode, redeemMode] = await Promise.all([
     publicClient.readContract({
       abi: [shouldFailDepositAbi],
-      address: GATEWAY_PROD,
+      address: gatewayProd,
       functionName: 'shouldFailDeposit',
     }),
     publicClient.readContract({
       abi: [shouldFailRedeemAbi],
-      address: GATEWAY_PROD,
+      address: gatewayProd,
       functionName: 'shouldFailRedeem',
     }),
     publicClient.readContract({
       abi: [depositFailureModeAbi],
-      address: GATEWAY_PROD,
+      address: gatewayProd,
       functionName: 'depositFailureMode',
     }),
     publicClient.readContract({
       abi: [redeemFailureModeAbi],
-      address: GATEWAY_PROD,
+      address: gatewayProd,
       functionName: 'redeemFailureMode',
     }),
   ])
@@ -204,10 +200,10 @@ function formatStatus(s: {
   redeem: boolean
   redeemMode: number
 }) {
-  const depositName: ModeName = MODE_NAMES[s.depositMode] ?? 'NONE'
-  const redeemName: ModeName = MODE_NAMES[s.redeemMode] ?? 'NONE'
+  const depositName: ModeName = modeNames[s.depositMode] ?? 'NONE'
+  const redeemName: ModeName = modeNames[s.redeemMode] ?? 'NONE'
   return (
-    `PreviewableGatewayMock @ ${GATEWAY_PROD}\n` +
+    `PreviewableGatewayMock @ ${gatewayProd}\n` +
     `  deposit=${s.deposit} depositMode=${depositName}\n` +
     `  redeem=${s.redeem} redeemMode=${redeemName}`
   )
@@ -226,7 +222,7 @@ async function clearLegacyIfSet({
 }) {
   const currentBool = await publicClient.readContract({
     abi: [kind === 'deposit' ? shouldFailDepositAbi : shouldFailRedeemAbi],
-    address: GATEWAY_PROD,
+    address: gatewayProd,
     functionName: kind === 'deposit' ? 'shouldFailDeposit' : 'shouldFailRedeem',
   })
   if (!currentBool) return
@@ -259,7 +255,7 @@ async function clearModeIfSet({
 }) {
   const currentMode = await publicClient.readContract({
     abi: [kind === 'deposit' ? depositFailureModeAbi : redeemFailureModeAbi],
-    address: GATEWAY_PROD,
+    address: gatewayProd,
     functionName:
       kind === 'deposit' ? 'depositFailureMode' : 'redeemFailureMode',
   })
@@ -311,7 +307,7 @@ async function applyFailure({
     return
   }
 
-  const uint = mode === 'off' ? 0 : MODE_ARG_TO_UINT[mode]
+  const uint = mode === 'off' ? 0 : modeArgToUint[mode]
   await writeAndWait({
     abi: [
       kind === 'deposit' ? setDepositFailureModeAbi : setRedeemFailureModeAbi,
@@ -325,7 +321,7 @@ async function applyFailure({
   })
   await clearLegacyIfSet({ account, kind, publicClient, walletClient })
 
-  const modeName: ModeName = MODE_NAMES[uint] ?? 'NONE'
+  const modeName: ModeName = modeNames[uint] ?? 'NONE'
   console.log(`✓ ${kind}FailureMode=${modeName}`)
 }
 

--- a/portal/scripts/hemi-earn/fundAccount.ts
+++ b/portal/scripts/hemi-earn/fundAccount.ts
@@ -4,18 +4,14 @@ import { isAddress, parseEther, toHex, type Address, type Hex } from 'viem'
 
 import { loadArtifact } from './artifacts.ts'
 import { scriptArgs } from './cli.ts'
-import {
-  DEFAULT_DEPLOYER_PK,
-  DEFAULT_FORK_URL,
-  GATEWAY_PROD,
-} from './constants.ts'
+import { defaultDeployerPk, defaultForkUrl, gatewayProd } from './constants.ts'
 import { anvilRpc, buildClients } from './rpcClients.ts'
 
 export async function fundAccount({
   address,
   cbBtc,
-  deployerPk = DEFAULT_DEPLOYER_PK,
-  forkUrl = DEFAULT_FORK_URL,
+  deployerPk = defaultDeployerPk,
+  forkUrl = defaultForkUrl,
   hemiBTC,
   wbtc,
 }: {
@@ -44,7 +40,7 @@ export async function fundAccount({
 
   const mints: [string, Address, Address, bigint][] = [
     ['hemiBTC (user)', hemiBTC, address, parseEther('10')],
-    ['hemiBTC (gateway liquidity)', hemiBTC, GATEWAY_PROD, parseEther('100')],
+    ['hemiBTC (gateway liquidity)', hemiBTC, gatewayProd, parseEther('100')],
   ]
   if (wbtc) mints.push(['WBTC (user)', wbtc, address, parseEther('10')])
   if (cbBtc) mints.push(['cbBTC (user)', cbBtc, address, parseEther('10')])

--- a/portal/scripts/hemi-earn/index.ts
+++ b/portal/scripts/hemi-earn/index.ts
@@ -6,7 +6,7 @@ import { runRelayer } from './relayer.ts'
 import { runSetIntervalMining } from './setIntervalMining.ts'
 import { runSetup } from './setup.ts'
 
-const HANDLERS = {
+const handlers = {
   'fail-gateway': runFailGateway,
   'keeper': runKeeper,
   'mining': runSetIntervalMining,
@@ -19,11 +19,11 @@ function printUsage() {
   console.error(
     'Usage: pnpm --filter portal sandbox:hemi-earn -- <subcommand> [flags]',
   )
-  console.error(`Subcommands: ${Object.keys(HANDLERS).join(', ')}`)
+  console.error(`Subcommands: ${Object.keys(handlers).join(', ')}`)
 }
 
 const [subcommand, ...rest] = scriptArgs()
-const handler = HANDLERS[subcommand as keyof typeof HANDLERS]
+const handler = handlers[subcommand as keyof typeof handlers]
 
 if (!handler) {
   printUsage()

--- a/portal/scripts/hemi-earn/keeper.ts
+++ b/portal/scripts/hemi-earn/keeper.ts
@@ -10,14 +10,14 @@ import {
 } from 'viem'
 
 import { scriptArgs } from './cli.ts'
-import { DEFAULT_DEPLOYER_PK, DEFAULT_FORK_URL } from './constants.ts'
+import { defaultDeployerPk, defaultForkUrl } from './constants.ts'
 import { buildClients } from './rpcClients.ts'
 
-const ACTION_VALUES = ['cancel', 'retry'] as const
-type Action = (typeof ACTION_VALUES)[number]
+const actionValues = ['cancel', 'retry'] as const
+type Action = (typeof actionValues)[number]
 
 const isAction = (v: unknown): v is Action =>
-  (ACTION_VALUES as readonly string[]).includes(v as string)
+  (actionValues as readonly string[]).includes(v as string)
 
 const failedRequestsAbi = parseAbiItem(
   'function failedRequests(uint256) view returns ((address tokenIn, uint256 amountIn, bytes msgIn, uint256 nativeFee))',
@@ -102,10 +102,8 @@ function parseKeeperArgs(argv: string[]) {
   return {
     action: values.action,
     agent,
-    deployerPk: validateDeployerPk(
-      values['deployer-pk'] ?? DEFAULT_DEPLOYER_PK,
-    ),
-    forkUrl: values['fork-url'] ?? DEFAULT_FORK_URL,
+    deployerPk: validateDeployerPk(values['deployer-pk'] ?? defaultDeployerPk),
+    forkUrl: values['fork-url'] ?? defaultForkUrl,
     requestId: parseNonNegativeBigInt(rawId, '--request-id'),
     value:
       values.value === undefined

--- a/portal/scripts/hemi-earn/mint.ts
+++ b/portal/scripts/hemi-earn/mint.ts
@@ -9,7 +9,7 @@ import {
 } from 'viem'
 
 import { scriptArgs } from './cli.ts'
-import { DEFAULT_DEPLOYER_PK, DEFAULT_FORK_URL } from './constants.ts'
+import { defaultDeployerPk, defaultForkUrl } from './constants.ts'
 import { buildClients } from './rpcClients.ts'
 
 const mintAbi = parseAbiItem('function mint(address,uint256)')
@@ -71,7 +71,7 @@ function parseMintArgs(argv: string[]) {
     process.exit(1)
   }
 
-  const deployerPk = (values['deployer-pk'] ?? DEFAULT_DEPLOYER_PK) as Hex
+  const deployerPk = (values['deployer-pk'] ?? defaultDeployerPk) as Hex
   if (!/^0x[0-9a-fA-F]{64}$/.test(deployerPk)) {
     console.error(
       '✗ --deployer-pk must be a 32-byte hex string starting with 0x',
@@ -83,7 +83,7 @@ function parseMintArgs(argv: string[]) {
   return {
     ...parseAmount(values.amount),
     deployerPk,
-    forkUrl: values['fork-url'] ?? DEFAULT_FORK_URL,
+    forkUrl: values['fork-url'] ?? defaultForkUrl,
     to: to as Address,
     token: token as Address,
   }

--- a/portal/scripts/hemi-earn/relayer.ts
+++ b/portal/scripts/hemi-earn/relayer.ts
@@ -3,10 +3,10 @@ import { parseArgs } from 'node:util'
 import { isAddress, parseAbiItem, type Address, type Hex } from 'viem'
 
 import { scriptArgs } from './cli.ts'
-import { DEFAULT_DEPLOYER_PK, DEFAULT_FORK_URL } from './constants.ts'
+import { defaultDeployerPk, defaultForkUrl } from './constants.ts'
 import { buildClients } from './rpcClients.ts'
 
-const DEFAULT_POLL_SECS = 1
+const defaultPollSecs = 1
 
 const unstakeRequestedAbi = parseAbiItem(
   'event UnstakeRequested(uint256 indexed requestId, uint256 claimableAt)',
@@ -42,7 +42,7 @@ function printUsage() {
   )
   console.error('  [--deployer-pk PK]      signer for keeper txs')
   console.error(
-    `  [--poll N]              poll interval in seconds (default ${DEFAULT_POLL_SECS})`,
+    `  [--poll N]              poll interval in seconds (default ${defaultPollSecs})`,
   )
   console.error(
     '  [--from-block N]        first block to scan for keeper events (default 0 — full backfill)',
@@ -85,7 +85,7 @@ function parseRelayerArgs(argv: string[]) {
     printUsage()
     process.exit(1)
   }
-  const pollSecs = values.poll ? Number(values.poll) : DEFAULT_POLL_SECS
+  const pollSecs = values.poll ? Number(values.poll) : defaultPollSecs
   if (!Number.isFinite(pollSecs) || pollSecs <= 0) {
     printUsage()
     process.exit(1)
@@ -93,10 +93,9 @@ function parseRelayerArgs(argv: string[]) {
 
   return {
     agent,
-    deployerPk:
-      (values['deployer-pk'] as Hex | undefined) ?? DEFAULT_DEPLOYER_PK,
+    deployerPk: (values['deployer-pk'] as Hex | undefined) ?? defaultDeployerPk,
     disableAutoclaim: values['disable-autoclaim'] === true,
-    forkUrl: values['fork-url'] ?? DEFAULT_FORK_URL,
+    forkUrl: values['fork-url'] ?? defaultForkUrl,
     fromBlock: parseFromBlock(values['from-block']),
     pollMs: Math.round(pollSecs * 1000),
     router,

--- a/portal/scripts/hemi-earn/setIntervalMining.ts
+++ b/portal/scripts/hemi-earn/setIntervalMining.ts
@@ -2,11 +2,11 @@ import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
 
 import { scriptArgs } from './cli.ts'
-import { DEFAULT_FORK_URL, DEFAULT_INTERVAL_MINING_SECS } from './constants.ts'
+import { defaultForkUrl, defaultIntervalMiningSecs } from './constants.ts'
 import { anvilRpc } from './rpcClients.ts'
 
 async function setIntervalMining({
-  forkUrl = DEFAULT_FORK_URL,
+  forkUrl = defaultForkUrl,
   seconds,
 }: {
   forkUrl?: string
@@ -37,7 +37,7 @@ export async function runSetIntervalMining(argv: string[]) {
   const seconds =
     values.seconds !== undefined
       ? Number(values.seconds)
-      : DEFAULT_INTERVAL_MINING_SECS
+      : defaultIntervalMiningSecs
 
   if (!Number.isInteger(seconds) || seconds < 0) {
     console.error(

--- a/portal/scripts/hemi-earn/setup.ts
+++ b/portal/scripts/hemi-earn/setup.ts
@@ -5,11 +5,11 @@ import { isAddress, type Address, type Hex } from 'viem'
 import { hemi } from 'viem/chains'
 
 import { scriptArgs } from './cli.ts'
-import { DEFAULT_DEPLOYER_PK } from './constants.ts'
+import { defaultDeployerPk } from './constants.ts'
 import { deployMocks } from './deployMocks.ts'
 import { fundAccount } from './fundAccount.ts'
 
-const BOX_WIDTH = 78
+const boxWidth = 78
 
 export async function runSetup(argv: string[]) {
   const { values } = parseArgs({
@@ -43,7 +43,7 @@ export async function runSetup(argv: string[]) {
 
   const userAddress = values.address as Address
   const deployerPk =
-    (values['deployer-pk'] as Hex | undefined) ?? DEFAULT_DEPLOYER_PK
+    (values['deployer-pk'] as Hex | undefined) ?? defaultDeployerPk
 
   let forkUrl: string
   if (values['fork-url']) {
@@ -76,12 +76,12 @@ export async function runSetup(argv: string[]) {
     wbtc: deployed.wbtc,
   })
 
-  const bar = '═'.repeat(BOX_WIDTH)
+  const bar = '═'.repeat(boxWidth)
   console.log(`\n╔${bar}╗`)
-  console.log(`║${'  Hemi Earn sandbox ready.'.padEnd(BOX_WIDTH)}║`)
+  console.log(`║${'  Hemi Earn sandbox ready.'.padEnd(boxWidth)}║`)
   console.log(`╠${bar}╣`)
   for (const [label, addr] of Object.entries(deployed)) {
-    const line = `  ${label.padEnd(10)} ${addr}`.padEnd(BOX_WIDTH)
+    const line = `  ${label.padEnd(10)} ${addr}`.padEnd(boxWidth)
     console.log(`║${line}║`)
   }
   console.log(`╚${bar}╝`)

--- a/portal/test/app/[locale]/hemi-earn/_constants/slippage.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_constants/slippage.test.ts
@@ -51,7 +51,7 @@ describe('applySlippage', function () {
     expect(applySlippage(BigInt(1000), BigInt(0))).toBe(BigInt(1000))
   })
 
-  it('rejects bps above BPS_DENOMINATOR', function () {
+  it('rejects bps above bpsDenominator', function () {
     expect(() => applySlippage(BigInt(1000), BigInt(10001))).toThrow(RangeError)
   })
 
@@ -59,12 +59,12 @@ describe('applySlippage', function () {
     expect(() => applySlippage(BigInt(1000), BigInt(-1))).toThrow(RangeError)
   })
 
-  it('clamps to 1n at bps = BPS_DENOMINATOR (100% slippage)', function () {
+  it('clamps to 1n at bps = bpsDenominator (100% slippage)', function () {
     // (1000 * 0) / 10000 = 0 → clamp to 1
     expect(applySlippage(BigInt(1000), BigInt(10000))).toBe(BigInt(1))
   })
 
-  // applySlippage throws outside [0, BPS_DENOMINATOR] and is now called during render
+  // applySlippage throws outside [0, bpsDenominator] and is now called during render
   // with a user-set value, so maxSlippage must never map past that ceiling.
   it('accepts the whole user-selectable range without throwing', function () {
     expect(() =>

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares.test.ts
@@ -24,19 +24,23 @@ vi.mock('utils/chainClients', () => ({
   getPublicClient: vi.fn(),
 }))
 
-const SVETBTC = '0xD8D63De3b64bd06d99F8F5AD8B78Ed2fE7525eC0' as Address
+const svetBtcAddress = '0xD8D63De3b64bd06d99F8F5AD8B78Ed2fE7525eC0' as Address
 // Any Ethereum-side staking vault address; the `asset()` read off it is seeded.
-const REMOTE_SHARE = '0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e' as Address
+const remoteShareAddress =
+  '0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e' as Address
 // The pegged token is the staking vault's `asset()` — an Ethereum-mainnet token.
-const VETBTC = '0xf196C68233464A16CFDa319a47c21f4cECa62001' as Address
+const vetBtcAddress = '0xf196C68233464A16CFDa319a47c21f4cECa62001' as Address
 // Real `@vetro-protocol/gateway` entries — the BTC peg aliases the pegged
 // token to the 'WBTC' proxy, the USD peg to 'USDT'.
-const BTC_GATEWAY = '0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB' as Address
-const USD_GATEWAY = '0xDaD503f8B9d42bb7af3AfC588358D30163e4416F' as Address
-const ASSET = '0x1111111111111111111111111111111111111111' as Address
-const ASSET_2 = '0x2222222222222222222222222222222222222222' as Address
-const REMOTE_ASSET = '0x3333333333333333333333333333333333333333' as Address
-const UNKNOWN_ADDRESS = '0x0000000000000000000000000000000000000bad' as Address
+const btcGatewayAddress =
+  '0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB' as Address
+const usdGatewayAddress =
+  '0xDaD503f8B9d42bb7af3AfC588358D30163e4416F' as Address
+const assetAddress = '0x1111111111111111111111111111111111111111' as Address
+const asset2Address = '0x2222222222222222222222222222222222222222' as Address
+const remoteAssetAddress =
+  '0x3333333333333333333333333333333333333333' as Address
+const unknownAddress = '0x0000000000000000000000000000000000000bad' as Address
 
 const makeToken = (
   address: Address,
@@ -46,18 +50,18 @@ const makeToken = (
 
 // Share + deposit assets live on Hemi; the pegged token lives on Ethereum
 // mainnet (the vault's `asset()`), so each is looked up on its own chain.
-const svetBtcToken = makeToken(SVETBTC, 'svetBTC', hemi.id)
-const vetBtcToken = makeToken(VETBTC, 'vetBTC', mainnet.id)
-const assetToken = makeToken(ASSET, 'hemiBTC', hemi.id)
-const asset2Token = makeToken(ASSET_2, 'enzoBTC', hemi.id)
+const svetBtcToken = makeToken(svetBtcAddress, 'svetBTC', hemi.id)
+const vetBtcToken = makeToken(vetBtcAddress, 'vetBTC', mainnet.id)
+const assetToken = makeToken(assetAddress, 'hemiBTC', hemi.id)
+const asset2Token = makeToken(asset2Address, 'enzoBTC', hemi.id)
 
 const makeConfig = (
   config: Pick<HemiEarnAssetConfig, 'asset' | 'share'> &
     Partial<HemiEarnAssetConfig>,
 ): HemiEarnAssetConfig => ({
   enabled: true,
-  remoteAsset: REMOTE_ASSET,
-  remoteShare: REMOTE_SHARE,
+  remoteAsset: remoteAssetAddress,
+  remoteShare: remoteShareAddress,
   ...config,
 })
 
@@ -67,7 +71,7 @@ const seed = function (
   queryClient: ReturnType<typeof createTestQueryClient>,
   {
     configs,
-    gateway = BTC_GATEWAY,
+    gateway = btcGatewayAddress,
     peggedAddress,
     tokens = [svetBtcToken, vetBtcToken, assetToken, asset2Token],
   }: {
@@ -79,11 +83,11 @@ const seed = function (
 ) {
   queryClient.setQueryData(hemiEarnAssetConfigsQueryOptions().queryKey, configs)
   queryClient.setQueryData(
-    vaultAssetQueryOptions(REMOTE_SHARE).queryKey,
+    vaultAssetQueryOptions(remoteShareAddress).queryKey,
     peggedAddress,
   )
   queryClient.setQueryData(
-    gatewayForRemoteShareQueryOptions(REMOTE_SHARE).queryKey,
+    gatewayForRemoteShareQueryOptions(remoteShareAddress).queryKey,
     gateway,
   )
   for (const token of tokens) {
@@ -98,15 +102,15 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares', function () {
   it('returns a skeleton for a share with at least one registered asset', async function () {
     const queryClient = createTestQueryClient()
     seed(queryClient, {
-      configs: [makeConfig({ asset: ASSET, share: SVETBTC })],
-      peggedAddress: VETBTC,
+      configs: [makeConfig({ asset: assetAddress, share: svetBtcAddress })],
+      peggedAddress: vetBtcAddress,
     })
 
     const result = await fetchHemiEarnShares(queryClient)
 
     expect(result).toHaveLength(1)
-    expect(result[0].shareAddress).toBe(SVETBTC)
-    expect(result[0].stakingVault).toBe(REMOTE_SHARE)
+    expect(result[0].shareAddress).toBe(svetBtcAddress)
+    expect(result[0].stakingVault).toBe(remoteShareAddress)
     expect(result[0].peggedToken.symbol).toBe('vetBTC')
     expect(result[0].shareToken.symbol).toBe('svetBTC')
     expect(result[0].assets).toHaveLength(1)
@@ -116,9 +120,9 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares', function () {
   it('aliases the BTC-pegged token to its whitelisted WBTC proxy', async function () {
     const queryClient = createTestQueryClient()
     seed(queryClient, {
-      configs: [makeConfig({ asset: ASSET, share: SVETBTC })],
-      gateway: BTC_GATEWAY,
-      peggedAddress: VETBTC,
+      configs: [makeConfig({ asset: assetAddress, share: svetBtcAddress })],
+      gateway: btcGatewayAddress,
+      peggedAddress: vetBtcAddress,
     })
 
     const result = await fetchHemiEarnShares(queryClient)
@@ -129,9 +133,9 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares', function () {
   it('aliases the USD-pegged token to its whitelisted USDT proxy', async function () {
     const queryClient = createTestQueryClient()
     seed(queryClient, {
-      configs: [makeConfig({ asset: ASSET, share: SVETBTC })],
-      gateway: USD_GATEWAY,
-      peggedAddress: VETBTC,
+      configs: [makeConfig({ asset: assetAddress, share: svetBtcAddress })],
+      gateway: usdGatewayAddress,
+      peggedAddress: vetBtcAddress,
     })
 
     const result = await fetchHemiEarnShares(queryClient)
@@ -143,16 +147,16 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares', function () {
     const queryClient = createTestQueryClient()
     seed(queryClient, {
       configs: [
-        makeConfig({ asset: ASSET, share: SVETBTC }),
-        makeConfig({ asset: ASSET_2, share: SVETBTC }),
+        makeConfig({ asset: assetAddress, share: svetBtcAddress }),
+        makeConfig({ asset: asset2Address, share: svetBtcAddress }),
       ],
-      peggedAddress: VETBTC,
+      peggedAddress: vetBtcAddress,
     })
 
     const result = await fetchHemiEarnShares(queryClient)
 
     expect(result).toHaveLength(1)
-    expect(result[0].shareAddress).toBe(SVETBTC)
+    expect(result[0].shareAddress).toBe(svetBtcAddress)
     expect(result[0].assets.map(asset => asset.token.symbol)).toEqual([
       'hemiBTC',
       'enzoBTC',
@@ -162,8 +166,8 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares', function () {
   it('skips a share whose pegged token cannot be resolved', async function () {
     const queryClient = createTestQueryClient()
     seed(queryClient, {
-      configs: [makeConfig({ asset: ASSET, share: SVETBTC })],
-      peggedAddress: UNKNOWN_ADDRESS,
+      configs: [makeConfig({ asset: assetAddress, share: svetBtcAddress })],
+      peggedAddress: unknownAddress,
     })
 
     const result = await fetchHemiEarnShares(queryClient)
@@ -173,8 +177,8 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchHemiEarnShares', function () {
   it('skips a share with no resolvable deposit assets', async function () {
     const queryClient = createTestQueryClient()
     seed(queryClient, {
-      configs: [makeConfig({ asset: UNKNOWN_ADDRESS, share: SVETBTC })],
-      peggedAddress: VETBTC,
+      configs: [makeConfig({ asset: unknownAddress, share: svetBtcAddress })],
+      peggedAddress: vetBtcAddress,
     })
 
     const result = await fetchHemiEarnShares(queryClient)

--- a/portal/test/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.test.ts
+++ b/portal/test/app/[locale]/hemi-earn/_fetchers/fetchOraclePrices.test.ts
@@ -25,10 +25,10 @@ vi.mock('@vetro-protocol/treasury/actions', () => ({
 }))
 vi.mock('viem/actions', () => ({ readContract: vi.fn() }))
 
-const GATEWAY = '0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB' as Address
-const TREASURY = '0x1111111111111111111111111111111111111111' as Address
-const ORACLE = '0x2222222222222222222222222222222222222222' as Address
-const WBTC = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599' as Address
+const gatewayAddress = '0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB' as Address
+const treasuryAddress = '0x1111111111111111111111111111111111111111' as Address
+const oracleAddress = '0x2222222222222222222222222222222222222222' as Address
+const wbtcAddress = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599' as Address
 
 // Each whitelisted token's oracle reports its price in the gateway's peg unit.
 // `latestRoundData` returns the price as the `answer` field of the round tuple;
@@ -59,11 +59,10 @@ const seedToken = (
 
 describe('app/[locale]/hemi-earn/_fetchers/fetchOraclePrices', function () {
   beforeEach(function () {
-    vi.clearAllMocks()
-    vi.mocked(getTreasury).mockResolvedValue(TREASURY)
+    vi.mocked(getTreasury).mockResolvedValue(treasuryAddress)
     vi.mocked(getTokenConfig).mockResolvedValue([
       zeroAddress,
-      ORACLE,
+      oracleAddress,
       BigInt(0),
       true,
       true,
@@ -73,23 +72,23 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchOraclePrices', function () {
 
   it("keys each whitelisted token's oracle price by its uppercased symbol", async function () {
     const queryClient = createTestQueryClient()
-    seedToken(queryClient, WBTC, 'WBTC')
-    vi.mocked(getWhitelistedTokens).mockResolvedValue([WBTC])
+    seedToken(queryClient, wbtcAddress, 'WBTC')
+    vi.mocked(getWhitelistedTokens).mockResolvedValue([wbtcAddress])
     // 0.998 WBTC/BTC at 8 decimals.
     mockOracleRead(BigInt(99800000), 8)
 
-    const result = await fetchOraclePrices(queryClient, GATEWAY)
+    const result = await fetchOraclePrices(queryClient, gatewayAddress)
 
     expect(result).toEqual({ WBTC: '0.998' })
   })
 
   it('uppercases mixed-case token symbols so the alias lookup matches', async function () {
     const queryClient = createTestQueryClient()
-    seedToken(queryClient, WBTC, 'wBTC')
-    vi.mocked(getWhitelistedTokens).mockResolvedValue([WBTC])
+    seedToken(queryClient, wbtcAddress, 'wBTC')
+    vi.mocked(getWhitelistedTokens).mockResolvedValue([wbtcAddress])
     mockOracleRead(BigInt(100000000), 8)
 
-    const result = await fetchOraclePrices(queryClient, GATEWAY)
+    const result = await fetchOraclePrices(queryClient, gatewayAddress)
 
     expect(result).toEqual({ WBTC: '1' })
   })
@@ -98,7 +97,7 @@ describe('app/[locale]/hemi-earn/_fetchers/fetchOraclePrices', function () {
     const queryClient = createTestQueryClient()
     vi.mocked(getWhitelistedTokens).mockResolvedValue([])
 
-    const result = await fetchOraclePrices(queryClient, GATEWAY)
+    const result = await fetchOraclePrices(queryClient, gatewayAddress)
 
     expect(result).toEqual({})
   })


### PR DESCRIPTION
### Description

This PR refactors the hemi-earn constants to camelCase, which CLAUDE.md asks for on variable names with no carve-out for constants. The page was the main holdout in the portal, and it was inconsistent with itself: _constants/slippage.ts already exported six camelCase constants sitting right next to BPS_DENOMINATOR.

There is no behavior change anywhere. Every renamed constant was file-local with no exports, and the two values that moved to shared helpers are numerically identical (7776000 for the local store TTL, 14400000 for the cooldown cache window). The localStorage key string is untouched, so operations tracked in an earlier session still show up.

A few things were deliberately left as they are. The enum-like DepositStatus and WithdrawStatus keys stay uppercase because they mirror the shared ProgressStatus that genesis-drop, stake, staking-dashboard and tunnel all use, so renaming them would have split the repo across two conventions for ~80 call sites. Same for the UPPER string literals pinned by the subgraph schema, PEGGED_TOKEN in the gateway mock (a Solidity function, renaming changes the selector), and TEST_PRIVATE_KEY from @hemilabs/anvil-fork-setup (aliasing it to a camelCase local is exactly what the convention asks for).

Scope is hemi-earn only: the page, its tests, and the anvil sandbox scripts. That last one is worth calling out because scripts/hemi-earn is excluded from the portal tsconfig, so it needs its own typecheck and is easy to miss in a sweep.

  Broken down into:
  - `7090041` - Use camelCase for hemi-earn constants
  - `0825435` - Reuse the shared time helpers in hemi-earn
  - `fb4d6ea` - Use camelCase for hemi-earn test fixtures
  - `1bee271` - Use camelCase for the earn sandbox constants
 
### Screenshots

N/A - No UI changes.

### Checklist


- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
