### PR TITLE
Use camelCase for the earn router address

### DIFF
--- a/packages/hemi-earn-actions/index.ts
+++ b/packages/hemi-earn-actions/index.ts
@@ -1,7 +1,4 @@
-export {
-  HEMI_EARN_ROUTER_ADDRESS,
-  getHemiEarnRouterAddress,
-} from './src/constants.ts'
+export { getHemiEarnRouterAddress } from './src/constants.ts'
 
 export type {
   CancelRedeemEvents,

--- a/packages/hemi-earn-actions/src/constants.ts
+++ b/packages/hemi-earn-actions/src/constants.ts
@@ -1,7 +1,7 @@
 import { type Address } from 'viem'
 
 // Hemi Earn Router deployed on Hemi mainnet.
-export const HEMI_EARN_ROUTER_ADDRESS: Address =
+const hemiEarnRouterAddress: Address =
   '0x8a23DF259c6798F9eacC51Ae816461218c3acddc'
 
-export const getHemiEarnRouterAddress = () => HEMI_EARN_ROUTER_ADDRESS
+export const getHemiEarnRouterAddress = () => hemiEarnRouterAddress


### PR DESCRIPTION
### Description

This PR refactors the last SCREAMING_SNAKE identifier in hemi-earn-actions to camelCase, following up on the same pass done for the portal's hemi-earn page.

While checking the blast radius I found the constant was exported from the package's public entrypoint and imported by nobody: every one of the 15 files inside the package that needs the Router address goes through the `getHemiEarnRouterAddress()` accessor, and so does the portal. So instead of just renaming it, the constant is now module-private and dropped from `index.ts`. That satisfies the "do not export what isn't strictly needed" rule as well as the camelCase one, and it lines the package up with `ve-hemi-actions` and `ve-hemi-rewards`, which both keep their address data private behind a getter.

The accessor keeps its name and signature, so no call site changes. The address value is untouched and still matches the one the Envio config indexes.

Before deciding, I confirmed nothing consumes the constant: an exact-name grep with no directory exclusions, no `export *` re-export chain, no namespace import, and a sweep of all 245 local and remote branch tips. The package is also workspace-only (`workspace:*` in both consumers, no publish workflow), so there is no external consumer to break.

### Screenshots

N/A - No UI changes.

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
