### PR TITLE
Read the portal configuration through import.meta.env

### DIFF
--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -113,7 +113,7 @@ The "Stake" entry of the nav covers two unrelated products, sharing a word and n
 
 ### Governance staking (veHEMI)
 
-Governance staking lives on `/staking-dashboard`. The user locks HEMI in the [`VeHemi`](https://github.com/hemilabs/veHEMI/blob/main/src/VeHemi.sol) contract on Hemi and receives an ERC-721 (symbol `veHemi`) representing that lock. The design is a voting-escrow one, in the veCRV tradition: the longer the lock, the more weight it carries. It is a mainnet feature; testnet is gated behind `NEXT_PUBLIC_ENABLE_STAKE_GOVERNANCE_TESTNET` and uses a testnet token.
+Governance staking lives on `/staking-dashboard`. The user locks HEMI in the [`VeHemi`](https://github.com/hemilabs/veHEMI/blob/main/src/VeHemi.sol) contract on Hemi and receives an ERC-721 (symbol `veHemi`) representing that lock. The design is a voting-escrow one, in the veCRV tradition: the longer the lock, the more weight it carries. It is a mainnet feature; testnet is gated behind `VITE_ENABLE_STAKE_GOVERNANCE_TESTNET` and uses a testnet token.
 
 Lock parameters, all enforced by the contract:
 

--- a/portal/.env
+++ b/portal/.env
@@ -1,5 +1,5 @@
-NEXT_PUBLIC_BTC_INPUTS_SIZE=105
-NEXT_PUBLIC_BTC_OUTPUTS_SIZE=25
-NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET=https://eth.drpc.org+https://ethereum-rpc.publicnode.com+https://1rpc.io/eth
-NEXT_PUBLIC_PORTAL_API_URL=https://portal-api.hemi.xyz
-NEXT_PUBLIC_SENTRY_FILTER_KEY_ID="portal-file-identifier-sentry"
+VITE_BTC_INPUTS_SIZE=105
+VITE_BTC_OUTPUTS_SIZE=25
+VITE_CUSTOM_RPC_URL_MAINNET=https://eth.drpc.org+https://ethereum-rpc.publicnode.com+https://1rpc.io/eth
+VITE_PORTAL_API_URL=https://portal-api.hemi.xyz
+VITE_SENTRY_FILTER_KEY_ID="portal-file-identifier-sentry"

--- a/portal/Environment Variables.md
+++ b/portal/Environment Variables.md
@@ -5,6 +5,7 @@ When adding/removing environment variables, check if updates are required in any
 ## Documentation
 
 - portal/README.md
+- docs/DOMAIN.md, when the variable is named in it (feature flags usually are)
 
 ## Default values
 
@@ -30,3 +31,5 @@ Update these files to forward variables from the CI environment (Github Actions)
 
 - .github/actions/deploy-portal
 - .github/workflows/hostinger-deployment.yml
+
+Both still pass the `NEXT_PUBLIC_` names. That holds only while `main` builds with Next, so the deploy step of the migration ([#2194](https://github.com/hemilabs/ui-monorepo/issues/2194)) has to land before this branch reaches `main`: `vite build` ignores anything not prefixed `VITE_`, so every value CI provides would be dropped and the defaults committed in `portal/.env` would win, silently and with a green build. That step retires both files, moving the build to Cloudflare where the variables are configured per environment.

--- a/portal/README.md
+++ b/portal/README.md
@@ -23,51 +23,58 @@ Follow the steps in the [main README](../README.md). No extra actions are needed
 ### Configuration and Environment variables
 
 The environment variables are defined in the `.env` file at the root of the project.
-The prefix `NEXT_PUBLIC_` is required for the variables to be available in the browser. A few variables can be set locally (in a `.env.local`), in addition to the ones already defined in the `.env`.
+The prefix `VITE_` is required: Vite only exposes variables carrying it to the browser, and inlines them at build time. A few variables can be set locally (in a `.env.local`), in addition to the ones already defined in the `.env`.
 
-> Vite only exposes variables prefixed with `VITE_`, so these reads resolve to `undefined` under the new build. The rename happens in the routing step of the migration, when the code that consumes them enters the bundle.
+> If you have a `.env.local` from before the Vite migration, rename its keys from `NEXT_PUBLIC_` to `VITE_`. It is gitignored, so the rename does not reach it on its own, and a stale key is read as `undefined` without any warning.
 
 This is the list of all variables that can be configured:
 
 ```sh
 # Use this variables to override RPC urls per chain. In order to join multiple RPC urls, join them with the "+" character.
-# For example NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA="https://rpc1.testnet.com/rpc+https://rpc2.testnet.com/rpc"
-NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_MAINNET=<urls>
-NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_SEPOLIA=<urls>
-NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET=<urls>
-NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA=<urls>
+# For example VITE_CUSTOM_RPC_URL_SEPOLIA="https://rpc1.testnet.com/rpc+https://rpc2.testnet.com/rpc"
+VITE_CUSTOM_RPC_URL_HEMI_MAINNET=<urls>
+VITE_CUSTOM_RPC_URL_HEMI_SEPOLIA=<urls>
+VITE_CUSTOM_RPC_URL_MAINNET=<urls>
+VITE_CUSTOM_RPC_URL_SEPOLIA=<urls>
 # enable logging on web workers
-NEXT_PUBLIC_WORKERS_DEBUG_ENABLE=<true|false>
+VITE_WORKERS_DEBUG_ENABLE=<true|false>
 # These env variables are required for Enabling Analytics
-NEXT_PUBLIC_ENABLE_ANALYTICS=<true|false> # Enable Analytics with Umami
-NEXT_PUBLIC_ANALYTICS_URL=<url> # Umami analytics URL
-NEXT_PUBLIC_ANALYTICS_WEBSITE_ID=<string> # Umami website ID
+VITE_ENABLE_ANALYTICS=<true|false> # Enable Analytics with Umami
+VITE_ANALYTICS_URL=<url> # Umami analytics URL
+VITE_ANALYTICS_WEBSITE_ID=<string> # Umami website ID
 # These env variables are required for enabling the following features
-NEXT_PUBLIC_ENABLE_HEMI_EARN_PAGE=<true|false> # Enable the Hemi Earn page
-NEXT_PUBLIC_ENABLE_STAKE_GOVERNANCE_TESTNET=<true|false> # Enable stake governance on Testnet, for local development
-NEXT_PUBLIC_ENABLE_STAKE_TESTNET=<true|false> # Enable Stake campaign on Testnet, for local development
-NEXT_PUBLIC_ENABLE_CLAIM_REWARDS_TESTNET=<true|false> # Enable claim rewards on Testnet, for local development
+VITE_ENABLE_HEMI_EARN_PAGE=<true|false> # Enable the Hemi Earn page
+VITE_ENABLE_STAKE_GOVERNANCE_TESTNET=<true|false> # Enable stake governance on Testnet, for local development
+VITE_ENABLE_STAKE_TESTNET=<true|false> # Enable Stake campaign on Testnet, for local development
+VITE_ENABLE_CLAIM_REWARDS_TESTNET=<true|false> # Enable claim rewards on Testnet, for local development
 # Bitcoin configuring
-NEXT_PUBLIC_BITCOIN_PAST_VAULTS_MAINNET=1,2 # Comma-separated list of past vault indexes. Do not include the active ones.
-NEXT_PUBLIC_BITCOIN_PAST_VAULTS_SEPOLIA=1,2,3 # Comma-separated list of past vault indexes. Do not include the active ones.
-NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_MAINNET=3 # Vault index to use for bitcoin in hemi mainnet, when the deposit and withdrawal ones are not set. Defaults to 0
-NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_SEPOLIA=4 # Vault index to use for bitcoin in hemi sepolia, when the deposit and withdrawal ones are not set. Defaults to 0
-NEXT_PUBLIC_DEFAULT_BITCOIN_DEPOSIT_VAULT_MAINNET=5 # Vault index to deposit bitcoin in hemi mainnet. Defaults to NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_MAINNET
-NEXT_PUBLIC_DEFAULT_BITCOIN_DEPOSIT_VAULT_SEPOLIA=6 # Vault index to deposit bitcoin in hemi sepolia. Defaults to NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_SEPOLIA
-NEXT_PUBLIC_DEFAULT_BITCOIN_WITHDRAWAL_VAULT_MAINNET=3 # Vault index to withdraw bitcoin from hemi mainnet. Defaults to NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_MAINNET
-NEXT_PUBLIC_DEFAULT_BITCOIN_WITHDRAWAL_VAULT_SEPOLIA=4 # Vault index to withdraw bitcoin from hemi sepolia. Defaults to NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_SEPOLIA
+VITE_BITCOIN_PAST_VAULTS_MAINNET=1,2 # Comma-separated list of past vault indexes. Do not include the active ones.
+VITE_BITCOIN_PAST_VAULTS_SEPOLIA=1,2,3 # Comma-separated list of past vault indexes. Do not include the active ones.
+VITE_DEFAULT_BITCOIN_VAULT_MAINNET=3 # Vault index to use for bitcoin in hemi mainnet, when the deposit and withdrawal ones are not set. Defaults to 0
+VITE_DEFAULT_BITCOIN_VAULT_SEPOLIA=4 # Vault index to use for bitcoin in hemi sepolia, when the deposit and withdrawal ones are not set. Defaults to 0
+VITE_DEFAULT_BITCOIN_DEPOSIT_VAULT_MAINNET=5 # Vault index to deposit bitcoin in hemi mainnet. Defaults to VITE_DEFAULT_BITCOIN_VAULT_MAINNET
+VITE_DEFAULT_BITCOIN_DEPOSIT_VAULT_SEPOLIA=6 # Vault index to deposit bitcoin in hemi sepolia. Defaults to VITE_DEFAULT_BITCOIN_VAULT_SEPOLIA
+VITE_DEFAULT_BITCOIN_WITHDRAWAL_VAULT_MAINNET=3 # Vault index to withdraw bitcoin from hemi mainnet. Defaults to VITE_DEFAULT_BITCOIN_VAULT_MAINNET
+VITE_DEFAULT_BITCOIN_WITHDRAWAL_VAULT_SEPOLIA=4 # Vault index to withdraw bitcoin from hemi sepolia. Defaults to VITE_DEFAULT_BITCOIN_VAULT_SEPOLIA
+VITE_BTC_INPUTS_SIZE=105 # Assumed size in vbytes of a single transaction input, used to estimate bitcoin fees
+VITE_BTC_OUTPUTS_SIZE=25 # Assumed size in vbytes of a single transaction output, used to estimate bitcoin fees
 # Backend API URL
-NEXT_PUBLIC_PORTAL_API_URL=<url> # To get the token prices, user points, TVL and more
-NEXT_PUBLIC_VETRO_API_URL=<url> # Vetro API URL; powers the Hemi Earn page (variable-stake APY and user rewards)
+VITE_PORTAL_API_URL=<url> # To get the token prices, user points, TVL and more
+VITE_VETRO_API_URL=<url> # Vetro API URL; powers the Hemi Earn page (variable-stake APY and user rewards)
 # The following variables could be used to customize the contracts addresses used by Hemi (for example, for testing with a forked blockchain):
-NEXT_PUBLIC_ADDRESS_MANAGER=<address>
-NEXT_PUBLIC_L2_BRIDGE=<address>
-NEXT_PUBLIC_L2_OUTPUT_ORACLE_PROXY=<address>
-NEXT_PUBLIC_OPTIMISM_PORTAL_PROXY=<address>
-NEXT_PUBLIC_PROXY_OVM_L1_CROSS_DOMAIN_MESSENGER=<address>
-NEXT_PUBLIC_PROXY_OVM_L1_STANDARD_BRIDGE=<address>
+VITE_ADDRESS_MANAGER=<address>
+VITE_L2_BRIDGE=<address>
+VITE_L2_OUTPUT_ORACLE_PROXY=<address>
+VITE_OPTIMISM_PORTAL_PROXY=<address>
+VITE_PROXY_OVM_L1_CROSS_DOMAIN_MESSENGER=<address>
+VITE_PROXY_OVM_L1_STANDARD_BRIDGE=<address>
 # Use it to enable wallet connect
-NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=<wallet-connect-id>
+VITE_WALLET_CONNECT_PROJECT_ID=<wallet-connect-id>
+# Error reporting with Sentry. Not wired under Vite yet: instrumentation-client.ts is a Next convention file that nothing imports
+VITE_SENTRY_DSN=<dsn> # Sentry DSN
+VITE_SENTRY_FILTER_KEY_ID=<string> # Application key used to tell first-party frames from third-party ones
+VITE_SENTRY_RELEASE=<string> # Release name, in the "portal@yyyymmdd_sequence" format. Envelopes not matching it are rewritten
+VITE_TRACES_SAMPLE_RATE=<number> # Ratio of transactions sampled for tracing. Ignored when not a number
 ```
 
 If not defined, the contracts addresses used will be the ones defined in [hemi-viem](https://github.com/hemilabs/hemi-viem).

--- a/portal/app/[locale]/_components/analytics.tsx
+++ b/portal/app/[locale]/_components/analytics.tsx
@@ -23,9 +23,9 @@ export const Analytics = function ({
       <UmamiAnalyticsProvider
         autoTrack={false}
         processUrl={removeLocaleAndTrailingSlash}
-        {...(process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true' && {
-          src: process.env.NEXT_PUBLIC_ANALYTICS_URL,
-          websiteId: process.env.NEXT_PUBLIC_ANALYTICS_WEBSITE_ID,
+        {...(import.meta.env.VITE_ENABLE_ANALYTICS === 'true' && {
+          src: import.meta.env.VITE_ANALYTICS_URL,
+          websiteId: import.meta.env.VITE_ANALYTICS_WEBSITE_ID,
         })}
       >
         <Suspense>

--- a/portal/app/[locale]/genesis-drop/_hooks/useAllEligibleForTokens.ts
+++ b/portal/app/[locale]/genesis-drop/_hooks/useAllEligibleForTokens.ts
@@ -8,7 +8,7 @@ import { useAccount } from 'wagmi'
 
 import { filterExclusiveGroups } from '../_utils'
 
-const portalApiUrl = process.env.NEXT_PUBLIC_PORTAL_API_URL
+const portalApiUrl = import.meta.env.VITE_PORTAL_API_URL
 
 const byClaimGroupId = (a: EligibilityData, b: EligibilityData) =>
   a.claimGroupId - b.claimGroupId

--- a/portal/app/[locale]/genesis-drop/_utils/index.ts
+++ b/portal/app/[locale]/genesis-drop/_utils/index.ts
@@ -14,7 +14,7 @@ export const formatHemi = (amount: bigint, decimals: number) =>
 
 export const isClaimRewardsEnabledOnTestnet = (networkType: NetworkType) =>
   networkType !== 'testnet' ||
-  process.env.NEXT_PUBLIC_ENABLE_CLAIM_REWARDS_TESTNET === 'true'
+  import.meta.env.VITE_ENABLE_CLAIM_REWARDS_TESTNET === 'true'
 
 /**
  * Calculates the staked and unlocked amounts based on the total amount and lockup ratio

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnCostBasis.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnCostBasis.ts
@@ -5,7 +5,7 @@ import { type Address } from 'viem'
 export const earnCostBasisKeyPrefix = ['hemi-earn', 'cost-basis'] as const
 
 const getEarnCostBasisUrl = (account: Address) =>
-  `${process.env.NEXT_PUBLIC_PORTAL_API_URL}/subgraphs/${hemi.id}/earn-cost-basis/${account}`
+  `${import.meta.env.VITE_PORTAL_API_URL}/subgraphs/${hemi.id}/earn-cost-basis/${account}`
 
 export const fetchEarnCostBasis = async function ({
   account,

--- a/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTransactions.ts
+++ b/portal/app/[locale]/hemi-earn/_fetchers/fetchEarnTransactions.ts
@@ -7,7 +7,7 @@ import { type EarnTransaction } from '../types'
 export const earnTransactionsKeyPrefix = ['hemi-earn', 'transactions'] as const
 
 const getEarnRequestsUrl = (account: Address) =>
-  `${process.env.NEXT_PUBLIC_PORTAL_API_URL}/subgraphs/${hemi.id}/earn-requests/${account}`
+  `${import.meta.env.VITE_PORTAL_API_URL}/subgraphs/${hemi.id}/earn-requests/${account}`
 
 export const fetchEarnTransactions = async function ({
   account,

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
@@ -5,7 +5,7 @@ import fetch from 'fetch-plus-plus'
 import { isValidUrl } from 'utils/url'
 import { type Address } from 'viem'
 
-const apiUrl = process.env.NEXT_PUBLIC_VETRO_API_URL
+const apiUrl = import.meta.env.VITE_VETRO_API_URL
 export const isApyApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
 
 type ApyByVault = Partial<Record<Address, { apy: number }>>

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useComposition.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useComposition.ts
@@ -25,7 +25,7 @@ export type CompositionItem = {
   share: number
 }
 
-const apiUrl = process.env.NEXT_PUBLIC_VETRO_API_URL
+const apiUrl = import.meta.env.VITE_VETRO_API_URL
 const isVetroApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
 
 type CompositionQueryOptions = {

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useHistoricalMetrics.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useHistoricalMetrics.ts
@@ -10,7 +10,7 @@ import {
   type MetricType,
 } from '../../../types'
 
-const apiUrl = process.env.NEXT_PUBLIC_VETRO_API_URL
+const apiUrl = import.meta.env.VITE_VETRO_API_URL
 const isVetroApiConfigured = apiUrl !== undefined && isValidUrl(apiUrl)
 
 type ApyHistory = { apy: number; timestamp: number }[]

--- a/portal/app/[locale]/staking-dashboard/_hooks/useRewardsPerVeHEMI.ts
+++ b/portal/app/[locale]/staking-dashboard/_hooks/useRewardsPerVeHEMI.ts
@@ -3,7 +3,7 @@ import fetch from 'fetch-plus-plus'
 import { useHemi } from 'hooks/useHemi'
 import { isValidUrl } from 'utils/url'
 
-const portalApiUrl = process.env.NEXT_PUBLIC_PORTAL_API_URL
+const portalApiUrl = import.meta.env.VITE_PORTAL_API_URL
 
 export function useRewardsPerVeHEMI() {
   const { id: chainId } = useHemi()

--- a/portal/app/[locale]/staking-dashboard/_utils/isStakingDashboardEnabledOnTestnet.ts
+++ b/portal/app/[locale]/staking-dashboard/_utils/isStakingDashboardEnabledOnTestnet.ts
@@ -2,4 +2,4 @@ import { NetworkType } from 'hooks/useNetworkType'
 
 export const isStakingDashboardEnabledOnTestnet = (networkType: NetworkType) =>
   networkType !== 'testnet' ||
-  process.env.NEXT_PUBLIC_ENABLE_STAKE_GOVERNANCE_TESTNET === 'true'
+  import.meta.env.VITE_ENABLE_STAKE_GOVERNANCE_TESTNET === 'true'

--- a/portal/app/featureFlags.ts
+++ b/portal/app/featureFlags.ts
@@ -1,3 +1,3 @@
 export const featureFlags = {
-  enableHemiEarnPage: process.env.NEXT_PUBLIC_ENABLE_HEMI_EARN_PAGE === 'true',
+  enableHemiEarnPage: import.meta.env.VITE_ENABLE_HEMI_EARN_PAGE === 'true',
 }

--- a/portal/components/syncHistoryWorkers.tsx
+++ b/portal/components/syncHistoryWorkers.tsx
@@ -89,7 +89,7 @@ const SyncHistoryWorker = function ({
       }
       setWorkerLoaded(true)
 
-      if (process.env.NEXT_PUBLIC_WORKERS_DEBUG_ENABLE === 'true') {
+      if (import.meta.env.VITE_WORKERS_DEBUG_ENABLE === 'true') {
         // See https://github.com/debug-js/debug/issues/916#issuecomment-1539231712
         const debugString = localStorage.getItem('debug') ?? '*'
         workerRef.current.postMessage({

--- a/portal/components/withWorker.tsx
+++ b/portal/components/withWorker.tsx
@@ -18,7 +18,7 @@ export const WithWorker = function <T extends Worker>({
       // load the Worker
       workerRef.current = getWorker()
 
-      if (process.env.NEXT_PUBLIC_WORKERS_DEBUG_ENABLE === 'true') {
+      if (import.meta.env.VITE_WORKERS_DEBUG_ENABLE === 'true') {
         // See https://github.com/debug-js/debug/issues/916#issuecomment-1539231712
         const debugString = localStorage.getItem('debug') ?? '*'
         workerRef.current.postMessage({

--- a/portal/context/evmWalletContext.tsx
+++ b/portal/context/evmWalletContext.tsx
@@ -32,7 +32,7 @@ const queryClient = new QueryClient()
 
 const appName = 'Hemi Portal'
 const projectId =
-  process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID'
+  import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID'
 
 // All wallets to show in the UI
 const configuredWallets = [

--- a/portal/context/evmWalletContext.tsx
+++ b/portal/context/evmWalletContext.tsx
@@ -32,7 +32,7 @@ const queryClient = new QueryClient()
 
 const appName = 'Hemi Portal'
 const projectId =
-  import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID'
+  import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID || 'YOUR_PROJECT_ID'
 
 // All wallets to show in the UI
 const configuredWallets = [

--- a/portal/hooks/useEstimateBtcFees.ts
+++ b/portal/hooks/useEstimateBtcFees.ts
@@ -4,8 +4,8 @@ import { createBtcApi, type Utxo } from 'utils/btcApi'
 
 import { useNetworkType } from './useNetworkType'
 
-const btcInputsSize = parseInt(process.env.NEXT_PUBLIC_BTC_INPUTS_SIZE!)
-const btcOutputsSize = parseInt(process.env.NEXT_PUBLIC_BTC_OUTPUTS_SIZE!)
+const btcInputsSize = parseInt(import.meta.env.VITE_BTC_INPUTS_SIZE!)
+const btcOutputsSize = parseInt(import.meta.env.VITE_BTC_OUTPUTS_SIZE!)
 // the value sent + OP_RETURN with hemi address
 const expectedOutputs = 2
 

--- a/portal/hooks/useTokenPrices.ts
+++ b/portal/hooks/useTokenPrices.ts
@@ -2,7 +2,7 @@ import { queryOptions, useQuery, UseQueryOptions } from '@tanstack/react-query'
 import fetch from 'fetch-plus-plus'
 import { isValidUrl } from 'utils/url'
 
-const portalApiUrl = process.env.NEXT_PUBLIC_PORTAL_API_URL
+const portalApiUrl = import.meta.env.VITE_PORTAL_API_URL
 
 type Prices = Record<string, string>
 

--- a/portal/hooks/useTvl.ts
+++ b/portal/hooks/useTvl.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import fetch from 'fetch-plus-plus'
 import { isValidUrl } from 'utils/url'
 
-const portalApiUrl = process.env.NEXT_PUBLIC_PORTAL_API_URL
+const portalApiUrl = import.meta.env.VITE_PORTAL_API_URL
 
 export const useTvl = () =>
   useQuery({

--- a/portal/instrumentation-client.ts
+++ b/portal/instrumentation-client.ts
@@ -65,19 +65,19 @@ function enableSentry() {
   // complexity IMO.
   const releaseNameRegex = /^portal@\d{8}_\d+$/
 
-  // Inlined at build time via NEXT_PUBLIC_ prefix, so it cannot be tampered
+  // Inlined at build time via the VITE_ prefix, so it cannot be tampered
   // with by browser extensions overwriting globalThis.SENTRY_RELEASE.
   // See https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/791
-  const release = process.env.NEXT_PUBLIC_SENTRY_RELEASE
+  const release = import.meta.env.VITE_SENTRY_RELEASE
 
   Sentry.init({
     denyUrls: [
       // Filter all Wallet Connect related urls
       /(https|wss):\/\/.*\.walletconnect\.(com|org)/,
-      process.env.NEXT_PUBLIC_PORTAL_API_URL,
+      import.meta.env.VITE_PORTAL_API_URL,
       // filter in case any of the env variables are undefined, although in prod all should be defined.
     ].filter(Boolean) as (string | RegExp)[],
-    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    dsn: import.meta.env.VITE_SENTRY_DSN,
     ignoreErrors,
     // Integrations listed here are added alongside the default ones.
     integrations: [
@@ -105,15 +105,15 @@ function enableSentry() {
         // Should skip all errors that are entirely made of third party frames in the stack trace.
         // Let's start with this, we can make it more strict if needed.
         behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
-        filterKeys: [process.env.NEXT_PUBLIC_SENTRY_FILTER_KEY_ID!],
+        filterKeys: [import.meta.env.VITE_SENTRY_FILTER_KEY_ID!],
       }),
     ],
     normalizeDepth: 6,
     release,
     tracesSampleRate:
-      process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE &&
-      !Number.isNaN(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)
-        ? Number(process.env.NEXT_PUBLIC_TRACES_SAMPLE_RATE)
+      import.meta.env.VITE_TRACES_SAMPLE_RATE &&
+      !Number.isNaN(import.meta.env.VITE_TRACES_SAMPLE_RATE)
+        ? Number(import.meta.env.VITE_TRACES_SAMPLE_RATE)
         : undefined,
     // Custom transport wrapper to prevent phantom releases created by browser
     // extensions that pollute globalThis.SENTRY_RELEASE. Rewrites any foreign
@@ -139,7 +139,7 @@ function enableSentry() {
   })
 }
 
-if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+if (import.meta.env.VITE_SENTRY_DSN) {
   enableSentry()
 }
 

--- a/portal/instrumentation-client.ts
+++ b/portal/instrumentation-client.ts
@@ -112,7 +112,7 @@ function enableSentry() {
     release,
     tracesSampleRate:
       import.meta.env.VITE_TRACES_SAMPLE_RATE &&
-      !Number.isNaN(import.meta.env.VITE_TRACES_SAMPLE_RATE)
+      !Number.isNaN(Number(import.meta.env.VITE_TRACES_SAMPLE_RATE))
         ? Number(import.meta.env.VITE_TRACES_SAMPLE_RATE)
         : undefined,
     // Custom transport wrapper to prevent phantom releases created by browser

--- a/portal/networks/hemiMainnet.ts
+++ b/portal/networks/hemiMainnet.ts
@@ -3,5 +3,5 @@ import { updateRpcUrls } from 'networks/utils'
 
 export const hemiMainnet = updateRpcUrls(
   hemi,
-  process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_MAINNET,
+  import.meta.env.VITE_CUSTOM_RPC_URL_HEMI_MAINNET,
 )

--- a/portal/networks/hemiTestnet.ts
+++ b/portal/networks/hemiTestnet.ts
@@ -3,5 +3,5 @@ import { updateRpcUrls } from 'networks/utils'
 
 export const hemiTestnet = updateRpcUrls(
   hemiSepolia,
-  process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_HEMI_SEPOLIA,
+  import.meta.env.VITE_CUSTOM_RPC_URL_HEMI_SEPOLIA,
 )

--- a/portal/networks/mainnet.ts
+++ b/portal/networks/mainnet.ts
@@ -3,5 +3,5 @@ import { mainnet as mainnetDefinition } from 'viem/chains'
 
 export const mainnet = updateRpcUrls(
   mainnetDefinition,
-  process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_MAINNET,
+  import.meta.env.VITE_CUSTOM_RPC_URL_MAINNET,
 )

--- a/portal/networks/sepolia.ts
+++ b/portal/networks/sepolia.ts
@@ -3,5 +3,5 @@ import { sepolia as sepoliaDefinition } from 'viem/chains'
 
 export const sepolia = updateRpcUrls(
   sepoliaDefinition,
-  process.env.NEXT_PUBLIC_CUSTOM_RPC_URL_SEPOLIA,
+  import.meta.env.VITE_CUSTOM_RPC_URL_SEPOLIA,
 )

--- a/portal/utils/chain.ts
+++ b/portal/utils/chain.ts
@@ -25,25 +25,25 @@ const getHemiForL1 = (l1ChainId: Chain['id']) =>
   findChainById(l1ChainId)?.testnet ? hemiTestnet : hemiMainnet
 
 const getTunnelContracts = (l2Chain: Chain, l1ChainId: Chain['id']) => ({
-  AddressManager: (import.meta.env.VITE_ADDRESS_MANAGER ??
+  AddressManager: (import.meta.env.VITE_ADDRESS_MANAGER ||
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.addressManager[l1ChainId].address) as Address,
   BondManager: zeroAddress,
   CanonicalTransactionChain: zeroAddress,
   L1CrossDomainMessenger: (import.meta.env
-    .VITE_PROXY_OVM_L1_CROSS_DOMAIN_MESSENGER ??
+    .VITE_PROXY_OVM_L1_CROSS_DOMAIN_MESSENGER ||
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.l1CrossDomainMessenger[l1ChainId].address) as Address,
-  L1StandardBridge: (import.meta.env.VITE_PROXY_OVM_L1_STANDARD_BRIDGE ??
+  L1StandardBridge: (import.meta.env.VITE_PROXY_OVM_L1_STANDARD_BRIDGE ||
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.l1StandardBridge[l1ChainId].address) as Address,
-  L2Bridge: (import.meta.env.VITE_L2_BRIDGE ??
+  L2Bridge: (import.meta.env.VITE_L2_BRIDGE ||
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.l2Bridge[l1ChainId].address) as Address,
-  L2OutputOracle: (import.meta.env.VITE_L2_OUTPUT_ORACLE_PROXY ??
+  L2OutputOracle: (import.meta.env.VITE_L2_OUTPUT_ORACLE_PROXY ||
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.l2OutputOracle[l1ChainId].address) as Address,
-  OptimismPortal: (import.meta.env.VITE_OPTIMISM_PORTAL_PROXY ??
+  OptimismPortal: (import.meta.env.VITE_OPTIMISM_PORTAL_PROXY ||
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.portal[l1ChainId].address) as Address,
   StateCommitmentChain: zeroAddress,

--- a/portal/utils/chain.ts
+++ b/portal/utils/chain.ts
@@ -25,25 +25,25 @@ const getHemiForL1 = (l1ChainId: Chain['id']) =>
   findChainById(l1ChainId)?.testnet ? hemiTestnet : hemiMainnet
 
 const getTunnelContracts = (l2Chain: Chain, l1ChainId: Chain['id']) => ({
-  AddressManager: (process.env.NEXT_PUBLIC_ADDRESS_MANAGER ??
+  AddressManager: (import.meta.env.VITE_ADDRESS_MANAGER ??
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.addressManager[l1ChainId].address) as Address,
   BondManager: zeroAddress,
   CanonicalTransactionChain: zeroAddress,
-  L1CrossDomainMessenger: (process.env
-    .NEXT_PUBLIC_PROXY_OVM_L1_CROSS_DOMAIN_MESSENGER ??
+  L1CrossDomainMessenger: (import.meta.env
+    .VITE_PROXY_OVM_L1_CROSS_DOMAIN_MESSENGER ??
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.l1CrossDomainMessenger[l1ChainId].address) as Address,
-  L1StandardBridge: (process.env.NEXT_PUBLIC_PROXY_OVM_L1_STANDARD_BRIDGE ??
+  L1StandardBridge: (import.meta.env.VITE_PROXY_OVM_L1_STANDARD_BRIDGE ??
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.l1StandardBridge[l1ChainId].address) as Address,
-  L2Bridge: (process.env.NEXT_PUBLIC_L2_BRIDGE ??
+  L2Bridge: (import.meta.env.VITE_L2_BRIDGE ??
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.l2Bridge[l1ChainId].address) as Address,
-  L2OutputOracle: (process.env.NEXT_PUBLIC_L2_OUTPUT_ORACLE_PROXY ??
+  L2OutputOracle: (import.meta.env.VITE_L2_OUTPUT_ORACLE_PROXY ??
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.l2OutputOracle[l1ChainId].address) as Address,
-  OptimismPortal: (process.env.NEXT_PUBLIC_OPTIMISM_PORTAL_PROXY ??
+  OptimismPortal: (import.meta.env.VITE_OPTIMISM_PORTAL_PROXY ??
     // @ts-expect-error hemi has these contracts defined
     l2Chain.contracts.portal[l1ChainId].address) as Address,
   StateCommitmentChain: zeroAddress,

--- a/portal/utils/hemiClientExtraActions.ts
+++ b/portal/utils/hemiClientExtraActions.ts
@@ -30,12 +30,14 @@ const withdrawalBitcoinVaults: Record<Chain['id'], number> = {
 }
 
 const pastBitcoinVaults: Record<Chain['id'], number[]> = {
-  [hemi.id]:
-    import.meta.env.VITE_BITCOIN_PAST_VAULTS_MAINNET?.split(',')?.map(Number) ??
-    [],
-  [hemiSepolia.id]:
-    import.meta.env.VITE_BITCOIN_PAST_VAULTS_SEPOLIA?.split(',')?.map(Number) ??
-    [],
+  [hemi.id]: (import.meta.env.VITE_BITCOIN_PAST_VAULTS_MAINNET ?? '')
+    .split(',')
+    .filter(Boolean)
+    .map(Number),
+  [hemiSepolia.id]: (import.meta.env.VITE_BITCOIN_PAST_VAULTS_SEPOLIA ?? '')
+    .split(',')
+    .filter(Boolean)
+    .map(Number),
 }
 
 // In incoming iterations, the vault index will be determined programmatically

--- a/portal/utils/hemiClientExtraActions.ts
+++ b/portal/utils/hemiClientExtraActions.ts
@@ -5,39 +5,37 @@ import { Chain, type Client } from 'viem'
 // be. Both fall back to the vault that used to serve the two flows.
 const depositBitcoinVaults: Record<Chain['id'], number> = {
   [hemi.id]: Number.parseInt(
-    process.env.NEXT_PUBLIC_DEFAULT_BITCOIN_DEPOSIT_VAULT_MAINNET ||
-      process.env.NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_MAINNET ||
+    import.meta.env.VITE_DEFAULT_BITCOIN_DEPOSIT_VAULT_MAINNET ||
+      import.meta.env.VITE_DEFAULT_BITCOIN_VAULT_MAINNET ||
       '0',
   ),
   [hemiSepolia.id]: Number.parseInt(
-    process.env.NEXT_PUBLIC_DEFAULT_BITCOIN_DEPOSIT_VAULT_SEPOLIA ||
-      process.env.NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_SEPOLIA ||
+    import.meta.env.VITE_DEFAULT_BITCOIN_DEPOSIT_VAULT_SEPOLIA ||
+      import.meta.env.VITE_DEFAULT_BITCOIN_VAULT_SEPOLIA ||
       '0',
   ),
 }
 
 const withdrawalBitcoinVaults: Record<Chain['id'], number> = {
   [hemi.id]: Number.parseInt(
-    process.env.NEXT_PUBLIC_DEFAULT_BITCOIN_WITHDRAWAL_VAULT_MAINNET ||
-      process.env.NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_MAINNET ||
+    import.meta.env.VITE_DEFAULT_BITCOIN_WITHDRAWAL_VAULT_MAINNET ||
+      import.meta.env.VITE_DEFAULT_BITCOIN_VAULT_MAINNET ||
       '0',
   ),
   [hemiSepolia.id]: Number.parseInt(
-    process.env.NEXT_PUBLIC_DEFAULT_BITCOIN_WITHDRAWAL_VAULT_SEPOLIA ||
-      process.env.NEXT_PUBLIC_DEFAULT_BITCOIN_VAULT_SEPOLIA ||
+    import.meta.env.VITE_DEFAULT_BITCOIN_WITHDRAWAL_VAULT_SEPOLIA ||
+      import.meta.env.VITE_DEFAULT_BITCOIN_VAULT_SEPOLIA ||
       '0',
   ),
 }
 
 const pastBitcoinVaults: Record<Chain['id'], number[]> = {
   [hemi.id]:
-    process.env.NEXT_PUBLIC_BITCOIN_PAST_VAULTS_MAINNET?.split(',')?.map(
-      Number,
-    ) ?? [],
+    import.meta.env.VITE_BITCOIN_PAST_VAULTS_MAINNET?.split(',')?.map(Number) ??
+    [],
   [hemiSepolia.id]:
-    process.env.NEXT_PUBLIC_BITCOIN_PAST_VAULTS_SEPOLIA?.split(',')?.map(
-      Number,
-    ) ?? [],
+    import.meta.env.VITE_BITCOIN_PAST_VAULTS_SEPOLIA?.split(',')?.map(Number) ??
+    [],
 }
 
 // In incoming iterations, the vault index will be determined programmatically

--- a/portal/utils/stake.ts
+++ b/portal/utils/stake.ts
@@ -14,7 +14,7 @@ import { parseTokenUnits } from './token'
 
 export const isStakeEnabledOnTestnet = (networkType: NetworkType) =>
   networkType !== 'testnet' ||
-  process.env.NEXT_PUBLIC_ENABLE_STAKE_TESTNET === 'true'
+  import.meta.env.VITE_ENABLE_STAKE_TESTNET === 'true'
 
 type CanSubmit = Omit<Parameters<typeof validateInput>[0], 'token'> & {
   token: EvmToken

--- a/portal/utils/subgraph.ts
+++ b/portal/utils/subgraph.ts
@@ -20,7 +20,7 @@ import { getWithdrawals } from 'viem/op-stack'
 import { isL2NetworkId } from './chain'
 
 const getSubgraphBaseUrl = (chainId: Chain['id']) =>
-  `${process.env.NEXT_PUBLIC_PORTAL_API_URL}/subgraphs/${chainId}`
+  `${import.meta.env.VITE_PORTAL_API_URL}/subgraphs/${chainId}`
 
 const request = <TResponse>(
   url: string,


### PR DESCRIPTION
### Description

This PR renames the portal's 35 environment variables from `NEXT_PUBLIC_` to `VITE_` and moves very read from `process.env` to `import.meta.env`.

The issue files this under phase 1 as a mechanical rename, and it mostly is, but it turned out to be more urgent than the checklist suggests. I expected `process.env` to blow up under Vite. It does not: `process.env` gets folded to an empty object, so every read resolved to `undefined` with no error at all. Measured on the previous build, the mainnet chain silently fell back to viem's default RPC while `portal/.env` defines three.

That is why this lands before routing. If routing came first, the app would boot on the Cloudflare environment, look fine, and be pointing at the wrong RPCs with no `PORTAL_API_URL`, no Sentry and every feature flag off. Anything we tested there would be worthless. The proof it works now is in the bundle: the `.env` string is inlined verbatim, and all three RPC URLs show up where only viem's default used to.

The first commit is the rename on its own, so it can be read as the mechanical change it is. The second one is separate on purpose, because it changes behavior: four guards that could never reject the value they existed to catch. An unset repository variable arrives as an empty string rather than `undefined`, so `??` passed it straight through, handing WalletConnect an empty projectId and casting `''` to `Address` for the six tunnel contract overrides. `Number.isNaN` does not coerce, so the traces sample rate accepted any string. Three of those predate the migration.

Following `web/`, there is no `ImportMetaEnv` declaration, so these reads are `any`. That is a deliberate call to match vetro rather than an oversight. It does trade against the "avoid `any`" rule in CLAUDE.md, so happy to revisit if you would rather have the declarations.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #2194 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
