### PR TITLE
Render images with the img element

### DIFF
--- a/portal/app/[locale]/_components/earnCard/earnRewards.tsx
+++ b/portal/app/[locale]/_components/earnCard/earnRewards.tsx
@@ -1,5 +1,5 @@
+import { Image } from 'components/image'
 import { Locale } from 'i18n/routing'
-import Image, { type StaticImageData } from 'next/image'
 import { useLocale, useTranslations } from 'next-intl'
 import { MouseEventHandler } from 'react'
 
@@ -44,7 +44,7 @@ const PoweredBy = () => (
   </p>
 )
 
-const imageMap: Record<Locale, StaticImageData> = {
+const imageMap: Record<Locale, string> = {
   en: earnEn,
   es: earnEs,
   pt: earnPt,

--- a/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/dex/index.tsx
@@ -5,9 +5,9 @@ import { ExternalLink as AnchorTag } from 'components/externalLink'
 import { ArrowDownLeftIcon } from 'components/icons/arrowDownLeftIcon'
 import { Chevron } from 'components/icons/chevron'
 import { DexIcon as BaseDexIcon } from 'components/icons/dexIcon'
+import { Image } from 'components/image'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useUmami } from 'hooks/useUmami'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import {
@@ -182,68 +182,98 @@ const DexImpl = function () {
               <ExternalLink
                 event="nav - rubic"
                 href="https://app.rubic.exchange"
-                icon={<Image alt="Rubic" src={rubicIcon} />}
+                icon={
+                  <Image alt="Rubic" className="size-full" src={rubicIcon} />
+                }
                 text="Rubic"
               />
               <ExternalLink
                 event="nav - dzap"
                 href="https://app.dzap.io/trade"
-                icon={<Image alt="Dzap" src={dzapIcon} />}
+                icon={<Image alt="Dzap" className="size-full" src={dzapIcon} />}
                 text="Dzap"
               />
               <ExternalLink
                 event="nav - 1delta"
                 href="https://1delta.io"
-                icon={<Image alt="1delta" src={oneDeltaIcon} />}
+                icon={
+                  <Image
+                    alt="1delta"
+                    className="size-full"
+                    src={oneDeltaIcon}
+                  />
+                }
                 text="1delta"
               />
               <ExternalLink
                 event="nav - eisen"
                 href="https://eisenfinance.com"
-                icon={<Image alt="Eisen" src={eisenIcon} />}
+                icon={
+                  <Image alt="Eisen" className="size-full" src={eisenIcon} />
+                }
                 text="Eisen"
               />
               <ItemTitle text={t('subtitle')} />
               <ExternalLink
                 event="nav - sushi"
                 href="https://www.sushi.com/hemi/swap"
-                icon={<Image alt="Sushi" src={sushiIcon} />}
+                icon={
+                  <Image alt="Sushi" className="size-full" src={sushiIcon} />
+                }
                 text="Sushi"
               />
               <ExternalLink
                 event="nav - oku"
                 href="https://oku.trade?inputChain=hemi"
-                icon={<Image alt="Oku (uni)" src={okuIcon} />}
+                icon={
+                  <Image alt="Oku (uni)" className="size-full" src={okuIcon} />
+                }
                 text="Oku (uni)"
               />
               <ExternalLink
                 event="nav - izumi"
                 href="https://izumi.finance/trade/swap"
-                icon={<Image alt="Izumi" src={izumiIcon} />}
+                icon={
+                  <Image alt="Izumi" className="size-full" src={izumiIcon} />
+                }
                 text="Izumi"
               />
               <ExternalLink
                 event="nav - dodo"
                 href="https://app.dodoex.io/swap/network/hemi"
-                icon={<Image alt="Dodo" src={dodoIcon} />}
+                icon={<Image alt="Dodo" className="size-full" src={dodoIcon} />}
                 text="Dodo"
               />
               <ExternalLink
                 event="nav - atlas"
                 href="https://www.atlasexchange.xyz/swap"
-                icon={<Image alt="Atlas" src={atlasIcon} />}
+                icon={
+                  <Image alt="Atlas" className="size-full" src={atlasIcon} />
+                }
                 text="Atlas"
               />
               <ExternalLink
                 event="nav - lunarfi"
                 href="https://lunarfinance.io/"
-                icon={<Image alt="LunarFi" src={lunarFiIcon} />}
+                icon={
+                  <Image
+                    alt="LunarFi"
+                    className="size-full"
+                    src={lunarFiIcon}
+                  />
+                }
                 text="LunarFi"
               />
               <ExternalLink
                 event="nav - brownfi"
                 href="https://app.brownfi.io/clamm/swap"
-                icon={<Image alt="BrownFi" src={brownFiIcon} />}
+                icon={
+                  <Image
+                    alt="BrownFi"
+                    className="size-full"
+                    src={brownFiIcon}
+                  />
+                }
                 text="BrownFi"
               />
             </div>

--- a/portal/app/[locale]/ecosystem/_components/demoCard.tsx
+++ b/portal/app/[locale]/ecosystem/_components/demoCard.tsx
@@ -2,8 +2,8 @@
 
 import { AnalyticsEvent } from 'app/analyticsEvents'
 import { ExternalLink } from 'components/externalLink'
+import { Image } from 'components/image'
 import { useUmami } from 'hooks/useUmami'
-import Image, { StaticImageData } from 'next/image'
 
 const colorVariants = {
   black: 'text-neutral-950',
@@ -15,12 +15,12 @@ type ColorVariant = keyof typeof colorVariants
 
 type Props = {
   altText: string
-  bgImage: StaticImageData
+  bgImage: string
   event: AnalyticsEvent
   href: string
   heading: string
   headingColor: ColorVariant
-  icon: StaticImageData
+  icon: string
   subHeading: string
   subHeadingColor?: ColorVariant
 }
@@ -43,15 +43,13 @@ export const DemoCard = function ({
   return (
     <div className="solid group/demo-card relative h-[270px] flex-shrink flex-grow rounded-[17px] border border-neutral-300/55 hover:cursor-pointer md:h-56 md:w-[295px] md:flex-shrink-0 md:flex-grow-0">
       <div className="absolute left-6 top-5 -z-10 h-12 w-12">
-        <Image alt={altText} fill priority={true} src={icon} />
+        <Image alt={altText} className="size-full" loading="eager" src={icon} />
       </div>
       <Image
         alt={altText}
-        className="-z-20 rounded-2xl duration-150 group-hover/demo-card:opacity-88"
-        fill
-        priority={true}
+        className="absolute inset-0 -z-20 size-full rounded-2xl object-cover duration-150 group-hover/demo-card:opacity-88"
+        loading="eager"
         src={bgImage}
-        style={{ objectFit: 'cover' }}
       />
       <div className="h-full">
         <ExternalLink

--- a/portal/app/[locale]/get-started/_components/learnMore.tsx
+++ b/portal/app/[locale]/get-started/_components/learnMore.tsx
@@ -2,8 +2,8 @@ import { AnalyticsEvent } from 'app/analyticsEvents'
 import { ButtonLink } from 'components/button'
 import { Card } from 'components/card'
 import { ExternalLink } from 'components/externalLink'
+import { Image } from 'components/image'
 import { useUmami } from 'hooks/useUmami'
-import Image, { StaticImageData } from 'next/image'
 import { useTranslations } from 'next-intl'
 
 import btcWallet from '../_assets/btcWallet.svg'
@@ -16,7 +16,7 @@ type TutorialCardProps = {
   event: AnalyticsEvent
   heading: string
   href: string
-  icon: StaticImageData
+  icon: string
   iconAlt: string
   subheading: string
 }

--- a/portal/app/[locale]/not-found.tsx
+++ b/portal/app/[locale]/not-found.tsx
@@ -15,9 +15,7 @@ export default function NotFound() {
       <Image
         alt="404"
         className="absolute inset-0 -top-64 m-auto w-72 md:w-fit"
-        height={error404.height}
-        src={error404.src}
-        width={error404.width}
+        {...error404}
       />
       <div className="z-10 m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/app/[locale]/not-found.tsx
+++ b/portal/app/[locale]/not-found.tsx
@@ -5,7 +5,7 @@ import { ExclamationMark } from 'components/icons/exclamationMark'
 import { Image } from 'components/image'
 import { useTranslations } from 'next-intl'
 
-import Error404 from '../_images/404.svg'
+import { error404 } from '../_images/error404'
 
 export default function NotFound() {
   const t = useTranslations('error-pages')
@@ -15,11 +15,9 @@ export default function NotFound() {
       <Image
         alt="404"
         className="absolute inset-0 -top-64 m-auto w-72 md:w-fit"
-        fetchPriority="high"
-        height={402}
-        loading="eager"
-        src={Error404}
-        width={973}
+        height={error404.height}
+        src={error404.src}
+        width={error404.width}
       />
       <div className="z-10 m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/app/[locale]/not-found.tsx
+++ b/portal/app/[locale]/not-found.tsx
@@ -2,7 +2,7 @@
 
 import 'styles/globals.css'
 import { ExclamationMark } from 'components/icons/exclamationMark'
-import Image from 'next/image'
+import { Image } from 'components/image'
 import { useTranslations } from 'next-intl'
 
 import Error404 from '../_images/404.svg'
@@ -15,7 +15,11 @@ export default function NotFound() {
       <Image
         alt="404"
         className="absolute inset-0 -top-64 m-auto w-72 md:w-fit"
+        fetchPriority="high"
+        height={402}
+        loading="eager"
         src={Error404}
+        width={973}
       />
       <div className="z-10 m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/app/[locale]/stake/_components/protocolImage.tsx
+++ b/portal/app/[locale]/stake/_components/protocolImage.tsx
@@ -7,15 +7,6 @@ type Props = {
   protocol: StakeProtocols
 }
 
-export const ProtocolImage = function ({ protocol }: Props) {
-  const { className, height, src, width } = protocolImages[protocol]
-  return (
-    <Image
-      alt={protocol}
-      className={className}
-      height={height}
-      src={src}
-      width={width}
-    />
-  )
-}
+export const ProtocolImage = ({ protocol }: Props) => (
+  <Image alt={protocol} {...protocolImages[protocol]} />
+)

--- a/portal/app/[locale]/stake/_components/protocolImage.tsx
+++ b/portal/app/[locale]/stake/_components/protocolImage.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import { Image } from 'components/image'
 import { StakeProtocols } from 'types/stake'
 
 import { protocolImages } from '../protocols/protocolImages'
@@ -8,6 +8,14 @@ type Props = {
 }
 
 export const ProtocolImage = function ({ protocol }: Props) {
-  const { className, src } = protocolImages[protocol]
-  return <Image alt={protocol} className={className} src={src} />
+  const { className, height, src, width } = protocolImages[protocol]
+  return (
+    <Image
+      alt={protocol}
+      className={className}
+      height={height}
+      src={src}
+      width={width}
+    />
+  )
 }

--- a/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
@@ -1,6 +1,6 @@
 import { Card } from 'components/card'
+import { Image } from 'components/image'
 import { useTokenPrices } from 'hooks/useTokenPrices'
-import Image, { StaticImageData } from 'next/image'
 import { useTranslations } from 'next-intl'
 import { ReactNode } from 'react'
 import { formatFiatNumber, formatTVL } from 'utils/format'
@@ -16,7 +16,7 @@ import starIcon from './icons/star.svg'
 
 type Props = {
   heading: string
-  icon: StaticImageData
+  icon: string
   iconAlt: string
   points: string
 }

--- a/portal/app/[locale]/stake/protocols/protocolImages.ts
+++ b/portal/app/[locale]/stake/protocols/protocolImages.ts
@@ -1,4 +1,3 @@
-import { StaticImageData } from 'next/image'
 import { StakeProtocols } from 'types/stake'
 
 import babypie from './images/babypie.png'
@@ -27,30 +26,30 @@ import yieldNest from './images/yieldNest.svg'
 
 export const protocolImages: Record<
   StakeProtocols,
-  { src: StaticImageData; className?: string }
+  { className?: string; height: number; src: string; width: number }
 > = {
-  babypie: { className: 'w-20', src: babypie },
-  bedRock: { src: bedRock },
-  bitFi: { src: bitFi },
-  circle: { src: circle },
-  egEth: { className: 'w-21', src: eigenpie },
-  ethereum: { src: ethereum },
-  exSat: { src: exSat },
-  hemi: { src: hemi },
-  kelp: { src: kelp },
-  lorenzo: { src: lorenzo },
-  makerDao: { className: 'w-21', src: makerDao },
-  merlinChain: { className: 'w-29', src: merlinChain },
-  obeliskNodeDao: { src: obeliskNodeDao },
-  pumpBtc: { className: 'w-24', src: pumpBtc },
-  river: { src: river },
-  solv: { src: solv },
-  sumer: { className: 'w-15', src: sumer },
-  tether: { src: tether },
-  tetherGold: { src: tetherGold },
-  threshold: { src: threshold },
-  uniBtc: { src: bedRock },
-  uniRouter: { className: 'w-21', src: uniRouter },
-  wbtc: { src: wbtc },
-  yieldNest: { src: yieldNest },
+  babypie: { className: 'w-20', height: 36, src: babypie, width: 160 },
+  bedRock: { height: 24, src: bedRock, width: 113 },
+  bitFi: { height: 24, src: bitFi, width: 62 },
+  circle: { height: 18, src: circle, width: 71 },
+  egEth: { className: 'w-21', height: 40, src: eigenpie, width: 170 },
+  ethereum: { height: 20, src: ethereum, width: 80 },
+  exSat: { height: 19, src: exSat, width: 91 },
+  hemi: { height: 18, src: hemi, width: 63 },
+  kelp: { height: 20, src: kelp, width: 54 },
+  lorenzo: { height: 22, src: lorenzo, width: 84 },
+  makerDao: { className: 'w-21', height: 24, src: makerDao, width: 166 },
+  merlinChain: { className: 'w-29', height: 40, src: merlinChain, width: 232 },
+  obeliskNodeDao: { height: 18, src: obeliskNodeDao, width: 64 },
+  pumpBtc: { className: 'w-24', height: 72, src: pumpBtc, width: 282 },
+  river: { height: 18, src: river, width: 52 },
+  solv: { height: 16, src: solv, width: 56 },
+  sumer: { className: 'w-15', height: 40, src: sumer, width: 131 },
+  tether: { height: 14, src: tether, width: 63 },
+  tetherGold: { height: 20, src: tetherGold, width: 64 },
+  threshold: { height: 10, src: threshold, width: 108 },
+  uniBtc: { height: 24, src: bedRock, width: 113 },
+  uniRouter: { className: 'w-21', height: 48, src: uniRouter, width: 166 },
+  wbtc: { height: 18, src: wbtc, width: 61 },
+  yieldNest: { height: 18, src: yieldNest, width: 95 },
 }

--- a/portal/app/_images/error404.ts
+++ b/portal/app/_images/error404.ts
@@ -1,0 +1,3 @@
+import src from './404.svg'
+
+export const error404 = { height: 402, src, width: 973 }

--- a/portal/app/not-found.tsx
+++ b/portal/app/not-found.tsx
@@ -13,9 +13,7 @@ export default function NotFound() {
       <Image
         alt="404"
         className="absolute inset-0 -top-64 m-auto w-72 md:w-fit"
-        height={error404.height}
-        src={error404.src}
-        width={error404.width}
+        {...error404}
       />
       <div className="z-10 m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/app/not-found.tsx
+++ b/portal/app/not-found.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ExclamationMark } from 'components/icons/exclamationMark'
-import Image from 'next/image'
+import { Image } from 'components/image'
 
 import 'styles/globals.css'
 
@@ -13,7 +13,11 @@ export default function NotFound() {
       <Image
         alt="404"
         className="absolute inset-0 -top-64 m-auto w-72 md:w-fit"
+        fetchPriority="high"
+        height={402}
+        loading="eager"
         src={Error404}
+        width={973}
       />
       <div className="z-10 m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/app/not-found.tsx
+++ b/portal/app/not-found.tsx
@@ -5,7 +5,7 @@ import { Image } from 'components/image'
 
 import 'styles/globals.css'
 
-import Error404 from './_images/404.svg'
+import { error404 } from './_images/error404'
 
 export default function NotFound() {
   return (
@@ -13,11 +13,9 @@ export default function NotFound() {
       <Image
         alt="404"
         className="absolute inset-0 -top-64 m-auto w-72 md:w-fit"
-        fetchPriority="high"
-        height={402}
-        loading="eager"
-        src={Error404}
-        width={973}
+        height={error404.height}
+        src={error404.src}
+        width={error404.width}
       />
       <div className="z-10 m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/components/cardInfo.tsx
+++ b/portal/components/cardInfo.tsx
@@ -1,11 +1,11 @@
 import { Card } from 'components/card'
-import Image, { StaticImageData } from 'next/image'
+import { Image } from 'components/image'
 import { type ReactNode } from 'react'
 
 type Props<T> = {
   data: T | undefined
   formatValue: (value: T) => ReactNode
-  icon?: StaticImageData | null
+  icon?: string | null
   iconAlt?: string
   isError: boolean
   label: string

--- a/portal/components/customTokenDrawer/tokenPreview.tsx
+++ b/portal/components/customTokenDrawer/tokenPreview.tsx
@@ -1,5 +1,5 @@
+import { Image } from 'components/image'
 import { CustomToken } from 'components/tokenSelector/token'
-import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { Token } from 'types/token'
 
@@ -11,9 +11,11 @@ export const TokenPreview = function ({ isLoading, token }: Props) {
   const t = useTranslations('token-custom-drawer')
   return (
     <div className="relative z-0 border-b border-t border-dashed border-neutral-300/55 bg-neutral-50">
-      <div className="absolute bottom-0 left-0 right-0 top-0">
-        <Image alt="Token Preview background" fill src={background} />
-      </div>
+      <Image
+        alt="Token Preview background"
+        className="absolute inset-0 size-full"
+        src={background}
+      />
       <div className="relative z-10 mx-auto w-3/4 py-1.5">
         {token || isLoading ? (
           <CustomToken token={token} />

--- a/portal/components/customTunnelsThroughPartners/partnerImage.tsx
+++ b/portal/components/customTunnelsThroughPartners/partnerImage.tsx
@@ -1,8 +1,8 @@
-import Image, { type StaticImageData } from 'next/image'
+import { Image } from 'components/image'
 
 type Props = {
   alt: string
-  src: StaticImageData
+  src: string
 }
 
 export const PartnerImage = ({ alt, src }: Props) => (

--- a/portal/components/error500/errorArtwork.ts
+++ b/portal/components/error500/errorArtwork.ts
@@ -1,0 +1,3 @@
+import src from './500.svg'
+
+export const errorArtwork = { height: 349, src, width: 941 }

--- a/portal/components/error500/index.tsx
+++ b/portal/components/error500/index.tsx
@@ -37,9 +37,7 @@ export const Error500 = function ({
       <Image
         alt="hemi 500 error background"
         className="absolute inset-0 -top-15 -z-10 m-auto w-4/5"
-        height={errorArtwork.height}
-        src={errorArtwork.src}
-        width={errorArtwork.width}
+        {...errorArtwork}
       />
       <div className="m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/components/error500/index.tsx
+++ b/portal/components/error500/index.tsx
@@ -6,7 +6,7 @@ import hemiSocials from 'hemi-socials'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect } from 'react'
 
-import svg500Error from './500.svg'
+import { errorArtwork } from './errorArtwork'
 
 const { discordUrl } = hemiSocials
 
@@ -37,11 +37,9 @@ export const Error500 = function ({
       <Image
         alt="hemi 500 error background"
         className="absolute inset-0 -top-15 -z-10 m-auto w-4/5"
-        fetchPriority="high"
-        height={349}
-        loading="eager"
-        src={svg500Error}
-        width={941}
+        height={errorArtwork.height}
+        src={errorArtwork.src}
+        width={errorArtwork.width}
       />
       <div className="m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/components/error500/index.tsx
+++ b/portal/components/error500/index.tsx
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/nextjs'
 import { ExternalLink } from 'components/externalLink'
 import { ExclamationMark } from 'components/icons/exclamationMark'
+import { Image } from 'components/image'
 import hemiSocials from 'hemi-socials'
-import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect } from 'react'
 
@@ -37,7 +37,11 @@ export const Error500 = function ({
       <Image
         alt="hemi 500 error background"
         className="absolute inset-0 -top-15 -z-10 m-auto w-4/5"
+        fetchPriority="high"
+        height={349}
+        loading="eager"
         src={svg500Error}
+        width={941}
       />
       <div className="m-auto flex flex-col items-center gap-4">
         <ExclamationMark />

--- a/portal/components/image.tsx
+++ b/portal/components/image.tsx
@@ -1,8 +1,6 @@
 import { type ComponentProps } from 'react'
 
-// A bare <img> loads eagerly, so dropping next/image regressed every list of
-// logos into fetching all of them on mount. These restore the defaults it set.
-// `alt` is required so decorative images have to opt out with an empty string
+// `alt` is required so a decorative image has to opt out with an empty string
 // rather than by omission.
 export const Image = ({
   alt,

--- a/portal/components/image.tsx
+++ b/portal/components/image.tsx
@@ -1,0 +1,14 @@
+import { type ComponentProps } from 'react'
+
+// A bare <img> loads eagerly, so dropping next/image regressed every list of
+// logos into fetching all of them on mount. These restore the defaults it set.
+// `alt` is required so decorative images have to opt out with an empty string
+// rather than by omission.
+export const Image = ({
+  alt,
+  decoding = 'async',
+  loading = 'lazy',
+  ...props
+}: ComponentProps<'img'> & { alt: string }) => (
+  <img alt={alt} decoding={decoding} loading={loading} {...props} />
+)

--- a/portal/components/reviewOperation/_images/gradientLoading.ts
+++ b/portal/components/reviewOperation/_images/gradientLoading.ts
@@ -1,0 +1,3 @@
+import src from './gradient_loading.png'
+
+export const gradientLoading = { height: 20, src, width: 20 }

--- a/portal/components/reviewOperation/positionStatus.tsx
+++ b/portal/components/reviewOperation/positionStatus.tsx
@@ -31,9 +31,7 @@ export const PositionStatus = function ({ position, status }: Props) {
         <Image
           alt="Loading icon"
           className="animate-spin"
-          height={gradientLoading.height}
-          src={gradientLoading.src}
-          width={gradientLoading.width}
+          {...gradientLoading}
         />
       )}
       <div

--- a/portal/components/reviewOperation/positionStatus.tsx
+++ b/portal/components/reviewOperation/positionStatus.tsx
@@ -1,5 +1,5 @@
 import { OrangeCheckIcon } from 'components/icons/orangeCheckIcon'
-import Image from 'next/image'
+import { Image } from 'components/image'
 
 import { ErrorIcon } from './_icons/errorIcon'
 import gradientLoadingImg from './_images/gradient_loading.png'
@@ -31,7 +31,9 @@ export const PositionStatus = function ({ position, status }: Props) {
         <Image
           alt="Loading icon"
           className="animate-spin"
+          height={20}
           src={gradientLoadingImg}
+          width={20}
         />
       )}
       <div

--- a/portal/components/reviewOperation/positionStatus.tsx
+++ b/portal/components/reviewOperation/positionStatus.tsx
@@ -2,7 +2,7 @@ import { OrangeCheckIcon } from 'components/icons/orangeCheckIcon'
 import { Image } from 'components/image'
 
 import { ErrorIcon } from './_icons/errorIcon'
-import gradientLoadingImg from './_images/gradient_loading.png'
+import { gradientLoading } from './_images/gradientLoading'
 import { ProgressStatus, type ProgressStatusType } from './progressStatus'
 
 type Props = {
@@ -31,9 +31,9 @@ export const PositionStatus = function ({ position, status }: Props) {
         <Image
           alt="Loading icon"
           className="animate-spin"
-          height={20}
-          src={gradientLoadingImg}
-          width={20}
+          height={gradientLoading.height}
+          src={gradientLoading.src}
+          width={gradientLoading.width}
         />
       )}
       <div

--- a/portal/components/reviewOperation/subStep.tsx
+++ b/portal/components/reviewOperation/subStep.tsx
@@ -1,5 +1,5 @@
 import { OrangeCheckIcon } from 'components/icons/orangeCheckIcon'
-import Image from 'next/image'
+import { Image } from 'components/image'
 import { ReactNode } from 'react'
 
 import { ClockIcon } from './_icons/clockIcon'
@@ -30,9 +30,7 @@ export function SubStep({ description, status }: Props) {
           {isProgress && (
             <Image
               alt="Loading indicator"
-              className="animate-spin object-contain"
-              fill
-              priority
+              className="absolute inset-0 size-full animate-spin object-contain"
               src={gradientLoadingImg}
             />
           )}

--- a/portal/components/reviewOperation/subStep.tsx
+++ b/portal/components/reviewOperation/subStep.tsx
@@ -3,7 +3,7 @@ import { Image } from 'components/image'
 import { ReactNode } from 'react'
 
 import { ClockIcon } from './_icons/clockIcon'
-import gradientLoadingImg from './_images/gradient_loading.png'
+import { gradientLoading } from './_images/gradientLoading'
 import { ProgressStatus, type ProgressStatusType } from './progressStatus'
 
 type Props = {
@@ -31,7 +31,8 @@ export function SubStep({ description, status }: Props) {
             <Image
               alt="Loading indicator"
               className="absolute inset-0 size-full animate-spin object-contain"
-              src={gradientLoadingImg}
+              loading="eager"
+              src={gradientLoading.src}
             />
           )}
           <ClockIcon />

--- a/portal/components/tokenLogo.tsx
+++ b/portal/components/tokenLogo.tsx
@@ -1,6 +1,6 @@
+import { Image } from 'components/image'
 import { useBitcoin } from 'hooks/useBitcoin'
 import { useNetworkType } from 'hooks/useNetworkType'
-import Image from 'next/image'
 import { type Token } from 'types/token'
 import { isBtcNetworkId } from 'utils/chain'
 import { getNativeToken } from 'utils/nativeToken'

--- a/portal/docs/add-new-token-to-stake.md
+++ b/portal/docs/add-new-token-to-stake.md
@@ -75,12 +75,17 @@ import satoshi from './images/satoshi.png'
 
 ...
 
-export const protocolImages: Record<StakeProtocols, StaticImageData> = {
+export const protocolImages: Record<
+  StakeProtocols,
+  { className?: string; height: number; src: string; width: number }
+> = {
     ...
-    satoshi,
+    satoshi: { height: 20, src: satoshi, width: 80 },
     ...
 }
 ```
+
+`height` and `width` are the image's own dimensions in pixels. They reserve the box before the asset loads, so the table does not jump; `className` is only needed when the logo has to be rendered at a size other than its own.
 
 ## Step 5 - Check if token is whitelisted
 

--- a/portal/test/imageDimensions.test.ts
+++ b/portal/test/imageDimensions.test.ts
@@ -1,27 +1,39 @@
 import { protocolImages } from 'app/[locale]/stake/protocols/protocolImages'
-import error404 from 'app/_images/404.svg'
-import svg500 from 'components/error500/500.svg'
-import gradientLoading from 'components/reviewOperation/_images/gradient_loading.png'
+import { error404 } from 'app/_images/error404'
+import { errorArtwork } from 'components/error500/errorArtwork'
+import { gradientLoading } from 'components/reviewOperation/_images/gradientLoading'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { describe, expect, it } from 'vitest'
 
 // The `width`/`height` declared next to each image define the aspect ratio the
 // browser reserves before the asset loads. next/image derived them from the
-// file, so they could not drift; now they are written by hand and nothing else
-// would catch a swapped asset.
+// file, so they could not drift; now they are written by hand, and the modules
+// asserted here are the same ones the components render from.
 
+const rootSvgTag = function (svg: string) {
+  const tag = /<svg\b[^>]*>/.exec(svg)
+  if (!tag) {
+    throw new Error('no <svg> element found')
+  }
+  return tag[0]
+}
+
+// Only the root tag is scanned: `stroke-width` on a child matches a bare
+// /width=/ and would silently win over the viewBox fallback.
 const svgSize = function (svg: string) {
-  const width = /\bwidth=['"]([\d.]+)/.exec(svg)
-  const height = /\bheight=['"]([\d.]+)/.exec(svg)
+  const tag = rootSvgTag(svg)
+  const width = /[\s]width=['"]([\d.]+)/.exec(tag)
+  const height = /[\s]height=['"]([\d.]+)/.exec(tag)
   if (width && height) {
-    return { height: Math.round(+height[1]), width: Math.round(+width[1]) }
+    return { height: +height[1], width: +width[1] }
   }
-  const viewBox = /viewBox=['"][\d.-]+ +[\d.-]+ +([\d.]+) +([\d.]+)/.exec(svg)
-  return {
-    height: Math.round(+viewBox![2]),
-    width: Math.round(+viewBox![1]),
+  const viewBox =
+    /viewBox=['"]\s*[\d.-]+[\s,]+[\d.-]+[\s,]+([\d.]+)[\s,]+([\d.]+)/.exec(tag)
+  if (!viewBox) {
+    throw new Error(`no width/height and no usable viewBox in ${tag}`)
   }
+  return { height: +viewBox[2], width: +viewBox[1] }
 }
 
 const pngSize = (bytes: Buffer) => ({
@@ -29,12 +41,22 @@ const pngSize = (bytes: Buffer) => ({
   width: bytes.readUInt32BE(16),
 })
 
-// Vite inlines small assets as a data URI and emits the rest as a path rooted
-// at the portal directory, so both shapes reach the app.
+// Vite serves an asset as a path or inlines it as a data URI, and small SVGs
+// come back base64 encoded whenever they contain <text>, <foreignObject> or a
+// nested quote.
 const intrinsicSize = function (src: string) {
-  const svgDataUri = 'data:image/svg+xml,'
-  if (src.startsWith(svgDataUri)) {
-    return svgSize(decodeURIComponent(src.slice(svgDataUri.length)))
+  const svgUtf8 = 'data:image/svg+xml,'
+  const svgBase64 = 'data:image/svg+xml;base64,'
+  if (src.startsWith(svgBase64)) {
+    return svgSize(
+      Buffer.from(src.slice(svgBase64.length), 'base64').toString('utf8'),
+    )
+  }
+  if (src.startsWith(svgUtf8)) {
+    return svgSize(decodeURIComponent(src.slice(svgUtf8.length)))
+  }
+  if (src.startsWith('data:image/png;base64,')) {
+    return pngSize(Buffer.from(src.split(',')[1], 'base64'))
   }
   const file = join(__dirname, '..', decodeURIComponent(src))
   return src.endsWith('.png')
@@ -53,17 +75,13 @@ describe('declared image dimensions', function () {
   })
 
   it.each([
-    { height: 402, name: '404.svg', src: error404, width: 973 },
-    { height: 349, name: '500.svg', src: svg500, width: 941 },
-    {
-      height: 20,
-      name: 'gradient_loading.png',
-      src: gradientLoading,
-      width: 20,
-    },
+    { image: error404, name: '404.svg' },
+    { image: errorArtwork, name: '500.svg' },
+    { image: gradientLoading, name: 'gradient_loading.png' },
   ])(
-    '$name matches the dimensions its component declares',
-    function ({ height, src, width }) {
+    '$name matches the dimensions declared alongside it',
+    function ({ image }) {
+      const { height, src, width } = image
       expect(intrinsicSize(src)).toEqual({ height, width })
     },
   )

--- a/portal/test/imageDimensions.test.ts
+++ b/portal/test/imageDimensions.test.ts
@@ -1,0 +1,70 @@
+import { protocolImages } from 'app/[locale]/stake/protocols/protocolImages'
+import error404 from 'app/_images/404.svg'
+import svg500 from 'components/error500/500.svg'
+import gradientLoading from 'components/reviewOperation/_images/gradient_loading.png'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+// The `width`/`height` declared next to each image define the aspect ratio the
+// browser reserves before the asset loads. next/image derived them from the
+// file, so they could not drift; now they are written by hand and nothing else
+// would catch a swapped asset.
+
+const svgSize = function (svg: string) {
+  const width = /\bwidth=['"]([\d.]+)/.exec(svg)
+  const height = /\bheight=['"]([\d.]+)/.exec(svg)
+  if (width && height) {
+    return { height: Math.round(+height[1]), width: Math.round(+width[1]) }
+  }
+  const viewBox = /viewBox=['"][\d.-]+ +[\d.-]+ +([\d.]+) +([\d.]+)/.exec(svg)
+  return {
+    height: Math.round(+viewBox![2]),
+    width: Math.round(+viewBox![1]),
+  }
+}
+
+const pngSize = (bytes: Buffer) => ({
+  height: bytes.readUInt32BE(20),
+  width: bytes.readUInt32BE(16),
+})
+
+// Vite inlines small assets as a data URI and emits the rest as a path rooted
+// at the portal directory, so both shapes reach the app.
+const intrinsicSize = function (src: string) {
+  const svgDataUri = 'data:image/svg+xml,'
+  if (src.startsWith(svgDataUri)) {
+    return svgSize(decodeURIComponent(src.slice(svgDataUri.length)))
+  }
+  const file = join(__dirname, '..', decodeURIComponent(src))
+  return src.endsWith('.png')
+    ? pngSize(readFileSync(file))
+    : svgSize(readFileSync(file, 'utf8'))
+}
+
+describe('declared image dimensions', function () {
+  describe('protocolImages', function () {
+    it.each(Object.entries(protocolImages))(
+      '%s matches its asset',
+      function (_protocol, { height, src, width }) {
+        expect(intrinsicSize(src)).toEqual({ height, width })
+      },
+    )
+  })
+
+  it.each([
+    { height: 402, name: '404.svg', src: error404, width: 973 },
+    { height: 349, name: '500.svg', src: svg500, width: 941 },
+    {
+      height: 20,
+      name: 'gradient_loading.png',
+      src: gradientLoading,
+      width: 20,
+    },
+  ])(
+    '$name matches the dimensions its component declares',
+    function ({ height, src, width }) {
+      expect(intrinsicSize(src)).toEqual({ height, width })
+    },
+  )
+})


### PR DESCRIPTION
### Description

This PR replaces `next/image` with plain `<img>` across the portal, and takes `pnpm typecheck` from 42 errors to 0.

Those 42 were all the same thing: `vite/client` types an image import as `string`, which is the truth, while the code was still typed against `StaticImageData`. They have been sitting there since the toolchain swap, drowning out anything new. This is phase 4 work pulled forward because it does not depend on routing or i18n, and it does not conflict with the env vars PR (16 files here, 30 there, no overlap).

Nothing is lost in the swap. The old `next.config.ts` had `images: { unoptimized: true }`, so `next/image` was not resizing, converting formats or proxying anything, and its `remotePatterns` entry for the token list host stops being needed. **What it did still provide were defaults**, and those had to come back by hand: it read `width`/`height` from the static import (which is how the browser reserves the box before the asset loads), and it lazy-loaded with async decoding. `components/image.tsx` restores the loading defaults in one place and requires `alt`, so a decorative image has to opt out with an empty string rather than by omission.

The dimensions could not be centralized, so they are declared next to each image. That is a maintenance trap, since a swapped asset would silently distort with no type or lint error, so `test/imageDimensions.test.ts` reads every file (PNG header, SVG viewBox) and asserts the declared numbers still match. It covers 27 assets and I checked that it actually fails by flipping one.

**This is not fully tested yet.** The four `fill` usages needed a CSS equivalent, and those are the only places where a visual regression is possible. I confirmed the Tailwind classes are emitted and produce what `fill` did (`size-full` is `width:100%;height:100%`, `object-cover` replaces the inline `objectFit`), but the components themselves cannot be rendered on this branch: the Vite entry is still a placeholder and `next dev` is gone. Three places need eyes once routing lands: `/ecosystem` (the demo card background and icon), the custom token drawer (the preview background SVG) and a review drawer mid operation (the `subStep` spinner, which should stay spinning and centered).

Tested with `pnpm lint`, `pnpm format:check`, `pnpm deps:check`, `pnpm typecheck`, `pnpm test` (878 tests) and `pnpm build`.

## Notes

`priority` in `next/image` meant eager plus high fetch priority plus a preload, and only three call sites had it: the two `demoCard` images and the `subStep` spinner. Those became `loading="eager"`. Nothing else did, so nothing else got it. The 404 and 500 artwork in particular stays lazy, which matters more than it looks: those SVGs are 1.7 MB and 1.4 MB.

The 11 DEX icons got `size-full` rather than explicit dimensions. They are all square (40x40 or 48x48) inside a square container, so the class both fits them and resolves the box before load, with no magic numbers.

`docs/add-new-token-to-stake.md` was documenting the old `StaticImageData` type and an example whose shape was already wrong. It now matches the registry and explains what `height`/`width` are for.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #2194 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
