### PR TITLE
Validate MIN_LOCK_AMOUNT when staking veHEMI

### DIFF
--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -128,7 +128,7 @@ The links point at a pinned commit, so the lines stay meaningful; `main` is the 
 
 Lock durations are given as a duration from now, and the resulting unlock time is rounded **down** to the epoch grid, so the actual unlock date is at most one epoch earlier than requested. The epoch is a "six days" that is not exactly six days, and the UI's 6 calendar-day slider steps approximate the grid rather than matching it — so treat every duration the UI shows as approximate and let the contract decide the real unlock date.
 
-The 10 HEMI minimum is only enforced on-chain: the staking form does not validate it, so a smaller amount can be submitted and reverts with `AmountTooSmall`. Tracked in [#2189](https://github.com/hemilabs/ui-monorepo/issues/2189).
+The 10 HEMI minimum is hardcoded as `minLockAmount` in the `ve-hemi-actions` package (it isn't readable from the contract, since `MIN_LOCK_AMOUNT` is private) and enforced both by `validateCreateLockInputs`, so any caller of the `createLock` action is protected, and by the staking form, which blocks submission and shows an error below 10 HEMI.
 
 Weight — used both for voting and for reward distribution — is `amount * (lock end - now) / MAX_TIME`. It therefore grows linearly with the remaining lock time and decays linearly to zero at the unlock date: 100 HEMI locked for the maximum four years starts at roughly 100 veHEMI, the same amount locked for one year at roughly 25. "Roughly" because the unlock date is rounded down to the epoch grid and the per-second slope is truncated, so the figure sits slightly below the round number.
 

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -128,7 +128,7 @@ The links point at a pinned commit, so the lines stay meaningful; `main` is the 
 
 Lock durations are given as a duration from now, and the resulting unlock time is rounded **down** to the epoch grid, so the actual unlock date is at most one epoch earlier than requested. The epoch is a "six days" that is not exactly six days, and the UI's 6 calendar-day slider steps approximate the grid rather than matching it — so treat every duration the UI shows as approximate and let the contract decide the real unlock date.
 
-The 10 HEMI minimum is hardcoded as `minLockAmount` in the `ve-hemi-actions` package (it isn't readable from the contract, since `MIN_LOCK_AMOUNT` is private) and enforced both by `validateCreateLockInputs`, so any caller of the `createLock` action is protected, and by the staking form, which blocks submission and shows an error below 10 HEMI.
+The 10 HEMI minimum is hardcoded as `minLockAmount` in the `ve-hemi-actions` package (it isn't readable from the contract, since `MIN_LOCK_AMOUNT` is private).
 
 Weight — used both for voting and for reward distribution — is `amount * (lock end - now) / MAX_TIME`. It therefore grows linearly with the remaining lock time and decays linearly to zero at the unlock date: 100 HEMI locked for the maximum four years starts at roughly 100 veHEMI, the same amount locked for one year at roughly 25. "Roughly" because the unlock date is rounded down to the epoch grid and the per-second slope is truncated, so the figure sits slightly below the round number.
 

--- a/packages/ve-hemi-actions/constants.ts
+++ b/packages/ve-hemi-actions/constants.ts
@@ -21,7 +21,7 @@ export const MinLockDurationSeconds = SixDaysSeconds * 2
 
 // MIN_LOCK_AMOUNT in the contract is a private constant set to 10 HEMI.
 // See https://github.com/hemilabs/veHEMI/blob/c6a65c74154377e8720f584b364bdc109fbdedc5/src/VeHemi.sol#L964
-export const MinLockAmount = parseUnits('10', 18)
+export const minLockAmount = parseUnits('10', 18)
 
 export const getVeHemiContractAddress = function (chainId: number) {
   const address = VE_HEMI_CONTRACT_ADDRESSES[chainId]

--- a/packages/ve-hemi-actions/constants.ts
+++ b/packages/ve-hemi-actions/constants.ts
@@ -1,5 +1,6 @@
 import { hemi, hemiSepolia } from 'hemi-viem'
 import type { Address } from 'viem'
+import { parseUnits } from 'viem'
 
 const VE_HEMI_CONTRACT_ADDRESSES: Record<number, Address> = {
   [hemi.id]: '0x371d3718D5b7F75EAb050FAe6Da7DF3092031c89',
@@ -17,6 +18,10 @@ export const MaxLockDurationSeconds = 4 * 365.25 * 24 * 60 * 60
 
 // MinLockDuration = 2 * SIX_DAYS = 1,051,920 seconds
 export const MinLockDurationSeconds = SixDaysSeconds * 2
+
+// MIN_LOCK_AMOUNT in the contract is a private constant set to 10 HEMI.
+// See https://github.com/hemilabs/veHEMI/blob/c6a65c74154377e8720f584b364bdc109fbdedc5/src/VeHemi.sol#L964
+export const MinLockAmount = parseUnits('10', 18)
 
 export const getVeHemiContractAddress = function (chainId: number) {
   const address = VE_HEMI_CONTRACT_ADDRESSES[chainId]

--- a/packages/ve-hemi-actions/index.ts
+++ b/packages/ve-hemi-actions/index.ts
@@ -8,7 +8,7 @@ export type {
 export {
   getVeHemiContractAddress,
   MaxLockDurationSeconds,
-  MinLockAmount,
+  minLockAmount,
   MinLockDurationSeconds,
   SixDaysSeconds,
 } from './constants.ts'

--- a/packages/ve-hemi-actions/index.ts
+++ b/packages/ve-hemi-actions/index.ts
@@ -8,6 +8,7 @@ export type {
 export {
   getVeHemiContractAddress,
   MaxLockDurationSeconds,
+  MinLockAmount,
   MinLockDurationSeconds,
   SixDaysSeconds,
 } from './constants.ts'

--- a/packages/ve-hemi-actions/test/actions/wallet/createLock.test.ts
+++ b/packages/ve-hemi-actions/test/actions/wallet/createLock.test.ts
@@ -9,7 +9,7 @@ import {
   getHemiTokenAddress,
   memoizedGetHemiTokenAddress,
 } from '../../../actions/public/veHemi'
-import { getVeHemiContractAddress } from '../../../constants'
+import { getVeHemiContractAddress, MinLockAmount } from '../../../constants'
 
 vi.mock('viem/actions', () => ({
   waitForTransactionReceipt: vi.fn(),
@@ -27,9 +27,11 @@ vi.mock('../../../actions/public/veHemi', () => ({
   memoizedGetHemiTokenAddress: vi.fn(),
 }))
 
+const sufficientBalance = MinLockAmount + BigInt(1000)
+
 const validParameters = {
   account: '0x1234567890123456789012345678901234567890' as const,
-  amount: BigInt(100),
+  amount: MinLockAmount,
   lockDurationInSeconds: BigInt(30 * 24 * 60 * 60), // 30 days
   walletClient: { chain: hemiSepolia },
 }
@@ -72,6 +74,22 @@ describe('createLock', function () {
     )
   })
 
+  it('should emit "lock-creation-failed-validation" if amount is less than the minimum lock amount', async function () {
+    const { emitter, promise } = createLock({
+      ...validParameters,
+      amount: MinLockAmount - BigInt(1),
+    })
+
+    const lockCreationFailedValidation = vi.fn()
+    emitter.on('lock-creation-failed-validation', lockCreationFailedValidation)
+
+    await promise
+
+    expect(lockCreationFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      'amount is less than the minimum lock amount',
+    )
+  })
+
   it('should emit "lock-creation-failed-validation" if user has insufficient balance', async function () {
     vi.mocked(balanceOf).mockResolvedValue(BigInt(50))
 
@@ -88,7 +106,7 @@ describe('createLock', function () {
   })
 
   it('should approve tokens if allowance is insufficient', async function () {
-    vi.mocked(balanceOf).mockResolvedValue(BigInt(1000))
+    vi.mocked(balanceOf).mockResolvedValue(sufficientBalance)
     vi.mocked(allowance).mockResolvedValue(BigInt(50))
     vi.mocked(approve).mockResolvedValue(zeroHash)
     vi.mocked(waitForTransactionReceipt).mockResolvedValue({
@@ -127,7 +145,7 @@ describe('createLock', function () {
   })
 
   it('should use custom approval amount if provided', async function () {
-    vi.mocked(balanceOf).mockResolvedValue(BigInt(1000))
+    vi.mocked(balanceOf).mockResolvedValue(sufficientBalance)
     vi.mocked(allowance).mockResolvedValue(BigInt(0))
     vi.mocked(approve).mockResolvedValue(zeroHash)
     vi.mocked(waitForTransactionReceipt).mockResolvedValue({
@@ -135,7 +153,7 @@ describe('createLock', function () {
     })
     vi.mocked(writeContract).mockResolvedValue(zeroHash)
 
-    const customApprovalAmount = BigInt(500)
+    const customApprovalAmount = MinLockAmount + BigInt(500)
 
     const { emitter, promise } = createLock({
       ...validParameters,
@@ -222,7 +240,7 @@ describe('createLock', function () {
   })
 
   it('should handle approve transaction failure', async function () {
-    vi.mocked(balanceOf).mockResolvedValue(BigInt(1000))
+    vi.mocked(balanceOf).mockResolvedValue(sufficientBalance)
     vi.mocked(allowance).mockResolvedValue(BigInt(0))
     vi.mocked(approve).mockResolvedValue(zeroHash)
     vi.mocked(waitForTransactionReceipt)
@@ -251,7 +269,7 @@ describe('createLock', function () {
   })
 
   it('should handle user rejecting approval', async function () {
-    vi.mocked(balanceOf).mockResolvedValue(BigInt(1000))
+    vi.mocked(balanceOf).mockResolvedValue(sufficientBalance)
     vi.mocked(allowance).mockResolvedValue(BigInt(0))
     vi.mocked(approve).mockRejectedValue(new Error('User rejected'))
 
@@ -273,8 +291,8 @@ describe('createLock', function () {
   })
 
   it('should handle user rejecting lock creation', async function () {
-    vi.mocked(balanceOf).mockResolvedValue(BigInt(1000))
-    vi.mocked(allowance).mockResolvedValue(BigInt(200))
+    vi.mocked(balanceOf).mockResolvedValue(sufficientBalance)
+    vi.mocked(allowance).mockResolvedValue(sufficientBalance)
     vi.mocked(writeContract).mockRejectedValue(new Error('User rejected'))
 
     const { emitter, promise } = createLock(validParameters)
@@ -298,8 +316,8 @@ describe('createLock', function () {
   })
 
   it('should handle lock creation transaction failure', async function () {
-    vi.mocked(balanceOf).mockResolvedValue(BigInt(1000))
-    vi.mocked(allowance).mockResolvedValue(BigInt(200))
+    vi.mocked(balanceOf).mockResolvedValue(sufficientBalance)
+    vi.mocked(allowance).mockResolvedValue(sufficientBalance)
     vi.mocked(writeContract).mockResolvedValue(zeroHash)
     vi.mocked(waitForTransactionReceipt).mockResolvedValue({
       status: 'reverted',
@@ -329,7 +347,7 @@ describe('createLock', function () {
   })
 
   it('should handle approval failure during waitForTransactionReceipt', async function () {
-    vi.mocked(balanceOf).mockResolvedValue(BigInt(1000))
+    vi.mocked(balanceOf).mockResolvedValue(sufficientBalance)
     vi.mocked(allowance).mockResolvedValue(BigInt(0))
     vi.mocked(approve).mockResolvedValue(zeroHash)
     vi.mocked(waitForTransactionReceipt).mockRejectedValue(
@@ -351,8 +369,8 @@ describe('createLock', function () {
   })
 
   it('should handle lock creation failure during waitForTransactionReceipt', async function () {
-    vi.mocked(balanceOf).mockResolvedValue(BigInt(1000))
-    vi.mocked(allowance).mockResolvedValue(BigInt(200))
+    vi.mocked(balanceOf).mockResolvedValue(sufficientBalance)
+    vi.mocked(allowance).mockResolvedValue(sufficientBalance)
     vi.mocked(writeContract).mockResolvedValue(zeroHash)
     vi.mocked(waitForTransactionReceipt).mockRejectedValue(
       new Error('Network error'),

--- a/packages/ve-hemi-actions/test/actions/wallet/createLock.test.ts
+++ b/packages/ve-hemi-actions/test/actions/wallet/createLock.test.ts
@@ -9,7 +9,7 @@ import {
   getHemiTokenAddress,
   memoizedGetHemiTokenAddress,
 } from '../../../actions/public/veHemi'
-import { getVeHemiContractAddress, MinLockAmount } from '../../../constants'
+import { getVeHemiContractAddress, minLockAmount } from '../../../constants'
 
 vi.mock('viem/actions', () => ({
   waitForTransactionReceipt: vi.fn(),
@@ -27,11 +27,11 @@ vi.mock('../../../actions/public/veHemi', () => ({
   memoizedGetHemiTokenAddress: vi.fn(),
 }))
 
-const sufficientBalance = MinLockAmount + BigInt(1000)
+const sufficientBalance = minLockAmount + BigInt(1000)
 
 const validParameters = {
   account: '0x1234567890123456789012345678901234567890' as const,
-  amount: MinLockAmount,
+  amount: minLockAmount,
   lockDurationInSeconds: BigInt(30 * 24 * 60 * 60), // 30 days
   walletClient: { chain: hemiSepolia },
 }
@@ -77,7 +77,7 @@ describe('createLock', function () {
   it('should emit "lock-creation-failed-validation" if amount is less than the minimum lock amount', async function () {
     const { emitter, promise } = createLock({
       ...validParameters,
-      amount: MinLockAmount - BigInt(1),
+      amount: minLockAmount - BigInt(1),
     })
 
     const lockCreationFailedValidation = vi.fn()
@@ -153,7 +153,7 @@ describe('createLock', function () {
     })
     vi.mocked(writeContract).mockResolvedValue(zeroHash)
 
-    const customApprovalAmount = MinLockAmount + BigInt(500)
+    const customApprovalAmount = minLockAmount + BigInt(500)
 
     const { emitter, promise } = createLock({
       ...validParameters,

--- a/packages/ve-hemi-actions/test/utils.test.ts
+++ b/packages/ve-hemi-actions/test/utils.test.ts
@@ -2,7 +2,11 @@ import { hemiSepolia } from 'hemi-viem'
 import { zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
 
-import { MaxLockDurationSeconds, MinLockDurationSeconds } from '../constants'
+import {
+  MaxLockDurationSeconds,
+  MinLockAmount,
+  MinLockDurationSeconds,
+} from '../constants'
 import {
   validateCreateLockInputs,
   validateIncreaseAmountInputs,
@@ -11,8 +15,8 @@ import {
 describe('validateCreateLockInputs', function () {
   const validParams = {
     account: '0x1234567890123456789012345678901234567890' as const,
-    amount: BigInt(100),
-    approvalAmount: BigInt(100),
+    amount: MinLockAmount,
+    approvalAmount: MinLockAmount,
     chainId: hemiSepolia.id,
     lockDurationInSeconds: 30 * 24 * 60 * 60, // 30 days
   }
@@ -55,6 +59,26 @@ describe('validateCreateLockInputs', function () {
         amount: -BigInt(1),
       }),
     ).toBe('amount cannot be negative')
+  })
+
+  it('should return error for amount less than the minimum lock amount', function () {
+    expect(
+      validateCreateLockInputs({
+        ...validParams,
+        amount: MinLockAmount - BigInt(1),
+        approvalAmount: MinLockAmount - BigInt(1),
+      }),
+    ).toBe('amount is less than the minimum lock amount')
+  })
+
+  it('should accept the minimum lock amount', function () {
+    expect(
+      validateCreateLockInputs({
+        ...validParams,
+        amount: MinLockAmount,
+        approvalAmount: MinLockAmount,
+      }),
+    ).toBeUndefined()
   })
 
   it('should return error for short lock duration', function () {

--- a/packages/ve-hemi-actions/test/utils.test.ts
+++ b/packages/ve-hemi-actions/test/utils.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   MaxLockDurationSeconds,
-  MinLockAmount,
+  minLockAmount,
   MinLockDurationSeconds,
 } from '../constants'
 import {
@@ -15,8 +15,8 @@ import {
 describe('validateCreateLockInputs', function () {
   const validParams = {
     account: '0x1234567890123456789012345678901234567890' as const,
-    amount: MinLockAmount,
-    approvalAmount: MinLockAmount,
+    amount: minLockAmount,
+    approvalAmount: minLockAmount,
     chainId: hemiSepolia.id,
     lockDurationInSeconds: 30 * 24 * 60 * 60, // 30 days
   }
@@ -65,8 +65,8 @@ describe('validateCreateLockInputs', function () {
     expect(
       validateCreateLockInputs({
         ...validParams,
-        amount: MinLockAmount - BigInt(1),
-        approvalAmount: MinLockAmount - BigInt(1),
+        amount: minLockAmount - BigInt(1),
+        approvalAmount: minLockAmount - BigInt(1),
       }),
     ).toBe('amount is less than the minimum lock amount')
   })
@@ -75,8 +75,8 @@ describe('validateCreateLockInputs', function () {
     expect(
       validateCreateLockInputs({
         ...validParams,
-        amount: MinLockAmount,
-        approvalAmount: MinLockAmount,
+        amount: minLockAmount,
+        approvalAmount: minLockAmount,
       }),
     ).toBeUndefined()
   })

--- a/packages/ve-hemi-actions/utils.ts
+++ b/packages/ve-hemi-actions/utils.ts
@@ -4,7 +4,7 @@ import { isAddress, parseEventLogs, zeroAddress } from 'viem'
 import { veHemiAbi } from './abi.ts'
 import {
   MaxLockDurationSeconds,
-  MinLockAmount,
+  minLockAmount,
   MinLockDurationSeconds,
   SupportedChains,
 } from './constants.ts'
@@ -89,7 +89,7 @@ export const validateCreateLockInputs = function ({
     return amountError
   }
 
-  if (amount < MinLockAmount) {
+  if (amount < minLockAmount) {
     return 'amount is less than the minimum lock amount'
   }
 

--- a/packages/ve-hemi-actions/utils.ts
+++ b/packages/ve-hemi-actions/utils.ts
@@ -4,6 +4,7 @@ import { isAddress, parseEventLogs, zeroAddress } from 'viem'
 import { veHemiAbi } from './abi.ts'
 import {
   MaxLockDurationSeconds,
+  MinLockAmount,
   MinLockDurationSeconds,
   SupportedChains,
 } from './constants.ts'
@@ -86,6 +87,10 @@ export const validateCreateLockInputs = function ({
   const amountError = validateAmount(amount)
   if (amountError) {
     return amountError
+  }
+
+  if (amount < MinLockAmount) {
+    return 'amount is less than the minimum lock amount'
   }
 
   const approvalError = validateApprovalAmount(amount, approvalAmount)

--- a/portal/app/[locale]/staking-dashboard/_components/stake.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stake.tsx
@@ -16,7 +16,7 @@ import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
 import { validateSubmit } from 'utils/validateSubmit'
 import { walletIsConnected } from 'utils/wallet'
-import { getVeHemiContractAddress, MinLockAmount } from 've-hemi-actions'
+import { getVeHemiContractAddress, minLockAmount } from 've-hemi-actions'
 import { formatUnits } from 'viem'
 import { useAccount as useEvmAccount } from 'wagmi'
 
@@ -74,7 +74,7 @@ export const Stake = function () {
   } = validateSubmit({
     amountInput: input,
     balance: walletTokenBalance,
-    minAmount: formatUnits(MinLockAmount, token.decimals),
+    minAmount: formatUnits(minLockAmount, token.decimals),
     operation: 'stake',
     t,
     token,

--- a/portal/app/[locale]/staking-dashboard/_components/stake.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stake.tsx
@@ -16,7 +16,7 @@ import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
 import { validateSubmit } from 'utils/validateSubmit'
 import { walletIsConnected } from 'utils/wallet'
-import { getVeHemiContractAddress } from 've-hemi-actions'
+import { getVeHemiContractAddress, MinLockAmount } from 've-hemi-actions'
 import { formatUnits } from 'viem'
 import { useAccount as useEvmAccount } from 'wagmi'
 
@@ -74,6 +74,7 @@ export const Stake = function () {
   } = validateSubmit({
     amountInput: input,
     balance: walletTokenBalance,
+    minAmount: formatUnits(MinLockAmount, token.decimals),
     operation: 'stake',
     t,
     token,


### PR DESCRIPTION
## Summary

Closes #2189.

The veHEMI contract enforces a minimum lock amount (`MIN_LOCK_AMOUNT`, 10 HEMI) when calling `createLock`, but the UI didn't validate this client-side, so a user staking less than 10 HEMI could submit a transaction that reverts on-chain.

- Added `MinLockAmount` to `packages/ve-hemi-actions/constants.ts`, mirroring how `MinLockDurationSeconds`/`MaxLockDurationSeconds` already hardcode other contract-derived values that aren't publicly readable.
- `validateCreateLockInputs` in `packages/ve-hemi-actions/utils.ts` now rejects amounts below `MinLockAmount`, so any caller of the `createLock` action (not just the portal UI) is protected.
- The staking dashboard's stake form (`portal/app/[locale]/staking-dashboard/_components/stake.tsx`) now passes `minAmount` into `validateSubmit`, reusing the existing `common.min-amount-stake` translated error message (already used by other operations) to show "Minimum stake is 10 HEMI" in the CTA.

## Screenshot

<!-- Add the screenshot of the validation error here -->

## Test plan

- [x] `pnpm test` in `packages/ve-hemi-actions` (107 tests passing, including new coverage for the minimum-amount validation)
- [x] `pnpm test` in `portal` (844 tests passing)
- [x] `tsc:check` in `packages/ve-hemi-actions`
- [x] Verified locally: entering an amount below 10 HEMI on `/staking-governance` now shows the "Minimum stake is 10 HEMI" error and disables the submit button

<img width="1339" height="596" alt="image" src="https://github.com/user-attachments/assets/3d788699-2da1-49af-ac28-942d7e7bac27" />
