### PR TITLE
Fix uneven card heights on boost stake page

### DIFF
--- a/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
@@ -33,8 +33,13 @@ const Points = ({
   'points'
 >) => <p className={`text-xl font-semibold ${color}`}>{points}</p>
 
+// No fixed height here on purpose: the parent row is a flex container, so
+// by default (align-items: stretch) every card is stretched to match the
+// tallest one. EarnedPoints, which is naturally shorter, fills that
+// stretched height itself (see its h-full chain) instead of the other
+// cards being clipped down to a fixed size.
 const Container = ({ children }: { children: ReactNode }) => (
-  <div className="h-24 w-full [&>div]:h-full [&>div]:overflow-hidden">
+  <div className="w-full [&>div]:h-full">
     <Card>
       <div className="relative h-full">{children}</div>
     </Card>

--- a/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
@@ -34,7 +34,7 @@ const Points = ({
 >) => <p className={`text-xl font-semibold ${color}`}>{points}</p>
 
 const Container = ({ children }: { children: ReactNode }) => (
-  <div className="h-24 w-full [&>div]:overflow-hidden">
+  <div className="h-24 w-full [&>div]:h-full [&>div]:overflow-hidden">
     <Card>
       <div className="relative">{children}</div>
     </Card>

--- a/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
@@ -36,7 +36,7 @@ const Points = ({
 const Container = ({ children }: { children: ReactNode }) => (
   <div className="h-24 w-full [&>div]:h-full [&>div]:overflow-hidden">
     <Card>
-      <div className="relative">{children}</div>
+      <div className="relative h-full">{children}</div>
     </Card>
   </div>
 )
@@ -46,9 +46,9 @@ export const EarnedPoints = function () {
 
   return (
     <Container>
-      <div className="p-2">
+      <div className="h-full p-2">
         <div
-          className="flex flex-shrink-0 flex-col gap-y-3 rounded-lg border border-solid border-[#FDEFE8] p-4"
+          className="flex h-full flex-col justify-center gap-y-2 rounded-lg border border-solid border-[#FDEFE8] p-4"
           style={{
             // Easier to read here than converting it into a inline tailwind class or in another file (the config).
             background:

--- a/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakePointsCards/index.tsx
@@ -33,11 +33,6 @@ const Points = ({
   'points'
 >) => <p className={`text-xl font-semibold ${color}`}>{points}</p>
 
-// No fixed height here on purpose: the parent row is a flex container, so
-// by default (align-items: stretch) every card is stretched to match the
-// tallest one. EarnedPoints, which is naturally shorter, fills that
-// stretched height itself (see its h-full chain) instead of the other
-// cards being clipped down to a fixed size.
 const Container = ({ children }: { children: ReactNode }) => (
   <div className="w-full [&>div]:h-full">
     <Card>


### PR DESCRIPTION
## Summary

Closes #2151.

On `/stake/dashboard`, the "Total Hemi points earned" card was taller than the "Your Stake" / "Total staked" cards.

- The shared `Container` in `stakePointsCards/index.tsx` wraps `Card` in a fixed `h-24` box, but `Card` itself has no height constraint, so it grows to fit its own content instead of the container's height.
- "Total Hemi points earned" has more content (a heading + description inside a bordered box) than the other cards (a heading + single value), so it rendered taller despite the `h-24` wrapper.
- Added `[&>div]:h-full` alongside the existing `[&>div]:overflow-hidden` so `Card` actually fills the `h-24` container, keeping all three cards the same height.

## Screenshot

<!-- Add the screenshot here -->

## Test plan

- [x] Verified locally on `/stake/dashboard` that all three cards now render at the same height

<img width="1112" height="256" alt="image" src="https://github.com/user-attachments/assets/0f74a661-9dab-476f-8eda-8b1fb7e7831e" />
