### PR TITLE
Fix crash opening stale staking drawer state

### DIFF
--- a/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
@@ -34,12 +34,22 @@ const SideDrawer = function () {
     unlockingDashboardOperation,
   } = useStakingDashboard()
 
-  if (
-    !drawerMode ||
-    (!collectRewardsDashboardOperation &&
-      !stakingDashboardOperation &&
-      !unlockingDashboardOperation)
-  ) {
+  // Each drawer mode reads a different piece of state. If that state is
+  // missing (for example, after reloading the page with a stale drawerMode
+  // in the URL), the matching review component would crash trying to read
+  // it, so the drawer must not be rendered in that case.
+  const hasRequiredOperation: Record<
+    NonNullable<typeof drawerMode>,
+    boolean
+  > = {
+    claimingRewards: !!collectRewardsDashboardOperation,
+    increasingAmount: !!stakingDashboardOperation,
+    increasingUnlockTime: !!stakingDashboardOperation,
+    staking: true,
+    unlocking: !!unlockingDashboardOperation,
+  }
+
+  if (!drawerMode || !hasRequiredOperation[drawerMode]) {
     return null
   }
 

--- a/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
@@ -34,10 +34,6 @@ const SideDrawer = function () {
     unlockingDashboardOperation,
   } = useStakingDashboard()
 
-  // Each drawer mode reads a different piece of state. If that state is
-  // missing (for example, after reloading the page with a stale drawerMode
-  // in the URL), the matching review component would crash trying to read
-  // it, so the drawer must not be rendered in that case.
   const hasRequiredOperation: Record<
     NonNullable<typeof drawerMode>,
     boolean


### PR DESCRIPTION
## Summary

Closes #2063.

Sentry reported: `TypeError: Cannot destructure property 'approvalTxHash' of 's' as it is undefined` in `ReviewIncreaseAmount` (`stakeReview/increaseAmount/index.tsx`).

`ReviewIncreaseAmount`, `ReviewIncreaseUnlockTime`, `ReviewUnlock`, and `ReviewCollectRewards` all assume their corresponding piece of staking-dashboard state (`stakingDashboardOperation`, `unlockingDashboardOperation`, `collectRewardsDashboardOperation`) is defined "because the component is only rendered in that case", using a non-null assertion (`!`) to destructure it.

That assumption is enforced in `stakeForm.tsx`'s `SideDrawer`, but the existing guard only checked that *at least one* of the three operations was defined:

```ts
if (
  !drawerMode ||
  (!collectRewardsDashboardOperation &&
    !stakingDashboardOperation &&
    !unlockingDashboardOperation)
) {
  return null
}
```

`drawerMode` comes from the URL query string (via `nuqs`) and can persist independently of the in-memory operation state (e.g. browser back/forward restoring an old `?drawerMode=increasingAmount` URL from earlier in the session while `stakingDashboardOperation` is `undefined`, but a leftover `unlockingDashboardOperation` or `collectRewardsDashboardOperation` from another action in the same session is still set). In that case the old guard passed (since not *all three* were undefined) and rendered `ReviewIncreaseAmount` with `stakingDashboardOperation` actually undefined, causing the crash.

Fixed by checking the specific operation required by the current `drawerMode`, instead of just checking that any operation exists:

```ts
const hasRequiredOperation: Record<NonNullable<typeof drawerMode>, boolean> = {
  claimingRewards: !!collectRewardsDashboardOperation,
  increasingAmount: !!stakingDashboardOperation,
  increasingUnlockTime: !!stakingDashboardOperation,
  staking: true,
  unlocking: !!unlockingDashboardOperation,
}

if (!drawerMode || !hasRequiredOperation[drawerMode]) {
  return null
}
```

## Test plan

- [x] `pnpm test` in `portal` (844 tests passing)
- [x] `tsc --noEmit` shows no new errors on the touched file