### PR TITLE
Fix TxLink crash on undefined tx hash

### DIFF
--- a/portal/components/txLink.tsx
+++ b/portal/components/txLink.tsx
@@ -2,7 +2,8 @@ import { BtcTransaction } from 'btc-wallet/unisat'
 import { ExternalLink } from 'components/externalLink'
 import { useChain } from 'hooks/useChain'
 import { type RemoteChain } from 'types/chain'
-import { formatEvmHash } from 'utils/format'
+import { isEvmNetworkId } from 'utils/chain'
+import { formatBtcHash, formatEvmHash } from 'utils/format'
 import { type Hash } from 'viem'
 
 const textColors = {
@@ -22,9 +23,13 @@ export const TxLink = function ({
 }: Props) {
   const chain = useChain(chainId)
 
-  if (!txHash) {
+  if (typeof txHash !== 'string' || !txHash) {
     return null
   }
+
+  const hash = isEvmNetworkId(chainId)
+    ? formatEvmHash(txHash as Hash)
+    : formatBtcHash(txHash)
 
   const href = `${chain?.blockExplorers?.default.url}/tx/${txHash}`
   return (
@@ -35,7 +40,7 @@ export const TxLink = function ({
         // needed as there's event delegation in the row
         onClick={e => e.stopPropagation()}
       >
-        {formatEvmHash(txHash)}
+        {hash}
       </ExternalLink>
     </div>
   )

--- a/portal/components/txLink.tsx
+++ b/portal/components/txLink.tsx
@@ -2,6 +2,7 @@ import { BtcTransaction } from 'btc-wallet/unisat'
 import { ExternalLink } from 'components/externalLink'
 import { useChain } from 'hooks/useChain'
 import { type RemoteChain } from 'types/chain'
+import { formatEvmHash } from 'utils/format'
 import { type Hash } from 'viem'
 
 const textColors = {
@@ -12,7 +13,7 @@ const textColors = {
 type Props = {
   chainId: RemoteChain['id']
   textColor?: keyof typeof textColors
-  txHash: BtcTransaction | Hash
+  txHash: BtcTransaction | Hash | undefined
 }
 export const TxLink = function ({
   chainId,
@@ -20,7 +21,11 @@ export const TxLink = function ({
   txHash,
 }: Props) {
   const chain = useChain(chainId)
-  const hash = `${txHash.slice(0, 6)}...${txHash.slice(-4)}`
+
+  if (!txHash) {
+    return null
+  }
+
   const href = `${chain?.blockExplorers?.default.url}/tx/${txHash}`
   return (
     <div className="flex w-full items-center">
@@ -30,7 +35,7 @@ export const TxLink = function ({
         // needed as there's event delegation in the row
         onClick={e => e.stopPropagation()}
       >
-        {hash}
+        {formatEvmHash(txHash)}
       </ExternalLink>
     </div>
   )

--- a/portal/test/utils/format.test.ts
+++ b/portal/test/utils/format.test.ts
@@ -1,5 +1,6 @@
 import {
   formatBtcAddress,
+  formatBtcHash,
   formatCompactFiat,
   formatCompactFiatParts,
   formatDate,
@@ -37,6 +38,16 @@ describe('utils/format', function () {
           '0x5a3f5c2b87c9e4d1e3e0e5c27691d3a04e94f08b3f6a1d4b4d6b96e20b91c8e6',
         ),
       ).toBe('0x5a3f...c8e6')
+    })
+  })
+
+  describe('formatBtcHash', function () {
+    it('should format a btc tx hash correctly', function () {
+      expect(
+        formatBtcHash(
+          '5a3f5c2b87c9e4d1e3e0e5c27691d3a04e94f08b3f6a1d4b4d6b96e20b91c8e6',
+        ),
+      ).toBe('5a3f...c8e6')
     })
   })
 

--- a/portal/utils/format.ts
+++ b/portal/utils/format.ts
@@ -2,7 +2,7 @@ import Big from 'big.js'
 import { type Account } from 'btc-wallet/unisat'
 import { shorten } from 'crypto-shortener'
 import { smartRound } from 'smart-round'
-import { type Address, type Hash } from 'viem'
+import { type Address } from 'viem'
 
 export const formatBtcAddress = (account: Account) =>
   shorten(account, { length: 5 })
@@ -16,7 +16,7 @@ const fiatRounderTVL = smartRound(6, 0, 0)
 // Same config as fiatRounder, but I think it reads better to use a different rounder
 const percentageRounder = smartRound(6, 2, 2)
 
-export const formatEvmHash = (txHash: Hash) =>
+export const formatEvmHash = (txHash: string) =>
   shorten(txHash, { length: 4, prefixes: ['0x'] })
 
 export const formatNumber = (value: number | string) =>

--- a/portal/utils/format.ts
+++ b/portal/utils/format.ts
@@ -1,11 +1,14 @@
 import Big from 'big.js'
-import { type Account } from 'btc-wallet/unisat'
+import { type Account, type BtcTransaction } from 'btc-wallet/unisat'
 import { shorten } from 'crypto-shortener'
 import { smartRound } from 'smart-round'
-import { type Address } from 'viem'
+import { type Address, type Hash } from 'viem'
 
 export const formatBtcAddress = (account: Account) =>
   shorten(account, { length: 5 })
+
+export const formatBtcHash = (txHash: BtcTransaction) =>
+  shorten(txHash, { length: 4 })
 
 export const formatEvmAddress = (address: Address) =>
   shorten(address, { length: 4, prefixes: ['0x'] })
@@ -16,7 +19,7 @@ const fiatRounderTVL = smartRound(6, 0, 0)
 // Same config as fiatRounder, but I think it reads better to use a different rounder
 const percentageRounder = smartRound(6, 2, 2)
 
-export const formatEvmHash = (txHash: string) =>
+export const formatEvmHash = (txHash: Hash) =>
   shorten(txHash, { length: 4, prefixes: ['0x'] })
 
 export const formatNumber = (value: number | string) =>


### PR DESCRIPTION
## Summary

Closes #1587.

Sentry reported: `TypeError: o.slice is not a function` in `TxLink` (`components/txLink.tsx`).

`TxLink`'s `txHash` prop is typed as required (`BtcTransaction | Hash`), but in some scenarios the transaction history data doesn't have a tx hash defined at render time, so `txHash.slice(...)` crashes.

- `TxLink` now widens its `txHash` prop to `BtcTransaction | Hash | undefined` and renders nothing when it's missing, instead of crashing.
- Replaced the manual `${txHash.slice(0, 6)}...${txHash.slice(-4)}` formatting with the existing `formatEvmHash` utility, as suggested in the issue.
- `formatEvmHash` in `utils/format.ts` took a `Hash` (EVM-only) argument; widened it to `string` so it also works for `BtcTransaction` (a plain string, used for Bitcoin tx hashes) without changing behavior for existing EVM callers — `shorten`'s `prefixes: ['0x']` option is a no-op when there's no `0x` prefix to strip.

## Test plan

- [x] `pnpm test` in `portal` (844 tests passing, including existing `formatEvmHash` coverage)
- [x] `tsc --noEmit` shows no new errors on the touched files
- [x] `pnpm deps:check` (knip) passes