### PR TITLE
Load components with lazy instead of next/dynamic

### DIFF
--- a/portal/app/[locale]/_components/analytics.tsx
+++ b/portal/app/[locale]/_components/analytics.tsx
@@ -1,10 +1,11 @@
 'use client'
 
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { UmamiAnalyticsProvider } from 'components/umamiAnalyticsProvider'
 import { useLocale } from 'next-intl'
-import { ComponentProps, lazy, Suspense } from 'react'
+import { ComponentProps } from 'react'
 
-const GlobalTracking = lazy(() =>
+const GlobalTracking = lazyWithFallback(() =>
   import('./globalTracking').then(mod => ({ default: mod.GlobalTracking })),
 )
 
@@ -26,9 +27,7 @@ export const Analytics = function ({
           websiteId: import.meta.env.VITE_ANALYTICS_WEBSITE_ID,
         })}
       >
-        <Suspense>
-          <GlobalTracking />
-        </Suspense>
+        <GlobalTracking />
         {children}
       </UmamiAnalyticsProvider>
     </>

--- a/portal/app/[locale]/_components/analytics.tsx
+++ b/portal/app/[locale]/_components/analytics.tsx
@@ -1,13 +1,11 @@
 'use client'
 
 import { UmamiAnalyticsProvider } from 'components/umamiAnalyticsProvider'
-import dynamic from 'next/dynamic'
 import { useLocale } from 'next-intl'
-import { ComponentProps, Suspense } from 'react'
+import { ComponentProps, lazy, Suspense } from 'react'
 
-const GlobalTracking = dynamic(
-  () => import('./globalTracking').then(mod => mod.GlobalTracking),
-  { ssr: false },
+const GlobalTracking = lazy(() =>
+  import('./globalTracking').then(mod => ({ default: mod.GlobalTracking })),
 )
 
 export const Analytics = function ({

--- a/portal/app/[locale]/_components/appOverlays.tsx
+++ b/portal/app/[locale]/_components/appOverlays.tsx
@@ -1,9 +1,13 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const EarnCard = dynamic(() => import('./earnCard').then(mod => mod.EarnCard), {
-  ssr: false,
-})
+const EarnCard = lazy(() =>
+  import('./earnCard').then(mod => ({ default: mod.EarnCard })),
+)
 
-export const AppOverlays = () => <EarnCard />
+export const AppOverlays = () => (
+  <Suspense>
+    <EarnCard />
+  </Suspense>
+)

--- a/portal/app/[locale]/_components/appOverlays.tsx
+++ b/portal/app/[locale]/_components/appOverlays.tsx
@@ -1,13 +1,9 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 
-const EarnCard = lazy(() =>
+const EarnCard = lazyWithFallback(() =>
   import('./earnCard').then(mod => ({ default: mod.EarnCard })),
 )
 
-export const AppOverlays = () => (
-  <Suspense>
-    <EarnCard />
-  </Suspense>
-)
+export const AppOverlays = () => <EarnCard />

--- a/portal/app/[locale]/_components/header/index.tsx
+++ b/portal/app/[locale]/_components/header/index.tsx
@@ -4,18 +4,16 @@ import { CloseIcon } from 'components/icons/closeIcon'
 import { HamburgerIcon } from 'components/icons/hamburgerIcon'
 import { StakeTabs } from 'components/stakeTabs'
 import { TunnelTabs } from 'components/tunnelTabs'
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
 import { Badge } from '../badge'
 
 import { HomeLink } from './homeLink'
 
-const WalletConnection = dynamic(
-  () => import('components/connectWallets').then(mod => mod.WalletConnection),
-  {
-    loading: () => <div className="ml-auto" />,
-    ssr: false,
-  },
+const WalletConnection = lazy(() =>
+  import('components/connectWallets').then(mod => ({
+    default: mod.WalletConnection,
+  })),
 )
 
 type Props = {
@@ -40,7 +38,9 @@ export const Header = ({ isMenuOpen, openNavbar, toggleMenu }: Props) => (
       <TunnelTabs />
       <GenesisDropTabs />
     </div>
-    <WalletConnection />
+    <Suspense fallback={<div className="ml-auto" />}>
+      <WalletConnection />
+    </Suspense>
     <div className="hidden sm:flex md:hidden">
       <ButtonIcon
         onClick={toggleMenu}

--- a/portal/app/[locale]/_components/header/index.tsx
+++ b/portal/app/[locale]/_components/header/index.tsx
@@ -2,18 +2,20 @@ import { GenesisDropTabs } from 'app/[locale]/genesis-drop/_components/genesisDr
 import { ButtonIcon } from 'components/button'
 import { CloseIcon } from 'components/icons/closeIcon'
 import { HamburgerIcon } from 'components/icons/hamburgerIcon'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { StakeTabs } from 'components/stakeTabs'
 import { TunnelTabs } from 'components/tunnelTabs'
-import { lazy, Suspense } from 'react'
 
 import { Badge } from '../badge'
 
 import { HomeLink } from './homeLink'
 
-const WalletConnection = lazy(() =>
-  import('components/connectWallets').then(mod => ({
-    default: mod.WalletConnection,
-  })),
+const WalletConnection = lazyWithFallback(
+  () =>
+    import('components/connectWallets').then(mod => ({
+      default: mod.WalletConnection,
+    })),
+  <div className="ml-auto" />,
 )
 
 type Props = {
@@ -38,9 +40,7 @@ export const Header = ({ isMenuOpen, openNavbar, toggleMenu }: Props) => (
       <TunnelTabs />
       <GenesisDropTabs />
     </div>
-    <Suspense fallback={<div className="ml-auto" />}>
-      <WalletConnection />
-    </Suspense>
+    <WalletConnection />
     <div className="hidden sm:flex md:hidden">
       <ButtonIcon
         onClick={toggleMenu}

--- a/portal/app/[locale]/_components/mobileBottomBar.tsx
+++ b/portal/app/[locale]/_components/mobileBottomBar.tsx
@@ -3,11 +3,12 @@
 import { ButtonIcon } from 'components/button'
 import { CloseIcon } from 'components/icons/closeIcon'
 import { HamburgerIcon } from 'components/icons/hamburgerIcon'
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const WalletConnection = dynamic(
-  () => import('components/connectWallets').then(mod => mod.WalletConnection),
-  { loading: () => <div className="flex-1" />, ssr: false },
+const WalletConnection = lazy(() =>
+  import('components/connectWallets').then(mod => ({
+    default: mod.WalletConnection,
+  })),
 )
 
 type Props = {
@@ -18,7 +19,9 @@ type Props = {
 
 export const MobileBottomBar = ({ closeMenu, isMenuOpen, openMenu }: Props) => (
   <div className="fixed inset-x-0 bottom-0 z-50 flex h-14 items-center border-t border-neutral-300/55 bg-white px-3 sm:hidden">
-    <WalletConnection placement="bottom-bar" />
+    <Suspense fallback={<div className="flex-1" />}>
+      <WalletConnection placement="bottom-bar" />
+    </Suspense>
     <div className="ml-auto">
       {/* When opening (hamburger): stopImmediatePropagation blocks
        * useOnClickOutside on any open drawer so it doesn't close on the

--- a/portal/app/[locale]/_components/mobileBottomBar.tsx
+++ b/portal/app/[locale]/_components/mobileBottomBar.tsx
@@ -3,12 +3,14 @@
 import { ButtonIcon } from 'components/button'
 import { CloseIcon } from 'components/icons/closeIcon'
 import { HamburgerIcon } from 'components/icons/hamburgerIcon'
-import { lazy, Suspense } from 'react'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 
-const WalletConnection = lazy(() =>
-  import('components/connectWallets').then(mod => ({
-    default: mod.WalletConnection,
-  })),
+const WalletConnection = lazyWithFallback(
+  () =>
+    import('components/connectWallets').then(mod => ({
+      default: mod.WalletConnection,
+    })),
+  <div className="flex-1" />,
 )
 
 type Props = {
@@ -19,9 +21,7 @@ type Props = {
 
 export const MobileBottomBar = ({ closeMenu, isMenuOpen, openMenu }: Props) => (
   <div className="fixed inset-x-0 bottom-0 z-50 flex h-14 items-center border-t border-neutral-300/55 bg-white px-3 sm:hidden">
-    <Suspense fallback={<div className="flex-1" />}>
-      <WalletConnection placement="bottom-bar" />
-    </Suspense>
+    <WalletConnection placement="bottom-bar" />
     <div className="ml-auto">
       {/* When opening (hamburger): stopImmediatePropagation blocks
        * useOnClickOutside on any open drawer so it doesn't close on the

--- a/portal/app/[locale]/_components/navbar/_components/tunnelLink.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/tunnelLink.tsx
@@ -1,12 +1,13 @@
 import { TunnelIcon as BaseIcon } from 'components/icons/tunnelIcon'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
 import { useTranslations } from 'next-intl'
-import { ComponentProps, lazy, Suspense } from 'react'
+import { ComponentProps, Suspense } from 'react'
 
 import { ItemLink } from './itemLink'
 
-const ActionableOperations = lazy(() =>
+const ActionableOperations = lazyWithFallback(() =>
   import('components/actionableOperations').then(mod => ({
     default: mod.ActionableOperations,
   })),
@@ -19,10 +20,7 @@ const UI = ({ href, icon, text }: ComponentProps<typeof ItemLink>) => (
     icon={icon}
     rightSection={
       <div className="ml-auto hidden md:block">
-        {/* Initially users will be disconnected, so no need for a fallback here. */}
-        <Suspense>
-          <ActionableOperations />
-        </Suspense>
+        <ActionableOperations />
       </div>
     }
     text={text}

--- a/portal/app/[locale]/_components/navbar/_components/tunnelLink.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/tunnelLink.tsx
@@ -1,18 +1,15 @@
 import { TunnelIcon as BaseIcon } from 'components/icons/tunnelIcon'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { ComponentProps, Suspense } from 'react'
+import { ComponentProps, lazy, Suspense } from 'react'
 
 import { ItemLink } from './itemLink'
 
-const ActionableOperations = dynamic(
-  () =>
-    import('components/actionableOperations').then(
-      mod => mod.ActionableOperations,
-    ),
-  { ssr: false },
+const ActionableOperations = lazy(() =>
+  import('components/actionableOperations').then(mod => ({
+    default: mod.ActionableOperations,
+  })),
 )
 
 const UI = ({ href, icon, text }: ComponentProps<typeof ItemLink>) => (

--- a/portal/app/[locale]/_components/navbar/navbarDesktop.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarDesktop.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { featureFlags } from 'app/featureFlags'
-import dynamic from 'next/dynamic'
-import { ReactNode } from 'react'
+import { lazy, ReactNode, Suspense } from 'react'
 
 import { Badge } from '../badge'
 
@@ -26,11 +25,9 @@ import { VideoAsset } from './_components/videoAsset'
 
 const Separator = () => <div className="my-1 h-px w-full bg-neutral-100" />
 
-const Help = dynamic(() => import('./_components/help').then(mod => mod.Help), {
-  // Render the closed version of the help button
-  loading: () => <HelpButton isOpen={false} />,
-  ssr: false,
-})
+const Help = lazy(() =>
+  import('./_components/help').then(mod => ({ default: mod.Help })),
+)
 
 const PaddedListItem = ({
   children,
@@ -47,7 +44,10 @@ export const NavbarDesktop = () => (
         <HomeLink />
         <Badge />
       </div>
-      <Help />
+      {/* Render the closed version of the help button while it loads */}
+      <Suspense fallback={<HelpButton isOpen={false} />}>
+        <Help />
+      </Suspense>
     </div>
     <ul className="z-10 flex h-full flex-col gap-y-0.5 overflow-y-auto overflow-x-hidden [&>li:not(.no-padding)]:px-3">
       {featureFlags.enableHemiEarnPage && (

--- a/portal/app/[locale]/_components/navbar/navbarDesktop.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarDesktop.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { featureFlags } from 'app/featureFlags'
-import { lazy, ReactNode, Suspense } from 'react'
+import { lazyWithFallback } from 'components/lazyWithFallback'
+import { ReactNode } from 'react'
 
 import { Badge } from '../badge'
 
@@ -25,8 +26,9 @@ import { VideoAsset } from './_components/videoAsset'
 
 const Separator = () => <div className="my-1 h-px w-full bg-neutral-100" />
 
-const Help = lazy(() =>
-  import('./_components/help').then(mod => ({ default: mod.Help })),
+const Help = lazyWithFallback(
+  () => import('./_components/help').then(mod => ({ default: mod.Help })),
+  <HelpButton isOpen={false} />,
 )
 
 const PaddedListItem = ({
@@ -44,10 +46,7 @@ export const NavbarDesktop = () => (
         <HomeLink />
         <Badge />
       </div>
-      {/* Render the closed version of the help button while it loads */}
-      <Suspense fallback={<HelpButton isOpen={false} />}>
-        <Help />
-      </Suspense>
+      <Help />
     </div>
     <ul className="z-10 flex h-full flex-col gap-y-0.5 overflow-y-auto overflow-x-hidden [&>li:not(.no-padding)]:px-3">
       {featureFlags.enableHemiEarnPage && (

--- a/portal/app/[locale]/_components/navbar/navbarMobile.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarMobile.tsx
@@ -1,6 +1,7 @@
 import { featureFlags } from 'app/featureFlags'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { useTranslations } from 'next-intl'
-import { ComponentProps, lazy, Suspense } from 'react'
+import { ComponentProps } from 'react'
 
 import { BitcoinKitLink } from './_components/bitcoinKitLink'
 import { Dex } from './_components/dex'
@@ -20,8 +21,9 @@ import { StakeMobile } from './_components/stake'
 import { TunnelLink } from './_components/tunnelLink'
 import { Tvl } from './_components/tvl'
 
-const Help = lazy(() =>
-  import('./_components/help').then(mod => ({ default: mod.Help })),
+const Help = lazyWithFallback(
+  () => import('./_components/help').then(mod => ({ default: mod.Help })),
+  <HelpButton isOpen={false} />,
 )
 
 const FullItem = (props: ComponentProps<'li'>) => (
@@ -144,10 +146,7 @@ export const NavbarMobile = function () {
         </ul>
       </div>
       <div className="flex w-full shrink-0 items-center gap-x-3 bg-white p-5 [&_a]:w-full [&_button]:size-11">
-        {/* Render the closed version of the help button while it loads */}
-        <Suspense fallback={<HelpButton isOpen={false} />}>
-          <Help />
-        </Suspense>
+        <Help />
         <GetStarted size="xLarge" />
       </div>
     </div>

--- a/portal/app/[locale]/_components/navbar/navbarMobile.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarMobile.tsx
@@ -1,7 +1,6 @@
 import { featureFlags } from 'app/featureFlags'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { ComponentProps } from 'react'
+import { ComponentProps, lazy, Suspense } from 'react'
 
 import { BitcoinKitLink } from './_components/bitcoinKitLink'
 import { Dex } from './_components/dex'
@@ -21,11 +20,9 @@ import { StakeMobile } from './_components/stake'
 import { TunnelLink } from './_components/tunnelLink'
 import { Tvl } from './_components/tvl'
 
-const Help = dynamic(() => import('./_components/help').then(mod => mod.Help), {
-  // Render the closed version of the help button
-  loading: () => <HelpButton isOpen={false} />,
-  ssr: false,
-})
+const Help = lazy(() =>
+  import('./_components/help').then(mod => ({ default: mod.Help })),
+)
 
 const FullItem = (props: ComponentProps<'li'>) => (
   <li className="w-full" {...props} />
@@ -147,7 +144,10 @@ export const NavbarMobile = function () {
         </ul>
       </div>
       <div className="flex w-full shrink-0 items-center gap-x-3 bg-white p-5 [&_a]:w-full [&_button]:size-11">
-        <Help />
+        {/* Render the closed version of the help button while it loads */}
+        <Suspense fallback={<HelpButton isOpen={false} />}>
+          <Help />
+        </Suspense>
         <GetStarted size="xLarge" />
       </div>
     </div>

--- a/portal/app/[locale]/_components/workers.tsx
+++ b/portal/app/[locale]/_components/workers.tsx
@@ -1,26 +1,26 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const SyncHistoryWorkers = dynamic(
-  () =>
-    import('components/syncHistoryWorkers').then(mod => mod.SyncHistoryWorkers),
-  { ssr: false },
+const SyncHistoryWorkers = lazy(() =>
+  import('components/syncHistoryWorkers').then(mod => ({
+    default: mod.SyncHistoryWorkers,
+  })),
 )
 
-const TunnelStatusUpdaters = dynamic(
-  () =>
-    import('components/tunnelStatusUpdaters').then(
-      mod => mod.TunnelStatusUpdaters,
-    ),
-  {
-    ssr: false,
-  },
+const TunnelStatusUpdaters = lazy(() =>
+  import('components/tunnelStatusUpdaters').then(mod => ({
+    default: mod.TunnelStatusUpdaters,
+  })),
 )
 
 export const Workers = () => (
   <>
-    <SyncHistoryWorkers />
-    <TunnelStatusUpdaters />
+    <Suspense>
+      <SyncHistoryWorkers />
+    </Suspense>
+    <Suspense>
+      <TunnelStatusUpdaters />
+    </Suspense>
   </>
 )

--- a/portal/app/[locale]/_components/workers.tsx
+++ b/portal/app/[locale]/_components/workers.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 
-const SyncHistoryWorkers = lazy(() =>
+const SyncHistoryWorkers = lazyWithFallback(() =>
   import('components/syncHistoryWorkers').then(mod => ({
     default: mod.SyncHistoryWorkers,
   })),
 )
 
-const TunnelStatusUpdaters = lazy(() =>
+const TunnelStatusUpdaters = lazyWithFallback(() =>
   import('components/tunnelStatusUpdaters').then(mod => ({
     default: mod.TunnelStatusUpdaters,
   })),
@@ -16,11 +16,7 @@ const TunnelStatusUpdaters = lazy(() =>
 
 export const Workers = () => (
   <>
-    <Suspense>
-      <SyncHistoryWorkers />
-    </Suspense>
-    <Suspense>
-      <TunnelStatusUpdaters />
-    </Suspense>
+    <SyncHistoryWorkers />
+    <TunnelStatusUpdaters />
   </>
 )

--- a/portal/app/[locale]/genesis-drop/_components/claimOptions.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/claimOptions.tsx
@@ -1,5 +1,6 @@
 import { MutationStatus } from '@tanstack/react-query'
 import { Button } from 'components/button'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { Spinner } from 'components/spinner'
 import {
   LockupMonths,
@@ -8,20 +9,20 @@ import {
 } from 'genesis-drop-actions'
 import { useUmami } from 'hooks/useUmami'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense, useState } from 'react'
+import { useState } from 'react'
 import { Hash, Hex } from 'viem'
 
 import { useClaimTokens } from '../_hooks/useClaimTokens'
 
 import { Strategy } from './strategy'
 
-const TermsAndConditions = lazy(() =>
+const TermsAndConditions = lazyWithFallback(() =>
   import('./termsAndConditions').then(mod => ({
     default: mod.TermsAndConditions,
   })),
 )
 
-const ClaimDrawer = lazy(() =>
+const ClaimDrawer = lazyWithFallback(() =>
   import('./claimDrawer').then(mod => ({ default: mod.ClaimDrawer })),
 )
 
@@ -169,32 +170,28 @@ export const ClaimOptions = function ({ eligibility }: Props) {
         </div>
       </div>
       {termsAndConditions.show && (
-        <Suspense>
-          <TermsAndConditions
-            onAccept={handleAcceptTermsAndConditions}
-            onClose={function () {
-              track?.('genesis-drop - terms rejected', {
-                lockupMonths: termsAndConditions.lockup!,
-              })
-              setTermsAndConditions({ lockup: undefined, show: false })
-            }}
-          />
-        </Suspense>
+        <TermsAndConditions
+          onAccept={handleAcceptTermsAndConditions}
+          onClose={function () {
+            track?.('genesis-drop - terms rejected', {
+              lockupMonths: termsAndConditions.lockup!,
+            })
+            setTermsAndConditions({ lockup: undefined, show: false })
+          }}
+        />
       )}
       {showDrawer && (
-        <Suspense>
-          <ClaimDrawer
-            eligibility={eligibility}
-            isRetrying={isRetrying}
-            lockupMonths={termsAndConditions.lockup!}
-            onClose={closeDrawer}
-            onRetry={handleRetry}
-            ratio={defaultRatio}
-            status={claimStatus}
-            termsSignature={signedTerms!}
-            transactionHash={transactionHash}
-          />
-        </Suspense>
+        <ClaimDrawer
+          eligibility={eligibility}
+          isRetrying={isRetrying}
+          lockupMonths={termsAndConditions.lockup!}
+          onClose={closeDrawer}
+          onRetry={handleRetry}
+          ratio={defaultRatio}
+          status={claimStatus}
+          termsSignature={signedTerms!}
+          transactionHash={transactionHash}
+        />
       )}
     </>
   )

--- a/portal/app/[locale]/genesis-drop/_components/claimOptions.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/claimOptions.tsx
@@ -7,21 +7,22 @@ import {
   type EligibilityData,
 } from 'genesis-drop-actions'
 import { useUmami } from 'hooks/useUmami'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { Hash, Hex } from 'viem'
 
 import { useClaimTokens } from '../_hooks/useClaimTokens'
 
 import { Strategy } from './strategy'
 
-const TermsAndConditions = dynamic(() =>
-  import('./termsAndConditions').then(mod => mod.TermsAndConditions),
+const TermsAndConditions = lazy(() =>
+  import('./termsAndConditions').then(mod => ({
+    default: mod.TermsAndConditions,
+  })),
 )
 
-const ClaimDrawer = dynamic(() =>
-  import('./claimDrawer').then(mod => mod.ClaimDrawer),
+const ClaimDrawer = lazy(() =>
+  import('./claimDrawer').then(mod => ({ default: mod.ClaimDrawer })),
 )
 
 type Props = {
@@ -168,28 +169,32 @@ export const ClaimOptions = function ({ eligibility }: Props) {
         </div>
       </div>
       {termsAndConditions.show && (
-        <TermsAndConditions
-          onAccept={handleAcceptTermsAndConditions}
-          onClose={function () {
-            track?.('genesis-drop - terms rejected', {
-              lockupMonths: termsAndConditions.lockup!,
-            })
-            setTermsAndConditions({ lockup: undefined, show: false })
-          }}
-        />
+        <Suspense>
+          <TermsAndConditions
+            onAccept={handleAcceptTermsAndConditions}
+            onClose={function () {
+              track?.('genesis-drop - terms rejected', {
+                lockupMonths: termsAndConditions.lockup!,
+              })
+              setTermsAndConditions({ lockup: undefined, show: false })
+            }}
+          />
+        </Suspense>
       )}
       {showDrawer && (
-        <ClaimDrawer
-          eligibility={eligibility}
-          isRetrying={isRetrying}
-          lockupMonths={termsAndConditions.lockup!}
-          onClose={closeDrawer}
-          onRetry={handleRetry}
-          ratio={defaultRatio}
-          status={claimStatus}
-          termsSignature={signedTerms!}
-          transactionHash={transactionHash}
-        />
+        <Suspense>
+          <ClaimDrawer
+            eligibility={eligibility}
+            isRetrying={isRetrying}
+            lockupMonths={termsAndConditions.lockup!}
+            onClose={closeDrawer}
+            onRetry={handleRetry}
+            ratio={defaultRatio}
+            status={claimStatus}
+            termsSignature={signedTerms!}
+            transactionHash={transactionHash}
+          />
+        </Suspense>
       )}
     </>
   )

--- a/portal/app/[locale]/genesis-drop/_components/disconnectedState.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/disconnectedState.tsx
@@ -1,20 +1,20 @@
 import { ButtonLoader } from 'components/buttonLoader'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
+import { lazy, Suspense } from 'react'
 
-const ConnectEvmWallet = dynamic(
-  () => import('components/connectEvmWallet').then(mod => mod.ConnectEvmWallet),
-  {
-    loading: ButtonLoader,
-    ssr: false,
-  },
+const ConnectEvmWallet = lazy(() =>
+  import('components/connectEvmWallet').then(mod => ({
+    default: mod.ConnectEvmWallet,
+  })),
 )
 
 export const DisconnectedState = function () {
   const t = useTranslations('common')
   return (
     <div className="mt-5">
-      <ConnectEvmWallet buttonSize="small" text={t('connect-wallet')} />
+      <Suspense fallback={<ButtonLoader />}>
+        <ConnectEvmWallet buttonSize="small" text={t('connect-wallet')} />
+      </Suspense>
     </div>
   )
 }

--- a/portal/app/[locale]/genesis-drop/_components/disconnectedState.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/disconnectedState.tsx
@@ -1,20 +1,11 @@
-import { ButtonLoader } from 'components/buttonLoader'
+import { LazyConnectEvmWallet } from 'components/lazyConnectEvmWallet'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense } from 'react'
-
-const ConnectEvmWallet = lazy(() =>
-  import('components/connectEvmWallet').then(mod => ({
-    default: mod.ConnectEvmWallet,
-  })),
-)
 
 export const DisconnectedState = function () {
   const t = useTranslations('common')
   return (
     <div className="mt-5">
-      <Suspense fallback={<ButtonLoader />}>
-        <ConnectEvmWallet buttonSize="small" text={t('connect-wallet')} />
-      </Suspense>
+      <LazyConnectEvmWallet buttonSize="small" text={t('connect-wallet')} />
     </div>
   )
 }

--- a/portal/app/[locale]/get-started/_components/addChainAutomatically.tsx
+++ b/portal/app/[locale]/get-started/_components/addChainAutomatically.tsx
@@ -1,4 +1,3 @@
-import dynamic from 'next/dynamic'
 import { lazy, Suspense } from 'react'
 import { type Chain } from 'viem'
 
@@ -14,12 +13,10 @@ const AddChain = lazy(() =>
   import('./addChain').then(mod => ({ default: mod.AddChain })),
 )
 
-const AddChainButton = dynamic(
-  () => import('./addChain/addChainButton').then(mod => mod.AddChainButton),
-  {
-    loading: () => <span aria-hidden="true" className="block h-7" />,
-    ssr: false,
-  },
+const AddChainButton = lazy(() =>
+  import('./addChain/addChainButton').then(mod => ({
+    default: mod.AddChainButton,
+  })),
 )
 
 export const AddChainAutomatically = function ({ chain, layer }: Props) {
@@ -27,7 +24,11 @@ export const AddChainAutomatically = function ({ chain, layer }: Props) {
     <ChainIdentityRow
       chain={chain}
       layer={layer}
-      trailing={<AddChainButton chain={chain} />}
+      trailing={
+        <Suspense fallback={<span aria-hidden="true" className="block h-7" />}>
+          <AddChainButton chain={chain} />
+        </Suspense>
+      }
     />
   )
 

--- a/portal/app/[locale]/get-started/_components/addChainAutomatically.tsx
+++ b/portal/app/[locale]/get-started/_components/addChainAutomatically.tsx
@@ -1,6 +1,7 @@
-import { lazy, Suspense } from 'react'
+import { lazy, type ReactNode, Suspense } from 'react'
 import { type Chain } from 'viem'
 
+import { AddChainButton } from './addChain/addChainButton'
 import { ChainIdentityRow } from './addChain/chainIdentityRow'
 import { Container } from './addChain/container'
 
@@ -13,28 +14,20 @@ const AddChain = lazy(() =>
   import('./addChain').then(mod => ({ default: mod.AddChain })),
 )
 
-const AddChainButton = lazy(() =>
-  import('./addChain/addChainButton').then(mod => ({
-    default: mod.AddChainButton,
-  })),
-)
-
 export const AddChainAutomatically = function ({ chain, layer }: Props) {
-  const content = (
-    <ChainIdentityRow
-      chain={chain}
-      layer={layer}
-      trailing={
-        <Suspense fallback={<span aria-hidden="true" className="block h-7" />}>
-          <AddChainButton chain={chain} />
-        </Suspense>
-      }
-    />
+  const row = (trailing: ReactNode) => (
+    <ChainIdentityRow chain={chain} layer={layer} trailing={trailing} />
   )
 
   return (
-    <Suspense fallback={<Container>{content}</Container>}>
-      <AddChain chain={chain}>{content}</AddChain>
+    <Suspense
+      fallback={
+        <Container>
+          {row(<span aria-hidden="true" className="block h-7" />)}
+        </Container>
+      }
+    >
+      <AddChain chain={chain}>{row(<AddChainButton chain={chain} />)}</AddChain>
     </Suspense>
   )
 }

--- a/portal/app/[locale]/hemi-earn/page.tsx
+++ b/portal/app/[locale]/hemi-earn/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { PageLayout } from 'components/pageLayout'
-import { lazy, type ReactNode, Suspense } from 'react'
+import { type ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import { InfoCards } from './_components/infoCards'
@@ -15,10 +16,12 @@ const PoolsListSkeleton = () => (
   </div>
 )
 
-const PoolsSection = lazy(() =>
-  import('./_components/poolsSection').then(mod => ({
-    default: mod.PoolsSection,
-  })),
+const PoolsSection = lazyWithFallback(
+  () =>
+    import('./_components/poolsSection').then(mod => ({
+      default: mod.PoolsSection,
+    })),
+  <PoolsListSkeleton />,
 )
 
 // Bails out of rendering the data section if the share registry can't be
@@ -38,9 +41,7 @@ export default function Page() {
       <TopSection />
       <TokensGate>
         <InfoCards />
-        <Suspense fallback={<PoolsListSkeleton />}>
-          <PoolsSection />
-        </Suspense>
+        <PoolsSection />
         <TransactionsSection />
       </TokensGate>
     </PageLayout>

--- a/portal/app/[locale]/hemi-earn/page.tsx
+++ b/portal/app/[locale]/hemi-earn/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { PageLayout } from 'components/pageLayout'
-import dynamic from 'next/dynamic'
-import { type ReactNode } from 'react'
+import { lazy, type ReactNode, Suspense } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import { InfoCards } from './_components/infoCards'
@@ -16,12 +15,10 @@ const PoolsListSkeleton = () => (
   </div>
 )
 
-const PoolsSection = dynamic(
-  () => import('./_components/poolsSection').then(mod => mod.PoolsSection),
-  {
-    loading: () => <PoolsListSkeleton />,
-    ssr: false,
-  },
+const PoolsSection = lazy(() =>
+  import('./_components/poolsSection').then(mod => ({
+    default: mod.PoolsSection,
+  })),
 )
 
 // Bails out of rendering the data section if the share registry can't be
@@ -41,7 +38,9 @@ export default function Page() {
       <TopSection />
       <TokensGate>
         <InfoCards />
-        <PoolsSection />
+        <Suspense fallback={<PoolsListSkeleton />}>
+          <PoolsSection />
+        </Suspense>
         <TransactionsSection />
       </TokensGate>
     </PageLayout>

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -3,9 +3,8 @@
 import { TokenInput } from 'components/tokenInput'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
 import { useTokenBalance } from 'hooks/useBalance'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { type EvmToken } from 'types/token'
 import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
@@ -37,9 +36,10 @@ import { OperationBelowForm } from './operationBelowForm'
 import { PoolFormContent } from './poolFormContent'
 import { SubmitDeposit } from './submitDeposit'
 
-const SetMaxEvmBalance = dynamic(
-  () => import('components/setMaxBalance').then(mod => mod.SetMaxEvmBalance),
-  { ssr: false },
+const SetMaxEvmBalance = lazy(() =>
+  import('components/setMaxBalance').then(mod => ({
+    default: mod.SetMaxEvmBalance,
+  })),
 )
 
 type Props = {
@@ -220,12 +220,14 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
             }
             label={t('common.deposit')}
             maxBalanceButton={
-              <SetMaxEvmBalance
-                disabled={isRunningOperation}
-                gas={depositGasFees + layerZeroFee}
-                onSetMaxBalance={updateInput}
-                token={selectedAsset.token}
-              />
+              <Suspense>
+                <SetMaxEvmBalance
+                  disabled={isRunningOperation}
+                  gas={depositGasFees + layerZeroFee}
+                  onSetMaxBalance={updateInput}
+                  token={selectedAsset.token}
+                />
+              </Suspense>
             }
             onChange={updateInput}
             token={selectedAsset.token}

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -1,10 +1,11 @@
 'use client'
 
+import { SetMaxEvmBalance } from 'components/setMaxBalance'
 import { TokenInput } from 'components/tokenInput'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'
 import { useTokenBalance } from 'hooks/useBalance'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense, useState } from 'react'
+import { useState } from 'react'
 import { type EvmToken } from 'types/token'
 import { getNativeToken } from 'utils/nativeToken'
 import { parseTokenUnits } from 'utils/token'
@@ -35,12 +36,6 @@ import { VaultFormLayout } from './form'
 import { OperationBelowForm } from './operationBelowForm'
 import { PoolFormContent } from './poolFormContent'
 import { SubmitDeposit } from './submitDeposit'
-
-const SetMaxEvmBalance = lazy(() =>
-  import('components/setMaxBalance').then(mod => ({
-    default: mod.SetMaxEvmBalance,
-  })),
-)
 
 type Props = {
   onSwitchToWithdraw: VoidFunction
@@ -220,14 +215,12 @@ export const Deposit = function ({ onSwitchToWithdraw }: Props) {
             }
             label={t('common.deposit')}
             maxBalanceButton={
-              <Suspense>
-                <SetMaxEvmBalance
-                  disabled={isRunningOperation}
-                  gas={depositGasFees + layerZeroFee}
-                  onSetMaxBalance={updateInput}
-                  token={selectedAsset.token}
-                />
-              </Suspense>
+              <SetMaxEvmBalance
+                disabled={isRunningOperation}
+                gas={depositGasFees + layerZeroFee}
+                onSetMaxBalance={updateInput}
+                token={selectedAsset.token}
+              />
             }
             onChange={updateInput}
             token={selectedAsset.token}

--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -15,8 +15,8 @@ import { useAmount } from 'hooks/useAmount'
 import { useTokenBalance } from 'hooks/useBalance'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useHemi } from 'hooks/useHemi'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
+import { lazy, Suspense } from 'react'
 import {
   StakeOperations,
   StakeStatusEnum,
@@ -33,20 +33,16 @@ import { useAccount } from 'wagmi'
 import { useEstimateStakeFees } from '../../_hooks/useEstimateStakeFees'
 import { useStake } from '../../_hooks/useStake'
 
-const StakeToast = dynamic(
-  () => import('../stakeToast').then(mod => mod.StakeToast),
-  {
-    loading: () => <ToastLoader />,
-    ssr: false,
-  },
-)
-
 import { StakeMaxBalance } from './maxBalance'
 import { Operation } from './operation'
 import { Preview } from './preview'
 import { StakeCallToAction } from './stakeCallToAction'
 import { StrategyDetails } from './strategyDetails'
 import { SubmitButton } from './submitButton'
+
+const StakeToast = lazy(() =>
+  import('../stakeToast').then(mod => ({ default: mod.StakeToast })),
+)
 
 type AllowanceQuery = Omit<
   UseQueryOptions<bigint, Error, bigint>,
@@ -289,11 +285,13 @@ export const StakeOperation = function ({
   return (
     <>
       {stakeStatus === StakeStatusEnum.STAKE_TX_CONFIRMED && (
-        <StakeToast
-          chainId={token.chainId}
-          txHash={stakeTransactionHash!}
-          type="stake"
-        />
+        <Suspense fallback={<ToastLoader />}>
+          <StakeToast
+            chainId={token.chainId}
+            txHash={stakeTransactionHash!}
+            type="stake"
+          />
+        </Suspense>
       )}
       <Operation
         amount={amountInput}

--- a/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/stakeOperation.tsx
@@ -3,6 +3,7 @@ import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { type UseQueryOptions } from '@tanstack/react-query'
 import { DrawerParagraph } from 'components/drawer'
 import { HemiFees } from 'components/hemiFees'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import {
   ProgressStatus,
   type ProgressStatusType,
@@ -16,7 +17,6 @@ import { useTokenBalance } from 'hooks/useBalance'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense } from 'react'
 import {
   StakeOperations,
   StakeStatusEnum,
@@ -40,8 +40,9 @@ import { StakeCallToAction } from './stakeCallToAction'
 import { StrategyDetails } from './strategyDetails'
 import { SubmitButton } from './submitButton'
 
-const StakeToast = lazy(() =>
-  import('../stakeToast').then(mod => ({ default: mod.StakeToast })),
+const StakeToast = lazyWithFallback(
+  () => import('../stakeToast').then(mod => ({ default: mod.StakeToast })),
+  <ToastLoader />,
 )
 
 type AllowanceQuery = Omit<
@@ -285,13 +286,11 @@ export const StakeOperation = function ({
   return (
     <>
       {stakeStatus === StakeStatusEnum.STAKE_TX_CONFIRMED && (
-        <Suspense fallback={<ToastLoader />}>
-          <StakeToast
-            chainId={token.chainId}
-            txHash={stakeTransactionHash!}
-            type="stake"
-          />
-        </Suspense>
+        <StakeToast
+          chainId={token.chainId}
+          txHash={stakeTransactionHash!}
+          type="stake"
+        />
       )}
       <Operation
         amount={amountInput}

--- a/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
@@ -1,4 +1,5 @@
 import { HemiFees } from 'components/hemiFees'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { ProgressStatus } from 'components/reviewOperation/progressStatus'
 import { StepPropsWithoutPosition } from 'components/reviewOperation/step'
 import { Spinner } from 'components/spinner'
@@ -6,7 +7,6 @@ import { ToastLoader } from 'components/toast/toastLoader'
 import { useAmount } from 'hooks/useAmount'
 import { useHemi } from 'hooks/useHemi'
 import { useTranslations } from 'next-intl'
-import { type ComponentProps, lazy, Suspense } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import {
   UnstakeStatusEnum,
@@ -28,20 +28,15 @@ import { Preview } from './preview'
 import { SubmitButton } from './submitButton'
 import { UnstakeCallToAction } from './unstakeCallToAction'
 
-const StakeToast = lazy(() =>
-  import('../stakeToast').then(mod => ({ default: mod.StakeToast })),
+const StakeToast = lazyWithFallback(
+  () => import('../stakeToast').then(mod => ({ default: mod.StakeToast })),
+  <ToastLoader />,
 )
 
-const LazyStakedBalance = lazy(() =>
-  import('../stakedBalance').then(mod => ({ default: mod.StakedBalance })),
-)
-
-const StakedBalance = (props: ComponentProps<typeof LazyStakedBalance>) => (
-  <Suspense
-    fallback={<Skeleton className="h-full" containerClassName="basis-1/3" />}
-  >
-    <LazyStakedBalance {...props} />
-  </Suspense>
+const StakedBalance = lazyWithFallback(
+  () =>
+    import('../stakedBalance').then(mod => ({ default: mod.StakedBalance })),
+  <Skeleton className="h-full" containerClassName="basis-1/3" />,
 )
 
 type Props = {
@@ -141,13 +136,11 @@ export const UnstakeOperation = function ({
     <>
       {unstakeStatus === UnstakeStatusEnum.UNSTAKE_TX_CONFIRMED &&
         unStakeTransactionHash && (
-          <Suspense fallback={<ToastLoader />}>
-            <StakeToast
-              chainId={token.chainId}
-              txHash={unStakeTransactionHash}
-              type="unstake"
-            />
-          </Suspense>
+          <StakeToast
+            chainId={token.chainId}
+            txHash={unStakeTransactionHash}
+            type="unstake"
+          />
         )}
       <Operation
         amount={amountInput}

--- a/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/unstakeOperation.tsx
@@ -5,8 +5,8 @@ import { Spinner } from 'components/spinner'
 import { ToastLoader } from 'components/toast/toastLoader'
 import { useAmount } from 'hooks/useAmount'
 import { useHemi } from 'hooks/useHemi'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
+import { type ComponentProps, lazy, Suspense } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import {
   UnstakeStatusEnum,
@@ -22,28 +22,26 @@ import { useEstimateUnstakeFees } from '../../_hooks/useEstimateUnstakeFees'
 import { useStakedBalance } from '../../_hooks/useStakedBalance'
 import { useUnstake } from '../../_hooks/useUnstake'
 
-const StakeToast = dynamic(
-  () => import('../stakeToast').then(mod => mod.StakeToast),
-  {
-    loading: () => <ToastLoader />,
-    ssr: false,
-  },
-)
-
 import { UnstakeMaxBalance } from './maxBalance'
 import { Operation } from './operation'
 import { Preview } from './preview'
 import { SubmitButton } from './submitButton'
 import { UnstakeCallToAction } from './unstakeCallToAction'
 
-const StakedBalance = dynamic(
-  () => import('../stakedBalance').then(mod => mod.StakedBalance),
-  {
-    loading: () => (
-      <Skeleton className="h-full" containerClassName="basis-1/3" />
-    ),
-    ssr: false,
-  },
+const StakeToast = lazy(() =>
+  import('../stakeToast').then(mod => ({ default: mod.StakeToast })),
+)
+
+const LazyStakedBalance = lazy(() =>
+  import('../stakedBalance').then(mod => ({ default: mod.StakedBalance })),
+)
+
+const StakedBalance = (props: ComponentProps<typeof LazyStakedBalance>) => (
+  <Suspense
+    fallback={<Skeleton className="h-full" containerClassName="basis-1/3" />}
+  >
+    <LazyStakedBalance {...props} />
+  </Suspense>
 )
 
 type Props = {
@@ -143,11 +141,13 @@ export const UnstakeOperation = function ({
     <>
       {unstakeStatus === UnstakeStatusEnum.UNSTAKE_TX_CONFIRMED &&
         unStakeTransactionHash && (
-          <StakeToast
-            chainId={token.chainId}
-            txHash={unStakeTransactionHash}
-            type="unstake"
-          />
+          <Suspense fallback={<ToastLoader />}>
+            <StakeToast
+              chainId={token.chainId}
+              txHash={unStakeTransactionHash}
+              type="unstake"
+            />
+          </Suspense>
         )}
       <Operation
         amount={amountInput}

--- a/portal/app/[locale]/staking-dashboard/_components/stake.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stake.tsx
@@ -2,13 +2,14 @@
 
 import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { FeesContainer } from 'components/feesContainer'
+import { SetMaxEvmBalance } from 'components/setMaxBalance'
 import { useTokenBalance } from 'hooks/useBalance'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiToken } from 'hooks/useHemiToken'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense, useState } from 'react'
+import { useState } from 'react'
 import { StakingOperationRunning } from 'types/stakingDashboard'
 import { getTotal } from 'utils/getTotal'
 import { getNativeToken } from 'utils/nativeToken'
@@ -27,12 +28,6 @@ import { daysToSeconds } from '../_utils/lockCreationTimes'
 import { FormContent, StakingForm } from './form'
 import { isValidLockup } from './lockup'
 import { SubmitStake } from './submitStake'
-
-const SetMaxEvmBalance = lazy(() =>
-  import('components/setMaxBalance').then(mod => ({
-    default: mod.SetMaxEvmBalance,
-  })),
-)
 
 export const Stake = function () {
   const token = useHemiToken()
@@ -176,14 +171,12 @@ export const Stake = function () {
           }
           isRunningOperation={isRunningOperation}
           setMaxBalanceButton={
-            <Suspense>
-              <SetMaxEvmBalance
-                disabled={isRunningOperation}
-                gas={createLockGasFees}
-                onSetMaxBalance={updateInput}
-                token={token}
-              />
-            </Suspense>
+            <SetMaxEvmBalance
+              disabled={isRunningOperation}
+              gas={createLockGasFees}
+              onSetMaxBalance={updateInput}
+              token={token}
+            />
           }
         />
       }

--- a/portal/app/[locale]/staking-dashboard/_components/stake.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stake.tsx
@@ -7,9 +7,8 @@ import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useHemi } from 'hooks/useHemi'
 import { useHemiToken } from 'hooks/useHemiToken'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { StakingOperationRunning } from 'types/stakingDashboard'
 import { getTotal } from 'utils/getTotal'
 import { getNativeToken } from 'utils/nativeToken'
@@ -29,9 +28,10 @@ import { FormContent, StakingForm } from './form'
 import { isValidLockup } from './lockup'
 import { SubmitStake } from './submitStake'
 
-const SetMaxEvmBalance = dynamic(
-  () => import('components/setMaxBalance').then(mod => mod.SetMaxEvmBalance),
-  { ssr: false },
+const SetMaxEvmBalance = lazy(() =>
+  import('components/setMaxBalance').then(mod => ({
+    default: mod.SetMaxEvmBalance,
+  })),
 )
 
 export const Stake = function () {
@@ -176,12 +176,14 @@ export const Stake = function () {
           }
           isRunningOperation={isRunningOperation}
           setMaxBalanceButton={
-            <SetMaxEvmBalance
-              disabled={isRunningOperation}
-              gas={createLockGasFees}
-              onSetMaxBalance={updateInput}
-              token={token}
-            />
+            <Suspense>
+              <SetMaxEvmBalance
+                disabled={isRunningOperation}
+                gas={createLockGasFees}
+                onSetMaxBalance={updateInput}
+                token={token}
+              />
+            </Suspense>
           }
         />
       }

--- a/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { ToastLoader } from 'components/toast/toastLoader'
 import { useHemiToken } from 'hooks/useHemiToken'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import {
   CollectAllRewardsDashboardStatus,
@@ -17,8 +18,9 @@ import { useDrawerStakingQueryString } from '../_hooks/useDrawerStakingQueryStri
 import { Stake } from './stake'
 import { StakeReview } from './stakeReview'
 
-const StakeToast = lazy(() =>
-  import('./stakeToast').then(mod => ({ default: mod.StakeToast })),
+const StakeToast = lazyWithFallback(
+  () => import('./stakeToast').then(mod => ({ default: mod.StakeToast })),
+  <ToastLoader />,
 )
 
 const SideDrawer = function () {
@@ -77,28 +79,22 @@ export const StakeForm = function () {
   return (
     <>
       {showStakeToast && (
-        <Suspense fallback={<ToastLoader />}>
-          <StakeToast
-            title={t('staking-dashboard.stake-successful')}
-            transactionHash={stakingDashboardOperation.transactionHash!}
-          />
-        </Suspense>
+        <StakeToast
+          title={t('staking-dashboard.stake-successful')}
+          transactionHash={stakingDashboardOperation.transactionHash!}
+        />
       )}
       {showUnlockToast && (
-        <Suspense fallback={<ToastLoader />}>
-          <StakeToast
-            title={t('staking-dashboard.unlock-successful')}
-            transactionHash={unlockingDashboardOperation.transactionHash!}
-          />
-        </Suspense>
+        <StakeToast
+          title={t('staking-dashboard.unlock-successful')}
+          transactionHash={unlockingDashboardOperation.transactionHash!}
+        />
       )}
       {showCollectRewardsToast && (
-        <Suspense fallback={<ToastLoader />}>
-          <StakeToast
-            title={t('staking-dashboard.claim-rewards-successful')}
-            transactionHash={collectRewardsDashboardOperation.transactionHash!}
-          />
-        </Suspense>
+        <StakeToast
+          title={t('staking-dashboard.claim-rewards-successful')}
+          transactionHash={collectRewardsDashboardOperation.transactionHash!}
+        />
       )}
       <Stake />
       <Suspense>

--- a/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
@@ -2,9 +2,8 @@
 
 import { ToastLoader } from 'components/toast/toastLoader'
 import { useHemiToken } from 'hooks/useHemiToken'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { Suspense } from 'react'
+import { lazy, Suspense } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import {
   CollectAllRewardsDashboardStatus,
@@ -18,12 +17,8 @@ import { useDrawerStakingQueryString } from '../_hooks/useDrawerStakingQueryStri
 import { Stake } from './stake'
 import { StakeReview } from './stakeReview'
 
-const StakeToast = dynamic(
-  () => import('./stakeToast').then(mod => mod.StakeToast),
-  {
-    loading: () => <ToastLoader />,
-    ssr: false,
-  },
+const StakeToast = lazy(() =>
+  import('./stakeToast').then(mod => ({ default: mod.StakeToast })),
 )
 
 const SideDrawer = function () {
@@ -82,22 +77,28 @@ export const StakeForm = function () {
   return (
     <>
       {showStakeToast && (
-        <StakeToast
-          title={t('staking-dashboard.stake-successful')}
-          transactionHash={stakingDashboardOperation.transactionHash!}
-        />
+        <Suspense fallback={<ToastLoader />}>
+          <StakeToast
+            title={t('staking-dashboard.stake-successful')}
+            transactionHash={stakingDashboardOperation.transactionHash!}
+          />
+        </Suspense>
       )}
       {showUnlockToast && (
-        <StakeToast
-          title={t('staking-dashboard.unlock-successful')}
-          transactionHash={unlockingDashboardOperation.transactionHash!}
-        />
+        <Suspense fallback={<ToastLoader />}>
+          <StakeToast
+            title={t('staking-dashboard.unlock-successful')}
+            transactionHash={unlockingDashboardOperation.transactionHash!}
+          />
+        </Suspense>
       )}
       {showCollectRewardsToast && (
-        <StakeToast
-          title={t('staking-dashboard.claim-rewards-successful')}
-          transactionHash={collectRewardsDashboardOperation.transactionHash!}
-        />
+        <Suspense fallback={<ToastLoader />}>
+          <StakeToast
+            title={t('staking-dashboard.claim-rewards-successful')}
+            transactionHash={collectRewardsDashboardOperation.transactionHash!}
+          />
+        </Suspense>
       )}
       <Stake />
       <Suspense>

--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -6,9 +6,8 @@ import { useBitcoin } from 'hooks/useBitcoin'
 import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useDepositBitcoin } from 'hooks/useBtcTunnel'
 import { useUmami } from 'hooks/useUmami'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import { formatEvmAddress } from 'utils/format'
 import { parseTokenUnits } from 'utils/token'
 import { validateSubmit } from 'utils/validateSubmit'
@@ -24,14 +23,14 @@ import { FormContent, TunnelForm } from './form'
 import { ReceivingAddress } from './receivingAddress'
 import { SubmitWithTwoWallets } from './submitWithTwoWallets'
 
-const SetMaxBtcBalance = dynamic(
-  () => import('components/setMaxBalance').then(mod => mod.SetMaxBtcBalance),
-  { ssr: false },
+const SetMaxBtcBalance = lazy(() =>
+  import('components/setMaxBalance').then(mod => ({
+    default: mod.SetMaxBtcBalance,
+  })),
 )
 
-const WalletsConnected = dynamic(
-  () => import('./walletsConnected').then(mod => mod.WalletsConnected),
-  { ssr: false },
+const WalletsConnected = lazy(() =>
+  import('./walletsConnected').then(mod => ({ default: mod.WalletsConnected })),
 )
 
 type BtcDepositProps = {
@@ -192,7 +191,11 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
           <BtcFees amount={amountBigInt} />
         </div>
       }
-      bottomSection={<WalletsConnected />}
+      bottomSection={
+        <Suspense>
+          <WalletsConnected />
+        </Suspense>
+      }
       formContent={
         <FormContent
           calculateReceiveAmount={calculateReceiveAmount}
@@ -203,11 +206,13 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
           }
           isRunningOperation={isDepositing}
           setMaxBalanceButton={
-            <SetMaxBtcBalance
-              disabled={isDepositing}
-              onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
-              token={fromToken}
-            />
+            <Suspense>
+              <SetMaxBtcBalance
+                disabled={isDepositing}
+                onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
+                token={fromToken}
+              />
+            </Suspense>
           }
           tunnelState={state}
         />

--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import { useDebounce } from '@hemilabs/react-hooks/useDebounce'
+import { lazyWithFallback } from 'components/lazyWithFallback'
+import { SetMaxBtcBalance } from 'components/setMaxBalance'
 import { useAccounts } from 'hooks/useAccounts'
 import { useBitcoin } from 'hooks/useBitcoin'
 import { useBitcoinBalance } from 'hooks/useBitcoinBalance'
 import { useDepositBitcoin } from 'hooks/useBtcTunnel'
 import { useUmami } from 'hooks/useUmami'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { formatEvmAddress } from 'utils/format'
 import { parseTokenUnits } from 'utils/token'
 import { validateSubmit } from 'utils/validateSubmit'
@@ -23,13 +25,7 @@ import { FormContent, TunnelForm } from './form'
 import { ReceivingAddress } from './receivingAddress'
 import { SubmitWithTwoWallets } from './submitWithTwoWallets'
 
-const SetMaxBtcBalance = lazy(() =>
-  import('components/setMaxBalance').then(mod => ({
-    default: mod.SetMaxBtcBalance,
-  })),
-)
-
-const WalletsConnected = lazy(() =>
+const WalletsConnected = lazyWithFallback(() =>
   import('./walletsConnected').then(mod => ({ default: mod.WalletsConnected })),
 )
 
@@ -191,11 +187,7 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
           <BtcFees amount={amountBigInt} />
         </div>
       }
-      bottomSection={
-        <Suspense>
-          <WalletsConnected />
-        </Suspense>
-      }
+      bottomSection={<WalletsConnected />}
       formContent={
         <FormContent
           calculateReceiveAmount={calculateReceiveAmount}
@@ -206,13 +198,11 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
           }
           isRunningOperation={isDepositing}
           setMaxBalanceButton={
-            <Suspense>
-              <SetMaxBtcBalance
-                disabled={isDepositing}
-                onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
-                token={fromToken}
-              />
-            </Suspense>
+            <SetMaxBtcBalance
+              disabled={isDepositing}
+              onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
+              token={fromToken}
+            />
           }
           tunnelState={state}
         />

--- a/portal/app/[locale]/tunnel/_components/evmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/evmDeposit.tsx
@@ -9,9 +9,8 @@ import { useChain } from 'hooks/useChain'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import { useNetworkType } from 'hooks/useNetworkType'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { getL1StandardBridgeAddress } from 'utils/chain'
 import { getTotal } from 'utils/getTotal'
 import { getNativeToken, isNativeToken } from 'utils/nativeToken'
@@ -30,9 +29,10 @@ import { FormContent, TunnelForm } from './form'
 import { SubmitEvmDeposit } from './submitEvmDeposit'
 import { TunnelProviderToggle } from './tunnelProviderToggle'
 
-const SetMaxEvmBalance = dynamic(
-  () => import('components/setMaxBalance').then(mod => mod.SetMaxEvmBalance),
-  { ssr: false },
+const SetMaxEvmBalance = lazy(() =>
+  import('components/setMaxBalance').then(mod => ({
+    default: mod.SetMaxEvmBalance,
+  })),
 )
 
 type OperationRunning = 'idle' | 'approving' | 'depositing'
@@ -230,12 +230,14 @@ export const EvmDeposit = function ({ state }: EvmDepositProps) {
             isRunningOperation={isRunningOperation}
             provider={renderTunnelProviderToggle()}
             setMaxBalanceButton={
-              <SetMaxEvmBalance
-                disabled={isRunningOperation}
-                gas={depositGasFees}
-                onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
-                token={fromToken}
-              />
+              <Suspense>
+                <SetMaxEvmBalance
+                  disabled={isRunningOperation}
+                  gas={depositGasFees}
+                  onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
+                  token={fromToken}
+                />
+              </Suspense>
             }
             tokenApproval={
               operatesNativeToken ? null : (

--- a/portal/app/[locale]/tunnel/_components/evmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/evmDeposit.tsx
@@ -4,13 +4,14 @@ import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { CustomTunnelsThroughPartners } from 'components/customTunnelsThroughPartners'
 import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { FeesContainer } from 'components/feesContainer'
+import { SetMaxEvmBalance } from 'components/setMaxBalance'
 import { useTokenBalance } from 'hooks/useBalance'
 import { useChain } from 'hooks/useChain'
 import { useEstimateApproveErc20Fees } from 'hooks/useEstimateApproveErc20Fees'
 import { useNeedsApproval } from 'hooks/useNeedsApproval'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense, useState } from 'react'
+import { useState } from 'react'
 import { getL1StandardBridgeAddress } from 'utils/chain'
 import { getTotal } from 'utils/getTotal'
 import { getNativeToken, isNativeToken } from 'utils/nativeToken'
@@ -28,12 +29,6 @@ import { Erc20TokenApproval } from './erc20TokenApproval'
 import { FormContent, TunnelForm } from './form'
 import { SubmitEvmDeposit } from './submitEvmDeposit'
 import { TunnelProviderToggle } from './tunnelProviderToggle'
-
-const SetMaxEvmBalance = lazy(() =>
-  import('components/setMaxBalance').then(mod => ({
-    default: mod.SetMaxEvmBalance,
-  })),
-)
 
 type OperationRunning = 'idle' | 'approving' | 'depositing'
 
@@ -230,14 +225,12 @@ export const EvmDeposit = function ({ state }: EvmDepositProps) {
             isRunningOperation={isRunningOperation}
             provider={renderTunnelProviderToggle()}
             setMaxBalanceButton={
-              <Suspense>
-                <SetMaxEvmBalance
-                  disabled={isRunningOperation}
-                  gas={depositGasFees}
-                  onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
-                  token={fromToken}
-                />
-              </Suspense>
+              <SetMaxEvmBalance
+                disabled={isRunningOperation}
+                gas={depositGasFees}
+                onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
+                token={fromToken}
+              />
             }
             tokenApproval={
               operatesNativeToken ? null : (

--- a/portal/app/[locale]/tunnel/_components/submitWithTwoWallets.tsx
+++ b/portal/app/[locale]/tunnel/_components/submitWithTwoWallets.tsx
@@ -1,5 +1,5 @@
 import { Button } from 'components/button'
-import { ButtonLoader } from 'components/buttonLoader'
+import { LazyConnectEvmWallet } from 'components/lazyConnectEvmWallet'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { SubmitWhenConnectedToChain } from 'components/submitWhenConnectedToChain'
 import { useAccounts } from 'hooks/useAccounts'
@@ -7,7 +7,6 @@ import { useBitcoin } from 'hooks/useBitcoin'
 import { useDrawerContext } from 'hooks/useDrawerContext'
 import { useUmami } from 'hooks/useUmami'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense } from 'react'
 
 import { ConnectBtcWallet } from './connectBtcWallet'
 
@@ -16,12 +15,6 @@ type Props = {
   text: string
   validationError: string | undefined
 }
-
-const ConnectEvmWallet = lazy(() =>
-  import('components/connectEvmWallet').then(mod => ({
-    default: mod.ConnectEvmWallet,
-  })),
-)
 
 export const SubmitWithTwoWallets = function ({
   disabled,
@@ -47,11 +40,7 @@ export const SubmitWithTwoWallets = function ({
   }
 
   if (evmWalletStatus !== 'connected') {
-    return (
-      <Suspense fallback={<ButtonLoader />}>
-        <ConnectEvmWallet />
-      </Suspense>
-    )
+    return <LazyConnectEvmWallet />
   }
 
   if (btcWalletStatus !== 'connected') {

--- a/portal/app/[locale]/tunnel/_components/submitWithTwoWallets.tsx
+++ b/portal/app/[locale]/tunnel/_components/submitWithTwoWallets.tsx
@@ -6,8 +6,8 @@ import { useAccounts } from 'hooks/useAccounts'
 import { useBitcoin } from 'hooks/useBitcoin'
 import { useDrawerContext } from 'hooks/useDrawerContext'
 import { useUmami } from 'hooks/useUmami'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
+import { lazy, Suspense } from 'react'
 
 import { ConnectBtcWallet } from './connectBtcWallet'
 
@@ -17,12 +17,10 @@ type Props = {
   validationError: string | undefined
 }
 
-const ConnectEvmWallet = dynamic(
-  () => import('components/connectEvmWallet').then(mod => mod.ConnectEvmWallet),
-  {
-    loading: () => <ButtonLoader />,
-    ssr: false,
-  },
+const ConnectEvmWallet = lazy(() =>
+  import('components/connectEvmWallet').then(mod => ({
+    default: mod.ConnectEvmWallet,
+  })),
 )
 
 export const SubmitWithTwoWallets = function ({
@@ -49,7 +47,11 @@ export const SubmitWithTwoWallets = function ({
   }
 
   if (evmWalletStatus !== 'connected') {
-    return <ConnectEvmWallet />
+    return (
+      <Suspense fallback={<ButtonLoader />}>
+        <ConnectEvmWallet />
+      </Suspense>
+    )
   }
 
   if (btcWalletStatus !== 'connected') {

--- a/portal/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/withdraw.tsx
@@ -12,9 +12,8 @@ import { useChain } from 'hooks/useChain'
 import { useNetworks } from 'hooks/useNetworks'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useUmami } from 'hooks/useUmami'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { isEvmNetwork } from 'utils/chain'
 import { formatBtcAddress } from 'utils/format'
@@ -45,14 +44,14 @@ import { SubmitEvmWithdrawal } from './submitEvmWithdrawal'
 import { SubmitWithTwoWallets } from './submitWithTwoWallets'
 import { TunnelProviderToggle } from './tunnelProviderToggle'
 
-const SetMaxEvmBalance = dynamic(
-  () => import('components/setMaxBalance').then(mod => mod.SetMaxEvmBalance),
-  { ssr: false },
+const SetMaxEvmBalance = lazy(() =>
+  import('components/setMaxBalance').then(mod => ({
+    default: mod.SetMaxEvmBalance,
+  })),
 )
 
-const WalletsConnected = dynamic(
-  () => import('./walletsConnected').then(mod => mod.WalletsConnected),
-  { ssr: false },
+const WalletsConnected = lazy(() =>
+  import('./walletsConnected').then(mod => ({ default: mod.WalletsConnected })),
 )
 
 type BtcWithdrawProps = {
@@ -229,7 +228,11 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
           </FeesContainer>
         </div>
       }
-      bottomSection={<WalletsConnected />}
+      bottomSection={
+        <Suspense>
+          <WalletsConnected />
+        </Suspense>
+      }
       formContent={
         <FormContent
           calculateReceiveAmount={calculateReceiveAmount}
@@ -242,12 +245,14 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
           }
           isRunningOperation={isWithdrawing}
           setMaxBalanceButton={
-            <SetMaxEvmBalance
-              disabled={isWithdrawing}
-              gas={estimatedFees}
-              onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
-              token={fromToken}
-            />
+            <Suspense>
+              <SetMaxEvmBalance
+                disabled={isWithdrawing}
+                gas={estimatedFees}
+                onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
+                token={fromToken}
+              />
+            </Suspense>
           }
           tunnelState={state}
         />
@@ -428,12 +433,14 @@ const EvmWithdraw = function ({ state }: EvmWithdrawProps) {
             isRunningOperation={isWithdrawing}
             provider={<RenderTunnelProviderToggle />}
             setMaxBalanceButton={
-              <SetMaxEvmBalance
-                disabled={isWithdrawing}
-                gas={withdrawGasFees}
-                onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
-                token={fromToken}
-              />
+              <Suspense>
+                <SetMaxEvmBalance
+                  disabled={isWithdrawing}
+                  gas={withdrawGasFees}
+                  onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
+                  token={fromToken}
+                />
+              </Suspense>
             }
             tunnelState={{
               ...state,

--- a/portal/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/withdraw.tsx
@@ -5,6 +5,8 @@ import { CustomTunnelsThroughPartners } from 'components/customTunnelsThroughPar
 import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { FeesContainer } from 'components/feesContainer'
 import { WarningIcon } from 'components/icons/warningIcon'
+import { lazyWithFallback } from 'components/lazyWithFallback'
+import { SetMaxEvmBalance } from 'components/setMaxBalance'
 import { useAccounts } from 'hooks/useAccounts'
 import { useTokenBalance } from 'hooks/useBalance'
 import { useWithdrawBitcoin } from 'hooks/useBtcTunnel'
@@ -13,7 +15,7 @@ import { useNetworks } from 'hooks/useNetworks'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useUmami } from 'hooks/useUmami'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { isEvmNetwork } from 'utils/chain'
 import { formatBtcAddress } from 'utils/format'
@@ -44,13 +46,7 @@ import { SubmitEvmWithdrawal } from './submitEvmWithdrawal'
 import { SubmitWithTwoWallets } from './submitWithTwoWallets'
 import { TunnelProviderToggle } from './tunnelProviderToggle'
 
-const SetMaxEvmBalance = lazy(() =>
-  import('components/setMaxBalance').then(mod => ({
-    default: mod.SetMaxEvmBalance,
-  })),
-)
-
-const WalletsConnected = lazy(() =>
+const WalletsConnected = lazyWithFallback(() =>
   import('./walletsConnected').then(mod => ({ default: mod.WalletsConnected })),
 )
 
@@ -228,11 +224,7 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
           </FeesContainer>
         </div>
       }
-      bottomSection={
-        <Suspense>
-          <WalletsConnected />
-        </Suspense>
-      }
+      bottomSection={<WalletsConnected />}
       formContent={
         <FormContent
           calculateReceiveAmount={calculateReceiveAmount}
@@ -245,14 +237,12 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
           }
           isRunningOperation={isWithdrawing}
           setMaxBalanceButton={
-            <Suspense>
-              <SetMaxEvmBalance
-                disabled={isWithdrawing}
-                gas={estimatedFees}
-                onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
-                token={fromToken}
-              />
-            </Suspense>
+            <SetMaxEvmBalance
+              disabled={isWithdrawing}
+              gas={estimatedFees}
+              onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
+              token={fromToken}
+            />
           }
           tunnelState={state}
         />
@@ -433,14 +423,12 @@ const EvmWithdraw = function ({ state }: EvmWithdrawProps) {
             isRunningOperation={isWithdrawing}
             provider={<RenderTunnelProviderToggle />}
             setMaxBalanceButton={
-              <Suspense>
-                <SetMaxEvmBalance
-                  disabled={isWithdrawing}
-                  gas={withdrawGasFees}
-                  onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
-                  token={fromToken}
-                />
-              </Suspense>
+              <SetMaxEvmBalance
+                disabled={isWithdrawing}
+                gas={withdrawGasFees}
+                onSetMaxBalance={maxBalance => updateFromInput(maxBalance)}
+                token={fromToken}
+              />
             }
             tunnelState={{
               ...state,

--- a/portal/app/[locale]/tunnel/transaction-history/page.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/page.tsx
@@ -2,29 +2,16 @@
 
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import { type FilterOptions, TopBar } from './_components/topBar'
 
-// using CSR because useWindowSize doesn't work on SSR
-const TransactionHistory = dynamic(
-  () =>
-    import('./_components/transactionHistory').then(
-      mod => mod.TransactionHistory,
-    ),
-  {
-    loading: () => (
-      // Mirrors the table's own height and radius so the first paint matches it
-      <Skeleton
-        className="block h-[56dvh] w-full rounded-lg md:min-h-136"
-        containerClassName="block"
-      />
-    ),
-    ssr: false,
-  },
+const TransactionHistory = lazy(() =>
+  import('./_components/transactionHistory').then(mod => ({
+    default: mod.TransactionHistory,
+  })),
 )
 
 const Page = function () {
@@ -47,10 +34,20 @@ const Page = function () {
           filterOption={filterOption}
           onFilterOptionChange={setFilterOption}
         />
-        <TransactionHistory
-          filterOption={filterOption}
-          setFilterOption={setFilterOption}
-        />
+        <Suspense
+          fallback={
+            // Mirrors the table's own height and radius so the first paint matches it
+            <Skeleton
+              className="block h-[56dvh] w-full rounded-lg md:min-h-136"
+              containerClassName="block"
+            />
+          }
+        >
+          <TransactionHistory
+            filterOption={filterOption}
+            setFilterOption={setFilterOption}
+          />
+        </Suspense>
       </div>
     </PageLayout>
   )

--- a/portal/app/[locale]/tunnel/transaction-history/page.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/page.tsx
@@ -1,25 +1,12 @@
 'use client'
 
-import { lazyWithFallback } from 'components/lazyWithFallback'
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
-import Skeleton from 'react-loading-skeleton'
 
 import { type FilterOptions, TopBar } from './_components/topBar'
-
-const TransactionHistory = lazyWithFallback(
-  () =>
-    import('./_components/transactionHistory').then(mod => ({
-      default: mod.TransactionHistory,
-    })),
-  // Mirrors the table's own height and radius so the first paint matches it
-  <Skeleton
-    className="block h-[56dvh] w-full rounded-lg md:min-h-136"
-    containerClassName="block"
-  />,
-)
+import { TransactionHistory } from './_components/transactionHistory'
 
 const Page = function () {
   const [filterOption, setFilterOption] = useState<FilterOptions>({

--- a/portal/app/[locale]/tunnel/transaction-history/page.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/page.tsx
@@ -1,17 +1,24 @@
 'use client'
 
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense, useState } from 'react'
+import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import { type FilterOptions, TopBar } from './_components/topBar'
 
-const TransactionHistory = lazy(() =>
-  import('./_components/transactionHistory').then(mod => ({
-    default: mod.TransactionHistory,
-  })),
+const TransactionHistory = lazyWithFallback(
+  () =>
+    import('./_components/transactionHistory').then(mod => ({
+      default: mod.TransactionHistory,
+    })),
+  // Mirrors the table's own height and radius so the first paint matches it
+  <Skeleton
+    className="block h-[56dvh] w-full rounded-lg md:min-h-136"
+    containerClassName="block"
+  />,
 )
 
 const Page = function () {
@@ -34,20 +41,10 @@ const Page = function () {
           filterOption={filterOption}
           onFilterOptionChange={setFilterOption}
         />
-        <Suspense
-          fallback={
-            // Mirrors the table's own height and radius so the first paint matches it
-            <Skeleton
-              className="block h-[56dvh] w-full rounded-lg md:min-h-136"
-              containerClassName="block"
-            />
-          }
-        >
-          <TransactionHistory
-            filterOption={filterOption}
-            setFilterOption={setFilterOption}
-          />
-        </Suspense>
+        <TransactionHistory
+          filterOption={filterOption}
+          setFilterOption={setFilterOption}
+        />
       </div>
     </PageLayout>
   )

--- a/portal/app/demos/page.tsx
+++ b/portal/app/demos/page.tsx
@@ -1,17 +1,7 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { LocalePageRedirect } from 'components/localePageRedirect'
 
-const LocalePageRedirect = lazy(() =>
-  import('components/localePageRedirect').then(mod => ({
-    default: mod.LocalePageRedirect,
-  })),
-)
-
-const Page = () => (
-  <Suspense>
-    <LocalePageRedirect redirectPage="/demos" />
-  </Suspense>
-)
+const Page = () => <LocalePageRedirect redirectPage="/demos" />
 
 export default Page

--- a/portal/app/demos/page.tsx
+++ b/portal/app/demos/page.tsx
@@ -1,13 +1,17 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const LocalePageRedirect = dynamic(
-  () =>
-    import('components/localePageRedirect').then(mod => mod.LocalePageRedirect),
-  { ssr: false },
+const LocalePageRedirect = lazy(() =>
+  import('components/localePageRedirect').then(mod => ({
+    default: mod.LocalePageRedirect,
+  })),
 )
 
-const Page = () => <LocalePageRedirect redirectPage="/demos" />
+const Page = () => (
+  <Suspense>
+    <LocalePageRedirect redirectPage="/demos" />
+  </Suspense>
+)
 
 export default Page

--- a/portal/app/genesis-drop/page.tsx
+++ b/portal/app/genesis-drop/page.tsx
@@ -1,13 +1,17 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const LocalePageRedirect = dynamic(
-  () =>
-    import('components/localePageRedirect').then(mod => mod.LocalePageRedirect),
-  { ssr: false },
+const LocalePageRedirect = lazy(() =>
+  import('components/localePageRedirect').then(mod => ({
+    default: mod.LocalePageRedirect,
+  })),
 )
 
-const Page = () => <LocalePageRedirect redirectPage="/genesis-drop" />
+const Page = () => (
+  <Suspense>
+    <LocalePageRedirect redirectPage="/genesis-drop" />
+  </Suspense>
+)
 
 export default Page

--- a/portal/app/genesis-drop/page.tsx
+++ b/portal/app/genesis-drop/page.tsx
@@ -1,17 +1,7 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { LocalePageRedirect } from 'components/localePageRedirect'
 
-const LocalePageRedirect = lazy(() =>
-  import('components/localePageRedirect').then(mod => ({
-    default: mod.LocalePageRedirect,
-  })),
-)
-
-const Page = () => (
-  <Suspense>
-    <LocalePageRedirect redirectPage="/genesis-drop" />
-  </Suspense>
-)
+const Page = () => <LocalePageRedirect redirectPage="/genesis-drop" />
 
 export default Page

--- a/portal/app/get-started/page.tsx
+++ b/portal/app/get-started/page.tsx
@@ -1,17 +1,7 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { LocalePageRedirect } from 'components/localePageRedirect'
 
-const LocalePageRedirect = lazy(() =>
-  import('components/localePageRedirect').then(mod => ({
-    default: mod.LocalePageRedirect,
-  })),
-)
-
-const Page = () => (
-  <Suspense>
-    <LocalePageRedirect redirectPage="/get-started" />
-  </Suspense>
-)
+const Page = () => <LocalePageRedirect redirectPage="/get-started" />
 
 export default Page

--- a/portal/app/get-started/page.tsx
+++ b/portal/app/get-started/page.tsx
@@ -1,13 +1,17 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const LocalePageRedirect = dynamic(
-  () =>
-    import('components/localePageRedirect').then(mod => mod.LocalePageRedirect),
-  { ssr: false },
+const LocalePageRedirect = lazy(() =>
+  import('components/localePageRedirect').then(mod => ({
+    default: mod.LocalePageRedirect,
+  })),
 )
 
-const Page = () => <LocalePageRedirect redirectPage="/get-started" />
+const Page = () => (
+  <Suspense>
+    <LocalePageRedirect redirectPage="/get-started" />
+  </Suspense>
+)
 
 export default Page

--- a/portal/app/hemi-earn/page.tsx
+++ b/portal/app/hemi-earn/page.tsx
@@ -1,13 +1,17 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const LocalePageRedirect = dynamic(
-  () =>
-    import('components/localePageRedirect').then(mod => mod.LocalePageRedirect),
-  { ssr: false },
+const LocalePageRedirect = lazy(() =>
+  import('components/localePageRedirect').then(mod => ({
+    default: mod.LocalePageRedirect,
+  })),
 )
 
-const Page = () => <LocalePageRedirect redirectPage="/hemi-earn" />
+const Page = () => (
+  <Suspense>
+    <LocalePageRedirect redirectPage="/hemi-earn" />
+  </Suspense>
+)
 
 export default Page

--- a/portal/app/hemi-earn/page.tsx
+++ b/portal/app/hemi-earn/page.tsx
@@ -1,17 +1,7 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { LocalePageRedirect } from 'components/localePageRedirect'
 
-const LocalePageRedirect = lazy(() =>
-  import('components/localePageRedirect').then(mod => ({
-    default: mod.LocalePageRedirect,
-  })),
-)
-
-const Page = () => (
-  <Suspense>
-    <LocalePageRedirect redirectPage="/hemi-earn" />
-  </Suspense>
-)
+const Page = () => <LocalePageRedirect redirectPage="/hemi-earn" />
 
 export default Page

--- a/portal/app/stake/page.tsx
+++ b/portal/app/stake/page.tsx
@@ -1,13 +1,17 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const LocalePageRedirect = dynamic(
-  () =>
-    import('components/localePageRedirect').then(mod => mod.LocalePageRedirect),
-  { ssr: false },
+const LocalePageRedirect = lazy(() =>
+  import('components/localePageRedirect').then(mod => ({
+    default: mod.LocalePageRedirect,
+  })),
 )
 
-const Page = () => <LocalePageRedirect redirectPage="/stake/dashboard" />
+const Page = () => (
+  <Suspense>
+    <LocalePageRedirect redirectPage="/stake/dashboard" />
+  </Suspense>
+)
 
 export default Page

--- a/portal/app/stake/page.tsx
+++ b/portal/app/stake/page.tsx
@@ -1,17 +1,7 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { LocalePageRedirect } from 'components/localePageRedirect'
 
-const LocalePageRedirect = lazy(() =>
-  import('components/localePageRedirect').then(mod => ({
-    default: mod.LocalePageRedirect,
-  })),
-)
-
-const Page = () => (
-  <Suspense>
-    <LocalePageRedirect redirectPage="/stake/dashboard" />
-  </Suspense>
-)
+const Page = () => <LocalePageRedirect redirectPage="/stake/dashboard" />
 
 export default Page

--- a/portal/app/staking-dashbord/page.tsx
+++ b/portal/app/staking-dashbord/page.tsx
@@ -1,13 +1,17 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const LocalePageRedirect = dynamic(
-  () =>
-    import('components/localePageRedirect').then(mod => mod.LocalePageRedirect),
-  { ssr: false },
+const LocalePageRedirect = lazy(() =>
+  import('components/localePageRedirect').then(mod => ({
+    default: mod.LocalePageRedirect,
+  })),
 )
 
-const Page = () => <LocalePageRedirect redirectPage="/staking-dashboard" />
+const Page = () => (
+  <Suspense>
+    <LocalePageRedirect redirectPage="/staking-dashboard" />
+  </Suspense>
+)
 
 export default Page

--- a/portal/app/staking-dashbord/page.tsx
+++ b/portal/app/staking-dashbord/page.tsx
@@ -1,17 +1,7 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { LocalePageRedirect } from 'components/localePageRedirect'
 
-const LocalePageRedirect = lazy(() =>
-  import('components/localePageRedirect').then(mod => ({
-    default: mod.LocalePageRedirect,
-  })),
-)
-
-const Page = () => (
-  <Suspense>
-    <LocalePageRedirect redirectPage="/staking-dashboard" />
-  </Suspense>
-)
+const Page = () => <LocalePageRedirect redirectPage="/staking-dashboard" />
 
 export default Page

--- a/portal/app/tunnel/page.tsx
+++ b/portal/app/tunnel/page.tsx
@@ -1,13 +1,17 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 
-const LocalePageRedirect = dynamic(
-  () =>
-    import('components/localePageRedirect').then(mod => mod.LocalePageRedirect),
-  { ssr: false },
+const LocalePageRedirect = lazy(() =>
+  import('components/localePageRedirect').then(mod => ({
+    default: mod.LocalePageRedirect,
+  })),
 )
 
-const Page = () => <LocalePageRedirect redirectPage="/tunnel" />
+const Page = () => (
+  <Suspense>
+    <LocalePageRedirect redirectPage="/tunnel" />
+  </Suspense>
+)
 
 export default Page

--- a/portal/app/tunnel/page.tsx
+++ b/portal/app/tunnel/page.tsx
@@ -1,17 +1,7 @@
 'use client'
 
-import { lazy, Suspense } from 'react'
+import { LocalePageRedirect } from 'components/localePageRedirect'
 
-const LocalePageRedirect = lazy(() =>
-  import('components/localePageRedirect').then(mod => ({
-    default: mod.LocalePageRedirect,
-  })),
-)
-
-const Page = () => (
-  <Suspense>
-    <LocalePageRedirect redirectPage="/tunnel" />
-  </Suspense>
-)
+const Page = () => <LocalePageRedirect redirectPage="/tunnel" />
 
 export default Page

--- a/portal/components/lazyConnectEvmWallet.tsx
+++ b/portal/components/lazyConnectEvmWallet.tsx
@@ -1,0 +1,10 @@
+import { ButtonLoader } from 'components/buttonLoader'
+import { lazyWithFallback } from 'components/lazyWithFallback'
+
+export const LazyConnectEvmWallet = lazyWithFallback(
+  () =>
+    import('components/connectEvmWallet').then(mod => ({
+      default: mod.ConnectEvmWallet,
+    })),
+  <ButtonLoader />,
+)

--- a/portal/components/lazyWithFallback.tsx
+++ b/portal/components/lazyWithFallback.tsx
@@ -1,0 +1,31 @@
+import {
+  type ComponentProps,
+  type ComponentType,
+  lazy,
+  type ReactNode,
+  Suspense,
+} from 'react'
+
+// Pairs a lazy component with its own boundary, the way next/dynamic's `loading`
+// option did. Declaring them together is what stops a call site from rendering a
+// lazy component with no boundary, which would suspend up to whatever ancestor
+// happens to have one. Call it at module scope: inside a render it would build a
+// new component type every pass and remount the subtree.
+//
+// The `any` mirrors React's own `lazy<T extends ComponentType<any>>`. Narrower
+// constraints compile but silently drop the weak-type check, letting stray
+// children and spreads through.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const lazyWithFallback = function <T extends ComponentType<any>>(
+  loader: () => Promise<{ default: T }>,
+  fallback?: ReactNode,
+) {
+  const Lazy = lazy(loader)
+  const WithFallback = (props: ComponentProps<T>) => (
+    <Suspense fallback={fallback}>
+      <Lazy {...props} />
+    </Suspense>
+  )
+  WithFallback.displayName = 'WithFallback'
+  return WithFallback
+}

--- a/portal/components/submitWhenConnected.tsx
+++ b/portal/components/submitWhenConnected.tsx
@@ -1,14 +1,8 @@
 import { ButtonSize } from 'components/button'
-import { ButtonLoader } from 'components/buttonLoader'
-import { lazy, ReactNode, Suspense } from 'react'
+import { LazyConnectEvmWallet } from 'components/lazyConnectEvmWallet'
+import { ReactNode } from 'react'
 import { walletIsConnected } from 'utils/wallet'
 import { useAccount } from 'wagmi'
-
-const ConnectEvmWallet = lazy(() =>
-  import('components/connectEvmWallet').then(mod => ({
-    default: mod.ConnectEvmWallet,
-  })),
-)
 
 type Props = {
   connectWalletText?: string
@@ -28,11 +22,9 @@ export const SubmitWhenConnected = function ({
   }
 
   return (
-    <Suspense fallback={<ButtonLoader />}>
-      <ConnectEvmWallet
-        buttonSize={submitButtonSize}
-        text={connectWalletText}
-      />
-    </Suspense>
+    <LazyConnectEvmWallet
+      buttonSize={submitButtonSize}
+      text={connectWalletText}
+    />
   )
 }

--- a/portal/components/submitWhenConnected.tsx
+++ b/portal/components/submitWhenConnected.tsx
@@ -1,16 +1,13 @@
 import { ButtonSize } from 'components/button'
 import { ButtonLoader } from 'components/buttonLoader'
-import dynamic from 'next/dynamic'
-import { ReactNode } from 'react'
+import { lazy, ReactNode, Suspense } from 'react'
 import { walletIsConnected } from 'utils/wallet'
 import { useAccount } from 'wagmi'
 
-const ConnectEvmWallet = dynamic(
-  () => import('components/connectEvmWallet').then(mod => mod.ConnectEvmWallet),
-  {
-    loading: () => <ButtonLoader />,
-    ssr: false,
-  },
+const ConnectEvmWallet = lazy(() =>
+  import('components/connectEvmWallet').then(mod => ({
+    default: mod.ConnectEvmWallet,
+  })),
 )
 
 type Props = {
@@ -31,6 +28,11 @@ export const SubmitWhenConnected = function ({
   }
 
   return (
-    <ConnectEvmWallet buttonSize={submitButtonSize} text={connectWalletText} />
+    <Suspense fallback={<ButtonLoader />}>
+      <ConnectEvmWallet
+        buttonSize={submitButtonSize}
+        text={connectWalletText}
+      />
+    </Suspense>
   )
 }

--- a/portal/components/submitWhenConnectedToChain.tsx
+++ b/portal/components/submitWhenConnectedToChain.tsx
@@ -3,18 +3,16 @@ import { ButtonLoader } from 'components/buttonLoader'
 import { useChain } from 'hooks/useChain'
 import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
 import { useSwitchChain } from 'hooks/useSwitchChain'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
+import { lazy, Suspense } from 'react'
 import { RemoteChain } from 'types/chain'
 import { walletIsConnected } from 'utils/wallet'
 import { useAccount } from 'wagmi'
 
-const ConnectEvmWallet = dynamic(
-  () => import('components/connectEvmWallet').then(mod => mod.ConnectEvmWallet),
-  {
-    loading: () => <ButtonLoader />,
-    ssr: false,
-  },
+const ConnectEvmWallet = lazy(() =>
+  import('components/connectEvmWallet').then(mod => ({
+    default: mod.ConnectEvmWallet,
+  })),
 )
 
 type Props = {
@@ -55,6 +53,11 @@ export const SubmitWhenConnectedToChain = function ({
   }
 
   return (
-    <ConnectEvmWallet buttonSize={submitButtonSize} text={connectWalletText} />
+    <Suspense fallback={<ButtonLoader />}>
+      <ConnectEvmWallet
+        buttonSize={submitButtonSize}
+        text={connectWalletText}
+      />
+    </Suspense>
   )
 }

--- a/portal/components/submitWhenConnectedToChain.tsx
+++ b/portal/components/submitWhenConnectedToChain.tsx
@@ -1,19 +1,12 @@
 import { Button, ButtonSize } from 'components/button'
-import { ButtonLoader } from 'components/buttonLoader'
+import { LazyConnectEvmWallet } from 'components/lazyConnectEvmWallet'
 import { useChain } from 'hooks/useChain'
 import { useIsConnectedToExpectedNetwork } from 'hooks/useIsConnectedToExpectedNetwork'
 import { useSwitchChain } from 'hooks/useSwitchChain'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense } from 'react'
 import { RemoteChain } from 'types/chain'
 import { walletIsConnected } from 'utils/wallet'
 import { useAccount } from 'wagmi'
-
-const ConnectEvmWallet = lazy(() =>
-  import('components/connectEvmWallet').then(mod => ({
-    default: mod.ConnectEvmWallet,
-  })),
-)
 
 type Props = {
   chainId: RemoteChain['id']
@@ -53,11 +46,9 @@ export const SubmitWhenConnectedToChain = function ({
   }
 
   return (
-    <Suspense fallback={<ButtonLoader />}>
-      <ConnectEvmWallet
-        buttonSize={submitButtonSize}
-        text={connectWalletText}
-      />
-    </Suspense>
+    <LazyConnectEvmWallet
+      buttonSize={submitButtonSize}
+      text={connectWalletText}
+    />
   )
 }

--- a/portal/components/tokenInput/index.tsx
+++ b/portal/components/tokenInput/index.tsx
@@ -1,23 +1,11 @@
+import { Balance } from 'components/cryptoBalance'
 import { RenderFiatBalance } from 'components/fiatBalance'
 import { useTranslations } from 'next-intl'
-import { ComponentProps, ComponentType, lazy, ReactNode, Suspense } from 'react'
-import Skeleton from 'react-loading-skeleton'
+import { ComponentProps, ComponentType, ReactNode } from 'react'
 import { Token } from 'types/token'
 import { parseTokenUnits } from 'utils/token'
 
 import { isInputError } from './utils'
-
-const LazyBalance = lazy(() =>
-  import('components/cryptoBalance').then(mod => ({ default: mod.Balance })),
-)
-
-const Balance = (props: ComponentProps<typeof LazyBalance>) => (
-  <Suspense
-    fallback={<Skeleton className="h-full" containerClassName="basis-1/3" />}
-  >
-    <LazyBalance {...props} />
-  </Suspense>
-)
 
 type Props<T extends Token> = {
   balanceComponent?: ComponentType<{

--- a/portal/components/tokenInput/index.tsx
+++ b/portal/components/tokenInput/index.tsx
@@ -1,21 +1,22 @@
 import { RenderFiatBalance } from 'components/fiatBalance'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { ComponentProps, ComponentType, ReactNode } from 'react'
+import { ComponentProps, ComponentType, lazy, ReactNode, Suspense } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { Token } from 'types/token'
 import { parseTokenUnits } from 'utils/token'
 
 import { isInputError } from './utils'
 
-const Balance = dynamic(
-  () => import('components/cryptoBalance').then(mod => mod.Balance),
-  {
-    loading: () => (
-      <Skeleton className="h-full" containerClassName="basis-1/3" />
-    ),
-    ssr: false,
-  },
+const LazyBalance = lazy(() =>
+  import('components/cryptoBalance').then(mod => ({ default: mod.Balance })),
+)
+
+const Balance = (props: ComponentProps<typeof LazyBalance>) => (
+  <Suspense
+    fallback={<Skeleton className="h-full" containerClassName="basis-1/3" />}
+  >
+    <LazyBalance {...props} />
+  </Suspense>
 )
 
 type Props<T extends Token> = {

--- a/portal/components/tokenSelector/index.tsx
+++ b/portal/components/tokenSelector/index.tsx
@@ -1,8 +1,9 @@
 import { useVisualViewportSize } from '@hemilabs/react-hooks/useVisualViewportSize'
 import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { Modal } from 'components/modal'
 import { useUmami } from 'hooks/useUmami'
-import { lazy, Suspense, useState } from 'react'
+import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { screenBreakpoints } from 'styles'
 import { RemoteChain } from 'types/chain'
@@ -32,8 +33,9 @@ const TokenListLoading = function () {
   )
 }
 
-const TokenList = lazy(() =>
-  import('./tokenList').then(mod => ({ default: mod.TokenList })),
+const TokenList = lazyWithFallback(
+  () => import('./tokenList').then(mod => ({ default: mod.TokenList })),
+  <TokenListLoading />,
 )
 
 type Props = {
@@ -80,14 +82,12 @@ export const TokenSelector = function ({
         )}
       </button>
       {showTokenSelector && typeof chainId === 'number' && (
-        <Suspense fallback={<TokenListLoading />}>
-          <TokenList
-            chainId={chainId}
-            closeModal={closeModal}
-            onSelectToken={handleSelection}
-            tokens={tokens}
-          />
-        </Suspense>
+        <TokenList
+          chainId={chainId}
+          closeModal={closeModal}
+          onSelectToken={handleSelection}
+          tokens={tokens}
+        />
       )}
     </>
   )

--- a/portal/components/tokenSelector/index.tsx
+++ b/portal/components/tokenSelector/index.tsx
@@ -2,8 +2,7 @@ import { useVisualViewportSize } from '@hemilabs/react-hooks/useVisualViewportSi
 import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
 import { Modal } from 'components/modal'
 import { useUmami } from 'hooks/useUmami'
-import dynamic from 'next/dynamic'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import { screenBreakpoints } from 'styles'
 import { RemoteChain } from 'types/chain'
@@ -33,12 +32,8 @@ const TokenListLoading = function () {
   )
 }
 
-const TokenList = dynamic(
-  () => import('./tokenList').then(mod => mod.TokenList),
-  {
-    loading: TokenListLoading,
-    ssr: false,
-  },
+const TokenList = lazy(() =>
+  import('./tokenList').then(mod => ({ default: mod.TokenList })),
 )
 
 type Props = {
@@ -85,12 +80,14 @@ export const TokenSelector = function ({
         )}
       </button>
       {showTokenSelector && typeof chainId === 'number' && (
-        <TokenList
-          chainId={chainId}
-          closeModal={closeModal}
-          onSelectToken={handleSelection}
-          tokens={tokens}
-        />
+        <Suspense fallback={<TokenListLoading />}>
+          <TokenList
+            chainId={chainId}
+            closeModal={closeModal}
+            onSelectToken={handleSelection}
+            tokens={tokens}
+          />
+        </Suspense>
       )}
     </>
   )

--- a/portal/components/tooltip/index.tsx
+++ b/portal/components/tooltip/index.tsx
@@ -2,8 +2,6 @@ import { lazy, Suspense } from 'react'
 
 import { type BaseTooltipProps } from './base'
 
-// Can't use dynamic here, because the fallback depends on the consumer.
-// next/dynamic offers a static fallback, defined at import time.
 const BaseTooltip = lazy(() =>
   import('./base').then(mod => ({ default: mod.BaseTooltip })),
 )

--- a/portal/components/tunnelTabs.tsx
+++ b/portal/components/tunnelTabs.tsx
@@ -5,17 +5,14 @@ import { Tab, Tabs } from 'components/tabs'
 import { usePathnameWithoutLocale } from 'hooks/usePathnameWithoutLocale'
 import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
 import { useUmami } from 'hooks/useUmami'
-import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
-import { Suspense } from 'react'
+import { lazy, Suspense } from 'react'
 import { UrlObject } from 'url'
 
-const ActionableOperations = dynamic(
-  () =>
-    import('components/actionableOperations').then(
-      mod => mod.ActionableOperations,
-    ),
-  { ssr: false },
+const ActionableOperations = lazy(() =>
+  import('components/actionableOperations').then(mod => ({
+    default: mod.ActionableOperations,
+  })),
 )
 
 const UI = function ({
@@ -55,7 +52,9 @@ const UI = function ({
         >
           <div className="flex items-center justify-center gap-x-2">
             <span>{t('transaction-history.title')}</span>
-            <ActionableOperations />
+            <Suspense>
+              <ActionableOperations />
+            </Suspense>
           </div>
         </Tab>
       </Tabs>

--- a/portal/components/tunnelTabs.tsx
+++ b/portal/components/tunnelTabs.tsx
@@ -1,15 +1,16 @@
 'use client'
 
 import { AnalyticsEvent } from 'app/analyticsEvents'
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import { Tab, Tabs } from 'components/tabs'
 import { usePathnameWithoutLocale } from 'hooks/usePathnameWithoutLocale'
 import { useTunnelOperationByConnectedWallet } from 'hooks/useTunnelOperationByConnectedWallet'
 import { useUmami } from 'hooks/useUmami'
 import { useTranslations } from 'next-intl'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { UrlObject } from 'url'
 
-const ActionableOperations = lazy(() =>
+const ActionableOperations = lazyWithFallback(() =>
   import('components/actionableOperations').then(mod => ({
     default: mod.ActionableOperations,
   })),
@@ -52,9 +53,7 @@ const UI = function ({
         >
           <div className="flex items-center justify-center gap-x-2">
             <span>{t('transaction-history.title')}</span>
-            <Suspense>
-              <ActionableOperations />
-            </Suspense>
+            <ActionableOperations />
           </div>
         </Tab>
       </Tabs>

--- a/portal/context/tunnelHistoryContext/index.tsx
+++ b/portal/context/tunnelHistoryContext/index.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import dynamic from 'next/dynamic'
 import {
   createContext,
   Dispatch,
+  lazy,
   ReactNode,
+  Suspense,
   useMemo,
   useReducer,
   useState,
@@ -17,9 +18,8 @@ import {
 import { historyReducer, initialState } from './reducer'
 import { HistoryActions, type HistoryReducerState } from './types'
 
-const HistoryLoader = dynamic(
-  () => import('./historyLoader').then(mod => mod.HistoryLoader),
-  { ssr: false },
+const HistoryLoader = lazy(() =>
+  import('./historyLoader').then(mod => ({ default: mod.HistoryLoader })),
 )
 
 type TunnelHistoryContext = {
@@ -101,12 +101,14 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
 
   return (
     <TunnelHistoryContext.Provider value={historyContext}>
-      <HistoryLoader
-        dispatch={dispatch}
-        forceResync={forceResync}
-        history={history}
-        setForceResync={setForceResync}
-      />
+      <Suspense>
+        <HistoryLoader
+          dispatch={dispatch}
+          forceResync={forceResync}
+          history={history}
+          setForceResync={setForceResync}
+        />
+      </Suspense>
       {children}
     </TunnelHistoryContext.Provider>
   )

--- a/portal/context/tunnelHistoryContext/index.tsx
+++ b/portal/context/tunnelHistoryContext/index.tsx
@@ -1,11 +1,10 @@
 'use client'
 
+import { lazyWithFallback } from 'components/lazyWithFallback'
 import {
   createContext,
   Dispatch,
-  lazy,
   ReactNode,
-  Suspense,
   useMemo,
   useReducer,
   useState,
@@ -18,7 +17,7 @@ import {
 import { historyReducer, initialState } from './reducer'
 import { HistoryActions, type HistoryReducerState } from './types'
 
-const HistoryLoader = lazy(() =>
+const HistoryLoader = lazyWithFallback(() =>
   import('./historyLoader').then(mod => ({ default: mod.HistoryLoader })),
 )
 
@@ -101,14 +100,12 @@ export const TunnelHistoryProvider = function ({ children }: Props) {
 
   return (
     <TunnelHistoryContext.Provider value={historyContext}>
-      <Suspense>
-        <HistoryLoader
-          dispatch={dispatch}
-          forceResync={forceResync}
-          history={history}
-          setForceResync={setForceResync}
-        />
-      </Suspense>
+      <HistoryLoader
+        dispatch={dispatch}
+        forceResync={forceResync}
+        history={history}
+        setForceResync={setForceResync}
+      />
       {children}
     </TunnelHistoryContext.Provider>
   )


### PR DESCRIPTION
### Description

This PR replaces `next/dynamic` with `React.lazy` and `Suspense` across the portal, 40 call sites in 35 files.

It is the first of two for the routing phase. It comes first because it does not depend on the router at all: `lazy` and `Suspense` are plain React and behave the same under Next and under Vite, so it can be reviewed and merged on its own instead of riding along with the route tree. It also clears 35 `next/*` imports ahead of the big one, which shrinks the conflict surface with `main` while the migration branch is open. `components/tooltip/index.tsx` already used this exact shape, so the pattern is the repo's own.

**No behavior change is intended**, and that is the requirement rather than a happy side effect. `next/dynamic` did two things: split the chunk, and through its `loading` option decide what shows meanwhile. `lazy` keeps the first, and the second moves to a `Suspense` boundary at the point of use. Which means the whole risk of this PR is where that boundary lands.

The 17 calls that had a `loading` got their fallback transplanted literally. **The 23 without one mattered just as much**: they used to render nothing on their own, and a `lazy` component with no boundary of its own suspends up to the nearest ancestor, which here is the last-resort wrapper in the root layout. Left implicit, something that used to disappear quietly would blank the page instead.

Two of them are not rendered where they are declared, they are passed by reference (`balanceComponent={StakedBalance}`, `balanceComponent ?? Balance`). Wrapping them at the render site would apply their skeleton to whatever a caller passes instead, so the boundary travels with the component. Those are the only two comments the PR adds.

`ssr: false` is the only option dropped outright, and it costs nothing: it told Next not to render on the server, and there is no server.

## Notes

**This is not visually verified.** The Vite entry is still a placeholder and `next dev` is gone, so nothing here can be rendered on this branch. Lint, types and tests do not catch a misplaced boundary either, which makes file by file review the real check on this one. It becomes observable when the routing PR lands.

### Screenshots

N/A - No UI changes.

### Related issue(s)

Related to #2194 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
