### PR TITLE
Hide BTC tunnel fees until amount is entered

### DIFF
--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -176,7 +176,7 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
   }
 
   function renderFees() {
-    if (!canDeposit) {
+    if (!canDeposit || amountBigInt === BigInt(0)) {
       return null
     }
 

--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -175,7 +175,7 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
     )
   }
 
-  function RenderFees() {
+  function renderFees() {
     if (!canDeposit) {
       return null
     }
@@ -197,7 +197,7 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
               },
             )}
           />
-          <RenderFees />
+          {renderFees()}
         </div>
       }
       bottomSection={<WalletsConnected />}

--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -175,6 +175,14 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
     )
   }
 
+  function RenderFees() {
+    if (!canDeposit) {
+      return null
+    }
+
+    return <BtcFees amount={amountBigInt} />
+  }
+
   return (
     <TunnelForm
       belowForm={
@@ -189,7 +197,7 @@ export const BtcDeposit = function ({ state }: BtcDepositProps) {
               },
             )}
           />
-          <BtcFees amount={amountBigInt} />
+          <RenderFees />
         </div>
       }
       bottomSection={<WalletsConnected />}

--- a/portal/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/withdraw.tsx
@@ -202,6 +202,26 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
     return t('tunnel-page.submit-button.initiate-withdrawal')
   }
 
+  function RenderFees() {
+    if (!canWithdraw) {
+      return null
+    }
+
+    return (
+      <FeesContainer>
+        <HemiBtcFeesSummary amount={amount} token={fromToken} />
+        <EvmFeesSummary
+          gas={gas}
+          operationToken={fromToken}
+          total={getTotal({
+            fromInput,
+            fromToken,
+          })}
+        />
+      </FeesContainer>
+    )
+  }
+
   return (
     <TunnelForm
       belowForm={
@@ -216,17 +236,7 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
               },
             )}
           />
-          <FeesContainer>
-            <HemiBtcFeesSummary amount={amount} token={fromToken} />
-            <EvmFeesSummary
-              gas={gas}
-              operationToken={fromToken}
-              total={getTotal({
-                fromInput,
-                fromToken,
-              })}
-            />
-          </FeesContainer>
+          <RenderFees />
         </div>
       }
       bottomSection={<WalletsConnected />}

--- a/portal/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/withdraw.tsx
@@ -203,7 +203,7 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
   }
 
   function renderFees() {
-    if (!canWithdraw) {
+    if (!feeEstimationEnabled) {
       return null
     }
 

--- a/portal/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/withdraw.tsx
@@ -202,7 +202,7 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
     return t('tunnel-page.submit-button.initiate-withdrawal')
   }
 
-  function RenderFees() {
+  function renderFees() {
     if (!canWithdraw) {
       return null
     }
@@ -236,7 +236,7 @@ const BtcWithdraw = function ({ state }: BtcWithdrawProps) {
               },
             )}
           />
-          <RenderFees />
+          {renderFees()}
         </div>
       }
       bottomSection={<WalletsConnected />}


### PR DESCRIPTION
## Summary

Closes #2128.

Fee breakdown items were visible even with an empty amount, showing `-` placeholders — the Bitcoin tunnel flows didn't gate the fees section on whether the form could actually submit, unlike the EVM withdrawal flow (`EvmWithdraw`'s `RenderBelowForm`), which already hides its fees section via `!canWithdraw`.

Applied the same pattern to both Bitcoin tunnel directions:
- **Hemi → Bitcoin** (`withdraw.tsx`, `BtcWithdraw`): the fees block (`HemiBtcFeesSummary` + `EvmFeesSummary`, i.e. "Tunnel fees" / "Hemi gas fee" / "Total") is now wrapped in a `RenderFees` helper gated by the existing `canWithdraw` flag. The receiving-address section is unaffected.
- **Bitcoin → Hemi** (`btcDeposit.tsx`, `BtcDeposit`): same issue existed in this direction too (confirmed with a screenshot showing "Network fees" / "Tunnel fees" visible with an empty/zero amount). `BtcFees` is now gated by the existing `canDeposit` flag the same way.

## Test plan

- [x] `pnpm test` in `portal` (844 tests passing)
- [x] `tsc --noEmit` shows no new errors on the touched files
- [x] Verified locally: fee breakdown stays hidden on both the withdraw (Hemi → Bitcoin) and deposit (Bitcoin → Hemi) forms until a valid amount is entered

<img width="811" height="560" alt="image" src="https://github.com/user-attachments/assets/4e0f7150-e244-4c3e-b465-f10c7f79ecfb" />
