### PR TITLE
Bump hemi-viem to 2.9.0

### DIFF
--- a/packages/genesis-drop-actions/package.json
+++ b/packages/genesis-drop-actions/package.json
@@ -20,7 +20,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.8.0",
+    "hemi-viem": "2.9.0",
     "to-promise-event": "1.0.0"
   },
   "devDependencies": {

--- a/packages/hemi-earn-actions/package.json
+++ b/packages/hemi-earn-actions/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@vetro-protocol/earn": "1.0.0",
-    "hemi-viem": "2.8.0",
+    "hemi-viem": "2.9.0",
     "to-promise-event": "1.0.0",
     "viem-erc20": "2.0.0"
   },

--- a/packages/hemi-tunnel-actions/package.json
+++ b/packages/hemi-tunnel-actions/package.json
@@ -19,7 +19,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.8.0",
+    "hemi-viem": "2.9.0",
     "to-promise-event": "1.0.0",
     "viem-erc20": "2.0.0"
   },

--- a/packages/hemi-viem-stake-actions/package.json
+++ b/packages/hemi-viem-stake-actions/package.json
@@ -19,7 +19,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.8.0"
+    "hemi-viem": "2.9.0"
   },
   "devDependencies": {
     "@tsconfig/node24": "24.0.3",

--- a/packages/ve-hemi-actions/package.json
+++ b/packages/ve-hemi-actions/package.json
@@ -21,7 +21,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.8.0",
+    "hemi-viem": "2.9.0",
     "promise-mem": "1.0.4",
     "to-promise-event": "1.0.0",
     "viem-erc20": "2.0.0"

--- a/packages/ve-hemi-rewards/package.json
+++ b/packages/ve-hemi-rewards/package.json
@@ -22,7 +22,7 @@
     "tsc:check": "tsc"
   },
   "dependencies": {
-    "hemi-viem": "2.8.0",
+    "hemi-viem": "2.9.0",
     "to-promise-event": "1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
   packages/genesis-drop-actions:
     dependencies:
       hemi-viem:
-        specifier: 2.8.0
-        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.9.0
+        version: 2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       to-promise-event:
         specifier: 1.0.0
         version: 1.0.0
@@ -118,8 +118,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hemi-viem:
-        specifier: 2.8.0
-        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.9.0
+        version: 2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       to-promise-event:
         specifier: 1.0.0
         version: 1.0.0
@@ -146,8 +146,8 @@ importers:
   packages/hemi-tunnel-actions:
     dependencies:
       hemi-viem:
-        specifier: 2.8.0
-        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.9.0
+        version: 2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       to-promise-event:
         specifier: 1.0.0
         version: 1.0.0
@@ -174,8 +174,8 @@ importers:
   packages/hemi-viem-stake-actions:
     dependencies:
       hemi-viem:
-        specifier: 2.8.0
-        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.9.0
+        version: 2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
     devDependencies:
       '@tsconfig/node24':
         specifier: 24.0.3
@@ -190,8 +190,8 @@ importers:
   packages/ve-hemi-actions:
     dependencies:
       hemi-viem:
-        specifier: 2.8.0
-        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.9.0
+        version: 2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       promise-mem:
         specifier: 1.0.4
         version: 1.0.4
@@ -221,8 +221,8 @@ importers:
   packages/ve-hemi-rewards:
     dependencies:
       hemi-viem:
-        specifier: 2.8.0
-        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.9.0
+        version: 2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       to-promise-event:
         specifier: 1.0.0
         version: 1.0.0
@@ -327,8 +327,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/hemi-tunnel-actions
       hemi-viem:
-        specifier: 2.8.0
-        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.9.0
+        version: 2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hemi-viem-stake-actions:
         specifier: workspace:*
         version: link:../packages/hemi-viem-stake-actions
@@ -502,8 +502,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/hemi-earn-actions
       hemi-viem:
-        specifier: 2.8.0
-        version: 2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 2.9.0
+        version: 2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       promise-mem:
         specifier: 1.0.4
         version: 1.0.4
@@ -11014,10 +11014,10 @@ packages:
         integrity: sha512-CRCFsr+kM5cWHWhOu+cJbZvjnSpLCknMoJY+QnwAWIIjg2xJezfbmN1U/CRTh2ATXQ0uDZPbqhGtGObp0ZivtQ==,
       }
 
-  hemi-viem@2.8.0:
+  hemi-viem@2.9.0:
     resolution:
       {
-        integrity: sha512-dRaG6RaFa8R8JeXU5cjxGNggQzU7E8ZY61U33ARSgZ/DDkh26u1/lAL/n44zQqSMjY4s6CBmqkrrFcG7VkqFAw==,
+        integrity: sha512-Ab/pqc/H0C/0VcKQaoVm/fwrU8IP8D1R43VZUzFyqTIoGZ7Kft/fTglEkwwdSQaGPzx6rc7luVHaKWhD0xCptA==,
       }
     peerDependencies:
       viem: ^2.x
@@ -25329,7 +25329,7 @@ snapshots:
 
   hemi-socials@2.1.0: {}
 
-  hemi-viem@2.8.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)):
+  hemi-viem@2.9.0(viem@2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)):
     dependencies:
       viem: 2.28.4(patch_hash=09896f5ef2ef7a197f087a06a5883ca11ba310873fcdd6d8e104581845a51cf9)(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - '@hemilabs/*'
   - '@vetro-protocol/*'
-  - 'hemi-viem' # first-party too, but published unscoped so the globs miss it
+  - 'hemi-viem'
 
 onlyBuiltDependencies:
   - '@parcel/watcher' # native file watcher used by next-intl in dev mode

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - '@hemilabs/*'
   - '@vetro-protocol/*'
+  - 'hemi-viem' # first-party too, but published unscoped so the globs miss it
 
 onlyBuiltDependencies:
   - '@parcel/watcher' # native file watcher used by next-intl in dev mode

--- a/portal-backend/api/package.json
+++ b/portal-backend/api/package.json
@@ -13,7 +13,7 @@
     "esplora-client": "1.2.0",
     "express": "5.1.0",
     "hemi-earn-actions": "workspace:*",
-    "hemi-viem": "2.8.0",
+    "hemi-viem": "2.9.0",
     "promise-mem": "1.0.4",
     "promise-swr": "1.0.2",
     "redis": "4.7.1",

--- a/portal/package.json
+++ b/portal/package.json
@@ -43,7 +43,7 @@
     "hemi-earn-actions": "workspace:*",
     "hemi-socials": "2.1.0",
     "hemi-tunnel-actions": "workspace:*",
-    "hemi-viem": "2.8.0",
+    "hemi-viem": "2.9.0",
     "hemi-viem-stake-actions": "workspace:*",
     "lodash": "4.18.1",
     "next": "16.2.12",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR bumps hemi-viem to 2.9.0, which exposes BitcoinKit's isAddressValid action. Note that hemi-viem is published unscoped, so the @hemilabs/* glob in minimumReleaseAgeExclude didn't cover it, and the install hit the 7-day quarantine. It is now listed there explicitly.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Fixes #
Related to #2203 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
