### PR TITLE
Bump openssl to 3.5.8-r0 in Dockerfiles

### DIFF
--- a/portal-backend/api/Dockerfile
+++ b/portal-backend/api/Dockerfile
@@ -30,7 +30,7 @@ FROM node:24.14.0-alpine3.23
 # Patch vulnerabilities
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
-RUN apk add --upgrade openssl=3.5.7-r0
+RUN apk add --upgrade openssl=3.5.8-r0
 RUN corepack enable
 # npm is unused at runtime (the app uses pnpm); removing it shrinks the image
 # and eliminates its transitive vulnerabilities (e.g. sigstore).

--- a/portal-backend/cron/hemi-supply/Dockerfile
+++ b/portal-backend/cron/hemi-supply/Dockerfile
@@ -21,7 +21,7 @@ FROM node:24.14.0-alpine3.23
 # Patch vulnerabilities
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
-RUN apk add --upgrade openssl=3.5.7-r0
+RUN apk add --upgrade openssl=3.5.8-r0
 RUN corepack enable
 # npm is unused at runtime (the app uses pnpm); removing it shrinks the image
 # and eliminates its transitive vulnerabilities (e.g. sigstore).

--- a/portal-backend/cron/token-prices/Dockerfile
+++ b/portal-backend/cron/token-prices/Dockerfile
@@ -21,7 +21,7 @@ FROM node:24.14.0-alpine3.23
 # Patch vulnerabilities
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
-RUN apk add --upgrade openssl=3.5.7-r0
+RUN apk add --upgrade openssl=3.5.8-r0
 RUN corepack enable
 # npm is unused at runtime (the app uses pnpm); removing it shrinks the image
 # and eliminates its transitive vulnerabilities (e.g. sigstore).

--- a/portal-backend/cron/vaults-monitor/Dockerfile
+++ b/portal-backend/cron/vaults-monitor/Dockerfile
@@ -21,7 +21,7 @@ FROM node:24.14.0-alpine3.23
 # Patch vulnerabilities
 RUN apk update
 RUN apk add --upgrade musl=1.2.5-r23 musl-utils=1.2.5-r23
-RUN apk add --upgrade openssl=3.5.7-r0
+RUN apk add --upgrade openssl=3.5.8-r0
 RUN corepack enable
 # npm is unused at runtime (the app uses pnpm); removing it shrinks the image
 # and eliminates its transitive vulnerabilities (e.g. sigstore).


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

npm is unused at runtime since the app uses pnpm; removing it reduces the image size. To resolve the issue, bump the OpenSSL version.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Fixes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
