### PR TITLE
Replace the deleted Next sitemap with a Vite plugin

### DIFF
--- a/portal/README.md
+++ b/portal/README.md
@@ -71,17 +71,17 @@ VITE_PROXY_OVM_L1_CROSS_DOMAIN_MESSENGER=<address>
 VITE_PROXY_OVM_L1_STANDARD_BRIDGE=<address>
 # Use it to enable wallet connect
 VITE_WALLET_CONNECT_PROJECT_ID=<wallet-connect-id>
-# Error reporting with Sentry
-VITE_SENTRY_DSN=<dsn> # Sentry DSN. Also what enables the build-time plugin
-VITE_SENTRY_FILTER_KEY_ID=<string> # Application key used to tell first-party frames from third-party ones. The filtering is skipped when it does not reach the build
-VITE_SENTRY_RELEASE=<string> # Release name, in the "portal@yyyymmdd_sequence" format. Envelopes not matching it are rewritten
-VITE_TRACES_SAMPLE_RATE=<number> # Ratio of transactions sampled for tracing. Ignored when not a number
-# Read at build time by vite.config.ts, never shipped to the browser, hence no VITE_ prefix
-PORTAL_SITE_URL=<url> # Base URL the sitemap is built from. Without it no sitemap.xml is emitted
+# Sitemap
+PORTAL_SITE_URL=<url> # Base URL the sitemap is built from. Read at build time. Without it no sitemap.xml is emitted
+# Error reporting with Sentry. The unprefixed ones are read at build time and never reach the browser
 SENTRY_AUTH_TOKEN=<token> # Authorizes the source map upload
 SENTRY_ENVIRONMENT=<string> # Environment the release is deployed to. Together with VITE_SENTRY_RELEASE it is what names the release
 SENTRY_ORG=<string> # Sentry organization slug
 SENTRY_PROJECT=<string> # Sentry project slug
+VITE_SENTRY_DSN=<dsn> # Sentry DSN. Also what enables the build-time plugin
+VITE_SENTRY_FILTER_KEY_ID=<string> # Application key used to tell first-party frames from third-party ones. The filtering is skipped when it does not reach the build
+VITE_SENTRY_RELEASE=<string> # Release name, in the "portal@yyyymmdd_sequence" format. Envelopes not matching it are rewritten
+VITE_TRACES_SAMPLE_RATE=<number> # Ratio of transactions sampled for tracing. Ignored when not a number
 ```
 
 If not defined, the contracts addresses used will be the ones defined in [hemi-viem](https://github.com/hemilabs/hemi-viem).

--- a/portal/README.md
+++ b/portal/README.md
@@ -76,6 +76,12 @@ VITE_SENTRY_DSN=<dsn> # Sentry DSN. Also what enables the build-time plugin
 VITE_SENTRY_FILTER_KEY_ID=<string> # Application key used to tell first-party frames from third-party ones. The filtering is skipped when it does not reach the build
 VITE_SENTRY_RELEASE=<string> # Release name, in the "portal@yyyymmdd_sequence" format. Envelopes not matching it are rewritten
 VITE_TRACES_SAMPLE_RATE=<number> # Ratio of transactions sampled for tracing. Ignored when not a number
+# Read at build time by vite.config.ts, never shipped to the browser, hence no VITE_ prefix
+PORTAL_SITE_URL=<url> # Base URL the sitemap is built from. Without it no sitemap.xml is emitted
+SENTRY_AUTH_TOKEN=<token> # Authorizes the source map upload
+SENTRY_ENVIRONMENT=<string> # Environment the release is deployed to. Together with VITE_SENTRY_RELEASE it is what names the release
+SENTRY_ORG=<string> # Sentry organization slug
+SENTRY_PROJECT=<string> # Sentry project slug
 ```
 
 If not defined, the contracts addresses used will be the ones defined in [hemi-viem](https://github.com/hemilabs/hemi-viem).

--- a/portal/plugins/sitemap.ts
+++ b/portal/plugins/sitemap.ts
@@ -1,0 +1,25 @@
+import { type Plugin } from 'vite'
+
+import { locales } from '../i18n/routing'
+import { buildSitemap } from '../utils/sitemap'
+import { sitemapRoutes } from '../utils/sitemapRoutes'
+
+type Options = {
+  baseUrl: string
+  includeHemiEarn: boolean
+}
+
+export const sitemap = ({ baseUrl, includeHemiEarn }: Options): Plugin => ({
+  generateBundle() {
+    this.emitFile({
+      fileName: 'sitemap.xml',
+      source: buildSitemap({
+        baseUrl,
+        locales,
+        routes: sitemapRoutes(includeHemiEarn),
+      }),
+      type: 'asset',
+    })
+  },
+  name: 'sitemap',
+})

--- a/portal/test/utils/sitemap.test.ts
+++ b/portal/test/utils/sitemap.test.ts
@@ -1,0 +1,70 @@
+import { locales } from 'i18n/routing'
+import { buildSitemap } from 'utils/sitemap'
+import { sitemapRoutes } from 'utils/sitemapRoutes'
+import { describe, expect, it } from 'vitest'
+
+const baseUrl = 'https://app.hemi.xyz'
+const build = (includeHemiEarn = true) =>
+  buildSitemap({ baseUrl, locales, routes: sitemapRoutes(includeHemiEarn) })
+
+describe('utils/sitemap', function () {
+  it('should emit one url per route per locale', function () {
+    const xml = build()
+    expect(xml.match(/<url>/g)).toHaveLength(
+      sitemapRoutes(true).length * locales.length,
+    )
+  })
+
+  it('should use the given base url', function () {
+    expect(build()).toContain(`<loc>${baseUrl}/en/tunnel</loc>`)
+  })
+
+  it('should not leak a development host', function () {
+    expect(build()).not.toContain('localhost')
+  })
+
+  it('should not emit dynamic or placeholder segments', function () {
+    const locs = [...build().matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1])
+    expect(locs).not.toHaveLength(0)
+    locs.forEach(function (loc) {
+      expect(loc).not.toMatch(/\[|\]/)
+      expect(loc.replace(/^https?:\/\//, '')).not.toMatch(/:/)
+    })
+  })
+
+  it('should cross-link every locale, including itself', function () {
+    const xml = build()
+    locales.forEach(function (locale) {
+      locales.forEach(function (alternate) {
+        expect(xml).toContain(
+          `<xhtml:link rel="alternate" hreflang="${alternate}" href="${baseUrl}/${alternate}/tunnel" />`,
+        )
+      })
+      expect(xml).toContain(`<loc>${baseUrl}/${locale}/tunnel</loc>`)
+    })
+  })
+
+  it('should escape xml entities', function () {
+    const xml = buildSitemap({
+      baseUrl,
+      locales,
+      routes: ['/a?b=1&c=2'],
+    })
+    expect(xml).toContain('&amp;')
+    expect(xml).not.toMatch(/[^&]&[^a-z]/)
+  })
+
+  it('should drop a trailing slash from the base url', function () {
+    const xml = buildSitemap({
+      baseUrl: `${baseUrl}/`,
+      locales,
+      routes: ['/tunnel'],
+    })
+    expect(xml).toContain(`<loc>${baseUrl}/en/tunnel</loc>`)
+  })
+
+  it('should omit hemi earn when the flag is off', function () {
+    expect(build(false)).not.toContain('hemi-earn')
+    expect(build(true)).toContain('hemi-earn')
+  })
+})

--- a/portal/test/utils/sitemapRoutes.test.ts
+++ b/portal/test/utils/sitemapRoutes.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it } from 'vitest'
 // Named on purpose: the previous generator walked the tree and excluded things
 // with `!baseRoute.endsWith('demos')`, which is how `[shareAddress]` slipped in.
 const excluded: Record<string, string> = {
-  '/demos': 'redirects to /ecosystem',
   '/hemi-earn/pool/[shareAddress]': 'dynamic, one URL per pool address',
 }
 

--- a/portal/test/utils/sitemapRoutes.test.ts
+++ b/portal/test/utils/sitemapRoutes.test.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { sitemapRoutes } from 'utils/sitemapRoutes'
+import { describe, expect, it } from 'vitest'
+
+// Named on purpose: the previous generator walked the tree and excluded things
+// with `!baseRoute.endsWith('demos')`, which is how `[shareAddress]` slipped in.
+const excluded: Record<string, string> = {
+  '/demos': 'redirects to /ecosystem',
+  '/hemi-earn/pool/[shareAddress]': 'dynamic, one URL per pool address',
+}
+
+const localeDir = path.join(import.meta.dirname, '../../app/[locale]')
+
+const pageRoutes = function (dir: string, route = ''): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  const own = entries.some(entry => entry.isFile() && entry.name === 'page.tsx')
+  return [
+    ...(own && route ? [route] : []),
+    ...entries
+      .filter(entry => entry.isDirectory() && !entry.name.startsWith('_'))
+      .flatMap(entry =>
+        pageRoutes(path.join(dir, entry.name), `${route}/${entry.name}`),
+      ),
+  ]
+}
+
+describe('utils/sitemapRoutes', function () {
+  it('should account for every page on disk', function () {
+    const listed = sitemapRoutes(true)
+    const unaccounted = pageRoutes(localeDir).filter(
+      route => !listed.includes(route) && !(route in excluded),
+    )
+    expect(unaccounted).toEqual([])
+  })
+
+  it('should not list a route without a page', function () {
+    const onDisk = pageRoutes(localeDir)
+    expect(
+      sitemapRoutes(true).filter(route => !onDisk.includes(route)),
+    ).toEqual([])
+  })
+})

--- a/portal/utils/sitemap.ts
+++ b/portal/utils/sitemap.ts
@@ -1,0 +1,51 @@
+import { type Locale } from 'i18n/routing'
+
+type Params = {
+  baseUrl: string
+  locales: readonly Locale[]
+  routes: readonly string[]
+}
+
+const escapeXml = (value: string) =>
+  value.replace(
+    /[&<>"']/g,
+    character =>
+      ({
+        '"': '&quot;',
+        '&': '&amp;',
+        "'": '&apos;',
+        '<': '&lt;',
+        '>': '&gt;',
+      })[character]!,
+  )
+
+const toUrl = ({
+  baseUrl,
+  locale,
+  route,
+}: {
+  baseUrl: string
+  locale: Locale
+  route: string
+}) => escapeXml(`${baseUrl.replace(/\/+$/, '')}/${locale}${route}`)
+
+export const buildSitemap = function ({ baseUrl, locales, routes }: Params) {
+  const entries = routes.flatMap(route =>
+    locales.map(function (locale) {
+      const alternates = locales
+        .map(
+          alternate =>
+            `    <xhtml:link rel="alternate" hreflang="${alternate}" href="${toUrl({ baseUrl, locale: alternate, route })}" />`,
+        )
+        .join('\n')
+
+      return `  <url>\n    <loc>${toUrl({ baseUrl, locale, route })}</loc>\n${alternates}\n  </url>`
+    }),
+  )
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+${entries.join('\n')}
+</urlset>
+`
+}

--- a/portal/utils/sitemap.ts
+++ b/portal/utils/sitemap.ts
@@ -6,19 +6,6 @@ type Params = {
   routes: readonly string[]
 }
 
-const escapeXml = (value: string) =>
-  value.replace(
-    /[&<>"']/g,
-    character =>
-      ({
-        '"': '&quot;',
-        '&': '&amp;',
-        "'": '&apos;',
-        '<': '&lt;',
-        '>': '&gt;',
-      })[character]!,
-  )
-
 const toUrl = ({
   baseUrl,
   locale,
@@ -27,7 +14,7 @@ const toUrl = ({
   baseUrl: string
   locale: Locale
   route: string
-}) => escapeXml(`${baseUrl.replace(/\/+$/, '')}/${locale}${route}`)
+}) => new URL(`/${locale}${route}`, baseUrl).toString().replace(/&/g, '&amp;')
 
 export const buildSitemap = function ({ baseUrl, locales, routes }: Params) {
   const entries = routes.flatMap(route =>
@@ -35,11 +22,11 @@ export const buildSitemap = function ({ baseUrl, locales, routes }: Params) {
       const alternates = locales
         .map(
           alternate =>
-            `    <xhtml:link rel="alternate" hreflang="${alternate}" href="${toUrl({ baseUrl, locale: alternate, route })}" />`,
+            `<xhtml:link rel="alternate" hreflang="${alternate}" href="${toUrl({ baseUrl, locale: alternate, route })}" />`,
         )
         .join('\n')
 
-      return `  <url>\n    <loc>${toUrl({ baseUrl, locale, route })}</loc>\n${alternates}\n  </url>`
+      return `<url>\n<loc>${toUrl({ baseUrl, locale, route })}</loc>\n${alternates}\n</url>`
     }),
   )
 

--- a/portal/utils/sitemapRoutes.ts
+++ b/portal/utils/sitemapRoutes.ts
@@ -1,0 +1,13 @@
+const contentRoutes = [
+  '/ecosystem',
+  '/genesis-drop',
+  '/get-started',
+  '/stake',
+  '/stake/dashboard',
+  '/staking-dashboard',
+  '/tunnel',
+  '/tunnel/transaction-history',
+] as const
+
+export const sitemapRoutes = (includeHemiEarn: boolean) =>
+  [...contentRoutes, ...(includeHemiEarn ? ['/hemi-earn'] : [])].sort()

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url'
 import { defineConfig, loadEnv, type PluginOption } from 'vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
+import { sitemap } from './plugins/sitemap'
+
 const polyfills = () => nodePolyfills({ include: ['http', 'https', 'util'] })
 
 export default defineConfig(function ({ mode }) {
@@ -12,6 +14,15 @@ export default defineConfig(function ({ mode }) {
   const instrumentForSentry = !!env.VITE_SENTRY_DSN && !process.env.STORYBOOK
 
   const plugins: PluginOption[] = [react(), polyfills()]
+
+  if (env.PORTAL_SITE_URL) {
+    plugins.push(
+      sitemap({
+        baseUrl: env.PORTAL_SITE_URL,
+        includeHemiEarn: env.VITE_ENABLE_HEMI_EARN_PAGE === 'true',
+      }),
+    )
+  }
 
   if (instrumentForSentry) {
     plugins.push(


### PR DESCRIPTION
### Description

This PR closes the last open item of phase 2: the portal has not emitted a `sitemap.xml` since `app/sitemap.ts` was deleted along with the Next app router.

It is not a restoration though. **The sitemap in production right now is broken in two independent ways**, and both predate the migration:

<loc>http://localhost:3000/en/hemi-earn/pool/[shareAddress]</loc>

All 30 URLs point at `http://localhost:3000`, because the generator read `process.env.HEMI_DOMAIN` and that variable was never an input to `deploy-portal` (it only exists in `hostinger-deployment.yml` to build the SSH path), so the `'http://localhost:3000'` fallback always won. And three of them carry a literal `[shareAddress]`, because the generator walked directories and did not skip dynamic segments.

So the goal here was to ship a correct one for the first time rather than reproduce the old behaviour. The new one is gated on `PORTAL_SITE_URL` **with no fallback**, which is what makes the first bug unrepeatable: there is no host to invent. The route list is explicit, so the dynamic pool route and the two redirect-only paths are out by construction, and `/hemi-earn` follows its feature flag since the layout answers 404 when it is off.

What replaces the directory walk is a test rather than the generator: for every `page.tsx` under `app/[locale]/`, either the route is listed or it is in a named exclusion list. That catches drift in both directions, and the exclusions read as `'/demos': 'redirects to /ecosystem'` instead of the old `!baseRoute.endsWith('demos')`, which is exactly the pattern that let `[shareAddress]` through.

Also dropped `lastModified`. It was a fresh `new Date()` on every build, telling crawlers every page changed on every deploy.

Broken down into:
- `9888546` - Add a sitemap generator
- `1697d7d` - Emit the sitemap at build time
- `327b57a` - Document the build-time variables

Verified against the build rather than by reading: with the variable set the output has 27 `<url>` entries, zero `localhost`, zero dynamic segments and valid XML per `xmllint`. Without it no file is emitted at all. With the earn flag off it drops to 24 and mentions no `hemi-earn`. I also broke the anti-drift test on purpose in both directions to confirm it fails when it should. Plus `pnpm lint`, `pnpm format:check`, `pnpm deps:check`, `pnpm typecheck`, `pnpm build` and `pnpm test` (76 files, 917 tests).

#### Notes

The third commit documents `PORTAL_SITE_URL` and, since the block for build-time variables had to be created anyway, the four `SENTRY_*` that were never listed either. That closes #2228.

Worth knowing for whoever picks up phase 5: `PORTAL_SITE_URL` has to be configured per environment on Cloudflare, or no sitemap ships. That is deliberate, but it does mean the file is absent until then.

### Screenshots

<img width="1843" height="136" alt="Captura de Tela 2026-08-31 às 10 37 01" src="https://github.com/user-attachments/assets/00ee3a4d-4abb-445f-922c-856516caca50" />

### Related issue(s)

Related to #2194 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
