### PR TITLE
Translate hardcoded document titles

### DIFF
--- a/portal/app/[locale]/ecosystem/layout.tsx
+++ b/portal/app/[locale]/ecosystem/layout.tsx
@@ -1,8 +1,18 @@
+import { type Locale } from 'i18n/routing'
 import type { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 import { PropsWithChildren } from 'react'
 
-export const metadata: Metadata = {
-  title: 'Ecosystem | Hemi Portal',
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale })
+  return {
+    title: `${t('ecosystem.document-title')} | ${t('metadata.title')}`,
+  }
 }
 
 export default function EcosystemLayout({ children }: PropsWithChildren) {

--- a/portal/app/[locale]/get-started/layout.tsx
+++ b/portal/app/[locale]/get-started/layout.tsx
@@ -1,8 +1,18 @@
+import { type Locale } from 'i18n/routing'
 import type { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 import { PropsWithChildren } from 'react'
 
-export const metadata: Metadata = {
-  title: 'Get Started | Hemi Portal',
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale })
+  return {
+    title: `${t('get-started.document-title')} | ${t('metadata.title')}`,
+  }
 }
 
 export default function GetStartedLayout({ children }: PropsWithChildren) {

--- a/portal/app/[locale]/stake/layout.tsx
+++ b/portal/app/[locale]/stake/layout.tsx
@@ -1,9 +1,19 @@
+import { type Locale } from 'i18n/routing'
 import { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 
 import StakeLayoutClient from './_components/stakeLayoutClient'
 
-export const metadata: Metadata = {
-  title: 'Stake | Hemi Portal',
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale })
+  return {
+    title: `${t('stake-page.document-title')} | ${t('metadata.title')}`,
+  }
 }
 
 export default function StakeLayout(props: { children: React.ReactNode }) {

--- a/portal/app/[locale]/staking-dashboard/layout.tsx
+++ b/portal/app/[locale]/staking-dashboard/layout.tsx
@@ -1,10 +1,20 @@
+import { type Locale } from 'i18n/routing'
 import { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 import { PropsWithChildren } from 'react'
 
 import StakingDashboardLayoutClient from './_components/stakingDashboardLayoutClient'
 
-export const metadata: Metadata = {
-  title: 'Staking dashboard | Hemi Portal',
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale })
+  return {
+    title: `${t('staking-dashboard.document-title')} | ${t('metadata.title')}`,
+  }
 }
 
 const StakingDashboardLayout = ({ children }: PropsWithChildren) => (

--- a/portal/app/[locale]/tunnel/layout.tsx
+++ b/portal/app/[locale]/tunnel/layout.tsx
@@ -1,11 +1,21 @@
 import { TunnelTabs } from 'components/tunnelTabs'
 import { TransactionsInProgressProvider } from 'context/transactionsInProgressContext'
+import { type Locale } from 'i18n/routing'
 import { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 
 import { ViewOperation } from './_components/viewOperation'
 
-export const metadata: Metadata = {
-  title: 'Tunnel | Hemi Portal',
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale })
+  return {
+    title: `${t('tunnel-page.document-title')} | ${t('metadata.title')}`,
+  }
 }
 
 type Props = {

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -102,6 +102,7 @@
       "heading": "Demos",
       "sub-heading": "Biometric verification solutions for Web3 applications."
     },
+    "document-title": "Ecosystem",
     "heading": "Demos",
     "purefinance": {
       "heading": "Pure Finance",
@@ -199,6 +200,7 @@
     "block-explorer-url": "Block explorer URL",
     "chain-id": "Chain ID",
     "currency-symbol": "Currency symbol",
+    "document-title": "Get Started",
     "heading": "Get started on Hemi",
     "l1-address": "L1 address",
     "l2-address": "L2 address",
@@ -496,6 +498,7 @@
       "total-staked-on-hemi": "Total Staked on Hemi",
       "your-stake": "Your Stake"
     },
+    "document-title": "Stake",
     "drawer": {
       "approve-and-stake": "Approve and Stake",
       "description-manage-stake": "Top up your stake, or withdraw anytime—you're in full control!",
@@ -542,6 +545,7 @@
       "subheading": "We’re processing your reward claim. You can follow the progress below."
     },
     "claim-rewards-successful": "Claim rewards successful",
+    "document-title": "Governance staking",
     "drawer": {
       "approving": "Approving {symbol}",
       "claim-rewards": "Claim rewards on {network}",
@@ -657,6 +661,7 @@
     "withdrawal-challenged": "Withdrawal challenged"
   },
   "tunnel-page": {
+    "document-title": "Tunnel",
     "form": {
       "balance": "Balance",
       "bitcoin-receiving-address": "Receiving Bitcoin address",

--- a/portal/messages/es.json
+++ b/portal/messages/es.json
@@ -102,6 +102,7 @@
       "heading": "Demos",
       "sub-heading": "Soluciones de verificación biométrica para aplicaciones Web3."
     },
+    "document-title": "Ecosistema",
     "heading": "Demos",
     "purefinance": {
       "heading": "Pure Finance",
@@ -199,6 +200,7 @@
     "block-explorer-url": "URL del explorador de bloques",
     "chain-id": "ID de la red",
     "currency-symbol": "Símbolo de la moneda nativa",
+    "document-title": "Comenzar",
     "heading": "Comience a usar Hemi",
     "l1-address": "Dirección L1",
     "l2-address": "Dirección L2",
@@ -496,6 +498,7 @@
       "total-staked-on-hemi": "Total en stake en Hemi",
       "your-stake": "Su Stake"
     },
+    "document-title": "Stake",
     "drawer": {
       "approve-and-stake": "Aprobar y Hacer Stake",
       "description-manage-stake": "Recargue su stake o retire en cualquier momento— ¡Usted tiene el control total!",
@@ -542,6 +545,7 @@
       "subheading": "Estamos procesando su solicitud de recompensas. Puede seguir el progreso a continuación."
     },
     "claim-rewards-successful": "Recompensas reclamadas con éxito",
+    "document-title": "Governance staking",
     "drawer": {
       "approving": "Aprobando {symbol}",
       "claim-rewards": "Reclamar recompensas en {network}",
@@ -657,6 +661,7 @@
     "withdrawal-challenged": "Retiro desafiado"
   },
   "tunnel-page": {
+    "document-title": "Túnel",
     "form": {
       "balance": "Balance",
       "bitcoin-receiving-address": "Dirección de recepción en Bitcoin",

--- a/portal/messages/pt.json
+++ b/portal/messages/pt.json
@@ -102,6 +102,7 @@
       "heading": "Demos",
       "sub-heading": "Soluções de verificação biométrica para aplicações Web3."
     },
+    "document-title": "Ecossistema",
     "heading": "Demonstrações",
     "purefinance": {
       "heading": "Pure Finance",
@@ -199,6 +200,7 @@
     "block-explorer-url": "URL do explorador de blocos",
     "chain-id": "ID da Rede",
     "currency-symbol": "Símbolo da Moeda",
+    "document-title": "Começar",
     "heading": "Comece a usar a Hemi",
     "l1-address": "Endereço L1",
     "l2-address": "Endereço L2",
@@ -496,6 +498,7 @@
       "total-staked-on-hemi": "Total em stake em Hemi",
       "your-stake": "O seu Stake"
     },
+    "document-title": "Stake",
     "drawer": {
       "approve-and-stake": "Aprovar e Fazer Stake",
       "description-manage-stake": "Aumente o seu stake ou levante a qualquer momento— tem controle total!",
@@ -542,6 +545,7 @@
       "subheading": "Estamos processando sua solicitação de recompensas. Você pode acompanhar o progresso abaixo."
     },
     "claim-rewards-successful": "Recompensas reclamadas com sucesso",
+    "document-title": "Governance staking",
     "drawer": {
       "approving": "A aprovar {symbol}",
       "claim-rewards": "Reclamar recompensas em {network}",
@@ -657,6 +661,7 @@
     "withdrawal-challenged": "Retirada desafiada"
   },
   "tunnel-page": {
+    "document-title": "Túnel",
     "form": {
       "balance": "Saldo",
       "bitcoin-receiving-address": "Endereço de receção Bitcoin",


### PR DESCRIPTION
## Summary

Closes #2220.

Document titles set via the `metadata` export in 5 layouts were hardcoded English strings (e.g. `'Tunnel | Hemi Portal'`), carried over from before locale routing was added. Converted each to a `generateMetadata` function that reads the locale and composes the title from translations via `getTranslations` (`next-intl/server`), matching the pattern already used in the root `[locale]/layout.tsx`.

Added a `document-title` key to each affected page's translation section (`ecosystem`, `get-started`, `stake-page`, `staking-dashboard`, `tunnel-page`) in `en`/`es`/`pt`, composed with the existing `metadata.title` ("Hemi Portal" / "Portal de Hemi" / "Portal Hemi") suffix. Kept `document-title` decoupled from other existing keys that share the same English text but are used for visible in-page headings elsewhere (e.g. `tunnel-page.title`), so translating one doesn't affect the other.

## Test plan

- [x] `pnpm test` in `portal` (845 tests passing)
- [x] `tsc --noEmit` shows no new errors on the touched files
- [x] `pnpm deps:check` (knip) passes
- [x] `next build` succeeds; verified the rendered `<title>` in the static export for all 5 routes across all 3 locales — `en` matches the original hardcoded strings exactly, `es`/`pt` are localized (e.g. `/en/tunnel` → "Tunnel | Hemi Portal", `/es/tunnel` → "Túnel | Portal de Hemi", `/pt/tunnel` → "Túnel | Portal Hemi")