### PR TITLE
Skip tokens without a price from CoinMarketCap

### DIFF
--- a/portal-backend/cron/token-prices/package.json
+++ b/portal-backend/cron/token-prices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-prices-cron",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "dependencies": {
     "@sentry/node": "10.53.1",
     "redis": "4.7.1",

--- a/portal-backend/cron/token-prices/src/refresh-prices.js
+++ b/portal-backend/cron/token-prices/src/refresh-prices.js
@@ -7,6 +7,8 @@ const config = require('./config')
 
 const coinMarketCap = config.get('coinMarketCap')
 
+const hasPrice = ({ quote }) => typeof quote?.USD?.price === 'number'
+
 async function fetchPrices() {
   const url =
     'https://pro-api.coinmarketcap.com/v2/cryptocurrency/quotes/latest'
@@ -17,11 +19,17 @@ async function fetchPrices() {
   }
   const fullUrl = `${url}?${new URLSearchParams(params).toString()}`
   const res = await fetchJson(fullUrl, { headers })
+  const tokens = Object.values(res.data)
+  const unpriced = tokens.filter(token => !hasPrice(token))
+  if (unpriced.length > 0) {
+    console.warn(
+      `Skipped tokens without a price: ${unpriced.map(({ symbol }) => symbol).join(', ')}`,
+    )
+  }
   return Object.fromEntries(
-    Object.values(res.data).map(({ quote, symbol }) => [
-      symbol.toUpperCase(),
-      quote.USD.price,
-    ]),
+    tokens
+      .filter(hasPrice)
+      .map(({ quote, symbol }) => [symbol.toUpperCase(), quote.USD.price]),
   )
 }
 


### PR DESCRIPTION
### Description

The token-prices cron failed with `TypeError: Invalid argument type` and stopped refreshing prices. CoinMarketCap returns `"price": null` for two of the configured tokens, and node-redis throws when a `SET` value is not a string or a number.

This PR skips the tokens without a numeric price, and logs a warning with their symbols.

**Commits:**

c5a985ea Skip tokens without a price from CoinMarketCap

### Screenshots

N/A. Backend cron job, no UI change.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
