### PR TITLE
Import viem once in the veHemi constants

### DIFF
--- a/packages/ve-hemi-actions/constants.ts
+++ b/packages/ve-hemi-actions/constants.ts
@@ -1,6 +1,5 @@
 import { hemi, hemiSepolia } from 'hemi-viem'
-import type { Address } from 'viem'
-import { parseUnits } from 'viem'
+import { type Address, parseUnits } from 'viem'
 
 const VE_HEMI_CONTRACT_ADDRESSES: Record<number, Address> = {
   [hemi.id]: '0x371d3718D5b7F75EAb050FAe6Da7DF3092031c89',


### PR DESCRIPTION
### Description

This PR fixes a duplicated `viem` import in the veHemi constants. The file imported the module twice, once for the `Address` type and once for `parseUnits`, and both are now a single declaration.

Nothing changes at runtime, and no lint job on main reports this today. The reason to fix it here is the Vite migration: it swaps the eslint preset for one that turns on `no-duplicate-imports`, and that branch flags the file. Six other files across the veHemi packages had the same shape and were already merged as a side effect of the migration work, so doing this one on main keeps the migration diff free of an unrelated cleanup.

Verified against `bloq/esm`, the preset that enables the rule, where the file goes from 1 warning to 0. Also ran lint, format:check and deps:check at the root, plus the portal build and its test suite (845 tests).

### Screenshots

N/A, this does not touch the UI.

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
