### PR TITLE
Drop the Next leftovers from the portal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Furthermore, consider the [code structure](./portal/README.md#structure), which 
 
 ### Rules
 
-- This app uses the App router from next (v14). Therefore, below the `app` folder, each folder that contains a `page.tsx` is a route segment.
+- Routing lives in `app.tsx` at the portal root, wired with react-router. Pages still live below the `app` folder, but a folder holding a `page.tsx` is not a route on its own: it only becomes reachable once it is added to the route table in `app.tsx`.
 - When creating a new component, hook, or function utility, prefer co-locating these new files in their `_components`, `_hooks` or `_utils` that belong to the page where it is being used. This means that each page will have their own folders for these types of files.
   If the component/hook/util is generic enough, they can be created in/moved to their respective folder `components`/`hooks`/`utils` in the root of the portal project.
 - When adding new functions to either `utils` or `_utils`, if they contain logic, add tests in the `test` folder. If the function is only code that calls an external source, tests may be skipped.

--- a/portal/app/[locale]/_components/analytics.tsx
+++ b/portal/app/[locale]/_components/analytics.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { lazyWithFallback } from 'components/lazyWithFallback'
 import { UmamiAnalyticsProvider } from 'components/umamiAnalyticsProvider'
 import { ComponentProps, useCallback } from 'react'

--- a/portal/app/[locale]/_components/analytics.tsx
+++ b/portal/app/[locale]/_components/analytics.tsx
@@ -23,18 +23,16 @@ export const Analytics = function ({
   )
 
   return (
-    <>
-      <UmamiAnalyticsProvider
-        autoTrack={false}
-        processUrl={processUrl}
-        {...(import.meta.env.VITE_ENABLE_ANALYTICS === 'true' && {
-          src: import.meta.env.VITE_ANALYTICS_URL,
-          websiteId: import.meta.env.VITE_ANALYTICS_WEBSITE_ID,
-        })}
-      >
-        <GlobalTracking />
-        {children}
-      </UmamiAnalyticsProvider>
-    </>
+    <UmamiAnalyticsProvider
+      autoTrack={false}
+      processUrl={processUrl}
+      {...(import.meta.env.VITE_ENABLE_ANALYTICS === 'true' && {
+        src: import.meta.env.VITE_ANALYTICS_URL,
+        websiteId: import.meta.env.VITE_ANALYTICS_WEBSITE_ID,
+      })}
+    >
+      <GlobalTracking />
+      {children}
+    </UmamiAnalyticsProvider>
   )
 }

--- a/portal/app/[locale]/_components/appLayout.tsx
+++ b/portal/app/[locale]/_components/appLayout.tsx
@@ -22,8 +22,6 @@ import { NavbarResponsive } from './navbar/navbarResponsive'
 import { NavBarUrlSync } from './navbar/navBarUrlSync'
 import { TestnetIndicator } from './testnetIndicator'
 
-// Rendered only when the wallet drawer is open — never during static
-// prerendering — so useUmami (useSearchParams) is safe here.
 const WalletDrawer = function ({ closeDrawer }: { closeDrawer: VoidFunction }) {
   const { track } = useUmami()
 

--- a/portal/app/[locale]/_components/appLayout.tsx
+++ b/portal/app/[locale]/_components/appLayout.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
 import { ConnectWalletsDrawer } from 'components/connectWallets/connectWalletsDrawer'
 import { Drawer } from 'components/drawer'

--- a/portal/app/[locale]/_components/appOverlays.tsx
+++ b/portal/app/[locale]/_components/appOverlays.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { lazyWithFallback } from 'components/lazyWithFallback'
 
 const EarnCard = lazyWithFallback(() =>

--- a/portal/app/[locale]/_components/earnCard/index.tsx
+++ b/portal/app/[locale]/_components/earnCard/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ErrorBoundary } from 'components/errorBoundary'
 import { ExternalLink } from 'components/externalLink'
 import { useNetworkType } from 'hooks/useNetworkType'

--- a/portal/app/[locale]/_components/globalTracking.tsx
+++ b/portal/app/[locale]/_components/globalTracking.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import * as Sentry from '@sentry/react'
 import { Connector, watchAccount } from '@wagmi/core'
 import { WalletConnector } from 'btc-wallet/connectors/types'

--- a/portal/app/[locale]/_components/mobileBottomBar.tsx
+++ b/portal/app/[locale]/_components/mobileBottomBar.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ButtonIcon } from 'components/button'
 import { CloseIcon } from 'components/icons/closeIcon'
 import { HamburgerIcon } from 'components/icons/hamburgerIcon'

--- a/portal/app/[locale]/_components/navbar/navbarDesktop.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarDesktop.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { featureFlags } from 'app/featureFlags'
 import { lazyWithFallback } from 'components/lazyWithFallback'
 import { ReactNode } from 'react'

--- a/portal/app/[locale]/_components/navbar/navbarResponsive.tsx
+++ b/portal/app/[locale]/_components/navbar/navbarResponsive.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
 import { screenBreakpoints } from 'styles'
 

--- a/portal/app/[locale]/_components/workers.tsx
+++ b/portal/app/[locale]/_components/workers.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { lazyWithFallback } from 'components/lazyWithFallback'
 
 const SyncHistoryWorkers = lazyWithFallback(() =>

--- a/portal/app/[locale]/ecosystem/_components/demoCard.tsx
+++ b/portal/app/[locale]/ecosystem/_components/demoCard.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { AnalyticsEvent } from 'app/analyticsEvents'
 import { ExternalLink } from 'components/externalLink'
 import { Image } from 'components/image'

--- a/portal/app/[locale]/ecosystem/page.tsx
+++ b/portal/app/[locale]/ecosystem/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
 import { useNetworkType } from 'hooks/useNetworkType'

--- a/portal/app/[locale]/genesis-drop/_components/claimDetails.tsx
+++ b/portal/app/[locale]/genesis-drop/_components/claimDetails.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button, ButtonLink } from 'components/button'
 import { ExternalLink } from 'components/externalLink'
 import { EligibilityData } from 'genesis-drop-actions'

--- a/portal/app/[locale]/genesis-drop/layout.tsx
+++ b/portal/app/[locale]/genesis-drop/layout.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { TestnetDisabled } from 'components/testnetDisabled'
 import { useNetworkType } from 'hooks/useNetworkType'

--- a/portal/app/[locale]/genesis-drop/page.tsx
+++ b/portal/app/[locale]/genesis-drop/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { HemiSymbolWhite } from 'components/icons/hemiSymbolWhite'
 import { Spinner } from 'components/spinner'
 import { type EligibilityData } from 'genesis-drop-actions'

--- a/portal/app/[locale]/get-started/_components/addHemiToken.tsx
+++ b/portal/app/[locale]/get-started/_components/addHemiToken.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ColumnDef } from '@tanstack/react-table'
 import { Card } from 'components/card'
 import { SearchInput } from 'components/inputText'

--- a/portal/app/[locale]/get-started/_components/addHemiWallet.tsx
+++ b/portal/app/[locale]/get-started/_components/addHemiWallet.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Card } from 'components/card'
 import { Tab, Tabs } from 'components/tabs'
 import { hemi as hemiMainnet, hemiSepolia as hemiTestnet } from 'hemi-viem'

--- a/portal/app/[locale]/get-started/_components/noMatchingTokens.tsx
+++ b/portal/app/[locale]/get-started/_components/noMatchingTokens.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { MagnifyingGlassIcon } from 'components/icons/magnifyingGlassIcon'
 import { useTranslations } from 'use-intl'
 

--- a/portal/app/[locale]/get-started/_components/tokenTable/addTokenButton.tsx
+++ b/portal/app/[locale]/get-started/_components/tokenTable/addTokenButton.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { CheckMark } from 'components/icons/checkMark'
 import { PlusIcon } from 'components/icons/plusIcon'

--- a/portal/app/[locale]/get-started/_components/tokenTable/addTokenToWalletToast.tsx
+++ b/portal/app/[locale]/get-started/_components/tokenTable/addTokenToWalletToast.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Toast } from 'components/toast'
 import { useTranslations } from 'use-intl'
 

--- a/portal/app/[locale]/get-started/page.tsx
+++ b/portal/app/[locale]/get-started/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
 import { useTranslations } from 'use-intl'

--- a/portal/app/[locale]/hemi-earn/_components/earnCard.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnCard.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Card } from 'components/card'
 import { type ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'

--- a/portal/app/[locale]/hemi-earn/_components/earnStatusUpdaters.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnStatusUpdaters.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useTranslations } from 'use-intl'
 
 import { useEarnDeliveryWatcher } from '../_hooks/useEarnDeliveryWatcher'

--- a/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnSuccessToast.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { hemi } from 'hemi-viem'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { type Address, type Hash } from 'viem'

--- a/portal/app/[locale]/hemi-earn/_components/earnedAmount.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/earnedAmount.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useTranslations } from 'use-intl'
 import { formatFiatNumber } from 'utils/format'
 import { walletIsConnected } from 'utils/wallet'

--- a/portal/app/[locale]/hemi-earn/_components/fromPoolsBadge.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/fromPoolsBadge.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueries } from '@tanstack/react-query'
 import { TokenLogo } from 'components/tokenLogo'
 import { Tooltip } from 'components/tooltip'

--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ButtonLink } from 'components/button'
 import { ExternalLink } from 'components/externalLink'
 import { TokenLogo } from 'components/tokenLogo'

--- a/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolInfoBar/stakedAmount.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQuery } from '@tanstack/react-query'
 import { useTranslations } from 'use-intl'
 

--- a/portal/app/[locale]/hemi-earn/_components/poolsList.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsList.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Skeleton from 'react-loading-skeleton'
 
 import { useEarnPools } from '../_hooks/useEarnPools'

--- a/portal/app/[locale]/hemi-earn/_components/poolsSection.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/poolsSection.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PoolsList } from './poolsList'
 
 export const PoolsSection = () => (

--- a/portal/app/[locale]/hemi-earn/_components/stakedBalance.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/stakedBalance.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useTranslations } from 'use-intl'
 import { formatFiatNumber } from 'utils/format'
 import { walletIsConnected } from 'utils/wallet'

--- a/portal/app/[locale]/hemi-earn/_components/topSection.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/topSection.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageTitle } from 'components/pageTitle'
 import { useTranslations } from 'use-intl'
 

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/cancelRedeemModal.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/cancelRedeemModal.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { Modal } from 'components/modal'
 import { useTranslations } from 'use-intl'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/columns.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { type ColumnDef } from '@tanstack/react-table'
 import { DisplayAmount } from 'components/displayAmount'
 import { ErrorBoundary } from 'components/errorBoundary'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/connectWallet.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/connectWallet.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { WalletIcon } from 'components/icons/walletIcon'
 import { InformationBox } from 'components/informationBox'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageTitle } from 'components/pageTitle'
 import { useTranslations } from 'use-intl'
 

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/rowActions.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button, ButtonIcon } from 'components/button'
 import { Tooltip } from 'components/tooltip'
 import { type MouseEvent, useState } from 'react'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/claimFromVault.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/claimFromVault.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { WarningBox } from 'components/warningBox'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalDepositReview.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Operation } from 'components/reviewOperation/operation'
 import {
   ProgressStatus,

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/historicalWithdrawReview.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Operation } from 'components/reviewOperation/operation'
 import {
   ProgressStatus,

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Drawer } from 'components/drawer'
 import { Suspense, useEffect } from 'react'
 import { isAddressEqual, isHash } from 'viem'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/remoteFailed.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { WarningBox } from 'components/warningBox'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedDeposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { type FormEvent, useState } from 'react'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/retryFailedWithdraw.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { type FormEvent, useState } from 'react'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/settleShared.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { AddTokenToWallet } from 'components/addTokenToWallet'
 import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/transactionDrawerSkeleton.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/transactionDrawerSkeleton.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { DrawerSection, DrawerTopSection } from 'components/drawer'
 import Skeleton from 'react-loading-skeleton'
 

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/transactionNotFound.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionDrawer/transactionNotFound.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { useDrawerAnimatedClose } from 'components/drawer'
 import { InboxIcon } from 'components/icons/inboxIcon'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionsTable.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/transactionsTable.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Table } from 'components/table'
 import { TableCard } from 'components/table/tableCard'
 import { useMemo } from 'react'

--- a/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
+++ b/portal/app/[locale]/hemi-earn/_components/transactionsSection/withdrawStatusCell.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useTranslations } from 'use-intl'
 import {
   secondsPerDay,

--- a/portal/app/[locale]/hemi-earn/_context/localEarnOperationsContext.tsx
+++ b/portal/app/[locale]/hemi-earn/_context/localEarnOperationsContext.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   createContext,
   type ReactNode,

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnApy.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { queryOptions } from '@tanstack/react-query'
 import fetch from 'fetch-plus-plus'
 import { isValidUrl } from 'utils/url'

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnCostBasis.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnCostBasis.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQuery } from '@tanstack/react-query'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useAccount } from 'wagmi'

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnDeliveryWatcher.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueryClient } from '@tanstack/react-query'
 import { hemi } from 'hemi-viem'
 import { getTokenBalanceQueryKey } from 'hooks/useBalance'

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPools.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { useNetworkType } from 'hooks/useNetworkType'
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnPositions.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useAccount } from 'wagmi'

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactions.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMemo } from 'react'
 import { type Hash } from 'viem'
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTransactionsQuery.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQuery } from '@tanstack/react-query'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useAccount } from 'wagmi'

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnTvl.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnTvl.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { queryOptions } from '@tanstack/react-query'
 import { mainnet } from 'networks/mainnet'
 import { getEvmL1PublicClient } from 'utils/chainClients'

--- a/portal/app/[locale]/hemi-earn/_hooks/useEarnedAmount.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useEarnedAmount.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueries } from '@tanstack/react-query'
 import Big from 'big.js'
 import { getTokenPrice } from 'utils/token'

--- a/portal/app/[locale]/hemi-earn/_hooks/useFailedRequest.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useFailedRequest.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getFailedRequest } from 'hemi-earn-actions/actions'
 import { mainnet } from 'networks/mainnet'

--- a/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnShares.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useHemiEarnShares.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQuery } from '@tanstack/react-query'
 
 import { hemiEarnSharesQueryOptions } from '../_fetchers/fetchHemiEarnShares'

--- a/portal/app/[locale]/hemi-earn/_hooks/useInTransitShares.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useInTransitShares.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { sumInTransitSharesByShare } from '../_utils/earnRows'
 
 import { useEarnPools } from './useEarnPools'

--- a/portal/app/[locale]/hemi-earn/_hooks/useLocalEarnOperations.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useLocalEarnOperations.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useContext } from 'react'
 
 import { LocalEarnOperationsContext } from '../_context/localEarnOperationsContext'

--- a/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedActions.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useEnsureConnectedTo } from '@hemilabs/react-hooks/useEnsureConnectedTo'
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { useUpdateNativeBalanceAfterReceipt } from '@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt'

--- a/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedState.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useRemoteFailedState.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { unixNowTimestamp } from 'utils/time'
 import { isAddressEqual, zeroAddress } from 'viem'
 

--- a/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
+++ b/portal/app/[locale]/hemi-earn/_hooks/useTotalDeposits.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueries } from '@tanstack/react-query'
 import Big from 'big.js'
 import { getTokenPrice } from 'utils/token'

--- a/portal/app/[locale]/hemi-earn/layout.tsx
+++ b/portal/app/[locale]/hemi-earn/layout.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { featureFlags } from 'app/featureFlags'
 import { PageLayout } from 'components/pageLayout'
 import { TestnetDisabled } from 'components/testnetDisabled'

--- a/portal/app/[locale]/hemi-earn/page.tsx
+++ b/portal/app/[locale]/hemi-earn/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { lazyWithFallback } from 'components/lazyWithFallback'
 import { PageLayout } from 'components/pageLayout'
 import { type ReactNode } from 'react'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/advancedSettings/highSlippageModal.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/advancedSettings/highSlippageModal.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { Checkbox } from 'components/checkbox'
 import { Modal } from 'components/modal'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/advancedSettings/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/advancedSettings/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type FocusEvent,
   type KeyboardEvent,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/assetSelector.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/assetSelector.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useOnClickOutside } from '@hemilabs/react-hooks/useOnClickOutside'
 import { Chevron } from 'components/icons/chevron'
 import { Menu } from 'components/menu'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionChart.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Skeleton from 'react-loading-skeleton'
 import { formatPercentage } from 'utils/format'
 import { VictoryPie } from 'victory'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionTable.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/compositionTable.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Table } from 'components/table'
 import { ComponentProps } from 'react'
 import Skeleton from 'react-loading-skeleton'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/composition/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Card } from 'components/card'
 import { useMemo, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/deposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { SetMaxEvmBalance } from 'components/setMaxBalance'
 import { TokenInput } from 'components/tokenInput'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/historicalMetricsChart.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
 import Skeleton from 'react-loading-skeleton'
 import { screenBreakpoints } from 'styles'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/historicalMetrics/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Card } from 'components/card'
 import { useState } from 'react'
 import Skeleton from 'react-loading-skeleton'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolCard.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolCard.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Card } from 'components/card'
 import { type ReactNode } from 'react'
 import Skeleton from 'react-loading-skeleton'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolForm.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolForm.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Suspense, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolInfoCards.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolInfoCards.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useTranslations } from 'use-intl'
 import { formatFiatNumber } from 'utils/format'
 

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolNavigation.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolNavigation.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useOnClickOutside } from '@hemilabs/react-hooks/useOnClickOutside'
 import { Button, ButtonIcon } from 'components/button'
 import { Chevron } from 'components/icons/chevron'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolPageContent.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolPageContent.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useRouter } from 'i18n/navigation'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/index.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Drawer } from 'components/drawer'
 
 import { usePoolForm } from '../../_context/poolFormContext'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewDeposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Operation } from 'components/reviewOperation/operation'
 import {
   ProgressStatus,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/poolReview/reviewWithdraw.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Operation } from 'components/reviewOperation/operation'
 import {
   ProgressStatus,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/submitDeposit.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/submitDeposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { Spinner } from 'components/spinner'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/submitWithdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/submitWithdraw.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { Spinner } from 'components/spinner'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/withdraw.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_components/withdraw.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { TokenInput } from 'components/tokenInput'
 import { TokenSelectorReadOnly } from 'components/tokenSelector/readonly'
 import { getHemiEarnRouterAddress } from 'hemi-earn-actions'

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_context/poolFormContext.tsx
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_context/poolFormContext.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   createContext,
   useCallback,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useComposition.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useComposition.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type QueryClient,
   queryOptions,

--- a/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
+++ b/portal/app/[locale]/hemi-earn/pool/[shareAddress]/_hooks/useEarnCooldownRemaining.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useEffect, useState } from 'react'
 import { unixNowTimestamp } from 'utils/time'
 

--- a/portal/app/[locale]/stake/_components/changeToMainnet.tsx
+++ b/portal/app/[locale]/stake/_components/changeToMainnet.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Link } from 'components/link'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { usePathname } from 'i18n/navigation'

--- a/portal/app/[locale]/stake/_components/manageStake/index.tsx
+++ b/portal/app/[locale]/stake/_components/manageStake/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Drawer } from 'components/drawer'
 import { useState } from 'react'
 import { type StakeOperations, type StakeToken } from 'types/stake'

--- a/portal/app/[locale]/stake/_components/stakeAndEarn.tsx
+++ b/portal/app/[locale]/stake/_components/stakeAndEarn.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Locale } from 'i18n/routing'
 import { ReactElement } from 'react'
 import { useLocale } from 'use-intl'

--- a/portal/app/[locale]/stake/_components/stakeDisabledTestnet.tsx
+++ b/portal/app/[locale]/stake/_components/stakeDisabledTestnet.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ChangeToMainnet } from './changeToMainnet'
 import { StakeGraph } from './icons/stakeGraph'
 import { StakeAndEarn } from './stakeAndEarn'

--- a/portal/app/[locale]/stake/_components/stakeLayoutClient.tsx
+++ b/portal/app/[locale]/stake/_components/stakeLayoutClient.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { StakeTabs } from 'components/stakeTabs'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { useStakeTokens } from 'hooks/useStakeTokens'

--- a/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
+++ b/portal/app/[locale]/stake/_components/stakeStrategyTable/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ColumnDef } from '@tanstack/react-table'
 import { ButtonLink } from 'components/button'
 import { Balance } from 'components/cryptoBalance'

--- a/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
+++ b/portal/app/[locale]/stake/dashboard/_components/stakeAssetsTable/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ColumnDef } from '@tanstack/react-table'
 import { ButtonLink } from 'components/button'
 import { Table } from 'components/table'

--- a/portal/app/[locale]/stake/dashboard/page.tsx
+++ b/portal/app/[locale]/stake/dashboard/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
 import { useTranslations } from 'use-intl'

--- a/portal/app/[locale]/stake/page.tsx
+++ b/portal/app/[locale]/stake/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
 import { useTokenPrices } from 'hooks/useTokenPrices'

--- a/portal/app/[locale]/staking-dashboard/_components/stake.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stake.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { EvmFeesSummary } from 'components/evmFeesSummary'
 import { FeesContainer } from 'components/feesContainer'
 import { SetMaxEvmBalance } from 'components/setMaxBalance'

--- a/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeForm.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { lazyWithFallback } from 'components/lazyWithFallback'
 import { ToastLoader } from 'components/toast/toastLoader'
 import { useHemiToken } from 'hooks/useHemiToken'

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseAmount/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseAmount/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import {
   ProgressStatus,

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseUnlockTime/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/increaseUnlockTime/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { DrawerParagraph, DrawerTopSection } from 'components/drawer'
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import {

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Drawer } from 'components/drawer'
 
 import { useDrawerStakingQueryString } from '../../_hooks/useDrawerStakingQueryString'

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/reviewCollectRewards.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/reviewCollectRewards.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import {
   ProgressStatus,

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/reviewStake.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/reviewStake.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import {
   ProgressStatus,

--- a/portal/app/[locale]/staking-dashboard/_components/stakeReview/reviewUnlock.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeReview/reviewUnlock.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import {
   ProgressStatus,

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ColumnDef } from '@tanstack/react-table'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { Table } from 'components/table'

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/noPositionStaked.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/noPositionStaked.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { InformationBox } from 'components/informationBox'
 import { useHemiToken } from 'hooks/useHemiToken'
 import { useTranslations } from 'use-intl'

--- a/portal/app/[locale]/staking-dashboard/_components/stakeTable/stakeTableFilter.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakeTable/stakeTableFilter.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Tab, Tabs } from 'components/tabs'
 import { useUmami } from 'hooks/useUmami'
 import { StakingPositionStatus } from 'types/stakingDashboard'

--- a/portal/app/[locale]/staking-dashboard/_components/stakingDashboardLayoutClient.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/stakingDashboardLayoutClient.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { ReactNode } from 'react'
 

--- a/portal/app/[locale]/staking-dashboard/_components/submitStake.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/submitStake.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button, ButtonSize } from 'components/button'
 import { Spinner } from 'components/spinner'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'

--- a/portal/app/[locale]/staking-dashboard/_components/votingPowerSummary.tsx
+++ b/portal/app/[locale]/staking-dashboard/_components/votingPowerSummary.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { CardInfo } from 'components/cardInfo'
 import { DisplayAmount } from 'components/displayAmount'
 import { useVeHemiToken } from 'hooks/useVeHemiToken'

--- a/portal/app/[locale]/staking-dashboard/_context/stakingDashboardContext.tsx
+++ b/portal/app/[locale]/staking-dashboard/_context/stakingDashboardContext.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { createContext, useContext, type ReactNode } from 'react'
 
 import {

--- a/portal/app/[locale]/staking-dashboard/page.tsx
+++ b/portal/app/[locale]/staking-dashboard/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
 import { TestnetDisabled } from 'components/testnetDisabled'

--- a/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/btcDeposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useDebounce } from '@hemilabs/react-hooks/useDebounce'
 import { lazyWithFallback } from 'components/lazyWithFallback'
 import { SetMaxBtcBalance } from 'components/setMaxBalance'

--- a/portal/app/[locale]/tunnel/_components/claimEvmWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/claimEvmWithdrawal.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { type FormEvent, useContext } from 'react'
 import { MessageStatus, ToEvmWithdrawOperation } from 'types/tunnel'

--- a/portal/app/[locale]/tunnel/_components/deposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/deposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useNetworks } from 'hooks/useNetworks'
 import Skeleton from 'react-loading-skeleton'
 import { isEvmNetwork } from 'utils/chain'

--- a/portal/app/[locale]/tunnel/_components/evmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/evmDeposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { CustomTunnelsThroughPartners } from 'components/customTunnelsThroughPartners'
 import { EvmFeesSummary } from 'components/evmFeesSummary'

--- a/portal/app/[locale]/tunnel/_components/proveEvmWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/proveEvmWithdrawal.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { type FormEvent, useContext } from 'react'
 import { MessageStatus, ToEvmWithdrawOperation } from 'types/tunnel'

--- a/portal/app/[locale]/tunnel/_components/retryBtcWithdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/retryBtcWithdraw.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { useWithdrawBitcoin } from 'hooks/useBtcTunnel'
 import { type FormEvent, useEffect, useState } from 'react'

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewBtcWithdrawal.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useAccount as useBtcAccount } from 'btc-wallet/hooks/useAccount'
 import { ChainLabel } from 'components/reviewOperation/chainLabel'
 import { Operation } from 'components/reviewOperation/operation'

--- a/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/reviewOperation/reviewEvmDeposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { AddTokenToWallet } from 'components/addTokenToWallet'
 import { ChainIcon } from 'components/reviewOperation/chainIcon'
 import { ChainLabel } from 'components/reviewOperation/chainLabel'

--- a/portal/app/[locale]/tunnel/_components/submitEvmDeposit.tsx
+++ b/portal/app/[locale]/tunnel/_components/submitEvmDeposit.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { Spinner } from 'components/spinner'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'

--- a/portal/app/[locale]/tunnel/_components/submitEvmWithdrawal.tsx
+++ b/portal/app/[locale]/tunnel/_components/submitEvmWithdrawal.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from 'components/button'
 import { SubmitWhenConnected } from 'components/submitWhenConnected'
 import { EvmToken } from 'types/token'

--- a/portal/app/[locale]/tunnel/_components/viewOperation.tsx
+++ b/portal/app/[locale]/tunnel/_components/viewOperation.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { isBtcTxHash } from 'btc-wallet/utils/hash'
 import { Drawer } from 'components/drawer'
 import { TransactionsInProgressContext } from 'context/transactionsInProgressContext'

--- a/portal/app/[locale]/tunnel/_components/withdraw.tsx
+++ b/portal/app/[locale]/tunnel/_components/withdraw.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { CustomTunnelsThroughPartners } from 'components/customTunnelsThroughPartners'
 import { EvmFeesSummary } from 'components/evmFeesSummary'

--- a/portal/app/[locale]/tunnel/_context/toEvmWithdrawalContext.tsx
+++ b/portal/app/[locale]/tunnel/_context/toEvmWithdrawalContext.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   createContext,
   Dispatch,

--- a/portal/app/[locale]/tunnel/page.tsx
+++ b/portal/app/[locale]/tunnel/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { Suspense } from 'react'
 

--- a/portal/app/[locale]/tunnel/transaction-history/_components/columns.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/columns.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ColumnDef } from '@tanstack/react-table'
 import { ErrorBoundary } from 'components/errorBoundary'
 import { Arrow } from 'components/icons/arrow'

--- a/portal/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/transactionHistory.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Table } from 'components/table'
 import { TableCard } from 'components/table/tableCard'
 import { useConnectedToSupportedEvmChain } from 'hooks/useConnectedToSupportedChain'

--- a/portal/app/[locale]/tunnel/transaction-history/_components/txTime.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/_components/txTime.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { InRelativeTime } from 'components/inRelativeTime'
 import Skeleton from 'react-loading-skeleton'
 

--- a/portal/app/[locale]/tunnel/transaction-history/page.tsx
+++ b/portal/app/[locale]/tunnel/transaction-history/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { PageLayout } from 'components/pageLayout'
 import { PageTitle } from 'components/pageTitle'
 import { useState } from 'react'

--- a/portal/components/addTokenToWallet.tsx
+++ b/portal/components/addTokenToWallet.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useAddTokenToWallet } from 'hooks/useAddTokenToWallet'
 import { useWatchedAsset } from 'hooks/useWatchedAsset'
 import { type ComponentProps } from 'react'

--- a/portal/components/connectWallets/box.tsx
+++ b/portal/components/connectWallets/box.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ReactNode } from 'react'
 
 type Props = {

--- a/portal/components/connectWallets/connectToSupportedChain.tsx
+++ b/portal/components/connectWallets/connectToSupportedChain.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useTranslations } from 'use-intl'
 
 export const ConnectToSupportedChain = function () {

--- a/portal/components/connectWallets/connectWalletsDrawer.tsx
+++ b/portal/components/connectWallets/connectWalletsDrawer.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { DrawerParagraph, DrawerTopSection } from 'components/drawer'
 import { useTranslations } from 'use-intl'
 

--- a/portal/components/connectWallets/index.tsx
+++ b/portal/components/connectWallets/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useAccount as useBtcAccount } from 'btc-wallet/hooks/useAccount'
 import { Button } from 'components/button'
 import { useDrawerContext } from 'hooks/useDrawerContext'

--- a/portal/components/cryptoBalance.tsx
+++ b/portal/components/cryptoBalance.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useNativeBalance } from '@hemilabs/react-hooks/useNativeBalance'
 import { DisplayAmount } from 'components/displayAmount'
 import { useTokenBalance } from 'hooks/useBalance'

--- a/portal/components/customTokenDrawer/acknowledge.tsx
+++ b/portal/components/customTokenDrawer/acknowledge.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Checkbox } from 'components/checkbox'
 import { useTranslations } from 'use-intl'
 

--- a/portal/components/customTokenDrawer/index.tsx
+++ b/portal/components/customTokenDrawer/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from 'components/button'
 import { Drawer, DrawerParagraph, DrawerTopSection } from 'components/drawer'

--- a/portal/components/customTokenDrawer/tokenSection.tsx
+++ b/portal/components/customTokenDrawer/tokenSection.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { DrawerParagraph } from 'components/drawer'
 import { SearchInput } from 'components/inputText'
 import { ShortVerticalLine } from 'components/verticalLines'

--- a/portal/components/drawer/index.tsx
+++ b/portal/components/drawer/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useOnClickOutside } from '@hemilabs/react-hooks/useOnClickOutside'
 import { useOnKeyUp } from '@hemilabs/react-hooks/useOnKeyUp'
 import { CloseIcon } from 'components/icons/closeIcon'

--- a/portal/components/errorBoundary.tsx
+++ b/portal/components/errorBoundary.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import * as Sentry from '@sentry/react'
 import { GenericError } from 'components/genericError'
 import React from 'react'

--- a/portal/components/hemiSubLogo.tsx
+++ b/portal/components/hemiSubLogo.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useHemi } from 'hooks/useHemi'
 import { orange600 } from 'styles'
 import { Token } from 'types/token'

--- a/portal/components/modal.tsx
+++ b/portal/components/modal.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useOnClickOutside } from '@hemilabs/react-hooks/useOnClickOutside'
 import { useOnKeyUp } from '@hemilabs/react-hooks/useOnKeyUp'
 import { ComponentType } from 'react'

--- a/portal/components/reviewOperation/amount.tsx
+++ b/portal/components/reviewOperation/amount.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { DisplayAmount } from 'components/displayAmount'
 import { Token } from 'types/token'
 import { useTranslations } from 'use-intl'

--- a/portal/components/stakeTabs.tsx
+++ b/portal/components/stakeTabs.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Tab, Tabs } from 'components/tabs'
 import { useNetworkType } from 'hooks/useNetworkType'
 import { usePathname } from 'i18n/navigation'

--- a/portal/components/syncHistoryWorkers.tsx
+++ b/portal/components/syncHistoryWorkers.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   SyncStatus,
   type HistoryActions,

--- a/portal/components/table/index.tsx
+++ b/portal/components/table/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'
 import {
   ColumnDef,

--- a/portal/components/tabs.tsx
+++ b/portal/components/tabs.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Link } from 'components/link'
 import { type ComponentProps, type MouseEvent, type ReactNode } from 'react'
 

--- a/portal/components/testnetDisabled.tsx
+++ b/portal/components/testnetDisabled.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ButtonLink } from 'components/button'
 import { LiveIcon } from 'components/icons/liveIcon'
 import { useNetworkType } from 'hooks/useNetworkType'

--- a/portal/components/toast/index.tsx
+++ b/portal/components/toast/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ButtonLink } from 'components/button'
 import { ExternalLink } from 'components/externalLink'
 import { CheckCircleIcon } from 'components/icons/checkCircleIcon'

--- a/portal/components/tokenSelector/list.tsx
+++ b/portal/components/tokenSelector/list.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { DatabaseIcon } from 'components/icons/databaseIcon'
 import { MultiTokensIcon } from 'components/icons/multiTokensIcon'

--- a/portal/components/tokenSelector/tokenList.tsx
+++ b/portal/components/tokenSelector/tokenList.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useDebounce } from '@hemilabs/react-hooks/useDebounce'
 import { useVisualViewportSize } from '@hemilabs/react-hooks/useVisualViewportSize'
 import { useWindowSize } from '@hemilabs/react-hooks/useWindowSize'

--- a/portal/components/tunnelStatusUpdaters/bitcoinDepositsStatusUpdater.tsx
+++ b/portal/components/tunnelStatusUpdaters/bitcoinDepositsStatusUpdater.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueryClient } from '@tanstack/react-query'
 import { WithWorker } from 'components/withWorker'
 import { useBitcoinBalance } from 'hooks/useBitcoinBalance'

--- a/portal/components/tunnelStatusUpdaters/bitcoinWithdrawalsStatusUpdater.tsx
+++ b/portal/components/tunnelStatusUpdaters/bitcoinWithdrawalsStatusUpdater.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueryClient } from '@tanstack/react-query'
 import { WithWorker } from 'components/withWorker'
 import { useBitcoinBalance } from 'hooks/useBitcoinBalance'

--- a/portal/components/tunnelTabs.tsx
+++ b/portal/components/tunnelTabs.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { AnalyticsEvent } from 'app/analyticsEvents'
 import { lazyWithFallback } from 'components/lazyWithFallback'
 import { Tab, Tabs } from 'components/tabs'

--- a/portal/components/withWorker.tsx
+++ b/portal/components/withWorker.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ReactNode, useEffect, useRef } from 'react'
 
 type Props<T> = {

--- a/portal/context/btcWalletContext.tsx
+++ b/portal/context/btcWalletContext.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { bitcoinTestnet, bitcoinMainnet } from 'btc-wallet/chains'
 import { okx } from 'btc-wallet/connectors/okx'
 import { unisat } from 'btc-wallet/connectors/unisat'

--- a/portal/context/connectWalletDrawerContext.tsx
+++ b/portal/context/connectWalletDrawerContext.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { createContext, ReactNode, useState } from 'react'
 
 type ConnectWalletDrawerContext = {

--- a/portal/context/evmWalletContext.tsx
+++ b/portal/context/evmWalletContext.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import binanceWallet from '@binance/w3w-rainbow-connector-v2'
 import {
   connectorsForWallets,

--- a/portal/context/transactionsInProgressContext.tsx
+++ b/portal/context/transactionsInProgressContext.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { createContext, ReactNode, useState } from 'react'
 import { DepositTunnelOperation } from 'types/tunnel'
 

--- a/portal/context/tunnelHistoryContext/historyLoader.tsx
+++ b/portal/context/tunnelHistoryContext/historyLoader.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useConnectedToSupportedEvmChain } from 'hooks/useConnectedToSupportedChain'
 import { useHemi } from 'hooks/useHemi'
 import { useNetworks } from 'hooks/useNetworks'

--- a/portal/context/tunnelHistoryContext/index.tsx
+++ b/portal/context/tunnelHistoryContext/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { lazyWithFallback } from 'components/lazyWithFallback'
 import {
   createContext,

--- a/portal/scripts/hemi-earn/README.md
+++ b/portal/scripts/hemi-earn/README.md
@@ -209,4 +209,4 @@ pnpm --filter portal sandbox:hemi-earn -- keeper \
 
 ## Why the nested `package.json`
 
-`portal/package.json` doesn't set `"type": "module"` (Next.js needs the default CJS resolution). The nested `package.json` in this folder scopes ESM to these scripts only, so Node can execute the `.ts` files with `import`/`export` syntax without touching the rest of `portal/`.
+It pins the Node floor these scripts need (`>=24`, which is what runs the `.ts` files directly) and keeps the folder a package boundary of its own. The `tsconfig.json` next to it does the same for typechecking: the portal excludes `scripts/hemi-earn/**/*`, so these files are checked against `@tsconfig/node24` instead of the app's browser config.

--- a/portal/styles/globals.css
+++ b/portal/styles/globals.css
@@ -30,8 +30,8 @@
 
 /* Metric-adjusted fallbacks: the overrides make the local font occupy the same
  * space as Inter, so text does not shift when the woff2 lands. The percentages
- * are next/font's, derived from the files' OS/2 metrics against Arial; changing
- * a woff2 means recomputing them. Helvetica and Liberation Sans are listed
+ * are derived from the files' OS/2 metrics against Arial; changing a woff2
+ * means recomputing them. Helvetica and Liberation Sans are listed
  * because both are metric-compatible with Arial, so the same numbers hold. */
 @font-face {
   ascent-override: 98.56%;
@@ -50,8 +50,8 @@
   src: url('/fonts/inter/variable/InterVariable.woff2') format('woff2');
 }
 
-/* Same as above, and this is the one that matters most: `*` uses
- * font-inter-variable, so stale metrics here shift every string on the page. */
+/* Same as above. This one matters most: font-inter-variable is the page-wide
+ * default, so stale metrics here shift almost every string. */
 @font-face {
   ascent-override: 89.79%;
   descent-override: 22.36%;


### PR DESCRIPTION
### Description

Removes what the Vite migration left behind in the portal: 165 `'use client'` directives, three pieces of text still describing Next, and a redundant fragment.

The directives are dead without RSC, and the bundler already discarded them, so the built `dist/assets` listing came out byte-identical (same 241 chunks, same content hashes). Only the fragment moves anything, thirty bytes off the main chunk.

- `e32dfe02` - Drop the use client directives
- `49cb8aed` - Drop stale Next references from comments and docs
- `680d280c` - Remove the redundant fragment

The Next entries in `.gitignore`, `.prettierignore`, `.eslintrc.json` and the tsconfigs are deliberately left alone: while main still builds with Next, they keep a branch switch from polluting lint and typecheck here.

### Screenshots

N/A, nothing renders differently.

### Related issue(s)

Related to #2194

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
