### PR TITLE
Add /hemi-stake endpoint to the portal API

### DIFF
--- a/packages/ve-hemi-actions/abi.ts
+++ b/packages/ve-hemi-actions/abi.ts
@@ -214,4 +214,11 @@ export const veHemiAbi = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [],
+    name: 'totalLocked',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
 ] as const

--- a/packages/ve-hemi-actions/actions/index.ts
+++ b/packages/ve-hemi-actions/actions/index.ts
@@ -15,4 +15,5 @@ export {
   getPositionsVotingPowerSum,
   getTotalVotingPower,
 } from './public/veHemi.ts'
+export { getTotalLocked } from './public/getTotalLocked.ts'
 export { getTotalVeHemiSupplyAt } from './public/getTotalVeHemiSupplyAt.ts'

--- a/packages/ve-hemi-actions/actions/public/getTotalLocked.ts
+++ b/packages/ve-hemi-actions/actions/public/getTotalLocked.ts
@@ -1,0 +1,20 @@
+import type { Client } from 'viem'
+import { readContract } from 'viem/actions'
+
+import { veHemiAbi } from '../../abi.ts'
+import { getVeHemiContractAddress } from '../../constants.ts'
+
+export const getTotalLocked = async function (client: Client) {
+  if (!client) {
+    throw new Error('Client is not defined')
+  }
+  if (!client.chain) {
+    throw new Error('Client chain is not defined')
+  }
+
+  return readContract(client, {
+    abi: veHemiAbi,
+    address: getVeHemiContractAddress(client.chain.id),
+    functionName: 'totalLocked',
+  })
+}

--- a/packages/ve-hemi-actions/test/actions/public/getTotalLocked.test.ts
+++ b/packages/ve-hemi-actions/test/actions/public/getTotalLocked.test.ts
@@ -1,0 +1,41 @@
+import { hemi } from 'hemi-viem'
+import { readContract } from 'viem/actions'
+import { describe, expect, it, vi } from 'vitest'
+
+import { veHemiAbi } from '../../../abi'
+import { getTotalLocked } from '../../../actions/public/getTotalLocked'
+import { getVeHemiContractAddress } from '../../../constants'
+
+vi.mock('viem/actions')
+
+describe('getTotalLocked', function () {
+  it('should return the total amount of HEMI locked', async function () {
+    const client = { chain: hemi }
+    const totalLocked = BigInt('1488392826436605230000147341')
+
+    vi.mocked(readContract).mockResolvedValue(totalLocked)
+
+    const result = await getTotalLocked(client)
+
+    expect(result).toBe(totalLocked)
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: veHemiAbi,
+      address: getVeHemiContractAddress(hemi.id),
+      functionName: 'totalLocked',
+    })
+  })
+
+  it('should throw error when client is not defined', async function () {
+    // @ts-expect-error testing invalid input
+    await expect(getTotalLocked(undefined)).rejects.toThrow(
+      'Client is not defined',
+    )
+  })
+
+  it('should throw error when client chain is not defined', async function () {
+    // @ts-expect-error testing invalid input
+    await expect(getTotalLocked({ chain: undefined })).rejects.toThrow(
+      'Client chain is not defined',
+    )
+  })
+})

--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -51,6 +51,17 @@ The data for each claim group must be located in individual files in the `src/cl
 
 Note that the route `GET /claims/:chain-id/:address` is kept for compatibility and will return just the first element of the array.
 
+#### `GET /hemi-stake`
+
+Returns the global veHEMI staking stats. It is Hemi mainnet only.
+
+```console
+$ curl http://localhost:3006/hemi-stake
+{"locksCount":15473,"rewards":[],"totalStaked":"1488392826436605230000147341","walletsStaking":13663}
+```
+
+`totalStaked` is the amount of HEMI locked, in its smallest unit. `locksCount` is the number of open positions and `walletsStaking` the number of wallets that hold at least one position, read from the [Hemi explorer](https://explorer.hemi.xyz). `rewards` is the list of all-time paid rewards (to be implemented).
+
 #### `GET /net-stats`
 
 Returns the Hemi network stats required by the [home page of the Marketing site](https://hemi.xyz).

--- a/portal-backend/api/server.ts
+++ b/portal-backend/api/server.ts
@@ -13,6 +13,7 @@ import { UpstreamGraphQLError } from './src/subgraphs/errors.ts'
 import { createSubgraphsRouter } from './src/subgraphs/router.ts'
 import { toJsonMiddleware, toTextMiddleware } from './src/to-middleware.ts'
 import { createVeHemi } from './src/ve-hemi/index.ts'
+import { getHemiStake } from './src/ve-hemi/stake.ts'
 
 const { getTvl } = createDune(config.get<DuneOptions>('tvl.dune'))
 const { getAllUserClaimData } = createClaims()
@@ -50,6 +51,13 @@ app.get(
   toJsonMiddleware(getAllUserClaimData, {
     maxAge: 5 * 60 * 1000,
     resolver: (chainId, address) => `${chainId}:${address}`,
+  }),
+)
+
+app.get(
+  '/hemi-stake',
+  toJsonMiddleware(getHemiStake, {
+    revalidate: 5 * 60 * 1000,
   }),
 )
 

--- a/portal-backend/api/src/btc-vaults.ts
+++ b/portal-backend/api/src/btc-vaults.ts
@@ -1,5 +1,4 @@
 import { esploraClient } from 'esplora-client'
-import { hemi, hemiSepolia } from 'hemi-viem'
 import {
   getBitcoinChainLastHeader,
   getBitcoinCustodyAddress,
@@ -11,14 +10,9 @@ import {
   getVaultCounter,
   getVaultStatus,
 } from 'hemi-viem/actions'
-import { type Address, createPublicClient, http, type PublicClient } from 'viem'
+import type { Address, PublicClient } from 'viem'
 
-function getHemiClient(chainId: string) {
-  const chain = { [hemi.id]: hemi, [hemiSepolia.id]: hemiSepolia }[
-    Number(chainId)
-  ]
-  return createPublicClient({ chain, transport: http() }) as PublicClient
-}
+import { getHemiClient } from './hemiClient.ts'
 
 async function getBitcoinChainHeight(network: 'testnet' | 'mainnet') {
   const client = esploraClient({ network })
@@ -113,7 +107,7 @@ async function getAllVaultsData(client: PublicClient) {
 }
 
 async function getBtcVaultsData(chainId: string) {
-  const client = getHemiClient(chainId)
+  const client = getHemiClient(Number(chainId))
   const isTestnet = client.chain!.testnet
   const [bitcoinChainData, tunnelManagerData, vaultsData] = await Promise.all([
     getBitcoinChainData(client),

--- a/portal-backend/api/src/hemi-earn/costBasis.ts
+++ b/portal-backend/api/src/hemi-earn/costBasis.ts
@@ -1,14 +1,8 @@
 import { getAssetData } from 'hemi-earn-actions/actions'
-import {
-  type Address,
-  type PublicClient,
-  createPublicClient,
-  formatUnits,
-  http,
-  zeroAddress,
-} from 'viem'
+import { type Address, type PublicClient, formatUnits, zeroAddress } from 'viem'
 import { hemi } from 'viem/chains'
 
+import { getHemiClient } from '../hemiClient.ts'
 import {
   type GraphResponse,
   checkGraphQLErrors,
@@ -27,10 +21,7 @@ import {
 let hemiEarnRpcClient: PublicClient | undefined
 const getHemiEarnRpcClient = function () {
   if (!hemiEarnRpcClient) {
-    hemiEarnRpcClient = createPublicClient({
-      chain: hemi,
-      transport: http(undefined, { batch: true }),
-    })
+    hemiEarnRpcClient = getHemiClient(hemi.id)
   }
   return hemiEarnRpcClient
 }

--- a/portal-backend/api/src/hemiClient.ts
+++ b/portal-backend/api/src/hemiClient.ts
@@ -1,0 +1,18 @@
+import { hemi, hemiSepolia } from 'hemi-viem'
+import { type Chain, createPublicClient, http, type PublicClient } from 'viem'
+
+const chains: Record<number, Chain> = {
+  [hemi.id]: hemi,
+  [hemiSepolia.id]: hemiSepolia,
+}
+
+export const getHemiClient = function (chainId: number) {
+  const chain = chains[chainId]
+  if (!chain) {
+    throw new Error(`Chain ${chainId} is not a Hemi chain`)
+  }
+  return createPublicClient({
+    chain,
+    transport: http(undefined, { batch: true }),
+  }) as PublicClient
+}

--- a/portal-backend/api/src/ve-hemi/index.ts
+++ b/portal-backend/api/src/ve-hemi/index.ts
@@ -1,6 +1,5 @@
 import { getTotalVeHemiSupplyAt } from 've-hemi-actions/actions'
 import { getRewardPeriod, getRewardTokens } from 've-hemi-rewards/actions'
-import { createPublicClient, http } from 'viem'
 import { hemi } from 'viem/chains'
 // This rule throws because the eslint-plugin-node version doesn't understand
 // the package.json#exports field which let's Typescript to resolve the correct file.
@@ -11,6 +10,7 @@ import {
   symbol as readSymbol,
 } from 'viem-erc20/actions'
 
+import { getHemiClient } from '../hemiClient.ts'
 import type { Cache } from '../redis.ts'
 
 const ONE_DAY = 24 * 60 * 60
@@ -32,10 +32,7 @@ function generateTimestamps(epochs: number, epoch: number) {
 }
 
 function createVeHemi({ cache }: { cache: Cache }) {
-  const client = createPublicClient({
-    chain: hemi,
-    transport: http(undefined, { batch: true }),
-  })
+  const client = getHemiClient(hemi.id)
 
   async function getTotalWeights(timestamps: number[]) {
     const totalWeights = await Promise.all(

--- a/portal-backend/api/src/ve-hemi/stake.ts
+++ b/portal-backend/api/src/ve-hemi/stake.ts
@@ -1,0 +1,39 @@
+import fetchJson from 'tiny-fetch-json'
+import { getVeHemiContractAddress } from 've-hemi-actions'
+import { getTotalLocked } from 've-hemi-actions/actions'
+import { hemi } from 'viem/chains'
+// Disabled until we bump the eslint-plugin-node version
+// See https://github.com/bloq/eslint-config-bloq/issues/64
+// eslint-disable-next-line node/no-missing-import
+import { totalSupply } from 'viem-erc20/actions'
+
+import { getHemiClient } from '../hemiClient.ts'
+
+const client = getHemiClient(hemi.id)
+
+const veHemiAddress = getVeHemiContractAddress(hemi.id)
+
+const holdersUrl = `https://explorer.hemi.xyz/api/v2/tokens/${veHemiAddress}/counters`
+
+async function getWalletsStaking() {
+  const { token_holders_count: tokenHoldersCount } = (await fetchJson(
+    holdersUrl,
+  )) as { token_holders_count: string }
+  return Number(tokenHoldersCount)
+}
+
+export const getHemiStake = async function () {
+  const [locksCount, totalLocked, walletsStaking] = await Promise.all([
+    totalSupply(client, { address: veHemiAddress }),
+    getTotalLocked(client),
+    getWalletsStaking(),
+  ])
+  // TODO implement rewards and average lock
+  // See https://github.com/hemilabs/ui-monorepo/issues/2244
+  return {
+    locksCount: Number(locksCount),
+    rewards: [],
+    totalStaked: totalLocked.toString(),
+    walletsStaking,
+  }
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds a partial initial implementation of the endpoints that will render the Stats cards

<img width="1226" height="196" alt="image" src="https://github.com/user-attachments/assets/7efdfdf0-ccce-4552-9e00-a098a35739a8" />

This initial implementation adds the `hemi-stake` endpoint, only for mainnet for simplicity (in prod, we don't support hemi sepolia).

The current implementation returns

```json
{
    "locksCount": 15473,
    "rewards": [],
    "totalStaked": "1488392826436605230000147341",
    "walletsStaking": 13663
}
```

which covers the first and second card. For the 3rd, we need to merge #2250 , publish, and update the endpoint. For the 4th card, we need to implement the rewards paid to date.

Based on this, I'm not bumping the API yet, as more changes are coming, so no need to deploy it (but it will work for local development)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #2244

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
