### PR TITLE
Show build metadata in the Portal help menu

### DIFF
--- a/portal/README.md
+++ b/portal/README.md
@@ -32,6 +32,9 @@ The prefix `VITE_` is required: Vite only exposes variables carrying it to the b
 This is the list of all variables that can be configured:
 
 ```sh
+# Build metadata shown in the Help menu. Vite derives these from Git locally; set them in Cloudflare Worker Builds.
+VITE_BUILD_BRANCH=<branch-name>
+VITE_BUILD_VERSION=<commit-sha>
 # Use this variables to override RPC urls per chain. In order to join multiple RPC urls, join them with the "+" character.
 # For example VITE_CUSTOM_RPC_URL_SEPOLIA="https://rpc1.testnet.com/rpc+https://rpc2.testnet.com/rpc"
 VITE_CUSTOM_RPC_URL_HEMI_MAINNET=<urls>

--- a/portal/README.md
+++ b/portal/README.md
@@ -32,7 +32,7 @@ The prefix `VITE_` is required: Vite only exposes variables carrying it to the b
 This is the list of all variables that can be configured:
 
 ```sh
-# Build metadata shown in the Help menu. Vite derives these from Git locally; set them in Cloudflare Worker Builds.
+# Build metadata shown in the Help menu. Vite derives these from Workers Builds or local Git; use these variables to override it.
 VITE_BUILD_BRANCH=<branch-name>
 VITE_BUILD_VERSION=<commit-sha>
 # Use this variables to override RPC urls per chain. In order to join multiple RPC urls, join them with the "+" character.

--- a/portal/app/[locale]/_components/navbar/_components/help/buildInfo.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/buildInfo.tsx
@@ -15,7 +15,7 @@ export const BuildInfo = function () {
     : version
 
   return (
-    <div className="mt-1 flex w-full cursor-default items-center gap-1.5 border-t border-neutral-100 px-3 pb-2 pt-3 font-mono text-[10px] leading-4 text-neutral-400">
+    <div className="mt-1 flex w-full cursor-default items-center gap-1.5 border-t border-neutral-100 px-4 pb-0 pt-3 font-mono text-[10px] leading-4 text-neutral-400 md:px-3 md:pb-2">
       <span className="min-w-0 truncate" title={branch}>
         {branch}
       </span>

--- a/portal/app/[locale]/_components/navbar/_components/help/buildInfo.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/buildInfo.tsx
@@ -16,7 +16,7 @@ export const BuildInfo = function () {
 
   return (
     <div className="mt-1 flex w-full cursor-default items-center gap-1.5 border-t border-neutral-100 px-3 pb-2 pt-3 font-mono text-[10px] leading-4 text-neutral-400">
-      <span className="truncate" title={branch}>
+      <span className="min-w-0 truncate" title={branch}>
         {branch}
       </span>
       <span aria-hidden="true" className="shrink-0">

--- a/portal/app/[locale]/_components/navbar/_components/help/buildInfo.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/buildInfo.tsx
@@ -5,12 +5,12 @@ const version = import.meta.env.VITE_BUILD_VERSION || 'dev'
 
 const dirtyMarker = version.endsWith('-dirty') ? '-dirty' : ''
 const commitSha = version.replace(/-dirty$/, '')
-const commitUrl = /^[0-9a-f]{7,40}$/i.test(commitSha)
-  ? `https://github.com/hemilabs/ui-monorepo/commit/${commitSha}`
+const sourceUrl = /^[0-9a-f]{7,40}$/i.test(commitSha)
+  ? `https://github.com/hemilabs/ui-monorepo/tree/${commitSha}`
   : undefined
 
 export const BuildInfo = function () {
-  const displayedVersion = commitUrl
+  const displayedVersion = sourceUrl
     ? `${commitSha.slice(0, 7)}${dirtyMarker}`
     : version
 
@@ -22,10 +22,10 @@ export const BuildInfo = function () {
       <span aria-hidden="true" className="shrink-0">
         ·
       </span>
-      {commitUrl ? (
+      {sourceUrl ? (
         <ExternalLink
           className="shrink-0 transition-colors hover:text-neutral-600 hover:underline"
-          href={commitUrl}
+          href={sourceUrl}
           title={version}
         >
           {displayedVersion}

--- a/portal/app/[locale]/_components/navbar/_components/help/buildInfo.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/buildInfo.tsx
@@ -1,0 +1,40 @@
+import { ExternalLink } from 'components/externalLink'
+
+const branch = import.meta.env.VITE_BUILD_BRANCH || 'dev'
+const version = import.meta.env.VITE_BUILD_VERSION || 'dev'
+
+const dirtyMarker = version.endsWith('-dirty') ? '-dirty' : ''
+const commitSha = version.replace(/-dirty$/, '')
+const commitUrl = /^[0-9a-f]{7,40}$/i.test(commitSha)
+  ? `https://github.com/hemilabs/ui-monorepo/commit/${commitSha}`
+  : undefined
+
+export const BuildInfo = function () {
+  const displayedVersion = commitUrl
+    ? `${commitSha.slice(0, 7)}${dirtyMarker}`
+    : version
+
+  return (
+    <div className="mt-1 flex w-full cursor-default items-center gap-1.5 border-t border-neutral-100 px-3 pb-2 pt-3 font-mono text-[10px] leading-4 text-neutral-400">
+      <span className="truncate" title={branch}>
+        {branch}
+      </span>
+      <span aria-hidden="true" className="shrink-0">
+        ·
+      </span>
+      {commitUrl ? (
+        <ExternalLink
+          className="shrink-0 transition-colors hover:text-neutral-600 hover:underline"
+          href={commitUrl}
+          title={version}
+        >
+          {displayedVersion}
+        </ExternalLink>
+      ) : (
+        <span className="shrink-0" title={version}>
+          {displayedVersion}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/portal/app/[locale]/_components/navbar/_components/help/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/index.tsx
@@ -215,7 +215,7 @@ export const Help = function () {
         helpPortalContainer &&
         ReactDOM.createPortal(
           <div
-            className="absolute bottom-0 left-0 z-30 flex h-fit w-full flex-col items-start rounded-t-2xl bg-white p-4 shadow-lg md:top-0 md:w-64 md:translate-x-58 md:translate-y-2 md:rounded-lg md:p-1 xl:translate-x-2"
+            className="absolute bottom-14 left-0 z-30 flex h-fit w-full flex-col items-start rounded-t-2xl bg-white p-4 pb-3 shadow-lg sm:bottom-0 md:top-0 md:w-64 md:translate-x-58 md:translate-y-2 md:rounded-lg md:p-1 xl:translate-x-2"
             onMouseDown={e => e.stopPropagation()}
             onTouchStart={e => e.stopPropagation()}
           >

--- a/portal/app/[locale]/_components/navbar/_components/help/index.tsx
+++ b/portal/app/[locale]/_components/navbar/_components/help/index.tsx
@@ -23,6 +23,7 @@ import { getDrawerPortalContainer, getPortalContainer } from 'utils/document'
 import { CmcAttribution } from '../cmcAttribution'
 import { TermsAndConditions } from '../termsAndConditions'
 
+import { BuildInfo } from './buildInfo'
 import { HelpButton } from './helpButton'
 
 type Selectable = { selected?: boolean }
@@ -214,7 +215,7 @@ export const Help = function () {
         helpPortalContainer &&
         ReactDOM.createPortal(
           <div
-            className="absolute bottom-0 left-0 z-30 flex h-36 w-full flex-col items-start rounded-t-2xl bg-white p-4 shadow-lg md:top-0 md:h-fit md:w-64 md:translate-x-58 md:translate-y-2 md:rounded-lg md:p-1 xl:translate-x-2"
+            className="absolute bottom-0 left-0 z-30 flex h-fit w-full flex-col items-start rounded-t-2xl bg-white p-4 shadow-lg md:top-0 md:w-64 md:translate-x-58 md:translate-y-2 md:rounded-lg md:p-1 xl:translate-x-2"
             onMouseDown={e => e.stopPropagation()}
             onTouchStart={e => e.stopPropagation()}
           >
@@ -231,6 +232,7 @@ export const Help = function () {
               subMenu={<LegalAndPrivacy />}
               text={t('legal-and-privacy')}
             />
+            <BuildInfo />
           </div>,
           helpPortalContainer,
         )}

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -31,9 +31,24 @@ const getLocalBuildInfo = function () {
   }
 }
 
+const getBuildInfo = function (env: Record<string, string>) {
+  const localBuildInfo = getLocalBuildInfo()
+
+  return {
+    branch:
+      env.VITE_BUILD_BRANCH ||
+      process.env.WORKERS_CI_BRANCH ||
+      localBuildInfo.branch,
+    version:
+      env.VITE_BUILD_VERSION ||
+      process.env.WORKERS_CI_COMMIT_SHA ||
+      localBuildInfo.version,
+  }
+}
+
 export default defineConfig(function ({ mode }) {
   const env = loadEnv(mode, process.cwd(), '')
-  const localBuildInfo = getLocalBuildInfo()
+  const buildInfo = getBuildInfo(env)
 
   const instrumentForSentry = !!env.VITE_SENTRY_DSN && !process.env.STORYBOOK
 
@@ -94,16 +109,8 @@ export default defineConfig(function ({ mode }) {
     // but not in worker ones.
     define: {
       'global': 'globalThis',
-      'import.meta.env.VITE_BUILD_BRANCH': JSON.stringify(
-        env.VITE_BUILD_BRANCH ||
-          process.env.WORKERS_CI_BRANCH ||
-          localBuildInfo.branch,
-      ),
-      'import.meta.env.VITE_BUILD_VERSION': JSON.stringify(
-        env.VITE_BUILD_VERSION ||
-          process.env.WORKERS_CI_COMMIT_SHA ||
-          localBuildInfo.version,
-      ),
+      'import.meta.env.VITE_BUILD_BRANCH': JSON.stringify(buildInfo.branch),
+      'import.meta.env.VITE_BUILD_VERSION': JSON.stringify(buildInfo.version),
     },
     plugins,
     resolve: {

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -1,6 +1,7 @@
 import { cloudflare } from '@cloudflare/vite-plugin'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import react from '@vitejs/plugin-react'
+import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { defineConfig, loadEnv, type PluginOption } from 'vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
@@ -12,8 +13,27 @@ const polyfills = () => nodePolyfills({ include: ['http', 'https', 'util'] })
 const onlyClient = (environment: { name: string }) =>
   environment.name === 'client'
 
+const getLocalBuildInfo = function () {
+  try {
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim()
+    const commit = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim()
+    const dirty = execFileSync('git', ['status', '--porcelain'], {
+      encoding: 'utf8',
+    }).trim()
+
+    return { branch, version: `${commit}${dirty ? '-dirty' : ''}` }
+  } catch {
+    return { branch: 'dev', version: 'dev' }
+  }
+}
+
 export default defineConfig(function ({ mode }) {
   const env = loadEnv(mode, process.cwd(), '')
+  const localBuildInfo = getLocalBuildInfo()
 
   const instrumentForSentry = !!env.VITE_SENTRY_DSN && !process.env.STORYBOOK
 
@@ -72,7 +92,15 @@ export default defineConfig(function ({ mode }) {
     // stream-http and readable-stream, pulled in by the http/https polyfills,
     // read the bare `global`. The polyfill plugin shims it in the main bundle
     // but not in worker ones.
-    define: { global: 'globalThis' },
+    define: {
+      'import.meta.env.VITE_BUILD_BRANCH': JSON.stringify(
+        env.VITE_BUILD_BRANCH || localBuildInfo.branch,
+      ),
+      'import.meta.env.VITE_BUILD_VERSION': JSON.stringify(
+        env.VITE_BUILD_VERSION || localBuildInfo.version,
+      ),
+      'global': 'globalThis',
+    },
     plugins,
     resolve: {
       // The plugin injects its shims into whichever file touches `Buffer`,

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -95,10 +95,14 @@ export default defineConfig(function ({ mode }) {
     define: {
       'global': 'globalThis',
       'import.meta.env.VITE_BUILD_BRANCH': JSON.stringify(
-        env.VITE_BUILD_BRANCH || localBuildInfo.branch,
+        env.VITE_BUILD_BRANCH ||
+          process.env.WORKERS_CI_BRANCH ||
+          localBuildInfo.branch,
       ),
       'import.meta.env.VITE_BUILD_VERSION': JSON.stringify(
-        env.VITE_BUILD_VERSION || localBuildInfo.version,
+        env.VITE_BUILD_VERSION ||
+          process.env.WORKERS_CI_COMMIT_SHA ||
+          localBuildInfo.version,
       ),
     },
     plugins,

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -93,13 +93,13 @@ export default defineConfig(function ({ mode }) {
     // read the bare `global`. The polyfill plugin shims it in the main bundle
     // but not in worker ones.
     define: {
+      'global': 'globalThis',
       'import.meta.env.VITE_BUILD_BRANCH': JSON.stringify(
         env.VITE_BUILD_BRANCH || localBuildInfo.branch,
       ),
       'import.meta.env.VITE_BUILD_VERSION': JSON.stringify(
         env.VITE_BUILD_VERSION || localBuildInfo.version,
       ),
-      'global': 'globalThis',
     },
     plugins,
     resolve: {


### PR DESCRIPTION
### Description

Display the built branch and commit hash at the bottom of the Portal help menu. The hash links to its commit in `hemilabs/ui-monorepo`.

Cloudflare Worker Builds can inject the metadata through `VITE_BUILD_BRANCH` and `VITE_BUILD_VERSION`. Local Vite builds derive it from Git and append `-dirty` when the working tree has changes.

### Screenshots

Prod example
<img width="481" height="124" alt="image" src="https://github.com/user-attachments/assets/b35559cc-187d-4f90-8368-03a9e16f35cb" />

Preview example
<img width="483" height="120" alt="image" src="https://github.com/user-attachments/assets/badac6d4-8695-4787-9d3a-d42c1516f2d8" />

Local development (dirty ref)
<img width="488" height="133" alt="image" src="https://github.com/user-attachments/assets/12311efc-61c0-41c9-8b24-9a22192a7b66" />

### Related issue(s)

n/a

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
