### PR TITLE
portal: disable preview deploys for staging-safe, enable workers.dev

### DIFF
--- a/portal/wrangler.jsonc
+++ b/portal/wrangler.jsonc
@@ -4,7 +4,7 @@
   "main": "./worker/index.ts",
   "compatibility_date": "2026-09-01",
   "workers_dev": false,
-  "preview_urls": true,
+  "preview_urls": false,
   "upload_source_maps": true,
   "observability": {
     "enabled": true,
@@ -26,9 +26,11 @@
     },
     "staging": {
       "name": "hemi-portal-staging",
+      "preview_urls": true,
     },
     "staging-safe": {
       "name": "hemi-portal-staging-safe",
+      "workers_dev": true,
     },
   },
 }

--- a/portal/wrangler.jsonc
+++ b/portal/wrangler.jsonc
@@ -30,6 +30,7 @@
     },
     "staging-safe": {
       "name": "hemi-portal-staging-safe",
+      "preview_urls": false,
       "workers_dev": true,
     },
   },


### PR DESCRIPTION
### Description

Disable preview deployments for `staging-safe` portal environment, and enable the `workers.dev` URL.

### Screenshots

n/a - no UI changes.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to https://github.com/hemilabs/ui-monorepo/issues/2237

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
