### PR TITLE
Add average lock to hemi-stake and fix backend images

### DIFF
--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -57,10 +57,10 @@ Returns the global veHEMI staking stats. It is Hemi mainnet only.
 
 ```console
 $ curl http://localhost:3006/hemi-stake
-{"locksCount":15473,"rewards":[],"totalStaked":"1488392826436605230000147341","walletsStaking":13663}
+{"averageLock":63072000,"locksCount":15473,"rewards":[],"totalStaked":"1488392826436605230000147341","walletsStaking":13663}
 ```
 
-`totalStaked` is the amount of HEMI locked, in its smallest unit. `locksCount` is the number of open positions and `walletsStaking` the number of wallets that hold at least one position, read from the [Hemi explorer](https://explorer.hemi.xyz). `rewards` is the list of all-time paid rewards (to be implemented).
+`averageLock` is the average lock duration of the active positions, in seconds, read from the veHEMI subgraph. `totalStaked` is the amount of HEMI locked, in its smallest unit. `locksCount` is the number of open positions and `walletsStaking` the number of wallets that hold at least one position, read from the [Hemi explorer](https://explorer.hemi.xyz). `rewards` is the list of all-time paid rewards (to be implemented).
 
 #### `GET /net-stats`
 

--- a/portal-backend/api/Dockerfile
+++ b/portal-backend/api/Dockerfile
@@ -38,6 +38,10 @@ RUN npm uninstall --global npm
 # Skip corepack's interactive download prompt so the `node` user can fetch
 # pnpm on first container start without a TTY to approve it.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+# pnpm 11 checks deps before `pnpm run` and runs `pnpm install` when it can't
+# verify them. The `pnpm deploy` output can't be verified, and the install
+# fails as `node` can't write to /app.
+ENV pnpm_config_verify_deps_before_run=false
 
 WORKDIR /app
 

--- a/portal-backend/api/src/subgraphs/subgraph.ts
+++ b/portal-backend/api/src/subgraphs/subgraph.ts
@@ -706,6 +706,36 @@ export const getLockedPositions = function ({
   )
 }
 
+type GetLockStatsQueryResponse = GraphResponse<{
+  lockStats: {
+    activeLocks: number
+    totalLockDuration: string
+  } | null
+}>
+
+export const getLockStats = function () {
+  const subgraphUrl = getSubgraphUrl({
+    chainId: hemi.id,
+    subgraphIds: { [hemi.id]: subgraphConfig.veHemi.mainnet },
+  })
+
+  const schema = {
+    query: `{
+      lockStats(id: "singleton") {
+        activeLocks
+        totalLockDuration
+      }
+    }`,
+  }
+
+  return request<GetLockStatsQueryResponse>(subgraphUrl, schema).then(
+    function (response) {
+      checkGraphQLErrors(response)
+      return response.data.lockStats
+    },
+  )
+}
+
 // `failed` is an Agent-side flag the indexer clears on `RequestRetried` but not
 // on cancel, so it lingers through CANCELLED/RECOVERED. A terminal Router status
 // wins over it: only a still-PENDING request surfaces as FAILED, otherwise a

--- a/portal-backend/api/src/ve-hemi/stake.ts
+++ b/portal-backend/api/src/ve-hemi/stake.ts
@@ -8,6 +8,7 @@ import { hemi } from 'viem/chains'
 import { totalSupply } from 'viem-erc20/actions'
 
 import { getHemiClient } from '../hemiClient.ts'
+import { getLockStats } from '../subgraphs/subgraph.ts'
 
 const client = getHemiClient(hemi.id)
 
@@ -22,15 +23,26 @@ async function getWalletsStaking() {
   return Number(tokenHoldersCount)
 }
 
+async function getAverageLock() {
+  const lockStats = await getLockStats()
+  if (!lockStats?.activeLocks) {
+    return 0
+  }
+  return Math.round(Number(lockStats.totalLockDuration) / lockStats.activeLocks)
+}
+
 export const getHemiStake = async function () {
-  const [locksCount, totalLocked, walletsStaking] = await Promise.all([
-    totalSupply(client, { address: veHemiAddress }),
-    getTotalLocked(client),
-    getWalletsStaking(),
-  ])
-  // TODO implement rewards and average lock
+  const [averageLock, locksCount, totalLocked, walletsStaking] =
+    await Promise.all([
+      getAverageLock(),
+      totalSupply(client, { address: veHemiAddress }),
+      getTotalLocked(client),
+      getWalletsStaking(),
+    ])
+  // TODO implement rewards
   // See https://github.com/hemilabs/ui-monorepo/issues/2244
   return {
+    averageLock,
     locksCount: Number(locksCount),
     rewards: [],
     totalStaked: totalLocked.toString(),

--- a/portal-backend/cron/hemi-supply/Dockerfile
+++ b/portal-backend/cron/hemi-supply/Dockerfile
@@ -29,6 +29,10 @@ RUN npm uninstall --global npm
 # Skip corepack's interactive download prompt so the `node` user can fetch
 # pnpm on first container start without a TTY to approve it.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+# pnpm 11 checks deps before `pnpm run` and runs `pnpm install` when it can't
+# verify them. The `pnpm deploy` output can't be verified, and the install
+# fails as `node` can't write to /app.
+ENV pnpm_config_verify_deps_before_run=false
 
 WORKDIR /app
 

--- a/portal-backend/cron/token-prices/Dockerfile
+++ b/portal-backend/cron/token-prices/Dockerfile
@@ -29,6 +29,10 @@ RUN npm uninstall --global npm
 # Skip corepack's interactive download prompt so the `node` user can fetch
 # pnpm on first container start without a TTY to approve it.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+# pnpm 11 checks deps before `pnpm run` and runs `pnpm install` when it can't
+# verify them. The `pnpm deploy` output can't be verified, and the install
+# fails as `node` can't write to /app.
+ENV pnpm_config_verify_deps_before_run=false
 
 WORKDIR /app
 

--- a/portal-backend/cron/vaults-monitor/Dockerfile
+++ b/portal-backend/cron/vaults-monitor/Dockerfile
@@ -29,6 +29,10 @@ RUN npm uninstall --global npm
 # Skip corepack's interactive download prompt so the `node` user can fetch
 # pnpm on first container start without a TTY to approve it.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+# pnpm 11 checks deps before `pnpm run` and runs `pnpm install` when it can't
+# verify them. The `pnpm deploy` output can't be verified, and the install
+# fails as `node` can't write to /app.
+ENV pnpm_config_verify_deps_before_run=false
 
 WORKDIR /app
 


### PR DESCRIPTION
### Description

Adds `averageLock` to `GET /hemi-stake`. The API reads `activeLocks` and `totalLockDuration` from the `LockStats` entity of the veHEMI mainnet subgraph. It divides them and returns the rounded result in seconds. When there are no active locks, the value is `0`.

Also turns off the pnpm dependency check in the 4 backend Docker images. In pnpm 11, `verify-deps-before-run` defaults to `install`. Thus `pnpm run start` tried to run `pnpm install` on the `pnpm deploy` output, and the containers failed with `EACCES` because `node` can't write to `/app`. `pnpm_config_verify_deps_before_run=false` restores the pnpm 10 behavior. This issue was introduced after https://github.com/hemilabs/ui-monorepo/pull/2263 and the fix restores the same behaviour as it was before

Example output:

```json
{
  "averageLock": 57054153,
  "locksCount": 15470,
  "rewards": [],
  "totalStaked": "1488392294456274430000147341",
  "walletsStaking": 13659
}
```

**Commits:**

- e7edcb84 Add average lock to hemi-stake endpoint
- ae326c8f Skip pnpm deps check in backend images

### Screenshots

N/A

### Related issue(s)

Related to #2244

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
